### PR TITLE
Add README badges (npm & RunKit) and update Travis

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,9 @@
-# Stripe Node.js Library [![Build Status](https://travis-ci.org/stripe/stripe-node.png?branch=master)](https://travis-ci.org/stripe/stripe-node)
+# Stripe Node.js Library
+
+[![Version](https://img.shields.io/npm/v/stripe.svg)](https://www.npmjs.org/package/stripe)
+[![Build Status](https://travis-ci.org/stripe/stripe-node.svg?branch=master)](https://travis-ci.org/stripe/stripe-node)
+[![Downloads](https://img.shields.io/npm/dm/stripe.svg)](https://www.npmjs.com/package/stripe)
+[![Try on RunKit](https://badge.runkitcdn.com/stripe.svg)](https://runkit.com/npm/stripe)
 
 The Stripe Node library provides convenient access to the Stripe API from
 applications written in server-side JavaScript.


### PR DESCRIPTION
r? @brandur-stripe 

I replaced the Travis badge with its vector version in the README, and added badges for npm version, npm downloads, and trying the package live in RunKit.