### PR TITLE
Handle Buffer.from TypeError on node versions prior to 4.5.x

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -162,5 +162,18 @@ function asBuffer(thing) {
     return thing;
   }
 
-  return Buffer.from ? Buffer.from(thing) : new Buffer(thing);
+  if (Buffer.from) {
+    // Buffer.from fix for node versions prior to 4.5.x
+    try {
+      return Buffer.from(thing);
+    } catch (e) {
+      if (e instanceof TypeError) {
+        return new Buffer(thing);
+      } else {
+        throw e;
+      }
+    }
+  } else {
+    return new Buffer(thing);
+  }
 }


### PR DESCRIPTION
The tests are currently failing on node v4 and versions prior to v4.5.x due to a mismatch in the **Buffer.from** API. This was fixed in https://github.com/nodejs/node/pull/7562 and backported to v4.5.x. PR fixes the current use of the function by handling the **TypeError** being thrown.

Alternative solutions:
- Exclude the failing node versions in package.json
- Use semver checking to use the correct API instead of handling the exception