### PR TITLE
Preparing for Stripe Connect support

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -19,7 +19,7 @@ function setup_response_handler(req, callback) {
             });
             res.on('end',
                 function() {
-                    var err = 200 == res.statusCode ? null : res.statusCode;
+                    var err = (200 == res.statusCode) ? null : res.statusCode;
                     try {
                         response = JSON.parse(response);
                     }
@@ -36,9 +36,17 @@ function setup_response_handler(req, callback) {
 module.exports = function (api_key, options) {
     var defaults = options || {};
 
-    var auth = 'Basic ' + new Buffer(api_key + ":").toString('base64');
+    var default_auth = new Buffer(api_key + ":").toString('base64');
 
-    function _request(method, path, data, callback) {
+    function _request(method, path, data, options, callback) {
+        if (typeof options === 'function') {
+            callback = options;
+            options = {};
+        }
+        options = options || {};
+
+        var auth = options.api_key ?
+            new Buffer(options.api_key + ":").toString('base64') : default_auth;
 
         //console.log("data", typeof data, data);
 
@@ -65,7 +73,7 @@ module.exports = function (api_key, options) {
               path: path,
               method: method,
               headers: {
-                  'Authorization': auth,
+                  'Authorization': 'Basic ' + auth,
                   'Accept': 'application/json',
                   'Content-Type': 'application/x-www-form-urlencoded',
                   'Content-Length': request_data.length
@@ -78,156 +86,182 @@ module.exports = function (api_key, options) {
         req.end();
     }
 
-    function post(path, data, callback) {
-        _request('POST', path, data, callback);
+    function post(path, data, options, callback) {
+        _request('POST', path, data, options, callback);
     }
 
-    function get(path, data, callback) {
-        _request('GET', path, data, callback);
+    function get(path, data, options, callback) {
+        _request('GET', path, data, options, callback);
     }
 
-    function del(path, data, callback) {
-        _request('DELETE', path, data, callback);
+    function del(path, data, options, callback) {
+        _request('DELETE', path, data, options, callback);
     }
 
     return {
         charges: {
-            create: function (data, cb) {
-                post("/v1/charges", data, cb);
+            create: function (data, options, cb) {
+                post("/v1/charges", data, options, cb);
             },
-            retrieve: function(charge_id, cb) {
-                if(!(charge_id && typeof charge_id === 'string')) {
+            retrieve: function(charge_id, options, cb) {
+                if (typeof options === 'function') {
+                    cb = options;
+                    options = {};
+                }
+                if (!(charge_id && typeof charge_id === 'string')) {
                     cb("charge_id required");
                 }
-                get("/v1/charges/" + charge_id, {}, cb);
+                get("/v1/charges/" + charge_id, {}, options, cb);
             },
-            refund: function(charge_id, amount, cb) {
-                var requestParams = {};
-                if(!(charge_id && typeof charge_id === 'string')) {
-                    cb("charge_id required");
-                }
+            refund: function(charge_id, amount, options, cb) {
                 if (typeof amount === 'function') {
                     cb = amount;
                     amount = null;
                 }
+                if (typeof options === 'function') {
+                    cb = options;
+                    options = {};
+                }
+                if(!(charge_id && typeof charge_id === 'string')) {
+                    cb("charge_id required");
+                }
+                var requestParams = {};
                 if (amount) {
                     requestParams.amount = amount;
                 }
-                post("/v1/charges/" + charge_id + "/refund", requestParams, cb);
+                post("/v1/charges/" + charge_id + "/refund", requestParams, options, cb);
             },
-            list: function(data, cb) {
-                get("/v1/charges", data, cb);
-            },
+            list: function(data, options, cb) {
+                get("/v1/charges", data, options, cb);
+            }
         },
         customers: {
-            create: function (data, cb) {
-                post("/v1/customers", data, cb);
+            create: function (data, options, cb) {
+                post("/v1/customers", data, options, cb);
             },
-            retrieve: function(customer_id, cb) {
+            retrieve: function(customer_id, options, cb) {
+                if (typeof options === 'function') {
+                    cb = options;
+                    options = {};
+                }
                 if (!(customer_id && typeof customer_id === 'string')) {
                     return cb("customer_id required");
                 }
-                get("/v1/customers/" + customer_id, {}, cb);
+                get("/v1/customers/" + customer_id, {}, options, cb);
             },
-            update: function(customer_id, data, cb) {
-                post("/v1/customers/" + customer_id, data, cb);
+            update: function(customer_id, data, options, cb) {
+                post("/v1/customers/" + customer_id, data, options, cb);
             },
-            del: function(customer_id, cb) {
-                del("/v1/customers/" + customer_id, {}, cb);
+            del: function(customer_id, options, cb) {
+                del("/v1/customers/" + customer_id, {}, options, cb);
             },
-            list: function(count, offset, cb) {
-                get("/v1/customers", { count: count, offset: offset}, cb );
+            list: function(count, offset, options, cb) {
+                get("/v1/customers", { count: count, offset: offset}, options, cb );
             },
-            update_subscription: function(customer_id, data, cb) {
-                post("/v1/customers/" + customer_id + '/subscription', data, cb);
+            update_subscription: function(customer_id, data, options, cb) {
+                post("/v1/customers/" + customer_id + '/subscription', data, options, cb);
             },
-            cancel_subscription: function(customer_id, at_period_end, cb) {
-                del("/v1/customers/" + customer_id + '/subscription', { at_period_end: at_period_end }, cb);
+            cancel_subscription: function(customer_id, at_period_end, options, cb) {
+                del("/v1/customers/" + customer_id + '/subscription',
+                    { at_period_end: at_period_end }, options, cb);
             }
         },
         plans: {
-            create: function (data, cb) {
-                post("/v1/plans", data, cb);
+            create: function (data, options, cb) {
+                post("/v1/plans", data, options, cb);
             },
-            retrieve: function(plan_id, cb) {
+            retrieve: function(plan_id, options, cb) {
+                if (typeof options === 'function') {
+                    cb = options;
+                    options = {};
+                }
                 if (!(plan_id && typeof plan_id === 'string')) {
                     return cb("plan_id required");
                 }
-                get("/v1/plans/" + plan_id, {}, cb);
+                get("/v1/plans/" + plan_id, {}, options, cb);
             },
-            del: function(plan_id, cb) {
-                del("/v1/plans/" + plan_id, {}, cb);
+            del: function(plan_id, options, cb) {
+                del("/v1/plans/" + plan_id, {}, options, cb);
             },
-            list: function(count, offset, cb) {
-                get("/v1/plans", { count: count, offset: offset}, cb );
+            list: function(count, offset, options, cb) {
+                get("/v1/plans", { count: count, offset: offset}, options, cb);
             },
-            update: function (plan_id, data, cb) {
-                post("/v1/plans/" + plan_id, data, cb);
+            update: function (plan_id, data, options, cb) {
+                post("/v1/plans/" + plan_id, data, options, cb);
             }
         },
         invoices: {
-            retrieve: function(invoice_id, cb) {
-                get("/v1/invoices/" + invoice_id, {}, cb);
+            retrieve: function(invoice_id, options, cb) {
+                get("/v1/invoices/" + invoice_id, {}, options, cb);
             },
-            list: function(data, cb) {
-                get("/v1/invoices", data, cb);
+            list: function(data, options, cb) {
+                get("/v1/invoices", data, options, cb);
             },
-            upcoming: function(customer_id, cb) {
-                get("/v1/invoices/upcoming", { customer: customer_id }, cb);
-            },
+            upcoming: function(customer_id, options, cb) {
+                get("/v1/invoices/upcoming", { customer: customer_id }, options, cb);
+            }
         },
         invoice_items: {
-            create: function(data, cb) {
-                post("/v1/invoiceitems", data, cb);
+            create: function(data, options, cb) {
+                post("/v1/invoiceitems", data, options, cb);
             },
-            retrieve: function(invoice_item_id, cb) {
+            retrieve: function(invoice_item_id, options, cb) {
+                if (typeof options === 'function') {
+                    cb = options;
+                    options = {};
+                }
                 if (!(invoice_item_id && typeof invoice_item_id === 'string')) {
                     return cb("invoice_item_id required");
                 }
-                get("/v1/invoiceitems/" + invoice_item_id, {}, cb);
+                get("/v1/invoiceitems/" + invoice_item_id, {}, options, cb);
             },
-            update: function(invoice_item_id, data, cb) {
-                post("/v1/invoiceitems/" + invoice_item_id, data, cb);
+            update: function(invoice_item_id, data, options, cb) {
+                post("/v1/invoiceitems/" + invoice_item_id, data, options, cb);
             },
-            del: function(invoice_item_id, cb) {
+            del: function(invoice_item_id, options, cb) {
                 del("/v1/invoiceitems/" + invoice_item_id, {}, cb);
             },
-            list: function(customer_id, count, offset, cb) {
-                get("/v1/invoiceitems", { customer: customer_id, count: count, offset: offset}, cb );
+            list: function(customer_id, count, offset, options, cb) {
+                get("/v1/invoiceitems", { customer: customer_id, count: count, offset: offset},
+                    options, cb);
             }
         },
         coupons: {
-            create: function (data, cb) {
-                post("/v1/coupons", data, cb);
+            create: function (data, options, cb) {
+                post("/v1/coupons", data, options, cb);
             },
-            retrieve: function(coupon_id, cb) {
+            retrieve: function(coupon_id, options, cb) {
+                if (typeof options === 'function') {
+                    cb = options;
+                    options = {};
+                }
                 if (!(coupon_id && typeof coupon_id === 'string')) {
                     cb("coupon_id required");
                 }
-                get("/v1/coupons/" + coupon_id, {}, cb);
+                get("/v1/coupons/" + coupon_id, {}, options, cb);
             },
-            del: function(coupon_id, cb) {
-                del("/v1/coupons/" + coupon_id, {}, cb);
+            del: function(coupon_id, options, cb) {
+                del("/v1/coupons/" + coupon_id, {}, options, cb);
             },
-            list: function(count, offset, cb) {
-                get("/v1/coupons", { count: count, offset: offset}, cb );
+            list: function(count, offset, options, cb) {
+                get("/v1/coupons", { count: count, offset: offset}, options, cb);
             }
         },
         token: {
-            create: function (data, cb) {
-                post("/v1/tokens", data, cb)
+            create: function (data, options, cb) {
+                post("/v1/tokens", data, options, cb);
             },
-            retrieve: function (token_id, cb) {
-                get("/v1/tokens/" + token_id, {}, cb)
+            retrieve: function (token_id, options, cb) {
+                get("/v1/tokens/" + token_id, {}, options, cb);
             }
         },
         events: {
-            retrieve: function (token_id, cb) {
-                get("/v1/events/" + token_id, {}, cb)
+            retrieve: function (token_id, options, cb) {
+                get("/v1/events/" + token_id, {}, options, cb);
             },
-            list: function (cb) {
-                get("/v1/events/", {}, cb)
+            list: function (options, cb) {
+                get("/v1/events/", {}, options, cb);
             }
-        },
+        }
     };
-}
+};

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "author": "Ask Bjørn Hansen <ask@develooper.com> (http://www.askask.com/)",
   "name": "stripe",
   "description": "Stripe API wrapper",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "homepage": "https://github.com/abh/node-stripe",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Adding support for Stripe connect by having options parameter to each method. When options object is present with api_key set, it will use that api_key as opposed to the global api_key upon making request.

For example,

``` javascript
var stripe = require('stripe')(<global_api_key>);
...
stripe.charges.create({ amount: 1000, card: stripeToken, ... },
    { api_key: <user's_api_key> }, function(err, res) {
  ...
})
...
```

@abh, what do you think?
