### PR TITLE
Add section "Examining Responses"

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,6 +118,16 @@ if (process.env.http_proxy) {
 }
 ```
 
+### Examining Responses
+
+Some information about the response which generated a resource is available
+with the `lastResponse` property:
+
+```js
+charge.lastResponse.requestId // see: https://stripe.com/docs/api/python#request_ids
+charge.lastResponse.statusCode
+```
+
 ## More Information
 
  * [REST API Version](https://github.com/stripe/stripe-node/wiki/REST-API-Version)

--- a/README.md
+++ b/README.md
@@ -168,3 +168,7 @@ $ npm test
 [connect]: https://stripe.com/connect
 [https-proxy-agent]: https://github.com/TooTallNate/node-https-proxy-agent
 [stripe-js]: https://stripe.com/docs/stripe.js
+
+<!--
+# vim: set tw=79:
+-->


### PR DESCRIPTION
Adds a section that includes some basic information on looking at
response information.

Requested on #315.

r? @ob-stripe 

@stripe/api-libraries 