### PR TITLE
Added support for the new Payout and RecipientTransfer objects

### DIFF
--- a/lib/resources/Payouts.js
+++ b/lib/resources/Payouts.js
@@ -1,0 +1,27 @@
+'use strict';
+
+var StripeResource = require('../StripeResource');
+var stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+
+  path: 'payouts',
+
+  includeBasic: [
+    'create', 'list', 'retrieve', 'update',
+    'setMetadata', 'getMetadata',
+  ],
+
+  cancel: stripeMethod({
+    method: 'POST',
+    path: '{payoutId}/cancel',
+    urlParams: ['payoutId'],
+  }),
+
+  listTransactions: stripeMethod({
+    method: 'GET',
+    path: '{payoutId}/transactions',
+    urlParams: ['payoutId'],
+  }),
+});
+

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -37,6 +37,7 @@ var resources = {
   Events: require('./resources/Events'),
   Invoices: require('./resources/Invoices'),
   InvoiceItems: require('./resources/InvoiceItems'),
+  Payouts: require('./resources/Payouts'),
   Plans: require('./resources/Plans'),
   RecipientCards: require('./resources/RecipientCards'),
   Recipients: require('./resources/Recipients'),

--- a/test/resources/Payouts.spec.js
+++ b/test/resources/Payouts.spec.js
@@ -1,0 +1,84 @@
+'use strict';
+
+var stripe = require('../testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+
+var PAYOUT_TEST_ID = 'po_testid1';
+
+describe('Payouts Resource', function() {
+  describe('retrieve', function() {
+    it('Sends the correct request', function() {
+      stripe.payouts.retrieve(PAYOUT_TEST_ID);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/payouts/' + PAYOUT_TEST_ID,
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('create', function() {
+    it('Sends the correct request', function() {
+      stripe.payouts.create({
+        amount: 200, currency: 'usd',
+      });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/payouts',
+        headers: {},
+        data: {amount: 200, currency: 'usd'},
+      });
+    });
+  });
+
+  describe('update', function() {
+    it('Sends the correct request', function() {
+      stripe.payouts.update(PAYOUT_TEST_ID, {
+        metadata: {key: 'value'},
+      });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/payouts/' + PAYOUT_TEST_ID,
+        headers: {},
+        data: {metadata: {key: 'value'}},
+      });
+    });
+  });
+
+  describe('cancel', function() {
+    it('Sends the correct request', function() {
+      stripe.payouts.cancel(PAYOUT_TEST_ID);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/payouts/' + PAYOUT_TEST_ID + '/cancel',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('list', function() {
+    it('Sends the correct request', function() {
+      stripe.payouts.list();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/payouts',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('listTransactions', function() {
+    it('Sends the correct request', function() {
+      stripe.payouts.listTransactions(PAYOUT_TEST_ID);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/payouts/' + PAYOUT_TEST_ID + '/transactions',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+});


### PR DESCRIPTION
The Transfer object used to represent all movements of funds in Stripe. It split in three resources:
- Transfer: this describes the movement of funds between Stripe accounts and is specific to Stripe Connect.
- Payout: this describes the movement of funds from a Stripe account to a bank account, debit card or any future payout method.
- RecipientTransfer: this describes the movement of funds from a Stripe account to a Recipient's card or Bank Account. This is here for legacy reasons and can only be accessed from an expanded BalanceTransaction.

This change is behind an API version so old API versions would still use the Transfer object for everything while new API version would see the split.

This applies beyond the new object as some properties/methods are removed from Transfer and other properties are renamed on other objects.
