### PR TITLE
Fix events.list() and add support for count/offset

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -259,7 +259,12 @@ module.exports = function (api_key, options) {
                 get("/v1/events/" + token_id, {}, cb)
             },
             list: function (count, offset, cb) {
-                var nArgs = normalizeArguments(arguments);
+                if (arguments.length === 1) {
+                  var nArgs = {count: 10, offset: 0};
+                  cb = count;
+                } else {
+                  var nArgs = normalizeArguments(arguments);
+                }
                 get("/v1/events", { count: nArgs.count, offset: nArgs.offset }, cb)
             }
         },


### PR DESCRIPTION
Hi, 
Thanks for writing this library! 

I fixed a small bug with the url in events.list (should not have a trailing slash) and added count/offset support as specified here: https://stripe.com/docs/api#list_events

```
list: function (count, offset, cb) {
    var nArgs = normalizeArguments(arguments);
    get("/v1/events", { count: nArgs.count, offset: nArgs.offset }, cb)
}

```
