### PR TITLE
Pass a more robust error object to the callback

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -27,7 +27,8 @@ function setup_response_handler(req, callback) {
                         err = 1;
                         response = { error : { message : "Invalid JSON from stripe.com" } };
                     }
-                    callback(err, response)
+                    err && (err = { statusCode: err, response: response });
+                    callback(err, response);
             });
         });
 }


### PR DESCRIPTION
This is targeted primarily at when this module is being used in conjunction with a module like [node-sync](https://github.com/0ctave/node-sync) that allows asynchronous calls to be used with a synchronous-like syntax and behavior.
