### PR TITLE
Remove uses of `Promise.defer`

### DIFF
--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Promise = require('bluebird');
 var stripeMethod = require('./StripeMethod');
 var utils = require('./utils');
 

--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -50,42 +50,41 @@ module.exports = {
     }
 
     var urlData = this.createUrlData();
-    var deferred = this.createDeferred(cb);
     var path = this.createFullPath('/' + id, urlData);
 
-    if (isNull) {
-      // Reset metadata:
-      sendMetadata(null, auth);
-    } else if (!isObject) {
-      // Set individual metadata property:
-      var metadata = {};
-      metadata[key] = value;
-      sendMetadata(metadata, auth);
-    } else {
-      // Set entire metadata object after resetting it:
-      this._request('POST', path, {
-        metadata: null,
-      }, auth, {}, function(err, response) {
-        if (err) {
-          return deferred.reject(err);
-        }
-        sendMetadata(data, auth);
-      });
-    }
+    return this.wrapTimeout(new Promise((function(resolve, reject) {
+      if (isNull) {
+        // Reset metadata:
+        sendMetadata(null, auth);
+      } else if (!isObject) {
+        // Set individual metadata property:
+        var metadata = {};
+        metadata[key] = value;
+        sendMetadata(metadata, auth);
+      } else {
+        // Set entire metadata object after resetting it:
+        this._request('POST', path, {
+          metadata: null,
+        }, auth, {}, function(err, response) {
+          if (err) {
+            return reject(err);
+          }
+          sendMetadata(data, auth);
+        });
+      }
 
-    function sendMetadata(metadata, auth) {
-      self._request('POST', path, {
-        metadata: metadata,
-      }, auth, {}, function(err, response) {
-        if (err) {
-          deferred.reject(err);
-        } else {
-          deferred.resolve(response.metadata);
-        }
-      });
-    }
-
-    return deferred.promise;
+      function sendMetadata(metadata, auth) {
+        self._request('POST', path, {
+          metadata: metadata,
+        }, auth, {}, function(err, response) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(response.metadata);
+          }
+        });
+      }
+    }).bind(this)), cb);
   },
 
   getMetadata: function(id, auth, cb) {
@@ -95,20 +94,17 @@ module.exports = {
     }
 
     var urlData = this.createUrlData();
-    var deferred = this.createDeferred(cb);
     var path = this.createFullPath('/' + id, urlData);
 
-    this._request('GET', path, {}, auth, {}, function(err, response) {
-      if (err) {
-        deferred.reject(err);
-      } else {
-        deferred.resolve(
-         response.metadata
-        );
-      }
-    });
-
-    return deferred.promise;
+    return this.wrapTimeout(new Promise((function(resolve, reject) {
+      this._request('GET', path, {}, auth, {}, function(err, response) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(response.metadata);
+        }
+      });
+    }).bind(this)), cb);
   },
 
 };

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -27,66 +27,65 @@ function stripeMethod(spec) {
     var args = [].slice.call(arguments);
 
     var callback = typeof args[args.length - 1] == 'function' && args.pop();
-    var deferred = this.createDeferred(callback);
     var urlData = this.createUrlData();
 
-    for (var i = 0, l = urlParams.length; i < l; ++i) {
-      // Note that we shift the args array after every iteration so this just
-      // grabs the "next" argument for use as a URL parameter.
-      var arg = args[0];
+    return this.wrapTimeout(new Promise((function(resolve, reject) {
+      for (var i = 0, l = urlParams.length; i < l; ++i) {
+        // Note that we shift the args array after every iteration so this just
+        // grabs the "next" argument for use as a URL parameter.
+        var arg = args[0];
 
-      var param = urlParams[i];
+        var param = urlParams[i];
 
-      var isOptional = OPTIONAL_REGEX.test(param);
-      param = param.replace(OPTIONAL_REGEX, '');
+        var isOptional = OPTIONAL_REGEX.test(param);
+        param = param.replace(OPTIONAL_REGEX, '');
 
-      if (!arg) {
-        if (isOptional) {
-          urlData[param] = '';
-          continue;
+        if (!arg) {
+          if (isOptional) {
+            urlData[param] = '';
+            continue;
+          }
+
+          var err = new Error(
+            'Stripe: Argument "' + urlParams[i] + '" required, but got: ' + arg +
+            ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
+          );
+          reject(err);
+          return;
         }
 
+        urlData[param] = args.shift();
+      }
+
+      var data = utils.getDataFromArgs(args);
+      var opts = utils.getOptionsFromArgs(args);
+
+      if (args.length) {
         var err = new Error(
-          'Stripe: Argument "' + urlParams[i] + '" required, but got: ' + arg +
+          'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options ' +
+          'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.' +
           ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
         );
-        deferred.reject(err);
-        return deferred.promise;
+        reject(err);
+        return;
       }
 
-      urlData[param] = args.shift();
-    }
+      var requestPath = this.createFullPath(commandPath, urlData);
+      function requestCallback(err, response) {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(
+            spec.transformResponseData ?
+              spec.transformResponseData(response) :
+              response
+          );
+        }
+      };
 
-    var data = utils.getDataFromArgs(args);
-    var opts = utils.getOptionsFromArgs(args);
-
-    if (args.length) {
-      var err = new Error(
-        'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options ' +
-        'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.' +
-        ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
-      );
-      deferred.reject(err);
-      return deferred.promise;
-    }
-
-    var requestPath = this.createFullPath(commandPath, urlData);
-    function requestCallback(err, response) {
-      if (err) {
-        deferred.reject(err);
-      } else {
-        deferred.resolve(
-          spec.transformResponseData ?
-            spec.transformResponseData(response) :
-            response
-        );
-      }
-    };
-
-    var options = {headers: _.extend(opts.headers, spec.headers)};
-    self._request(requestMethod, requestPath, data, opts.auth, options, requestCallback);
-
-    return deferred.promise;
+      var options = {headers: _.extend(opts.headers, spec.headers)};
+      self._request(requestMethod, requestPath, data, opts.auth, options, requestCallback);
+    }).bind(this)), callback);
   };
 };
 

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -2,6 +2,7 @@
 
 var _ = require('lodash');
 var path = require('path');
