### PR TITLE
Add SubscriptionItem object

### DIFF
--- a/lib/resources/SubscriptionItems.js
+++ b/lib/resources/SubscriptionItems.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
+  path: 'subscription_items',
+  includeBasic: ['create', 'list', 'retrieve', 'update', 'del',],
+});
+

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -50,6 +50,7 @@ var resources = {
   Orders: require('./resources/Orders'),
   OrderReturns: require('./resources/OrderReturns'),
   Subscriptions: require('./resources/Subscriptions'),
+  SubscriptionItems: require('./resources/SubscriptionItems'),
   ThreeDSecure: require('./resources/ThreeDSecure'),
   Sources: require('./resources/Sources'),
 

--- a/test/resources/SubscriptionItems.spec.js
+++ b/test/resources/SubscriptionItems.spec.js
@@ -1,0 +1,83 @@
+'use strict';
+
+var stripe = require('../testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+
+describe('SubscriptionItems Resource', function() {
+  describe('retrieve', function() {
+    it('Sends the correct request', function() {
+      stripe.subscriptionItems.retrieve('test_sub_item');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/subscription_items/test_sub_item',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('del', function() {
+    it('Sends the correct request', function() {
+      stripe.subscriptionItems.del('test_sub_item');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'DELETE',
+        url: '/v1/subscription_items/test_sub_item',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('update', function() {
+    it('Sends the correct request', function() {
+      stripe.subscriptionItems.update('test_sub_item', {
+        plan: 'gold',
+      });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/subscription_items/test_sub_item',
+        headers: {},
+        data: {
+          plan: 'gold',
+        },
+      });
+    });
+  });
+
+  describe('create', function() {
+    it('Sends the correct request', function() {
+      stripe.subscriptionItems.create({
+        subscription: 'test_sub',
+        plan: 'gold',
+      });
+
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/subscription_items',
+        headers: {},
+        data: {
+          subscription: 'test_sub',
+          plan: 'gold',
+        },
+      });
+    });
+  });
+
+  describe('list', function() {
+    it('Sends the correct request', function() {
+      stripe.subscriptionItems.list({
+        limit: 3,
+        subscription: 'test_sub',
+      });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/subscription_items',
+        headers: {},
+        data: {
+          limit: 3,
+          subscription: 'test_sub',
+        },
+      });
+    });
+  });
+});


### PR DESCRIPTION
Add SubscriptionItem object to support list, retrieve, create, update, deletion on subscriptions items through `v1/subscription_items`. Note that documentation for this endpoint in the README has yet to be filled out since this feature is still in development.