### PR TITLE
Adding file uploads

### DIFF
--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -1,0 +1,42 @@
+'use strict';
+
+var _ = require('lodash');
+
+// Method for formatting HTTP body for the multipart/form-data specification
+// Mostly taken from Fermata.js
+// https://github.com/natevw/fermata/blob/5d9732a33d776ce925013a265935facd1626cc88/fermata.js#L315-L343
+module.exports = function multipartDataGenerator(method, data, headers) {
+  var segno = '' + Math.round(Math.random() * 1e16) + Math.round(Math.random() * 1e16);
+  headers['Content-Type'] = ("multipart/form-data; boundary=" + segno);
+  var buffer = new Buffer(0);
+
+  function push(l) {
+    var prevBuffer = buffer;
+    var newBuffer = (l instanceof Buffer) ? l : new Buffer(l);
+    buffer = new Buffer(prevBuffer.length + newBuffer.length + 2);
+    prevBuffer.copy(buffer);
+    newBuffer.copy(buffer, prevBuffer.length);
+    buffer.write("\r\n", buffer.length - 2);
+  }
+
+  function q(s) {
+    return '"' + s.replace(/"|"/g, "%22").replace(/\r\n|\r|\n/g, ' ') + '"';
+  }
+
+  _.forEach(data, function (v, k) {
+    push("--" + segno);
+    if (v.hasOwnProperty('data')) {
+      push("Content-Disposition: form-data; name=" + q(k) + "; filename=" + q(v.name || "blob"));
+      push("Content-Type: " + (v.type || "application/octet-stream"));
+      push('');
+      push(v.data);
+    } else {
+      push("Content-Disposition: form-data; name=" + q(k));
+      push('');
+      push(v);
+    }
+  });
+  push("--" + segno + "--");
+
+  return buffer;
+};

