### PR TITLE
Ignore `tags` file for NPM, fixes #302

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules
 .npm-debug.log
+tags


### PR DESCRIPTION
Dug into this issue, and it looks like NPM defaults to "include everything" even if `tags` would be excluded, for example, by a global `.gitignore` rule.

https://docs.npmjs.com/misc/developers


r? @brandur-stripe 