### PR TITLE
Remove ability for API keys to be passed as 1st param to acct.retrieve

### DIFF
--- a/lib/resources/Accounts.js
+++ b/lib/resources/Accounts.js
@@ -31,17 +31,21 @@ module.exports = StripeResource.extend({
   }),
 
   retrieve: function(id) {
-    // Old bindings supported no-arg / callback access to /v1/account, support that if ID is not passed
-    if (id === undefined || typeof id === 'function' || (typeof id === 'string' && utils.isAuthKey(id))) {
-      return stripeMethod({
-        method: 'GET',
-        path: 'account'
-      }).apply(this, arguments);
-    } else {
+    // No longer allow an api key to be passed as the first string to this function due to ambiguity between
+    // old account ids and api keys. To request the account for an api key, send null as the id
+    if (typeof id === "string") {
       return stripeMethod({
         method: 'GET',
         path: 'accounts/{id}',
         urlParams: ['id']
+      }).apply(this, arguments);
+    }
+    else {
+      if (id === null || id === undefined)
+          [].shift.apply(arguments); //remove id as stripeMethod would complain of unexpected argument
+      return stripeMethod({
+        method: 'GET',
+        path: 'account'
       }).apply(this, arguments);
     }
   },

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -67,9 +67,22 @@ describe('Account Resource', function() {
     it('Sends the correct request with secret key', function() {
 
       var key = 'sk_12345678901234567890123456789012';
-      stripe.account.retrieve(key);
+      stripe.account.retrieve(null, key);
       expect(stripe.LAST_REQUEST).to.deep.equal({
         auth: key,
+        method: 'GET',
+        url: '/v1/account',
+        data: {},
+        headers: {},
+      });
+    });
+    
+    it('Sends the correct request with secret key as first object', function() {
+
+      var params = {api_key: 'sk_12345678901234567890123456789012'};
+      stripe.account.retrieve(params);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        auth: params.api_key,
         method: 'GET',
         url: '/v1/account',
         data: {},


### PR DESCRIPTION
Old (pre-prefix) account ids and api keys are hard to differentiate. As
such old account ids would pass the `isAuthKey` tried to identify
whether a user was requesting a connected account or if they were trying
to request the account for the passed api key.

This is a "major" change in that an api key cannot be passed as a string
to the first argument. It can be passed in the options parameter as the
`api_key` value, or as a string if the user passes `null` as the account
id.

[stripe/stripe-node#194]