### PR TITLE
Add Account.reject method.

### DIFF
--- a/lib/resources/Accounts.js
+++ b/lib/resources/Accounts.js
@@ -30,6 +30,12 @@ module.exports = StripeResource.extend({
     urlParams: ['id'],
   }),
 
+  reject: stripeMethod({
+    method: 'POST',
+    path: 'accounts/{id}/reject',
+    urlParams: ['id'],
+  }),
+
   retrieve: function(id) {
     // No longer allow an api key to be passed as the first string to this function due to ambiguity between
     // old account ids and api keys. To request the account for an api key, send null as the id

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -38,6 +38,18 @@ describe('Account Resource', function() {
     });
   });
 
+  describe('reject', function() {
+    it('rejects an account successfully', function() {
+      stripe.account.reject('acct_16Tzq6DBahdM4C8s', {reason: 'fraud'});
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/accounts/acct_16Tzq6DBahdM4C8s/reject',
+        data: {reason: 'fraud'},
+        headers: {},
+      });
+    });
+  });
+
   describe('retrieve', function() {
     it('Sends the correct request with no params', function() {
       stripe.account.retrieve();


### PR DESCRIPTION
Corresponding to the [Account.reject API method](https://stripe.com/docs/api/node#reject_account).

r? @stripe/api-libraries 