### PR TITLE
Make response headers accessible on errors

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -40,6 +40,7 @@ var StripeError = _Error.StripeError = _Error.extend({
     this.message = raw.message;
     this.detail = raw.detail;
     this.raw = raw;
+    this.headers = raw.headers;
     this.requestId = raw.requestId;
     this.statusCode = raw.statusCode;
   },

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -140,9 +140,7 @@ StripeResource.prototype = {
           if (response.error) {
             var err;
 
-            // These are now available on the top-level resource's
-            // lastResponse, but we keep them here too for backwards
-            // compatibility.
+            response.error.headers = headers;
             response.error.statusCode = res.statusCode;
             response.error.requestId = res.requestId;
 

--- a/test/Error.spec.js
+++ b/test/Error.spec.js
@@ -22,6 +22,12 @@ describe('Error', function() {
       expect(Error.StripeError.generate({type: 'api_error'})).to.be.instanceOf(Error.StripeAPIError);
     });
 
+    it('Pulls in headers', function() {
+      var headers = {'Request-Id': '123'};
+      var e = Error.StripeError.generate({type: 'card_error', headers: headers});
+      expect(e).to.have.property('headers', headers);
+    });
+
     it('Pulls in request IDs', function() {
       var e = Error.StripeError.generate({type: 'card_error', requestId: 'foo'});
       expect(e).to.have.property('requestId', 'foo');


### PR DESCRIPTION
It can't hurt to have these accessible when handling an error. We
already have a few other pieces of response information like request ID
and status code, so it's fairly conventional.

Fixes #335.

r? @jlomas-stripe 