### PR TITLE
Added missing data parameter to the internal `get` function...

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -143,7 +143,7 @@ module.exports = function (api_key, options) {
                 post("/v1/tokens", data, cb)
             },
             retrieve: function (token_id, cb) {
-                get("/v1/tokens/" + token_id, cb)
+                get("/v1/tokens/" + token_id, {}, cb)
             }
         },
     };


### PR DESCRIPTION
...that's called in `stripe.token.retrieve`.  This results in `stripe.token.retrieve` silently failing and the callback parameter never being executed.
