### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ stripe.customers.create({
   * [`update(planId[, params])`](https://stripe.com/docs/api/node#update_plan)
   * [`retrieve(planId)`](https://stripe.com/docs/api/node#retrieve_plan)
   * [`del(planId)`](https://stripe.com/docs/api/node#delete_plan)
- * recipient
+ * recipients
   * [`create(params)`](https://stripe.com/docs/api/node#create_recipient)
   * [`list([params])`](https://stripe.com/docs/api/node#list_recipients)
   * [`update(recipientId[, params])`](https://stripe.com/docs/api/node#update_recipient)


### PR DESCRIPTION
This was a super small typo, but it left me a bit perplexed at first when trying to use `Stripe.recipient.list()` in stead of `Stripe.recipients.list()`
