### PR TITLE
Added a few more properties to Errors returned from Stripe

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -25,6 +25,8 @@ function setup_response_handler(req, callback) {
                         if(200 != res.statusCode) {
                             err = new Error(response.error.message);
                             err.name = response.error.type;
+                            err.code = response.error.code;
+                            err.param = response.error.param;
                             response = null;
                         }
                     }


### PR DESCRIPTION
Stripe actually sends a good amount of information back in errors, but some of this information is lost. I just added it back to the error returned so it is available.

I apologize about not adding to the errors test suite. I can update that if necessary.
