### PR TITLE
Fix full path references in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,10 +88,10 @@ stripe.customers.create({
   * `setMetadata(customerId, metadataObject)` ([metadata info](https://stripe.com/docs/api/node#metadata))
   * `setMetadata(customerId, key, value)`
   * `getMetadata(customerId)`
-  * [`stripe.customers.createSubscription(customerId, params)`](https://stripe.com/docs/api/node#create_subscription)
+  * [`createSubscription(customerId, params)`](https://stripe.com/docs/api/node#create_subscription)
   * [`updateSubscription(customerId, subscriptionId, [, params])`](https://stripe.com/docs/api/node#update_subscription)
   * [`cancelSubscription(customerId, subscriptionId, [, params])`](https://stripe.com/docs/api/node#cancel_subscription)
-  * [`stripe.customers.listSubscriptions(params)`](https://stripe.com/docs/api/node#list_subscriptions)
+  * [`listSubscriptions(params)`](https://stripe.com/docs/api/node#list_subscriptions)
   * [`createCard(customerId[, params])`](https://stripe.com/docs/api/node#create_card)
   * [`listCards(customerId)`](https://stripe.com/docs/api/node#list_cards)
   * [`retrieveCard(customerId, cardId)`](https://stripe.com/docs/api/node#retrieve_card)


### PR DESCRIPTION
Should be createSubscription and listSubscriptions instead of stripe.customers.createSubscription and stripe.customers.listSubscriptions