+var Promise = require('bluebird');
 var utils = require('./utils');
 var OPTIONAL_REGEX = /^optional!/;
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -74,20 +74,17 @@ StripeResource.prototype = {
     return urlData;
   },
 
-  createDeferred: function(callback) {
-    var deferred = Promise.defer();
-
+  wrapTimeout: function(promise, callback) {
     if (callback) {
-      // Callback, if provided, is a simply translated to Promise'esque:
-      // (Ensure callback is called outside of promise stack)
-      deferred.promise.then(function(res) {
-          setTimeout(function() { callback(null, res) }, 0);
-        }, function(err) {
-          setTimeout(function() { callback(err, null); }, 0);
-        });
+      // Ensure callback is called outside of promise stack.
+      return promise.then(function(res) {
+        setTimeout(function() { callback(null, res) }, 0);
+      }, function(err) {
+        setTimeout(function() { callback(err, null); }, 0);
+      });
     }
 
-    return deferred;
+    return promise;
   },
 
   _timeoutHandler: function(timeout, req, callback) {

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -278,21 +278,19 @@ describe('Customers Resource', function() {
 
       describe('When setting new metadata', function() {
         it('Sends one request to get current, and another to set new data', function() {
-          var defer = Promise.defer();
-
-          stripe.customers.setMetadata('customerIdFoo321', {
-            foo: 123,
-            baz: 456,
-          }).then(function() {
-            var reqs = stripe.REQUESTS;
-            defer.resolve([
-              // Last two requests
-              reqs[reqs.length - 2],
-              reqs[reqs.length - 1],
-            ]);
-          });
-
-          return expect(defer.promise).to.eventually.deep.equal([
+          return expect(new Promise(function(resolve, reject) {
+            stripe.customers.setMetadata('customerIdFoo321', {
+              foo: 123,
+              baz: 456,
+            }).then(function() {
+              var reqs = stripe.REQUESTS;
+              resolve([
+                // Last two requests
+                reqs[reqs.length - 2],
+                reqs[reqs.length - 1],
+              ]);
+            });
+          })).to.eventually.deep.equal([
             {
               // First reset metadata:
               method: 'POST',

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -26,11 +26,11 @@ describe('Stripe Module', function() {
 
   describe('ClientUserAgent', function() {
     it('Should return a user-agent serialized JSON object', function() {
-      var d = Promise.defer();
-      stripe.getClientUserAgent(function(c) {
-        d.resolve(JSON.parse(c));
-      });
-      return expect(d.promise).to.eventually.have.property('lang', 'node');
+      return expect(new Promise(function(resolve, reject) {
+        stripe.getClientUserAgent(function(c) {
+          resolve(JSON.parse(c));
+        });
+      })).to.eventually.have.property('lang', 'node');
     });
   });
 
@@ -51,53 +51,49 @@ describe('Stripe Module', function() {
   describe('Callback support', function() {
     describe('Any given endpoint', function() {
       it('Will call a callback if successful', function() {
-        var defer = Promise.defer();
-        stripe.customers.create({
-          description: 'Some customer',
-          card: {
-            number: '4242424242424242',
-            exp_month: 12,
-            exp_year: exp_year,
-          },
-        }, function(err, customer) {
-          cleanup.deleteCustomer(customer.id);
-          defer.resolve('Called!');
-        });
-
-        return expect(defer.promise).to.eventually.equal('Called!');
+        return expect(new Promise(function(resolve, reject) {
+          stripe.customers.create({
+            description: 'Some customer',
+            card: {
+              number: '4242424242424242',
+              exp_month: 12,
+              exp_year: exp_year,
+            },
+          }, function(err, customer) {
+            cleanup.deleteCustomer(customer.id);
+            resolve('Called!');
+          });
+        })).to.eventually.equal('Called!');
       });
 
       it('Will expose HTTP response object', function() {
-        var defer = Promise.defer();
-        stripe.customers.create({
-          description: 'Some customer',
-          card: {
-            number: '4242424242424242',
-            exp_month: 12,
-            exp_year: exp_year,
-          },
-        }, function(err, customer) {
-          cleanup.deleteCustomer(customer.id);
-          var headers = customer.lastResponse.headers;
-          expect(headers).to.contain.keys('request-id');
-          defer.resolve('Called!');
-        });
-
-        return expect(defer.promise).to.eventually.equal('Called!');
+        return expect(new Promise(function(resolve, reject) {
+          stripe.customers.create({
+            description: 'Some customer',
+            card: {
+              number: '4242424242424242',
+              exp_month: 12,
+              exp_year: exp_year,
+            },
+          }, function(err, customer) {
+            cleanup.deleteCustomer(customer.id);
+            var headers = customer.lastResponse.headers;
+            expect(headers).to.contain.keys('request-id');
+            resolve('Called!');
+          });
+        })).to.eventually.equal('Called!');
       });
 
       it('Given an error the callback will receive it', function() {
-        var defer = Promise.defer();
-
-        stripe.customers.createCard('nonExistentCustId', {card: {}}, function(err, customer) {
-          if (err) {
-            defer.resolve('ErrorWasPassed');
-          } else {
-            defer.reject('NoErrorPassed');
-          }
-        });
-
-        return expect(defer.promise).to.eventually.become('ErrorWasPassed')
+        return expect(new Promise(function(resolve, reject) {
+          stripe.customers.createCard('nonExistentCustId', {card: {}}, function(err, customer) {
+            if (err) {
+              resolve('ErrorWasPassed');
+            } else {
+              reject('NoErrorPassed');
+            }
+          });
+        })).to.eventually.become('ErrorWasPassed');
       });
     });
   });


### PR DESCRIPTION
`Promise.defer` from Bluebird is considered deprecated [1]. Here we
remove its uses and replace them with `Promise.new`.

It would be nice to find a reviewer for this one who is somewhat familiar with
the Node/Bluebird idioms. If anyone wants to volunteer, that would be amazing,
otherwise I'll try and track someone down.

Fixes #257.

[1] http://bluebirdjs.com/docs/deprecated-apis.html#promise-resolution