### PR TITLE
Explicitly specify utf8 encoding when calculating signature

### DIFF
--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -20,7 +20,7 @@ var signature = {
 
   _computeSignature: function(payload, secret) {
     return crypto.createHmac('sha256', secret)
-      .update(payload)
+      .update(payload, 'utf8')
       .digest('hex');
   },
 

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -432,7 +432,7 @@ describe('Flows', function() {
     });
 
     it('should emit a `request` event to listeners on request', function(done) {
-      var apiVersion = '2017-06-05';
+      var apiVersion = '2017-08-15';
       var idempotencyKey = Math.random().toString(36).slice(2);
 
       function onRequest(request) {
@@ -465,7 +465,7 @@ describe('Flows', function() {
     });
 
     it('should emit a `response` event to listeners on response', function(done) {
-      var apiVersion = '2017-06-05';
+      var apiVersion = '2017-08-15';
       var idempotencyKey = Math.random().toString(36).slice(2);
 
       function onResponse(response) {

--- a/test/resources/EphemeralKeys.spec.js
+++ b/test/resources/EphemeralKeys.spec.js
@@ -12,7 +12,7 @@ function errorsOnNoStripeVersion() {
 function sendsCorrectStripeVersion() {
   stripe.ephemeralKeys.create(
     {customer: 'cus_123'},
-    {stripe_version: '2017-06-05'}
+    {stripe_version: '2017-08-15'}
   );
 
   expect(stripe.LAST_REQUEST).to.deep.equal({
@@ -22,7 +22,7 @@ function sendsCorrectStripeVersion() {
       customer: 'cus_123',
     },
     headers: {
-      'Stripe-Version': '2017-06-05',
+      'Stripe-Version': '2017-08-15',
     },
   });
 }


### PR DESCRIPTION
This is a pull-request for a supporting ticket titled as "Signatures failing when using UTF-8 in charge". (Sorry I am not sure where to find the ticket number)

In some Ubuntu environments, the `payload` might follows another encoding and even setting the request encoding to 'utf8' will not affect the received data. Explicitly setting the encoding to 'utf8' will ensure that Stripe side and user side using the same encoding when computing signature.