### PR TITLE
Return usage errors through callback

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -46,7 +46,10 @@ function stripeMethod(spec) {
           continue;
         }
 
-        var err = new Error('Stripe: I require argument "' + urlParams[i] + '", but I got: ' + arg);
+        var err = new Error(
+          'Stripe: Argument "' + urlParams[i] + '" required, but got: ' + arg +
+          ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
+        );
         deferred.reject(err);
         return deferred.promise;
       }
@@ -59,8 +62,9 @@ function stripeMethod(spec) {
 
     if (args.length) {
       var err = new Error(
-        'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options object? ' +
-        'See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
+        'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options ' +
+        'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.' +
+        ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
       );
       deferred.reject(err);
       return deferred.promise;

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -45,7 +45,10 @@ function stripeMethod(spec) {
           urlData[param] = '';
           continue;
         }
-        throw new Error('Stripe: I require argument "' + urlParams[i] + '", but I got: ' + arg);
+
+        var err = new Error('Stripe: I require argument "' + urlParams[i] + '", but I got: ' + arg);
+        deferred.reject(err);
+        return deferred.promise;
       }
 
       urlData[param] = args.shift();
@@ -55,10 +58,12 @@ function stripeMethod(spec) {
     var opts = utils.getOptionsFromArgs(args);
 
     if (args.length) {
-      throw new Error(
+      var err = new Error(
         'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options object? ' +
         'See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
       );
+      deferred.reject(err);
+      return deferred.promise;
     }
 
     var requestPath = this.createFullPath(commandPath, urlData);

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -120,9 +120,9 @@ describe('Charge Resource', function() {
     });
 
     it('Throws an error on incorrect arguments', function() {
-      expect(function() {
-        stripe.charges.refund('chargeIdExample123', 39392);
-      }).to.throw(/unknown arguments/i);
+      expect(
+        stripe.charges.refund('chargeIdExample123', 39392)
+      ).to.be.eventually.rejectedWith(/unknown arguments/i);
     });
   });
 

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -119,7 +119,7 @@ describe('Charge Resource', function() {
       });
     });
 
-    it('Throws an error on incorrect arguments', function() {
+    it('Incorrect arguments result in an error', function() {
       expect(
         stripe.charges.refund('chargeIdExample123', 39392)
       ).to.be.eventually.rejectedWith(/unknown arguments/i);


### PR DESCRIPTION
Return usage errors through callbacks as described in #215. This has the advantage of never throwing an error unexpectedly in user code.

@kyleconroy Would you mind taking a review pass on this? I literally learned how promises work 45 seconds ago. Thanks!