### PR TITLE
Set an explicit cipher list that doesn't include EXPORT ciphers

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -195,7 +195,8 @@ StripeResource.prototype = {
         port: self._stripe.getApiField('port'),
         path: path,
         method: method,
-        headers: headers
+        headers: headers,
+        ciphers: "DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2:!MD5"
       });
 
       req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));


### PR DESCRIPTION
See 639eef0 for original commit, plus @ab’s suggestion to include `!MD5`

Something about the previous branch being marked stale made a mess of the old PR (#84). This branch overrides that one.
