### PR TITLE
Update README for retrieving/deleting Apple Pay domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,8 @@ stripe.balance.retrieve({
  * applePayDomains
   * [`create(params)`](https://stripe.com/docs/api/node#create_apple_pay_domain)
   * [`list([params])`](https://stripe.com/docs/api/node#list_apple_pay_domains)
-  * [`retrieve(chargeId)`](https://stripe.com/docs/api/node#retrieve_apple_pay_domain)
-  * [`del(chargeId)`](https://stripe.com/docs/api/node#delete_apple_pay_domain)
+  * [`retrieve(applePayDomainId)`](https://stripe.com/docs/api/node#retrieve_apple_pay_domain)
+  * [`del(applePayDomainId)`](https://stripe.com/docs/api/node#delete_apple_pay_domain)
  * balance
   * [`retrieve()`](https://stripe.com/docs/api/node#retrieve_balance)
   * [`listTransactions([params])`](https://stripe.com/docs/api/node#balance_history)


### PR DESCRIPTION
Small typo: you don't pass a `chargeId` to retrieve/delete an Apple Pay domain.

r? @brandur 