### PR TITLE
Prevent package-lock.json files from being created

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+package-lock = false


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

npm 5 creates a `package-lock.json` and recommends commiting it to the the repo. When present, the lock file is used instead of `package.json`.

This makes sense for apps, but not for libraries like stripe-node. This PR adds a `.npmrc` config file so that npm will not create `package-lock.json` files.
