### PR TITLE
Switch from using timestamps to a random string in tests

### DIFF
--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -41,7 +41,7 @@ describe('Flows', function() {
       return expect(
         Promise.join(
           stripe.plans.create({
-            id: 'plan' + (new Date()).getTime(),
+            id: 'plan' + testUtils.getRandomString(),
             amount: 1700,
             currency: CURRENCY,
             interval: 'month',
@@ -69,7 +69,7 @@ describe('Flows', function() {
         return expect(
           Promise.join(
             stripe.plans.create({
-              id: 'plan' + (new Date()).getTime(),
+              id: 'plan' + testUtils.getRandomString(),
               amount: 1700,
               currency: CURRENCY,
               interval: 'month',
@@ -104,7 +104,7 @@ describe('Flows', function() {
             cleanup.deleteCustomer(customer.id);
 
             return stripe.customers.updateSubscription(customer.id, {
-              plan: 'someNonExistentPlan' + (new Date()).getTime(),
+              plan: 'someNonExistentPlan' + testUtils.getRandomString(),
             }).then(null, function(err) {
               // Resolve with the error so we can inspect it below
               return err;
@@ -120,7 +120,7 @@ describe('Flows', function() {
       return expect(
         Promise.join(
           stripe.plans.create({
-            id: 'plan' + (new Date()).getTime(),
+            id: 'plan' + testUtils.getRandomString(),
             amount: 1700,
             currency: CURRENCY,
             interval: 'month',
@@ -147,10 +147,10 @@ describe('Flows', function() {
 
     describe('Plan name variations', function() {
       [
-        '34535 355453' + (new Date()).getTime(),
-        'TEST 239291' + (new Date()).getTime(),
-        'TEST_a-i' + (new Date()).getTime(),
-        'foobarbazteston###etwothree' + (new Date()).getTime(),
+        '34535 355453' + testUtils.getRandomString(),
+        'TEST 239291' + testUtils.getRandomString(),
+        'TEST_a-i' + testUtils.getRandomString(),
+        'foobarbazteston###etwothree' + testUtils.getRandomString(),
       ].forEach(function(planID) {
         it('Allows me to create and retrieve plan with ID: ' + planID, function() {
           var plan;

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -137,7 +137,7 @@ describe('Stripe Module', function() {
 
     it('should be included in the ClientUserAgent and be added to the UserAgent String', function(done) {
       var appInfo = {
-        name: Math.random().toString(36).slice(2),
+        name: testUtils.getRandomString(),
         version: '1.2.345',
         url: 'https://myawesomeapp.info',
       };

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -122,5 +122,11 @@ var utils = module.exports = {
     return CleanupUtility;
   }()),
 
-};
+  /**
+  * Get a random string for test Object creation
+  */
+  getRandomString: function() {
+    return Math.random().toString(36).slice(2);
+  },
 
+};


### PR DESCRIPTION
A [test just popped](https://travis-ci.org/stripe/stripe-node/jobs/262392702) because we are using timestamps as our 'random string suffix' and ... the tests happened in the same second.

This just switches those all from a timestamp to a random string.