### PR TITLE
Add missing method to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,7 @@ stripe.balance.retrieve({
   * [`updateSubscription(customerId, subscriptionId, [, params])`](https://stripe.com/docs/api/node#update_subscription)
   * [`cancelSubscription(customerId, subscriptionId, [, params])`](https://stripe.com/docs/api/node#cancel_subscription)
   * [`listSubscriptions(params)`](https://stripe.com/docs/api/node#list_subscriptions)
+  * [`retrieveSubscription(customerId, subscriptionId)`](https://stripe.com/docs/api/node#retrieve_subscription)
   * [`createSource(customerId[, params])`](https://stripe.com/docs/api/node#create_card)
   * [`listCards(customerId)`](https://stripe.com/docs/api/node#list_cards)
   * [`retrieveCard(customerId, cardId)`](https://stripe.com/docs/api/node#retrieve_card)


### PR DESCRIPTION
Add description for `customers.retrieveSubscription` method, which was missing.