### PR TITLE
Remove Lodash dependency

### DIFF
--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
-
 // Method for formatting HTTP body for the multipart/form-data specification
 // Mostly taken from Fermata.js
 // https://github.com/natevw/fermata/blob/5d9732a33d776ce925013a265935facd1626cc88/fermata.js#L315-L343
@@ -23,8 +21,8 @@ function multipartDataGenerator(method, data, headers) {
     return '"' + s.replace(/"|"/g, '%22').replace(/\r\n|\r|\n/g, ' ') + '"';
   }
 
-  _.forEach(data, function(v, k) {
-    push('--' + segno);
+  for (var k in data) {
+    var v = data[k];
     if (v.hasOwnProperty('data')) {
       push('Content-Disposition: form-data; name=' + q(k) + '; filename=' + q(v.name || 'blob'));
       push('Content-Type: ' + (v.type || 'application/octet-stream'));
@@ -35,7 +33,7 @@ function multipartDataGenerator(method, data, headers) {
       push('');
       push(v);
     }
-  });
+  };
   push('--' + segno + '--');
 
   return buffer;

--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -23,6 +23,7 @@ function multipartDataGenerator(method, data, headers) {
 
   for (var k in data) {
     var v = data[k];
+    push('--' + segno);
     if (v.hasOwnProperty('data')) {
       push('Content-Disposition: form-data; name=' + q(k) + '; filename=' + q(v.name || 'blob'));
       push('Content-Type: ' + (v.type || 'application/octet-stream'));

--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Promise = require('bluebird');
+var isPlainObject = require('lodash.isplainobject');
 var stripeMethod = require('./StripeMethod');
 var utils = require('./utils');
 
@@ -36,7 +37,7 @@ module.exports = {
   setMetadata: function(id, key, value, auth, cb) {
     var self = this;
     var data = key;
-    var isObject = utils.isPlainObject(key);
+    var isObject = isPlainObject(key);
     // We assume null for an empty object
     var isNull = data === null || (isObject && !Object.keys(data).length);
 

--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -36,7 +36,7 @@ module.exports = {
   setMetadata: function(id, key, value, auth, cb) {
     var self = this;
     var data = key;
-    var isObject = utils.isObject(key);
+    var isObject = utils.isPlainObject(key);
     // We assume null for an empty object
     var isNull = data === null || (isObject && !Object.keys(data).length);
 

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var path = require('path');
 var Promise = require('bluebird');
 var utils = require('./utils');
@@ -84,7 +83,7 @@ function stripeMethod(spec) {
         }
       };
 
-      var options = {headers: _.extend(opts.headers, spec.headers)};
+      var options = {headers: utils.assign(opts.headers, spec.headers)};
       self._request(requestMethod, requestPath, data, opts.auth, options, requestCallback);
     }).bind(this)), callback);
   };

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var objectAssign = require('object-assign');
 var path = require('path');
 var Promise = require('bluebird');
 var utils = require('./utils');
@@ -83,7 +84,7 @@ function stripeMethod(spec) {
         }
       };
 
-      var options = {headers: utils.assign(opts.headers, spec.headers)};
+      var options = {headers: objectAssign(opts.headers, spec.headers)};
       self._request(requestMethod, requestPath, data, opts.auth, options, requestCallback);
     }).bind(this)), callback);
   };

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -2,6 +2,7 @@
 
 var http = require('http');
 var https = require('https');
+var objectAssign = require('object-assign');
 var path = require('path');
 var Promise = require('bluebird');
 
