### PR TITLE
Check if a callback is passed to Retrieve Customer

### DIFF
--- a/lib/resources/Accounts.js
+++ b/lib/resources/Accounts.js
@@ -24,8 +24,8 @@ module.exports = StripeResource.extend({
   }),
 
   retrieve: function(id) {
-    // Old bindings supported no-arg access to /v1/account, support that if ID is not passed
-    if (id === undefined || (typeof id === 'string' && utils.isAuthKey(id))) {
+    // Old bindings supported no-arg / callback access to /v1/account, support that if ID is not passed
+    if (id === undefined || typeof id === 'function' || (typeof id === 'string' && utils.isAuthKey(id))) {
       return stripeMethod({
         method: 'GET',
         path: 'account'

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -42,6 +42,17 @@ describe('Account Resource', function() {
         data: {},
         headers: {},
       });
+    });
+
+    it('Sends the correct request with a callback', function() {
+      
+      stripe.account.retrieve(function (err, account){});
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/account',
+        data: {},
+        headers: {},
+      });
 
     });
 


### PR DESCRIPTION
If a parameter is passed to Retrieve customer that isn't an
auth key, the library incorrectly assumed it was a account id.

Updated the check to ensure that a function could be passed in as
a sole argument and it would retrieve the account for the pre-set
api key.

Fixes #147