### PR TITLE
Add keywords to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,12 @@
   "name": "stripe",
   "version": "3.3.4",
   "description": "Stripe API wrapper",
+  "keywords": [
+    "stripe",
+    "payment processing",
+    "credit cards",
+    "api"
+  ],
   "homepage": "https://github.com/stripe/stripe-node",
   "author": "Stripe <james@stripe.com> (https://stripe.com/)",
   "contributors": [


### PR DESCRIPTION
Took the keywords from [`stripe-php`](https://github.com/stripe/stripe-php)'s [`composer.json`](https://github.com/stripe/stripe-php/blob/0195310a7b08098d71966cde86fc1407f1562b0a/composer.json#L4-L8) - and added `"credit cards"`.