### PR TITLE
Check if object property isPrototype before adding it to Constructor.

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,6 +5,7 @@ var crypto = require('crypto');
 
 var hasOwn = {}.hasOwnProperty;
 var isPlainObject = require('lodash.isplainobject');
+var objectAssign = require('object-assign');
 
 var utils = module.exports = {
 
@@ -97,17 +98,11 @@ var utils = module.exports = {
     var Constructor = hasOwn.call(sub, 'constructor') ? sub.constructor : function() {
       Super.apply(this, arguments);
     };
+
+    objectAssign(Constructor, Super);
     Constructor.prototype = Object.create(Super.prototype);
-    for (var i in sub) {
-      if (hasOwn.call(sub, i)) {
-        Constructor.prototype[i] = sub[i];
-      }
-    }
-    for (i in Super) {
-      if (i !== 'prototype' && hasOwn.call(Super, i)) {
-        Constructor[i] = Super[i];
-      }
-    }
+    objectAssign(Constructor.prototype, sub);
+
     return Constructor;
   },
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -104,7 +104,7 @@ var utils = module.exports = {
       }
     }
     for (i in Super) {
-      if (hasOwn.call(Super, i)) {
+      if (i !== 'prototype' && hasOwn.call(Super, i)) {
         Constructor[i] = Super[i];
       }
     }


### PR DESCRIPTION
Some JavaScript environments incorrectly expose `prototype` in the `Object.hasOwnProperty()` method. The `protoExtend()` function should handle this.
