### PR TITLE
Send original data to requestDataProcessor if available.

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -166,7 +166,6 @@ StripeResource.prototype = {
   },
 
   _request: function(method, path, data, auth, options, callback) {
-    var requestData = utils.stringifyRequestData(data || {});
     var self = this;
     var requestData;
 


### PR DESCRIPTION
It is a problem for fileUploads since the utils#stringifyRequestData can't handle binary files. If the resource has a requestDataProcessor, it should send the original unprocessed data. Since the variable requestData is being declared twice, I assume someone forgot to erase this line.

With the line there, the following error happens on fileUploads (binary files):

/node_modules/stripe/node_modules/qs/lib/stringify.js:40
URIError: URI malformed
    at encodeURIComponent (native)
at Object.internals.stringify (/Users/gabrielmarques/Desktop/CareLuLu/v2/CareLuLu/node_modules/stripe/node_modules/qs/lib/stringify.js:40:52)
    at Object.internals.stringify (/node_modules/stripe/node_modules/qs/lib/stringify.js:56:46)
    at Object.module.exports [as stringify] (/node_modules/stripe/node_modules/qs/lib/stringify.js:93:38)
    at Object.module.exports.stringifyRequestData (/node_modules/stripe/lib/utils.js:37:15)
    at Object.StripeResource._request (/node_modules/stripe/lib/StripeResource.js:169:29)
    at Object.create (/node_modules/stripe/lib/StripeMethod.js:77:10)