### PR TITLE
Remove eval from url interpolator

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -31,7 +31,6 @@ var utils = module.exports = {
   },
 
   /**
-   * https://gist.github.com/padolsey/6008842
    * Outputs a new function with interpolated object property values.
    * Use like so:
    *   var fn = makeURLInterpolator('some/url/{param1}/{param2}');
@@ -43,16 +42,14 @@ var utils = module.exports = {
       '\u2028': '\\u2028', '\u2029': '\\u2029',
     };
     return function makeURLInterpolator(str) {
-      return new Function(
-        'o',
-        'return "' + (
-          str
-          .replace(/["\n\r\u2028\u2029]/g, function($0) {
-            return rc[$0];
-          })
-          .replace(/\{([\s\S]+?)\}/g, '" + encodeURIComponent(o["$1"]) + "')
-        ) + '";'
-      );
+      var cleanString = str.replace(/["\n\r\u2028\u2029]/g, function($0) {
+        return rc[$0];
+      });
+      return function(outputs) {
+        return cleanString.replace(/\{([\s\S]+?)\}/g, function($0, $1) {
+          return encodeURIComponent(outputs[$1] || '');
+        });
+      };
     };
   }()),
 


### PR DESCRIPTION
makeURLInterpolator requires use of eval to create a function which interpolates url strings in constant time.

By taking a small increase in interpolator complexity to linear time with respect to parts interpolated, we can improve the security of stripe-node. This also helps this package conform to security requirements an electron application might have.