### PR TITLE
Set an explicit cipher list that doesn't include EXPORT ciphers

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -188,7 +188,8 @@ StripeResource.prototype = {
         port: self._stripe.getApiField('port'),
         path: path,
         method: method,
-        headers: headers
+        headers: headers,
+        ciphers: "DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2",
       });
 
       req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));


### PR DESCRIPTION
@ab mind taking a look?

Is there a better cipher list we should use? Since we know what's on the other end, it seems like we should be able to bind it pretty tightly, although I worry about that affecting people running dummy servers for testing purposes.
