### PR TITLE
add support for transfers/transactions end point

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,6 +137,7 @@ stripe.customers.create({
   * [`retrieve(transferId)`](https://stripe.com/docs/api/node#retrieve_transfer)
   * [`update(transferId[, params])`](https://stripe.com/docs/api/node#update_transfer)
   * [`cancel(transferId)`](https://stripe.com/docs/api/node#cancel_transfer)
+  * [`transactions(transferId[, params])`](https://stripe.com/docs/api/curl#list_transfers)
   * `setMetadata(transferId, metadataObject)` ([metadata info](https://stripe.com/docs/api/node#metadata))
   * `setMetadata(transferId, key, value)`
   * `getMetadata(transferId)`

--- a/lib/resources/Transfers.js
+++ b/lib/resources/Transfers.js
@@ -15,7 +15,12 @@ module.exports = StripeResource.extend({
     method: 'POST',
     path: '{transferId}/cancel',
     urlParams: ['transferId']
-  })
+  }),
 
+  transactions: stripeMethod({
+    method: 'GET',
+    path: '{transferId}/transactions',
+    urlParams: ['transferId']
+  })
 });
 


### PR DESCRIPTION
This end point is not really documented in stripe documentation but is returned in the `url` property of transfer objects.
