### PR TITLE
Adds support for verify source endpoint

### DIFF
--- a/lib/resources/Sources.js
+++ b/lib/resources/Sources.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var StripeResource = require('../StripeResource');
+var stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
 
@@ -9,5 +10,11 @@ module.exports = StripeResource.extend({
   includeBasic: [
     'create', 'retrieve', 'setMetadata', 'getMetadata',
   ],
+
+  verify: stripeMethod({
+    method: 'POST',
+    path: '/{id}/verify',
+    urlParams: ['id'],
+  }),
 
 });

--- a/test/resources/Sources.spec.js
+++ b/test/resources/Sources.spec.js
@@ -45,4 +45,16 @@ describe('Sources Resource', function() {
       });
     });
   });
+
+  describe('verify', function() {
+    it('Sends the correct request', function() {
+      stripe.sources.verify('src_foo', {values: [32, 45]});
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/sources/src_foo/verify',
+        headers: {},
+        data: {values: [32, 45]},
+      });
+    });
+  });
 });


### PR DESCRIPTION
r? @will-stripe
cc @stripe/api-libraries @stan-stripe

This PR adds support for the `/verify` endpoint for sources, for use with ACH debit and other source types that require a verification.