@@ -208,7 +209,7 @@ StripeResource.prototype = {
       headers['X-Stripe-Client-User-Agent'] = cua;
 
       if (options.headers) {
-        utils.assign(headers, options.headers);
+        objectAssign(headers, options.headers);
       }
 
       makeRequest();

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -4,7 +4,6 @@ var http = require('http');
 var https = require('https');
 var path = require('path');
 var Promise = require('bluebird');
-var _ = require('lodash');
 
 var utils = require('./utils');
 var Error = require('./Error');
@@ -209,7 +208,7 @@ StripeResource.prototype = {
       headers['X-Stripe-Client-User-Agent'] = cua;
 
       if (options.headers) {
-        headers = _.extend(headers, options.headers);
+        utils.assign(headers, options.headers);
       }
 
       makeRequest();

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -3,100 +3,18 @@
 var qs = require('qs');
 
 var hasOwn = {}.hasOwnProperty;
-var toString = {}.toString;
+var isPlainObject = require('lodash.isplainobject');
 
 var utils = module.exports = {
-
-  // Note that in ES6 all uses of this can just be replaced with Object.assign.
-  // Given a few more years we should drop this function completely.
-  assign: function(o1, o2) {
-    for (var attr in o2) {
-      o1[attr] = o2[attr];
-    }
-    return o1;
-  },
 
   isAuthKey: function(key) {
     return typeof key == 'string' && /^(?:[a-z]{2}_)?[A-z0-9]{32}$/.test(key);
   },
 
   isOptionsHash: function(o) {
-    return utils.isPlainObject(o) && ['api_key', 'idempotency_key', 'stripe_account'].some(function(key) {
+    return isPlainObject(o) && ['api_key', 'idempotency_key', 'stripe_account'].some(function(key) {
       return o.hasOwnProperty(key);
     });
-  },
-
-  /**
-   * Checks if `value` is a plain object, that is, an object created by the
-   * `Object` constructor or one with a `[[Prototype]]` of `null`.
-   *
-   * Note that this function is vendored from Lodash with some minor
-   * modifications.
-   *
-   * @static
-   * @memberOf utils
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is a plain object, else `false`.
-   * @example
-   *
-   * function Foo() {
-   *   this.a = 1;
-   * }
-   *
-   * utils.isPlainObject(new Foo);
-   * // => false
-   *
-   * utils.isPlainObject([1, 2, 3]);
-   * // => false
-   *
-   * utils.isPlainObject({ 'x': 0, 'y': 0 });
-   * // => true
-   *
-   * utils.isPlainObject(Object.create(null));
-   * // => true
-   */
-  isPlainObject: function(value) {
-    if (!utils.isObjectLike(value) || value.toString() != '[object Object]') {
-      return false;
-    }
-    var proto = Object.getPrototypeOf(value);
-    if (proto === null) {
-      return true;
-    }
-    var Ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor;
-    return (typeof Ctor == 'function' &&
-      Ctor instanceof Ctor && Ctor.toString() == Object.toString());
-  },
-
-  /**
-   * Checks if `value` is object-like. A value is object-like if it's not `null`
-   * and has a `typeof` result of "object".
-   *
-   * Note that this function is vendored from Lodash with some minor
-   * modifications.
-   *
-   * @static
-   * @memberOf utils
-   * @category Lang
-   * @param {*} value The value to check.
-   * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
-   * @example
-   *
-   * utils.isObjectLike({});
-   * // => true
-   *
-   * utils.isObjectLike([1, 2, 3]);
-   * // => true
-   *
-   * utils.isObjectLike(_.noop);
-   * // => false
-   *
-   * utils.isObjectLike(null);
-   * // => false
-   */
-  isObjectLike: function(value) {
-    return value != null && typeof value == 'object';
   },
 
   /**
@@ -135,7 +53,7 @@ var utils = module.exports = {
    */
   getDataFromArgs: function(args) {
     if (args.length > 0) {
-      if (utils.isPlainObject(args[0]) && !utils.isOptionsHash(args[0])) {
+      if (isPlainObject(args[0]) && !utils.isOptionsHash(args[0])) {
         return args.shift();
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,25 +1,102 @@
 'use strict';
 
 var qs = require('qs');
-var _ = require('lodash');
 
 var hasOwn = {}.hasOwnProperty;
 var toString = {}.toString;
 
 var utils = module.exports = {
 
+  // Note that in ES6 all uses of this can just be replaced with Object.assign.
+  // Given a few more years we should drop this function completely.
+  assign: function(o1, o2) {
+    for (var attr in o2) {
+      o1[attr] = o2[attr];
+    }
+    return o1;
+  },
+
   isAuthKey: function(key) {
     return typeof key == 'string' && /^(?:[a-z]{2}_)?[A-z0-9]{32}$/.test(key);
   },
 
   isOptionsHash: function(o) {
-    return _.isPlainObject(o) && ['api_key', 'idempotency_key', 'stripe_account'].some(function(key) {
+    return utils.isPlainObject(o) && ['api_key', 'idempotency_key', 'stripe_account'].some(function(key) {
       return o.hasOwnProperty(key);
     });
   },
 
-  isObject: function(o) {
-    return _.isPlainObject(o);
+  /**
+   * Checks if `value` is a plain object, that is, an object created by the
+   * `Object` constructor or one with a `[[Prototype]]` of `null`.
+   *
+   * Note that this function is vendored from Lodash with some minor
+   * modifications.
+   *
+   * @static
+   * @memberOf utils
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is a plain object, else `false`.
+   * @example
+   *
+   * function Foo() {
+   *   this.a = 1;
+   * }
+   *
+   * utils.isPlainObject(new Foo);
+   * // => false
+   *
+   * utils.isPlainObject([1, 2, 3]);
+   * // => false
+   *
+   * utils.isPlainObject({ 'x': 0, 'y': 0 });
+   * // => true
+   *
+   * utils.isPlainObject(Object.create(null));
+   * // => true
+   */
+  isPlainObject: function(value) {
+    if (!utils.isObjectLike(value) || value.toString() != '[object Object]') {
+      return false;
+    }
+    var proto = Object.getPrototypeOf(value);
+    if (proto === null) {
+      return true;
+    }
+    var Ctor = hasOwnProperty.call(proto, 'constructor') && proto.constructor;
+    return (typeof Ctor == 'function' &&
+      Ctor instanceof Ctor && Ctor.toString() == Object.toString());
+  },
+
+  /**
+   * Checks if `value` is object-like. A value is object-like if it's not `null`
+   * and has a `typeof` result of "object".
+   *
+   * Note that this function is vendored from Lodash with some minor
+   * modifications.
+   *
+   * @static
+   * @memberOf utils
+   * @category Lang
+   * @param {*} value The value to check.
+   * @returns {boolean} Returns `true` if `value` is object-like, else `false`.
+   * @example
+   *
+   * utils.isObjectLike({});
+   * // => true
+   *
+   * utils.isObjectLike([1, 2, 3]);
+   * // => true
+   *
+   * utils.isObjectLike(_.noop);
+   * // => false
+   *
+   * utils.isObjectLike(null);
+   * // => false
+   */
+  isObjectLike: function(value) {
+    return value != null && typeof value == 'object';
   },
 
   /**
@@ -58,7 +135,7 @@ var utils = module.exports = {
    */
   getDataFromArgs: function(args) {
     if (args.length > 0) {
-      if (utils.isObject(args[0]) && !utils.isOptionsHash(args[0])) {
+      if (utils.isPlainObject(args[0]) && !utils.isOptionsHash(args[0])) {
         return args.shift();
       }
     }

--- a/package.json
+++ b/package.json
@@ -34,7 +34,6 @@
   },
   "dependencies": {
     "bluebird": "^2.10.2",
-    "lodash": "^4.11.1",
     "qs": "^2.4.2"
   },
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -34,6 +34,8 @@
   },
   "dependencies": {
     "bluebird": "^2.10.2",
+    "lodash.isplainobject": "^4.0.6",
+    "object-assign": "^4.1.0",
     "qs": "^2.4.2"
   },
   "license": "MIT",

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -6,6 +6,30 @@ var utils = require('../lib/utils');
 var expect = require('chai').expect;
 
 describe('utils', function() {
+  // Vendored from lodash's own testing implementation with very minor changes.
+  describe('isObjectLike', function() {
+    expect(utils.isObjectLike([1, 2, 3])).to.equal(true);
+    expect(utils.isObjectLike(Object(false))).to.equal(true);
+    expect(utils.isObjectLike(new Date)).to.equal(true);
+    expect(utils.isObjectLike(new Error)).to.equal(true);
+    expect(utils.isObjectLike({'a': 1})).to.equal(true);
+    expect(utils.isObjectLike(Object(0))).to.equal(true);
+    expect(utils.isObjectLike(/x/)).to.equal(true);
+    expect(utils.isObjectLike(Object('a'))).to.equal(true);
+    expect(utils.isObjectLike(null)).to.equal(false);
+  });
+
+  // Vendored from lodash's own testing implementation with very minor changes.
+  describe('isPlainObject', function() {
+    // Note that I'm using `expect` as a non-plain object here for convenience
+    // sake.
+    expect(utils.isPlainObject({})).to.equal(true);
+    expect(utils.isPlainObject({'a': 1})).to.equal(true);
+    expect(utils.isPlainObject({'constructor': expect})).to.equal(true);
+    expect(utils.isPlainObject([1, 2, 3])).to.equal(false);
+    expect(utils.isPlainObject(expect)).to.equal(false);
+  });
+
   describe('makeURLInterpolator', function() {
     it('Interpolates values into a prepared template', function() {
       var template = utils.makeURLInterpolator('/some/url/{foo}/{baz}?ok=1');

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -6,30 +6,6 @@ var utils = require('../lib/utils');
 var expect = require('chai').expect;
 
 describe('utils', function() {
-  // Vendored from lodash's own testing implementation with very minor changes.
-  describe('isObjectLike', function() {
-    expect(utils.isObjectLike([1, 2, 3])).to.equal(true);
-    expect(utils.isObjectLike(Object(false))).to.equal(true);
-    expect(utils.isObjectLike(new Date)).to.equal(true);
-    expect(utils.isObjectLike(new Error)).to.equal(true);
-    expect(utils.isObjectLike({'a': 1})).to.equal(true);
-    expect(utils.isObjectLike(Object(0))).to.equal(true);
-    expect(utils.isObjectLike(/x/)).to.equal(true);
-    expect(utils.isObjectLike(Object('a'))).to.equal(true);
-    expect(utils.isObjectLike(null)).to.equal(false);
-  });
-
-  // Vendored from lodash's own testing implementation with very minor changes.
-  describe('isPlainObject', function() {
-    // Note that I'm using `expect` as a non-plain object here for convenience
-    // sake.
-    expect(utils.isPlainObject({})).to.equal(true);
-    expect(utils.isPlainObject({'a': 1})).to.equal(true);
-    expect(utils.isPlainObject({'constructor': expect})).to.equal(true);
-    expect(utils.isPlainObject([1, 2, 3])).to.equal(false);
-    expect(utils.isPlainObject(expect)).to.equal(false);
-  });
-
   describe('makeURLInterpolator', function() {
     it('Interpolates values into a prepared template', function() {
       var template = utils.makeURLInterpolator('/some/url/{foo}/{baz}?ok=1');


### PR DESCRIPTION
Lodash is being used in relatively few places and as described in #259
can cause some problems in transforming objects to versions that cannot
be properly encoded.

Here we remove Lodash. Much of its functionality has been added to ES6
anyway, so we can eventually even remove some of the vendored functions
that we have.

Fixes a report received in #259.