### PR TITLE
Switch array rendering syntax to brackets

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -23,18 +23,12 @@ var utils = module.exports = {
   },
 
   /**
-   * Stringifies an Object, accommodating a single-level of nested objects
+   * Stringifies an Object, accommodating nested objects
    * (forming the conventional key "parent[child]=value")
    */
-  stringifyRequestData: function(data, _key) {
+  stringifyRequestData: function(data) {
 
-    if (data.expand) {
-      data = _.cloneDeep(data);
-      data['expand[]'] = data.expand;
-      delete data.expand;
-    }
-
-    return qs.stringify(data, {indices: false});
+    return qs.stringify(data, {arrayFormat: 'brackets'});
 
   },
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "bluebird": "^2.9.6",
-    "qs": "^2.3.3",
+    "qs": "^2.4.1",
     "lodash": "^3.1.0"
   },
   "license": "MIT",

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -37,7 +37,7 @@ describe('utils', function() {
     });
 
     it('Handles deeply nested object', function() {
-      expect(utils.stringifyRequestData({
+      expect(decodeURI(utils.stringifyRequestData({
         a: {
           b: {
             c: {
@@ -45,8 +45,17 @@ describe('utils', function() {
             }
           }
         }
-      })).to.equal('a%5Bb%5D%5Bc%5D%5Bd%5D=2');
+      }))).to.equal('a[b][c][d]=2');
     });
+
+    it('Handles arrays of objects', function() {
+      expect(decodeURI(utils.stringifyRequestData({
+        a: [
+          { b: 'c' },
+          { b: 'd' },
+        ]
+      }))).to.equal('a[][b]=c&a[][b]=d');
+    })
 
     it('Creates a string from an object, handling shallow nested objects', function() {
       expect(utils.stringifyRequestData({
@@ -69,9 +78,9 @@ describe('utils', function() {
     describe('Stripe-specific cases', function() {
 
       it('Handles the `expand` array correctly (producing the form `expand[]=_` for each item', function() {
-        expect(utils.stringifyRequestData({
+        expect(decodeURI(utils.stringifyRequestData({
           expand: ['a', 'foo', 'a.b.c']
-        })).to.equal('expand%5B%5D=a&expand%5B%5D=foo&expand%5B%5D=a.b.c');
+        }))).to.equal('expand[]=a&expand[]=foo&expand[]=a.b.c');
       });
 
     });


### PR DESCRIPTION
Fixes a bug where arrays of hashes do not work properly. Also `a[]=first&a[]=second` is more commonly used than `a=first&a=second`.

r? @michelle 