### PR TITLE
Add utils.arrayToObject() to retrieveUpcoming() for `subscription_items`

### DIFF
--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -29,6 +29,10 @@ module.exports = StripeResource.extend({
       if (urlData.invoiceOptions && typeof urlData.invoiceOptions === 'string') {
         return url + '&subscription=' + urlData.invoiceOptions;
       } else if (urlData.invoiceOptions && typeof urlData.invoiceOptions === 'object') {
+        if (urlData.invoiceOptions.subscription_items !== undefined) {
+          urlData.invoiceOptions.subscription_items = utils.arrayToObject(urlData.invoiceOptions.subscription_items);
+        }
+
         return url + '&' + utils.stringifyRequestData(urlData.invoiceOptions);
       }
       return url;

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -77,6 +77,25 @@ describe('Invoices Resource', function() {
       });
     });
 
+    describe('With a options object that includes `subscription_items`', function() {
+      it('Sends the correct request', function() {
+        stripe.invoices.retrieveUpcoming('customerId1', {
+          subscription_items: [
+            {plan: 'potato'},
+            {plan: 'rutabaga'},
+          ],
+        });
+
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/invoices/upcoming?customer=customerId1&' +
+            'subscription_items%5B0%5D%5Bplan%5D=potato&subscription_items%5B1%5D%5Bplan%5D=rutabaga',
+          headers: {},
+          data: {},
+        });
+      });
+    });
+
     describe('With a options object in addition to a customer ID', function() {
       it('Sends the correct request', function() {
         stripe.invoices.retrieveUpcoming('customerId1', {plan: 'planId123'});


### PR DESCRIPTION
Given the following: 

```
stripe.invoices.retrieveUpcoming(customerId, {
    subscription: subscriptionId,
    subscription_items: [
      {
        id: itemToDelete,
        deleted: true
      },
      {
        plan: 'something-1'
      },
      {
        plan: 'something-2'
      }
    ],
    subscription_prorate: true
  });
```

The result would only contain one new plan - specifically, `something-2`, because the API can't find the boundary there.

This PR makes use of the same thing that was [used in `Subscription.update`](https://github.com/stripe/stripe-node/blob/bd4bd44975d4427aad60a488e959f10677f396e9/lib/resources/Subscriptions.js#L28) to make sure the arrays get converted into indexed objects.