### PR TITLE
Add refunds resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,7 +94,6 @@ stripe.balance.retrieve({
   * [`list([params])`](https://stripe.com/docs/api/node#list_charges)
   * [`retrieve(chargeId)`](https://stripe.com/docs/api/node#retrieve_charge)
   * [`capture(chargeId[, params])`](https://stripe.com/docs/api/node#charge_capture)
-  * [`refund(chargeId[, params])`](https://stripe.com/docs/api/node#create_refund)
   * [`update(chargeId[, params])`](https://stripe.com/docs/api/node#update_charge)
   * [`updateDispute(chargeId[, params])`](https://stripe.com/docs/api/node#update_dispute)
   * [`closeDispute(chargeId[, params])`](https://stripe.com/docs/api/node#close_dispute)
@@ -175,7 +174,11 @@ stripe.balance.retrieve({
   * [`del(recipientId)`](https://stripe.com/docs/api/node#delete_recipient)
   * `setMetadata(recipientId, metadataObject)` ([metadata info](https://stripe.com/docs/api/node#metadata))
   * `setMetadata(recipientId, key, value)`
-  * `getMetadata(recipientId)`
+ * refunds
+  * [`create(params)`](https://stripe.com/docs/api/node#create_refund)
+  * [`list([params])`](https://stripe.com/docs/api/node#list_refunds)
+  * [`update(refundId[, params])`](https://stripe.com/docs/api/node#update_refund)
+  * [`retrieve(refundId)`](https://stripe.com/docs/api/node#retrieve_refund)
  * skus
   * [`create(params)`](https://stripe.com/docs/api/node#create_sku)
   * [`list([params])`](https://stripe.com/docs/api/node#list_skus)


### PR DESCRIPTION
This adds the refunds resource to the README and removes the old
`refund` helper from charge (which is now deprecated in favor of the
resource).

Fixes #280.