### PR TITLE
Add parameters when calling `pay` on an invoice

### DIFF
--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -111,12 +111,14 @@ describe('Invoices Resource', function() {
 
   describe('pay', function() {
     it('Sends the correct request', function() {
-      stripe.invoices.pay('invoiceId6');
+      stripe.invoices.pay('invoiceId6', {
+        source: 'tok_FooBar',
+      });
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'POST',
         url: '/v1/invoices/invoiceId6/pay',
         headers: {},
-        data: {},
+        data: {source: 'tok_FooBar'},
       });
     });
   });


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @ark-stripe

Users can now provide a `source` parameter when paying invoices. The Node library actually already supports this, I just updated the test to make sure that sending parameters is supported.
