### PR TITLE
Make Request-Id easily available on `lastResponse`

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -121,11 +121,19 @@ StripeResource.prototype = {
 
         try {
           response = JSON.parse(response);
+
+          // For convenience, make Request-Id easily accessible on
+          // lastResponse.
+          res.requestId = headers['request-id'];
+
           if (response.error) {
             var err;
 
+            // These are now available on the top-level resource's
+            // lastResponse, but we keep them here too for backwards
+            // compatibility.
             response.error.statusCode = res.statusCode;
-            response.error.requestId = headers['request-id'];
+            response.error.requestId = response.requestId;
 
             if (res.statusCode === 401) {
               err = new Error.StripeAuthenticationError(response.error);

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -97,8 +97,13 @@ describe('Stripe Module', function() {
             },
           }, function(err, customer) {
             cleanup.deleteCustomer(customer.id);
+
             var headers = customer.lastResponse.headers;
             expect(headers).to.contain.keys('request-id');
+
+            expect(customer.lastResponse.requestId).to.match(/^req_/);
+            expect(customer.lastResponse.statusCode).to.equal(200);
+
             resolve('Called!');
           });
         })).to.eventually.equal('Called!');


### PR DESCRIPTION
Makes access to `Request-Id` easier for non-error responses. So for
example:

``` node
stripe.balance.retrieve({
  stripe_account: "acct_foo"
}).then(function(balance) {
  console.log(balance.lastResponse.requestId);
})
```

Fixes #315.

r? @ob-stripe 