### PR TITLE
Free bugfix!

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -22,12 +22,12 @@ function setup_response_handler(req, callback) {
                     var err = 200 == res.statusCode ? 0 : res.statusCode;
                     try {
                         response = JSON.parse(response);
-                        callback(null, response);
                     }
                     catch(e) {
-                        console.log(response);
-                        callback(err, {});
+                        err = 1;
+                        response = { error : { message : "Invalid JSON from stripe.com" } };
                     }
+                    callback(err, response)
             });
         });
 }


### PR DESCRIPTION
I fixed a bug where callback() could be called twice, if callback() threw an error itself.

Here is what I mean. Here is the old code:

```
                try {
                    response = JSON.parse(response);
                    callback(null, response);  // PLACE 1
                }
                catch(e) {
                    console.log(response); // PLACE 2
                    callback(err, {});
                }
```

Now when you call callback() in the try block the response has been successfully parsed callback at "PLACE 1" can throw. If it throws, it gets caught by catch(e) below at "PLACE 2", which calls callback again!

Experienced this myself in my code. Didn't feel good.

Pull it in!
