### PR TITLE
add Stripe.setHttpAgent to handle proxy

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -195,6 +195,7 @@ StripeResource.prototype = {
         port: self._stripe.getApiField('port'),
         path: path,
         method: method,
+        agent: self._stripe.getApiField('agent'),
         headers: headers,
         ciphers: "DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2:!MD5"
       });

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -64,6 +64,7 @@ function Stripe(key, version) {
     basePath: Stripe.DEFAULT_BASE_PATH,
     version: Stripe.DEFAULT_API_VERSION,
     timeout: Stripe.DEFAULT_TIMEOUT,
+    agent: null,
     dev: false
   };
 
@@ -110,6 +111,10 @@ Stripe.prototype = {
     );
   },
 
+  setHttpAgent: function(agent) {
+    this._setApiField('agent', agent);
+  },
+  
   _setApiField: function(key, value) {
     this._api[key] = value;
   },


### PR DESCRIPTION
This fixes #123

Can be used for example with:

```
var ProxyAgent = require('https-proxy-agent');
var stripe = require('stripe')(...);

stripe.setHttpAgent(new ProxyAgent({
  host: 'proxy',
  port: 8080
}));
```
