### PR TITLE
Allow an options hash to be passed in to Upcoming Invoice API

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ stripe.balance.retrieve({
   * [`update(invoiceId[, params])`](https://stripe.com/docs/api/node#update_invoice)
   * [`retrieve(invoiceId)`](https://stripe.com/docs/api/node#retrieve_invoice)
   * [`retrieveLines(invoiceId)`](https://stripe.com/docs/api/node#invoice_lines)
-  * [`retrieveUpcoming(customerId[, subscriptionId])`](https://stripe.com/docs/api/node#retrieve_customer_invoice)
+  * [`retrieveUpcoming(customerId[, params])`](https://stripe.com/docs/api/node#retrieve_customer_invoice)
   * [`pay(invoiceId)`](https://stripe.com/docs/api/node#pay_invoice)
  * plans
   * [`create(params)`](https://stripe.com/docs/api/node#create_plan)

--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -2,6 +2,7 @@
 
 var StripeResource = require('../StripeResource');
 var stripeMethod = StripeResource.method;
+var utils = require("../utils");
 
 module.exports = StripeResource.extend({
 
@@ -24,12 +25,16 @@ module.exports = StripeResource.extend({
     method: 'GET',
     path: function(urlData) {
       var url = 'upcoming?customer=' + urlData.customerId;
-      if (urlData.subscriptionId) {
-        return url + '&subscription=' + urlData.subscriptionId;
+      // Legacy support where second argument is a the subscription id
+      if (urlData.invoiceOptions && typeof urlData.invoiceOptions === 'string') {
+        return url + '&subscription=' + urlData.invoiceOptions;
+      }
+      else if (urlData.invoiceOptions && typeof urlData.invoiceOptions === 'object') {
+        return url + "&" + utils.stringifyRequestData(urlData.invoiceOptions);
       }
       return url;
     },
-    urlParams: ['customerId', 'optional!subscriptionId']
+    urlParams: ['customerId', 'optional!invoiceOptions']
   })
 
 });

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -99,6 +99,20 @@ describe('Invoices Resource', function() {
       });
     });
 
+    describe('With a options object in addition to a customer ID', function() {
+      it('Sends the correct request', function() {
+
+        stripe.invoices.retrieveUpcoming('customerId1', { plan:'planId123' });
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/invoices/upcoming?customer=customerId1&plan=planId123',
+          headers: {},
+          data: {}
+        });
+
+      });
+    });
+
   });
 
   describe('pay', function() {


### PR DESCRIPTION
The Upcoming Invoice API now supports a ton of cool optional params
to help calculate prorations.

Since the customer ID is still required, and the subscription id is
optional, the second parameter to the retrieveUpcoming endpoint
can be an options object or a string (string must be the subscription
id for legacy compatibility).

Fixes #176