### PR TITLE
Throw an error if options are provided inside the data argument

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -70,7 +70,12 @@ function stripeMethod(spec) {
         urlData[param] = args.shift();
       }
 
-      var data = encode(utils.getDataFromArgs(args));
+      var data;
+      try {
+        data = encode(utils.getDataFromArgs(args));
+      } catch (e) {
+        reject(e);
+      }
       var opts = utils.getOptionsFromArgs(args);
 
       if (args.length) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,6 +7,8 @@ var crypto = require('crypto');
 var hasOwn = {}.hasOwnProperty;
 var isPlainObject = require('lodash.isplainobject');
 
+var OPTIONS_KEYS = ['api_key', 'idempotency_key', 'stripe_account', 'stripe_version'];
+
 var utils = module.exports = {
 
   isAuthKey: function(key) {
@@ -14,7 +16,7 @@ var utils = module.exports = {
   },
 
   isOptionsHash: function(o) {
-    return isPlainObject(o) && ['api_key', 'idempotency_key', 'stripe_account', 'stripe_version'].some(function(key) {
+    return isPlainObject(o) && OPTIONS_KEYS.some(function(key) {
       return hasOwn.call(o, key);
     });
   },
@@ -54,11 +56,27 @@ var utils = module.exports = {
    * Return the data argument from a list of arguments
    */
   getDataFromArgs: function(args) {
-    if (args.length > 0) {
-      if (isPlainObject(args[0]) && !utils.isOptionsHash(args[0])) {
-        return args.shift();
-      }
+    if (args.length < 1 || !isPlainObject(args[0])) {
+      return {};
     }
+
+    if (!utils.isOptionsHash(args[0])) {
+      return args.shift();
+    }
+
+    var argKeys = Object.keys(args[0]);
+
+    var optionKeysInArgs = argKeys.filter(function(key) {
+      return OPTIONS_KEYS.indexOf(key) > -1;
+    });
+
+    if (argKeys.length > optionKeysInArgs.length) {
+      throw new Error(
+        'Stripe: Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
+        'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
+      );
+    }
+
     return {};
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,8 +70,8 @@ var utils = module.exports = {
       return OPTIONS_KEYS.indexOf(key) > -1;
     });
 
-    if (argKeys.length > optionKeysInArgs.length) {
-      throw new Error(
+    if (optionKeysInArgs.length > 0) {
+      console.warn(
         'Stripe: Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
         'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
       );

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -106,10 +106,14 @@ describe('utils', function() {
       expect(utils.getDataFromArgs(args)).to.deep.equal({});
       expect(args.length).to.equal(2);
     });
-    it('ignores an options hash', function() {
+    it('ignores a hash with only options', function() {
       var args = [{api_key: 'foo'}];
       expect(utils.getDataFromArgs(args)).to.deep.equal({});
       expect(args.length).to.equal(1);
+    });
+    it('throws an error if the hash contains both data and options', function() {
+      var args = [{foo: 'bar', api_key: 'foo', idempotency_key: 'baz'}];
+      expect(function() { utils.getDataFromArgs(args); }).to.throw(/Options found in arguments/);
     });
     it('finds the data', function() {
       var args = [{foo: 'bar'}, {api_key: 'foo'}];

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -113,7 +113,20 @@ describe('utils', function() {
     });
     it('throws an error if the hash contains both data and options', function() {
       var args = [{foo: 'bar', api_key: 'foo', idempotency_key: 'baz'}];
-      expect(function() { utils.getDataFromArgs(args); }).to.throw(/Options found in arguments/);
+
+      // Hack to make sure we're logging to console.warn here:
+      var _warn = console.warn;
+
+      console.warn = function(message) {
+        expect(message).to.equal(
+          'Stripe: Options found in arguments (api_key, idempotency_key).' +
+            ' Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
+        );
+      };
+
+      utils.getDataFromArgs(args);
+
+      console.warn = _warn;
     });
     it('finds the data', function() {
       var args = [{foo: 'bar'}, {api_key: 'foo'}];


### PR DESCRIPTION
If you include any of `stripe_account`, `api_key` or `idempotency_key` in the `data` object, that object will be treated as the `options` object and so only the options will be processed - i.e., the data will be discarded.

With this change, the first argument object will be stripped of the `options` keys and returned, allowing for both `data` and `options` to come from the same object.

Also added some Charge creation tests to ensure that this works - at least in terms of adding a `Stripe-Account` header.