### PR TITLE
Rename StripeInvalidRequest to StripeInvalidRequestError

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -62,7 +62,7 @@ StripeError.generate = function(rawStripeError) {
 
 // Specific Stripe Error types:
 _Error.StripeCardError = StripeError.extend({ type: 'StripeCardError' });
-_Error.StripeInvalidRequestError = StripeError.extend({ type: 'StripeInvalidRequest' });
+_Error.StripeInvalidRequestError = StripeError.extend({ type: 'StripeInvalidRequestError' });
 _Error.StripeAPIError = StripeError.extend({ type: 'StripeAPIError' });
 _Error.StripeAuthenticationError = StripeError.extend({ type: 'StripeAuthenticationError' });
 _Error.StripeConnectionError = StripeError.extend({ type: 'StripeConnectionError' });

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -140,7 +140,7 @@ describe('Flows', function() {
 
           })
       ).to.eventually.satisfy(function(err) {
-        return err.type === 'StripeInvalidRequest' &&
+        return err.type === 'StripeInvalidRequestError' &&
           err.rawType === 'invalid_request_error';
       });
 


### PR DESCRIPTION
For consistency, lets rename all errors to end in Error.

closes #159