### PR TITLE
Add a `timeout` option for the request.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,11 @@ Access to the [Stripe](https://stripe.com/) [API](https://stripe.com/docs/api).
        }
      );
 
+`options` is an optional second argument. Currently only `timeout` is supported,
+which sets the socket to timeout after the given number of milliseconds of
+inactivity.
+
+    var stripe = require('stripe')(api_key, {timeout: 5000}); // timeout after 5 seconds
 
 ## API
 

--- a/lib/main.js
+++ b/lib/main.js
@@ -38,6 +38,7 @@ function setup_response_handler(req, callback) {
             });
         });
     req.on('error', function(error){
+        if (req._aborted) return;
         callback(error);
     });
 }
@@ -82,6 +83,13 @@ module.exports = function (api_key, options) {
           };
 
         var req = https.request(request_options);
+        req.setTimeout(defaults.timeout || 0, function() {
+            req._aborted = true;
+            req.abort();
+            var e = new Error("ETIMEDOUT")
+            e.code = "ETIMEDOUT"
+            callback(e);
+        });
         setup_response_handler(req, callback);
         req.write(request_data);
         req.end();


### PR DESCRIPTION
Allows a timeout to be set on the request's socket to protect against
a slow or unresponsive Stripe API.
