### PR TITLE
URI-encode all fields of User-Agent

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -144,14 +144,31 @@ Stripe.prototype = {
     return Stripe[c];
   },
 
+  // Gets a JSON version of a User-Agent and uses a cached version for a slight
+  // speed advantage.
   getClientUserAgent: function(cb) {
     if (Stripe.USER_AGENT_SERIALIZED) {
       return cb(Stripe.USER_AGENT_SERIALIZED);
     }
-    exec('uname -a', function(err, uname) {
-      Stripe.USER_AGENT.uname = uname || 'UNKNOWN';
-      Stripe.USER_AGENT_SERIALIZED = JSON.stringify(Stripe.USER_AGENT);
+    this.getClientUserAgentSeeded(Stripe.USER_AGENT, function(cua) {
+      Stripe.USER_AGENT_SERIALIZED = cua;
       cb(Stripe.USER_AGENT_SERIALIZED);
+    })
+  },
+
+  // Gets a JSON version of a User-Agent by encoding a seeded object and
+  // fetching a uname from the system.
+  getClientUserAgentSeeded: function(seed, cb) {
+    exec('uname -a', function(err, uname) {
+      var userAgent = {};
+      for (var field in seed) {
+        userAgent[field] = encodeURIComponent(seed[field]);
+      }
+
+      // URI-encode in case there are unusual characters in the system's uname.
+      userAgent.uname = encodeURIComponent(uname) || 'UNKNOWN';
+
+      cb(JSON.stringify(userAgent));
     });
   },
 

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -24,7 +24,7 @@ describe('Stripe Module', function() {
   var cleanup = new testUtils.CleanupUtility();
   this.timeout(20000);
 
-  describe('ClientUserAgent', function() {
+  describe('GetClientUserAgent', function() {
     it('Should return a user-agent serialized JSON object', function() {
       var d = Promise.defer();
       stripe.getClientUserAgent(function(c) {
@@ -32,6 +32,26 @@ describe('Stripe Module', function() {
       });
       return expect(d.promise).to.eventually.have.property('lang', 'node');
     });
+  });
+
+  describe('GetClientUserAgentSeeded', function() {
+    it('Should return a user-agent serialized JSON object', function() {
+      var userAgent = {lang: 'node'};
+      var d = Promise.defer();
+      stripe.getClientUserAgentSeeded(userAgent, function(c) {
+        d.resolve(JSON.parse(c));
+      });
+      return expect(d.promise).to.eventually.have.property('lang', 'node');
+    });
+
+    it('Should URI-encode user-agent fields', function() {
+      var userAgent = {lang: 'ï'};
+      var d = Promise.defer();
+      stripe.getClientUserAgentSeeded(userAgent, function(c) {
+        d.resolve(JSON.parse(c));
+      });
+      return expect(d.promise).to.eventually.have.property('lang', '%C3%AF');
+    })
   });
 
   describe('setTimeout', function() {


### PR DESCRIPTION
URI-encodes all fields of the JSON version of the Stripe User-Agent
field in case something like the system `uname` contains a special
character.

Fixes #246.

r? @dpetrovics Mind taking a look at this?