### PR TITLE
Fix request headers in tests

### DIFF
--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -456,7 +456,7 @@ describe('Flows', function() {
         currency: 'usd',
         card: 'tok_chargeDeclined',
       }, {
-        api_version: apiVersion,
+        stripe_version: apiVersion,
         idempotency_key: idempotencyKey,
         stripe_account: connectedAccountId,
       }).then(null, function() {
@@ -496,7 +496,7 @@ describe('Flows', function() {
         currency: 'usd',
         card: 'tok_chargeDeclined',
       }, {
-        api_version: apiVersion,
+        stripe_version: apiVersion,
         idempotency_key: idempotencyKey,
         stripe_account: connectedAccountId,
       }).then(null, function() {


### PR DESCRIPTION
_My tests were bad and I should feel bad._

I was sending `api_version` in the header, instead of `stripe_version`, so it ... wasn't actually setting them.

Couldn't understand why the versions needed updating in #371 but after investigating I realized it's because I wasn't _actually_ specifying them, and `latest` no longer mapped to the value I was using.

r? @brandur-stripe 