### PR TITLE
Add `request` and `response` events to Stripe object

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,48 @@ charge.lastResponse.requestId // see: https://stripe.com/docs/api/node#request_i
 charge.lastResponse.statusCode
 ```
 
+### `request` and `response` events
+
+The Stripe object emits `request` and `response` events.  You can use them like this:
+
+```js
+var stripe = require('stripe')('sk_test_...');
+
+function onRequest(request) {
+  // Do something.
+}
+
+stripe.on('request', onRequest);
+
+stripe.removeListener('request', onRequest);
+// OR: stripe.off('request', onRequest);
+```
+
+#### `request` object
+```js
+{
+  api_version: 'latest',
+  account: 'acct_TEST',       // Only present if provided
+  idempotency_key: 'abc123',  // Only present if provided
+  method: 'POST',
+  path: '/v1/charges'
+}
+```
+
+#### `response` object
+```js
+{
+  api_version: 'latest',
+  account: 'acct_TEST',       // Only present if provided
+  idempotency_key: 'abc123',  // Only present if provided
+  method: 'POST',
+  path: '/v1/charges',
+  status: 402,
+  request_id: 'req_Ghc9r26ts73DRf',
+  elapsed: 445
+}
+```
+
 ### Webhook signing
 
 Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party.  You can read more about it [here](https://stripe.com/docs/webhooks#signatures).

--- a/README.md
+++ b/README.md
@@ -139,10 +139,11 @@ function onRequest(request) {
   // Do something.
 }
 
+// Add the event handler function:
 stripe.on('request', onRequest);
 
-stripe.removeListener('request', onRequest);
-// OR: stripe.off('request', onRequest);
+// Remove the event handler function:
+stripe.off('request', onRequest);
 ```
 
 #### `request` object
@@ -166,7 +167,7 @@ stripe.removeListener('request', onRequest);
   path: '/v1/charges',
   status: 402,
   request_id: 'req_Ghc9r26ts73DRf',
