### PR TITLE
Provide HTTP response status code to error object of a rejected promise

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -129,6 +129,7 @@ StripeResource.prototype = {
         try {
           response = JSON.parse(response);
           if (response.error) {
+            response.error.code = res.statusCode; // add response status to error object
             var err;
             if (res.statusCode === 401) {
               err = new Error.StripeAuthenticationError(response.error);

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -84,6 +84,20 @@ describe('Stripe Module', function() {
         return expect(defer.promise).to.eventually.become('ErrorWasPassed')
       });
 
+      it('Will return the HTTP response status code', function() {
+        var defer = Promise.defer();
+
+        stripe.customers.createCard('nonExistentCustId', { card: {} }, function(err, customer) {
+          if (err) {
+            defer.resolve(err);
+          } else {
+            defer.reject(customer);
+          }
+        });
+
+        return expect(defer.promise).to.eventually.have.property('code', 400)
+      });
+
     });
   });
 


### PR DESCRIPTION
Added the http status code to the error object in the main response handler so that the return from a rejected promise is more descriptive. This is in response to [Issue #145](https://github.com/stripe/stripe-node/issues/145). 

Added test to stripe spec to confirm functionality.

![screen shot 2015-03-08 at 3 35 01 pm](https://cloud.githubusercontent.com/assets/9010671/6548264/0263af3e-c5b0-11e4-97af-b1c9347d1077.png)

All other tests still pass.

![screen shot 2015-03-08 at 3 35 26 pm](https://cloud.githubusercontent.com/assets/9010671/6548061/05c7a136-c5aa-11e4-9cfd-673a5e880a53.png)