### PR TITLE
Update qs

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "chai-as-promised": "~4.1.1",
     "jscs": "^2.3.5",
     "mocha": "~2.1.0",
-    "qs": "~6.0.2",
+    "qs": "~6.0.4",
     "stripe-javascript-style": "^1.0.1"
   },
   "dependencies": {
     "bluebird": "^2.10.2",
     "lodash.isplainobject": "^4.0.6",
     "object-assign": "^4.1.0",
-    "qs": "~6.0.2"
+    "qs": "~6.0.4"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "chai-as-promised": "~4.1.1",
     "jscs": "^2.3.5",
     "mocha": "~2.1.0",
-    "qs": "~6.0.4",
     "stripe-javascript-style": "^1.0.1"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -30,14 +30,14 @@
     "chai-as-promised": "~4.1.1",
     "jscs": "^2.3.5",
     "mocha": "~2.1.0",
-    "qs": "^6.4.0",
+    "qs": "~6.0.2",
     "stripe-javascript-style": "^1.0.1"
   },
   "dependencies": {
     "bluebird": "^2.10.2",
     "lodash.isplainobject": "^4.0.6",
     "object-assign": "^4.1.0",
-    "qs": ">=6.4.0"
+    "qs": "~6.0.2"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -30,13 +30,14 @@
     "chai-as-promised": "~4.1.1",
     "jscs": "^2.3.5",
     "mocha": "~2.1.0",
+    "qs": "^6.4.0",
     "stripe-javascript-style": "^1.0.1"
   },
   "dependencies": {
     "bluebird": "^2.10.2",
     "lodash.isplainobject": "^4.0.6",
     "object-assign": "^4.1.0",
-    "qs": "^2.4.2"
+    "qs": ">=6.4.0"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
There appears to be an open security vulnerability on earlier versions:

https://snyk.io/vuln/npm:qs:20170213

Fixes #308.

This may cause a problem in that it looks like from their changelog they dropped support for Node 4 already ...