--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -65,7 +65,7 @@ module.exports = {
       // Set entire metadata object after resetting it:
       this._request('POST', path, {
         metadata: null
-      }, auth, function(err, response) {
+      }, auth, {}, function(err, response) {
         if (err) return deferred.reject(err);
         sendMetadata(data, auth);
       });
@@ -74,7 +74,7 @@ module.exports = {
     function sendMetadata(metadata, auth) {
       self._request('POST', path, {
         metadata: metadata
-      }, auth, function(err, response) {
+      }, auth, {}, function(err, response) {
         if (err) deferred.reject(err);
         else deferred.resolve(response.metadata);
       });
@@ -95,7 +95,7 @@ module.exports = {
     var deferred = this.createDeferred(cb);
     var path = this.createFullPath('/' + id, urlData);
 
-    this._request('GET', path, {}, auth, function(err, response) {
+    this._request('GET', path, {}, auth, {}, function(err, response) {
       if (err) deferred.reject(err);
       else deferred.resolve(
         response.metadata

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -23,7 +23,6 @@ module.exports = function stripeMethod(spec) {
   var urlParams = spec.urlParams || [];
 
   return function() {
-  
     var self = this;
     var args = [].slice.call(arguments);
 
@@ -61,8 +60,7 @@ module.exports = function stripeMethod(spec) {
     }
 
     var requestPath = this.createFullPath(commandPath, urlData);
-
-    self._request(requestMethod, requestPath, data, auth, function(err, response) {
+    var requestCallback = function(err, response) {
       if (err) {
         deferred.reject(err);
       } else {
@@ -72,7 +70,10 @@ module.exports = function stripeMethod(spec) {
             response
         );
       }
-    });
+    };
+
+    var options = {headers: spec.headers};
+    self._request(requestMethod, requestPath, data, auth, options, requestCallback);
 
     return deferred.promise;
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -4,6 +4,7 @@ var http = require('http');
 var https = require('https');
 var path = require('path');
 var when = require('when');
+var _ = require('lodash');
 
 var utils = require('./utils');
 var Error = require('./Error');
@@ -47,6 +48,17 @@ StripeResource.prototype = {
   path: '',
 
   initialize: function() {},
+
+  // Function to override the default data processor. This allows full control
+  // over how a StripeResource's request data will get converted into an HTTP
+  // body. This is useful for non-standard HTTP requests. The function should
+  // take method name, data, and headers as arguments.
+  requestDataProcessor: null,
+
+  // String that overrides the base API endpoint. If `overrideHost` is not null
+  // then all requests for a particular resource will be sent to a base API
+  // endpoint as defined by `overrideHost`.
+  overrideHost: null,
 
   createFullPath: function(commandPath, urlData) {
     return path.join(
@@ -156,10 +168,15 @@ StripeResource.prototype = {
     }
   },
 
-  _request: function(method, path, data, auth, callback) {
-
-    var requestData = utils.stringifyRequestData(data || {});
+  _request: function(method, path, data, auth, options, callback) {
     var self = this;
+    var requestData;
+
+    if (self.requestDataProcessor) {
+      requestData = self.requestDataProcessor(method, data, options.headers);
+    } else {
+      requestData = utils.stringifyRequestData(data || {});
+    }
 
     var apiVersion = this._stripe.getApiField('version');
     var headers = {
@@ -180,18 +197,26 @@ StripeResource.prototype = {
     // Grab client-user-agent before making the request:
     this._stripe.getClientUserAgent(function(cua) {
       headers['X-Stripe-Client-User-Agent'] = cua;
+
+      if (options.headers) {
+        headers = _.extend(headers, options.headers);
+      }
+
       makeRequest();
     });
+
 
     function makeRequest() {
 
       var timeout = self._stripe.getApiField('timeout');
       var isInsecureConnection = self._stripe.getApiField('protocol') == 'http';
 
+      var host = self.overrideHost || self._stripe.getApiField('host');
+
       var req = (
         isInsecureConnection ? http : https
       ).request({
-        host: self._stripe.getApiField('host'),
+        host: host,
         port: self._stripe.getApiField('port'),
         path: path,
         method: method,

--- a/lib/resources/FileUploads.js
+++ b/lib/resources/FileUploads.js
@@ -1,0 +1,35 @@
+'use strict';
+
+var utils = require('../utils');
+var StripeResource = require('../StripeResource');
+var stripeMethod = StripeResource.method;
+var _ = require('lodash');
+var multipartDataGenerator = require('../MultipartDataGenerator');
+
+module.exports = StripeResource.extend({
+
+  overrideHost: 'uploads.stripe.com',
+
+  requestDataProcessor: function(method, data, headers) {
+    data = data || {};
+
+    if (method === 'POST') {
+      return multipartDataGenerator(method, data, headers);
+    } else {
+      return utils.stringifyRequestData(data);
+    }
+  },
+
+  path: 'files',
+
+  includeBasic: [
+    'retrieve'
+  ],
+
+  create: stripeMethod({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    }
+  })
+});

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -39,6 +39,7 @@ var resources = {
   Tokens: require('./resources/Tokens'),
   Transfers: require('./resources/Transfers'),
   ApplicationFees: require('./resources/ApplicationFees'),
+  FileUploads: require('./resources/FileUploads'),
 
   // The following rely on pre-filled IDs:
   CustomerCards: require('./resources/CustomerCards'),

--- a/test/resources/FileUploads.spec.js
+++ b/test/resources/FileUploads.spec.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var stripe = require('../testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+var when = require('when');
+var fs = require('fs');
+var path = require('path');
+
+var TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
+
+describe('File Uploads Resource', function() {
+
+  describe('retrieve', function() {
+
+    it('Sends the correct request', function() {
+
+      stripe.fileUploads.retrieve('fil_12345');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/files/fil_12345',
+        data: {}
+      });
+
+    });
+
+    it('Sends the correct request [with specified auth]', function() {
+
+      stripe.fileUploads.retrieve('fil_12345', TEST_AUTH_KEY);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/files/fil_12345',
+        data: {},
+        auth: TEST_AUTH_KEY
+      });
+
+    });
+
+  });
+
+  describe('create', function() {
+
+    it('Sends the correct file upload request', function() {
+
+      var testFilename = path.join(__dirname, "data/minimal.pdf");
+      var f = fs.readFileSync(testFilename);
+
+      stripe.fileUploads.create({
+        purpose: 'dispute_evidence',
+        file: {
+          data: f,
+          name: 'minimal.pdf',
+          type: 'application/octet-stream'
+        }
+      });
+
+      expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
+      expect(stripe.LAST_REQUEST).to.deep.property('url', '/v1/files');
+
+    });
+
+    it('Sends the correct file upload request [with specified auth]', function() {
+
+      var testFilename = path.join(__dirname, "data/minimal.pdf");
+      var f = fs.readFileSync(testFilename);
+
+      stripe.fileUploads.create({
+        purpose: 'dispute_evidence',
+        file: {
+          data: f,
+          name: 'minimal.pdf',
+          type: 'application/octet-stream'
+        }
+      }, TEST_AUTH_KEY);
+
+      expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
+      expect(stripe.LAST_REQUEST).to.deep.property('url', '/v1/files');
+      expect(stripe.LAST_REQUEST).to.deep.property('auth', TEST_AUTH_KEY);
+
+    });
+
+  });
+
+});

--- a/test/resources/data/minimal.pdf
+++ b/test/resources/data/minimal.pdf
@@ -1,0 +1,58 @@
+%PDF-1.1
+%¥±ë
+
+1 0 obj
+  << /Type /Catalog
+     /Pages 2 0 R
+  >>
+endobj
+
+2 0 obj
+  << /Type /Pages
+     /Kids [3 0 R]
+     /Count 1
+     /MediaBox [0 0 300 144]
+  >>
+endobj
+
+3 0 obj
+  <<  /Type /Page
+      /Parent 2 0 R
+      /Resources
+       << /Font
+           << /F1
+               << /Type /Font
+                  /Subtype /Type1
+                  /BaseFont /Times-Roman
+               >>
+           >>
+       >>
+      /Contents 4 0 R
+  >>
+endobj
+
+4 0 obj
+  << /Length 55 >>
+stream
+  BT
+    /F1 18 Tf
+    0 0 Td
+    (Hello World) Tj
+  ET
+endstream
+endobj
+
+xref
+0 5
+0000000000 65535 f 
+0000000018 00000 n 
+0000000077 00000 n 
+0000000178 00000 n 
+0000000457 00000 n 
+trailer
+  <<  /Root 1 0 R
+      /Size 5
+  >>
+startxref
+565
+%%EOF

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -29,9 +29,9 @@ var utils = module.exports = {
       if (stripeInstance[i] instanceof Stripe.StripeResource) {
 
         // Override each _request method so we can make the params
-        // avaialable to consuming tests (revealing requests made on
+        // available to consuming tests (revealing requests made on
         // REQUESTS and LAST_REQUEST):
-        stripeInstance[i]._request = function(method, url, data, auth, cb) {
+        stripeInstance[i]._request = function(method, url, data, auth, options, cb) {
           var req = stripeInstance.LAST_REQUEST = {
             method: method,
             url: url,


### PR DESCRIPTION
This PR adds file uploads to the the node bindings. Here's a sample script using the `create` and `retrieve` methods on a file upload:

``` node
var stripe = require('stripe')('SECRET_API_KEY');
var fs = require('fs');

var testFilename = "/home/wangjohn/stripe/stripe-node/test/resources/data/minimal.pdf";
var f = fs.readFileSync(testFilename);

stripe.fileUploads.create({
  purpose: 'dispute_evidence',
  file: {
    data: f,
    name: 'minimal.pdf',
    type: 'application/octet-stream'
  }
}, function(err, fileUpload) {
  if (err) {
    return console.log('ERROR:', err);
  }
  console.log(fileUpload);

  stripe.fileUploads.retrieve(fileUpload.id, function(err, fu) {
    if (err) {
      return console.log('ERROR:', err);
    }
    console.log(fu);
  });
});
```

The PR also adds a couple of things to the underlying `StripeResource` and `StripeMethod` which allow us to override the default headers, provide our own http data, and override the default host of `api.stripe.com`.

r? @michelle 
cc @jayeb, @amfeng 
