### PR TITLE
Use Bearer auth

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -214,6 +214,31 @@ StripeResource.prototype = {
     }
   },
 
+  _defaultHeaders: function(auth, contentLength, apiVersion) {
+    var userAgentString = 'Stripe/v1 NodeBindings/' + this._stripe.getConstant('PACKAGE_VERSION');
+
+    if (this._stripe._appInfo) {
+      userAgentString += ' ' + this._stripe.getAppInfoAsString();
+    }
+
+    var headers = {
+      // Use specified auth token or use default from this stripe instance:
+      'Authorization': auth ?
+        'Bearer ' + auth :
+        this._stripe.getApiField('auth'),
+      'Accept': 'application/json',
+      'Content-Type': 'application/x-www-form-urlencoded',
+      'Content-Length': contentLength,
+      'User-Agent': userAgentString,
+    };
+
+    if (apiVersion) {
+      headers['Stripe-Version'] = apiVersion;
+    }
+
+    return headers;
+  },
+
   _request: function(method, path, data, auth, options, callback) {
     var self = this;
     var requestData;
@@ -226,26 +251,7 @@ StripeResource.prototype = {
 
     var apiVersion = this._stripe.getApiField('version');
 
-    var userAgentString = 'Stripe/v1 NodeBindings/' + this._stripe.getConstant('PACKAGE_VERSION');
-
-    if (this._stripe._appInfo) {
-      userAgentString += ' ' + this._stripe.getAppInfoAsString();
-    }
-
-    var headers = {
-      // Use specified auth token or use default from this stripe instance:
-      'Authorization': auth ?
-        'Basic ' + new Buffer(auth + ':').toString('base64') :
-        this._stripe.getApiField('auth'),
-      'Accept': 'application/json',
-      'Content-Type': 'application/x-www-form-urlencoded',
-      'Content-Length': requestData.length,
-      'User-Agent': userAgentString,
-    };
-
-    if (apiVersion) {
-      headers['Stripe-Version'] = apiVersion;
-    }
+    var headers = self._defaultHeaders(auth, requestData.length, apiVersion);
 
     // Grab client-user-agent before making the request:
     this._stripe.getClientUserAgent(function(cua) {

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -138,7 +138,7 @@ Stripe.prototype = {
     if (key) {
       this._setApiField(
         'auth',
-        'Basic ' + new Buffer(key + ':').toString('base64')
+        'Bearer ' + key
       );
     }
   },

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -13,4 +13,23 @@ describe('StripeResource', function() {
       expect(path).to.equal('/invoices/{id}');
     });
   });
+
+  describe('_defaultHeaders', function() {
+    it('sets the Authorization header with Bearer auth using the global API key', function() {
+      var headers = stripe.invoices._defaultHeaders(null, 0, null);
+      expect(headers.Authorization).to.equal('Bearer fakeAuthToken');
+    });
+    it('sets the Authorization header with Bearer auth using the specified API key', function() {
+      var headers = stripe.invoices._defaultHeaders('anotherFakeAuthToken', 0, null);
+      expect(headers.Authorization).to.equal('Bearer anotherFakeAuthToken');
+    });
+    it('sets the Stripe-Version header if an API version is provided', function() {
+      var headers = stripe.invoices._defaultHeaders(null, 0, '1970-01-01');
+      expect(headers['Stripe-Version']).to.equal('1970-01-01');
+    });
+    it('does not the set the Stripe-Version header if no API version is provided', function() {
+      var headers = stripe.invoices._defaultHeaders(null, 0, null);
+      expect(headers).to.not.include.keys('Stripe-Version');
+    });
+  });
 });

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -20,6 +20,12 @@ describe('Stripe Module', function() {
   var cleanup = new testUtils.CleanupUtility();
   this.timeout(20000);
 
+  describe('setApiKey', function() {
+    it('uses Bearer auth', function() {
+      expect(stripe.getApiField('auth')).to.equal('Bearer ' + testUtils.getUserStripeKey());
+    });
+  });
+
   describe('GetClientUserAgent', function() {
     it('Should return a user-agent serialized JSON object', function() {
       return expect(new Promise(function(resolve, reject) {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Use Bearer auth instead of Basic auth to authenticate with the API.

I don't have much experience working with Node so it's possible what I've written isn't very idiomatic.