### PR TITLE
Add in support for expand parameter

### DIFF
--- a/lib/main.js
+++ b/lib/main.js
@@ -47,6 +47,8 @@ module.exports = function (api_key, options) {
 
     var auth = 'Basic ' + new Buffer(api_key + ":").toString('base64');
 
+    var reqExpands = [];
+
     function _request(method, path, data, callback) {
 
         //console.log("data", typeof data, data);
@@ -62,6 +64,11 @@ module.exports = function (api_key, options) {
                 });
             }
         });
+
+        if (reqExpands.length) {
+            data['expand[]'] = reqExpands
+            reqExpands = []
+        }
 
         var request_data = querystring.stringify(data);
 
@@ -108,6 +115,10 @@ module.exports = function (api_key, options) {
     }
 
     return {
+        expand: function() {
+            reqExpands = [].slice.apply(arguments);
+            return this;
+        },
         charges: {
             capture: function (charge_id, data, cb) {
                 if (typeof data === 'function') {


### PR DESCRIPTION
Hi I've added in support for expanded fields when making calls.  You can use it like

```
stripe.expand('customer','charge').invoices.retrieve(invoice.id, this.callback);
```
