### PR TITLE
Add instructions for running single tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,11 +226,23 @@ stripe.balance.retrieve({
 
 ## Development
 
-Run the tests using [`npm`](https://www.npmjs.com/):
+Run all tests:
 
 ```bash
 $ npm install
 $ npm test
+```
+
+Run a single test suite:
+
+```bash
+$ npm run mocha -- test/Error.spec.js
+```
+
+Run a single test (case sensitive):
+
+```bash
+$ npm run mocha -- test/Error.spec.js --grep 'Populates with type'
 ```
 
 If you wish, you may run tests using your Stripe *Test* API key by setting the environment variable `STRIPE_TEST_API_KEY` before running tests:

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "mocha": "mocha",
     "test": "npm run lint && mocha",
     "lint": "jscs ."
   }


### PR DESCRIPTION
Adds a section in the README like some of our other languages for
running either a single file of tests or a single test within a file. A
script is also added to `package.json` to support this.

Slightly unfortunate: the `--grep` flag of Mocha is case sensitive which
will probably lead to confusion because we use a lot of inconsistent
casing in test names. There is a case insensitive version in modern
version of Mocha, but we'll have to upgrade to 3.0.0+ to get it.