### PR TITLE
Changed installation instructions to use correct npm package name.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Access to the [Stripe](https://stripe.com/) [API](https://stripe.com/docs/api).
 
 ## Installation
 
-`npm install node-strip`
+`npm install stripe`
 
 ## Usage overview
 


### PR DESCRIPTION
The installation instructions seem to be a bit out of date.  They don't use the package name listed in NPM: http://search.npmjs.org/#/stripe