-  elapsed: 445
+  elapsed: 445                // Elapsed time in milliseconds
 }
 ```
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -134,12 +134,25 @@ StripeResource.prototype = {
       res.on('end', function() {
         var headers = res.headers || {};
 
+        // For convenience, make Request-Id easily accessible on
+        // lastResponse.
+        res.requestId = headers['request-id'];
+
+        var responseEvent = utils.removeEmpty({
+          api_version: req._requestEvent.api_version,
+          account: headers['Stripe-Account'],
+          idempotency_key: headers['Idempotency-Key'],
+          method: req._requestEvent.method,
+          path: req._requestEvent.path,
+          status: res.statusCode,
+          request_id: res.requestId,
+          elapsed: Date.now() - req._requestStart,
+        });
+
+        self._stripe._emitter.emit('response', responseEvent);
+
         try {
           response = JSON.parse(response);
-
-          // For convenience, make Request-Id easily accessible on
-          // lastResponse.
-          res.requestId = headers['request-id'];
 
           if (response.error) {
             var err;
@@ -262,6 +275,20 @@ StripeResource.prototype = {
         ciphers: 'DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2:!MD5',
       });
 
+      var requestEvent = utils.removeEmpty({
+        api_version: apiVersion,
+        account: headers['Stripe-Account'],
+        idempotency_key: headers['Idempotency-Key'],
+        method: method,
+        path: path,
+      });
+
+      req._requestEvent = requestEvent;
+
+      req._requestStart = Date.now();
+
+      self._stripe._emitter.emit('request', requestEvent);
+
       req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));
       req.on('response', self._responseHandler(req, callback));
       req.on('error', self._errorHandler(req, callback));
@@ -270,6 +297,7 @@ StripeResource.prototype = {
         socket.on((isInsecureConnection ? 'connect' : 'secureConnect'), function() {
           // Send payload; we're safe:
           req.write(requestData);
+
           req.end();
         });
       });

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -133,15 +133,16 @@ StripeResource.prototype = {
       });
       res.on('end', function() {
         var headers = res.headers || {};
+        // NOTE: Stripe responds with lowercase header names/keys.
 
         // For convenience, make Request-Id easily accessible on
         // lastResponse.
         res.requestId = headers['request-id'];
 
         var responseEvent = utils.removeEmpty({
-          api_version: req._requestEvent.api_version,
-          account: headers['Stripe-Account'],
-          idempotency_key: headers['Idempotency-Key'],
+          api_version: headers['stripe-version'],
+          account: headers['stripe-account'],
+          idempotency_key: headers['idempotency-key'],
           method: req._requestEvent.method,
           path: req._requestEvent.path,
           status: res.statusCode,

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -23,10 +23,10 @@ Stripe.USER_AGENT_SERIALIZED = null;
 
 var APP_INFO_PROPERTIES = ['name', 'version', 'url'];
 
-var exec = require('child_process').exec;
-var util = require('util');
 var EventEmitter = require('events').EventEmitter;
+var exec = require('child_process').exec;
 var objectAssign = require('object-assign');
+var util = require('util');
 
 var resources = {
   // Support Accounts for consistency, Account for backwards compat
@@ -88,7 +88,7 @@ function Stripe(key, version) {
   });
 
   this.on = this._emitter.on.bind(this._emitter);
-  this.off = this.removeListener = this._emitter.removeListener.bind(this._emitter);
+  this.off = this._emitter.removeListener.bind(this._emitter);
 
   this._api = {
     auth: null,

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -24,6 +24,9 @@ Stripe.USER_AGENT_SERIALIZED = null;
 var APP_INFO_PROPERTIES = ['name', 'version', 'url'];
 
 var exec = require('child_process').exec;
+var util = require('util');
+var EventEmitter = require('events').EventEmitter;
+var objectAssign = require('object-assign');
 
 var resources = {
   // Support Accounts for consistency, Account for backwards compat
@@ -76,6 +79,16 @@ function Stripe(key, version) {
   if (!(this instanceof Stripe)) {
     return new Stripe(key, version);
   }
+
+  Object.defineProperty(this, '_emitter', {
+    value: new EventEmitter(),
+    enumerable: false,
+    configurable: false,
+    writeable: false,
+  });
+
+  this.on = this._emitter.on.bind(this._emitter);
+  this.off = this.removeListener = this._emitter.removeListener.bind(this._emitter);
 
   this._api = {
     auth: null,

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -155,6 +155,23 @@ var utils = module.exports = {
     }
     return result === 0;
   },
+
+  /**
+  * Remove empty values from an object
+  */
+  removeEmpty: function(obj) {
+    if (typeof obj !== 'object') {
+      throw new Error('Argument must be an object');
+    }
+
+    Object.keys(obj).forEach(function(key) {
+      if (obj[key] === null || obj[key] === undefined) {
+        delete obj[key];
+      }
+    });
+
+    return obj;
+  },
 };
 
 function asBuffer(thing) {

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -410,4 +410,75 @@ describe('Flows', function() {
       ).to.eventually.have.property('object', 'three_d_secure');
     });
   });
+
+  describe('Request/Response Events', function() {
+    it('should emit a `request` event to listeners on request', function(done) {
+      var idempotency_key = Math.random().toString(36).slice(2);
+
+      function onRequest(request) {
+        stripe.removeListener('request', onRequest);
+
+        expect(request).to.eql({
+          api_version: 'latest',
+          idempotency_key: idempotency_key,
+          method: 'POST',
+          path: '/v1/charges',
+        });
+
+        done();
+      }
+
+      stripe.on('request', onRequest);
+
+      stripe.charges.create({
+        amount: 1234,
+        currency: 'usd',
+        card: 'tok_chargeDeclined',
+      }, {
+        idempotency_key: idempotency_key,
+      }).then(null, function() {});
+    });
+
+    it('should emit a `response` event to listeners on response', function(done) {
+      function onResponse(response) {
+        stripe.removeListener('response', onResponse);
+
+        expect(response.api_version).to.equal('latest');
+        expect(response.method).to.equal('POST');
+        expect(response.path).to.equal('/v1/charges');
+        expect(response.request_id).to.match(/req_[\w\d]/);
+        expect(response.status).to.equal(402);
+        expect(response.elapsed).to.be.within(50, 30000);;
+
+        done();
+      }
+
+      stripe.on('response', onResponse);
+
+      stripe.charges.create({
+        amount: 1234,
+        currency: 'usd',
+        card: 'tok_chargeDeclined',
+      }).then(null, function() {
+        // I expect there to be an error here.
+      });
+    });
+
+    it('should not emit a `response` event to removed listeners on response', function(done) {
+      function onResponse(response) {
+        done(new Error('How did you get here?'));
+      }
+
+      stripe.on('response', onResponse);
+      stripe.removeListener('response', onResponse);
+
+      stripe.charges.create({
+        amount: 1234,
+        currency: 'usd',
+        card: 'tok_visa',
+      }).then(function() {
+        done();
+      });
+    });
+  });
 });

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -412,17 +412,38 @@ describe('Flows', function() {
   });
 
   describe('Request/Response Events', function() {
+    var connectedAccountId;
+
+    before(function(done) {
+      // Pick a random connected account to use in the `Stripe-Account` header
+      stripe.accounts.list({
+        limit: 1,
+      }).then(function(accounts) {
+        if (accounts.data.length < 1) {
+          return done(
+            new Error('Test requires at least one Connected Account in the Test Account')
+          );
+        }
+
+        connectedAccountId = accounts.data[0].id;
+
+        done();
+      });
+    });
+
     it('should emit a `request` event to listeners on request', function(done) {
-      var idempotency_key = Math.random().toString(36).slice(2);
+      var apiVersion = '2017-06-05';
+      var idempotencyKey = Math.random().toString(36).slice(2);
 
       function onRequest(request) {
-        stripe.removeListener('request', onRequest);
+        stripe.off('request', onRequest);
 
         expect(request).to.eql({
           api_version: 'latest',
-          idempotency_key: idempotency_key,
+          idempotency_key: idempotencyKey,
           method: 'POST',
           path: '/v1/charges',
+          account: connectedAccountId,
         });
 
         done();
@@ -435,15 +456,30 @@ describe('Flows', function() {
         currency: 'usd',
         card: 'tok_chargeDeclined',
       }, {
-        idempotency_key: idempotency_key,
-      }).then(null, function() {});
+        api_version: apiVersion,
+        idempotency_key: idempotencyKey,
+        stripe_account: connectedAccountId,
+      }).then(null, function() {
+        // I expect there to be an error here.
+      });
     });
 
     it('should emit a `response` event to listeners on response', function(done) {
-      function onResponse(response) {
-        stripe.removeListener('response', onResponse);
+      var apiVersion = '2017-06-05';
+      var idempotencyKey = Math.random().toString(36).slice(2);
 
-        expect(response.api_version).to.equal('latest');
+      function onResponse(response) {
+        // On the off chance we're picking up a response from a differentrequest
+        // then just ignore this and wait for the right one:
+        if (response.idempotency_key !== idempotencyKey) {
+          return;
+        }
+
+        stripe.off('response', onResponse);
+
+        expect(response.api_version).to.equal(apiVersion);
+        expect(response.idempotency_key).to.equal(idempotencyKey);
+        expect(response.account).to.equal(connectedAccountId);
         expect(response.method).to.equal('POST');
         expect(response.path).to.equal('/v1/charges');
         expect(response.request_id).to.match(/req_[\w\d]/);
@@ -459,6 +495,10 @@ describe('Flows', function() {
         amount: 1234,
         currency: 'usd',
         card: 'tok_chargeDeclined',
+      }, {
+        api_version: apiVersion,
+        idempotency_key: idempotencyKey,
+        stripe_account: connectedAccountId,
       }).then(null, function() {
         // I expect there to be an error here.
       });
@@ -470,7 +510,7 @@ describe('Flows', function() {
       }
 
       stripe.on('response', onResponse);
-      stripe.removeListener('response', onResponse);
+      stripe.off('response', onResponse);
 
       stripe.charges.create({
         amount: 1234,

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -224,4 +224,22 @@ describe('utils', function() {
       expect(function() { utils.secureCompare('potato'); }).to.throw();
     });
   });
+
+  describe('removeEmpty', function() {
+    it('removes empty properties and leave non-empty ones', function() {
+      expect(utils.removeEmpty({
+        cat: 3,
+        dog: false,
+        rabbit: undefined,
+        pointer: null,
+      })).to.eql({
+        cat: 3,
+        dog: false,
+      });
+    });
+
+    it('throws an error if not given two things to compare', function() {
+      expect(function() { utils.removeEmpty('potato'); }).to.throw();
+    });
+  });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -226,7 +226,7 @@ describe('utils', function() {
   });
 
   describe('removeEmpty', function() {
-    it('removes empty properties and leave non-empty ones', function() {
+    it('removes empty properties and leaves non-empty ones', function() {
       expect(utils.removeEmpty({
         cat: 3,
         dog: false,


### PR DESCRIPTION
Still need to add docs; I can't get `jscs` to run without 💥 for some reason, so ... I'm making Travis-CI run my linting.  ¯\\\_(ツ)_/¯