### PR TITLE
Add Stripe exports for easier mocking

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -161,3 +161,4 @@ Stripe.prototype = {
 };
 
 module.exports = Stripe;
+module.exports.Stripe = Stripe;

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -161,4 +161,5 @@ Stripe.prototype = {
 };
 
 module.exports = Stripe;
+// expose constructor as a named property to enable mocking with Sinon.JS
 module.exports.Stripe = Stripe;


### PR DESCRIPTION
In order to be able to stub the library sinonjs needs an property to stub:

> https://github.com/sinonjs/sinon/issues/664
> https://github.com/sinonjs/sinon/issues/664#issuecomment-71980876

After that it would be possible to do:

```
var stripe = require('stripe');
var stubStripe = sinon.stub(stripe, 'Stripe').returns(stubStripeClient);
```