### PR TITLE
Check to make sure the `id` is a String

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -44,6 +44,16 @@ function stripeMethod(spec) {
         var isOptional = OPTIONAL_REGEX.test(param);
         param = param.replace(OPTIONAL_REGEX, '');
 
+        if (param == 'id' && typeof arg !== 'string') {
+          var path = this.createResourcePathWithSymbols(spec.path);
+          var err = new Error(
+            'Stripe: "id" must be a string, but got: ' + typeof arg +
+            ' (on API request to `' + requestMethod + ' ' + path + '`)'
+          );
+          reject(err);
+          return;
+        }
+
         if (!arg) {
           if (isOptional) {
             urlData[param] = '';

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -123,6 +123,14 @@ describe('Charge Resource', function() {
       expect(
         stripe.charges.refund('chargeIdExample123', 39392)
       ).to.be.eventually.rejectedWith(/unknown arguments/i);
+
+      expect(
+        stripe.charges.refund({potato: 'chargeIdExample123'})
+      ).to.be.eventually.rejectedWith(/must be a string, but got: object/i);
+
+      expect(
+        stripe.charges.refund(442)
+      ).to.be.eventually.rejectedWith(/must be a string, but got: number/i);
     });
   });
 


### PR DESCRIPTION
If you accidentally do `stripe.charges.capture(chargeObject)` instead of `stripe.charges.capture(chargeObject.id)`, you currently get this error back from Stripe:

```
{ 
"type": "invalid_request_error", 
"message": "No such charge: [object Object]", 
"param": "id", 
"statusCode": 404, 
"requestId": "req_ABC123xyz" 
}
```

It would be better if you got something like this before the API call was even made:

```
Unhandled rejection Error: Stripe: "id" must be a string, but got: object (on API request to `POST /charges/{id}/refund`)
```

So ... that's what this does.  ¯\\\_(ツ)_/¯