### PR TITLE
Improve error message when ommitting a parameter

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -50,9 +50,10 @@ function stripeMethod(spec) {
             continue;
           }
 
+          var path = this.createResourcePathWithSymbols(spec.path);
           var err = new Error(
             'Stripe: Argument "' + urlParams[i] + '" required, but got: ' + arg +
-            ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
+            ' (on API request to `' + requestMethod + ' ' + path + '`)'
           );
           reject(err);
           return;
@@ -65,10 +66,11 @@ function stripeMethod(spec) {
       var opts = utils.getOptionsFromArgs(args);
 
       if (args.length) {
+        var path = this.createResourcePathWithSymbols(spec.path);
         var err = new Error(
           'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options ' +
           'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.' +
-          ' (on API request to ' + requestMethod + ' ' + commandPath + ')'
+          ' (on API request to ' + requestMethod + ' `' + path + '`)'
         );
         reject(err);
         return;

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -26,6 +26,7 @@ function StripeResource(stripe, urlData) {
   this._urlData = urlData || {};
 
   this.basePath = utils.makeURLInterpolator(stripe.getApiField('basePath'));
+  this.resourcePath = this.path;
   this.path = utils.makeURLInterpolator(this.path);
 
   if (this.includeBasic) {
@@ -60,6 +61,16 @@ StripeResource.prototype = {
       this.path(urlData),
       typeof commandPath == 'function' ?
         commandPath(urlData) : commandPath
+    ).replace(/\\/g, '/'); // ugly workaround for Windows
+  },
+
+  // Creates a relative resource path with symbols left in (unlike
+  // createFullPath which takes some data to replace them with). For example it
+  // might produce: /invoices/{id}
+  createResourcePathWithSymbols: function(pathWithSymbols) {
+    return '/' + path.join(
+      this.resourcePath,
+      pathWithSymbols
     ).replace(/\\/g, '/'); // ugly workaround for Windows
   },
 

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+require('./testUtils');
+
+var stripe = require('./testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+
+describe('StripeResource', function() {
+  describe('createResourcePathWithSymbols', function() {
+    it('Generates a path', function() {
+      var invoice = stripe.invoices.create({});
+      var path = stripe.invoices.createResourcePathWithSymbols('{id}');
+      expect(path).to.equal('/invoices/{id}');
+    });
+  });
+});


### PR DESCRIPTION
Improve the error message when a `stripeMethod` is called but a
parameter is accidentally ommitted. Previously, we were accidentally
including the product of `utils.makeURLInterpolator` in the error
string, which made it very difficult to read:

```
Error: Stripe: Argument "id" required, but got: undefined (on API request to GET function (outputs) {
        return cleanString.replace(/\{([\s\S]+?)\}/g, function($0, $1) {
          return encodeURIComponent(outputs[$1] || '');
        });
      })
    at Object.<anonymous> (/Users/brandur/stripe/stripe-node/lib/StripeMethod.js:53:21)
```

I think this was basically an implementation accident, as what it's
actually trying to do is print the path of the API call that's about to
be invoked. We now produce this instead:

```
Error: Stripe: Argument "id" required, but got: undefined (on API request to `GET /invoices/{id}`)
    at Object.<anonymous> (/Users/brandur/stripe/stripe-node/lib/StripeMethod.js:53:21)
```

Fixes #323.

r? @ob-stripe 