### PR TITLE
Remove header keys instead of discarding argument if it contains a he…

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -54,10 +54,13 @@ var utils = module.exports = {
    * Return the data argument from a list of arguments
    */
   getDataFromArgs: function(args) {
-    if (args.length > 0) {
-      if (isPlainObject(args[0]) && !utils.isOptionsHash(args[0])) {
-        return args.shift();
-      }
+    if (args.length > 0 && isPlainObject(args[0])) {
+      var headerKeys = ['api_key', 'idempotency_key', 'stripe_account', 'stripe_version'];
+      var result = args.shift();
+      headerKeys.map(function(k) {
+        delete result[k];
+      });
+      return result;
     }
     return {};
   },


### PR DESCRIPTION
args was getting discarded if it contained stripe_account (or other headers) which caused the stripe.balance.listTransactions call to ignore paging calls like limit and starting_after keys if using a Stripe Connect account.