### PR TITLE
Fixes #76, sends version to Stripe API in tests.

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -50,7 +50,7 @@ Stripe.resources = resources;
 function Stripe(key, version) {
 
   if (!(this instanceof Stripe)) {
-    return new Stripe(key);
+    return new Stripe(key, version);
   }
 
   this._api = {
@@ -65,7 +65,7 @@ function Stripe(key, version) {
 
   this._prepResources();
   this.setApiKey(key);
-
+  this.setApiVersion(version);
 }
 
 Stripe.prototype = {
@@ -85,7 +85,9 @@ Stripe.prototype = {
   },
 
   setApiVersion: function(version) {
-    this._setApiField('version', version);
+    if (version) {
+      this._setApiField('version', version);
+    }
   },
 
   setApiKey: function(key) {

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -4,7 +4,8 @@ var testUtils = require('./testUtils');
 var chai = require('chai');
 var when = require('when');
 var stripe = require('../lib/stripe')(
-  testUtils.getUserStripeKey()
+  testUtils.getUserStripeKey(),
+  'latest'
 );
 
 var expect = chai.expect;
@@ -22,7 +23,7 @@ var CURRENCY = '_DEFAULT_CURRENCY_NOT_YET_GOTTEN_';
 
 describe('Flows', function() {
 
-  // Note: These tests must be run as one so we can retrieve the 
+  // Note: These tests must be run as one so we can retrieve the
   // default_currency (required in subsequent tests);
 
   var cleanup = new testUtils.CleanupUtility();

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -4,7 +4,8 @@ var testUtils = require('./testUtils');
 var chai = require('chai');
 var when = require('when');
 var stripe = require('../lib/stripe')(
-  testUtils.getUserStripeKey()
+  testUtils.getUserStripeKey(),
+  'latest'
 );
 
 var expect = chai.expect;

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -62,7 +62,8 @@ var utils = module.exports = {
       var self = this;
       this._cleanupFns = [];
       this._stripe = require('../lib/stripe')(
-        utils.getUserStripeKey()
+        utils.getUserStripeKey(),
+        'latest'
       );
       afterEach(function(done) {
         this.timeout(timeout || CleanupUtility.DEFAULT_TIMEOUT);


### PR DESCRIPTION
So we had support to pass a version into the `Stripe` constructor, but we weren't actually using it. This addresses that, and adds 'latest' to the tests so our tests always use the latest version.
