### PR TITLE
Use ESLint instead of jscs

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,0 +1,292 @@
+module.exports = {
+    "env": {
+        "node": true
+    },
+    "extends": "eslint:recommended",
+    "rules": {
+        "accessor-pairs": "error",
+        "array-bracket-spacing": [
+            "error",
+            "never"
+        ],
+        "array-callback-return": "off",
+        "arrow-body-style": "error",
+        "arrow-parens": "error",
+        "arrow-spacing": "error",
+        "block-scoped-var": "off",
+        "block-spacing": "off",
+        "brace-style": [
+            "error",
+            "1tbs",
+            {
+                "allowSingleLine": true
+            }
+        ],
+        "callback-return": "error",
+        "camelcase": [
+            "error",
+            {
+                "properties": "never"
+            }
+        ],
+        "capitalized-comments": "off",
+        "class-methods-use-this": "error",
+        "comma-dangle": "off",
+        "comma-spacing": "off",
+        "comma-style": [
+            "error",
+            "last"
+        ],
+        "complexity": "error",
+        "computed-property-spacing": [
+            "error",
+            "never"
+        ],
+        "consistent-return": "off",
+        "consistent-this": "off",
+        "curly": "error",
+        "default-case": "off",
+        "dot-location": [
+            "error",
+            "property"
+        ],
+        "dot-notation": "error",
+        "eol-last": "error",
+        "eqeqeq": "off",
+        "func-call-spacing": "error",
+        "func-name-matching": "error",
+        "func-names": "off",
+        "func-style": [
+            "error",
+            "declaration"
+        ],
+        "generator-star-spacing": "error",
+        "global-require": "off",
+        "guard-for-in": "off",
+        "handle-callback-err": "off",
+        "id-blacklist": "error",
+        "id-length": "off",
+        "id-match": "error",
+        "indent": "off",
+        "init-declarations": "off",
+        "jsx-quotes": "error",
+        "key-spacing": "error",
+        "keyword-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": true
+            }
+        ],
+        "line-comment-position": "off",
+        "linebreak-style": [
+            "error",
+            "unix"
+        ],
+        "lines-around-comment": "error",
+        "lines-around-directive": "error",
+        "max-depth": "error",
+        "max-len": "off",
+        "max-lines": "off",
+        "max-nested-callbacks": "error",
+        "max-params": "off",
+        "max-statements": "off",
+        "max-statements-per-line": "off",
+        "multiline-ternary": "off",
+        "new-cap": "error",
+        "new-parens": "error",
+        "newline-after-var": "off",
+        "newline-before-return": "off",
+        "newline-per-chained-call": "off",
+        "no-alert": "error",
+        "no-array-constructor": "error",
+        "no-await-in-loop": "error",
+        "no-bitwise": "off",
+        "no-caller": "error",
+        "no-catch-shadow": "off",
+        "no-compare-neg-zero": "error",
+        "no-confusing-arrow": "error",
+        "no-continue": "off",
+        "no-div-regex": "error",
+        "no-duplicate-imports": "error",
+        "no-else-return": "off",
+        "no-empty-function": "off",
+        "no-eq-null": "off",
+        "no-eval": "error",
+        "no-extend-native": "error",
+        "no-extra-bind": "error",
+        "no-extra-label": "error",
+        "no-extra-parens": "off",
+        "no-floating-decimal": "error",
+        "no-implicit-globals": "error",
+        "no-implied-eval": "error",
+        "no-inline-comments": "off",
+        "no-inner-declarations": [
+            "error",
+            "functions"
+        ],
+        "no-invalid-this": "off",
+        "no-iterator": "error",
+        "no-label-var": "error",
+        "no-labels": "error",
+        "no-lone-blocks": "error",
+        "no-lonely-if": "error",
+        "no-loop-func": "error",
+        "no-magic-numbers": "off",
+        "no-mixed-operators": "error",
+        "no-mixed-requires": "error",
+        "no-multi-assign": "off",
+        "no-multi-spaces": "error",
+        "no-multi-str": "error",
+        "no-multiple-empty-lines": "error",
+        "no-native-reassign": "error",
+        "no-negated-condition": "off",
+        "no-negated-in-lhs": "error",
+        "no-nested-ternary": "error",
+        "no-new": "error",
+        "no-new-func": "error",
+        "no-new-object": "error",
+        "no-new-require": "error",
+        "no-new-wrappers": "error",
+        "no-octal-escape": "error",
+        "no-param-reassign": "off",
+        "no-path-concat": "error",
+        "no-plusplus": [
+            "error",
+            {
+                "allowForLoopAfterthoughts": true
+            }
+        ],
+        "no-process-env": "off",
+        "no-process-exit": "error",
+        "no-proto": "error",
+        "no-prototype-builtins": "off",
+        "no-restricted-globals": "error",
+        "no-restricted-imports": "error",
+        "no-restricted-modules": "error",
+        "no-restricted-properties": "error",
+        "no-restricted-syntax": "error",
+        "no-return-assign": "error",
+        "no-return-await": "error",
+        "no-script-url": "error",
+        "no-self-compare": "error",
+        "no-sequences": "error",
+        "no-shadow": "off",
+        "no-shadow-restricted-names": "error",
+        "no-spaced-func": "error",
+        "no-sync": "error",
+        "no-tabs": "error",
+        "no-template-curly-in-string": "error",
+        "no-ternary": "off",
+        "no-throw-literal": "error",
+        "no-trailing-spaces": "error",
+        "no-undef-init": "error",
+        "no-undefined": "off",
+        "no-underscore-dangle": "off",
+        "no-unmodified-loop-condition": "error",
+        "no-unneeded-ternary": "error",
+        "no-unused-expressions": "error",
+        "no-unused-vars": [
+            "error",
+            {
+                "args": "none"
+            }
+        ],
+        "no-use-before-define": "off",
+        "no-useless-call": "error",
+        "no-useless-computed-key": "error",
+        "no-useless-concat": "error",
+        "no-useless-constructor": "error",
+        "no-useless-escape": "off",
+        "no-useless-rename": "error",
+        "no-useless-return": "error",
+        "no-var": "off",
+        "no-void": "error",
+        "no-warning-comments": "error",
+        "no-whitespace-before-property": "error",
+        "no-with": "error",
+        "nonblock-statement-body-position": "error",
+        "object-curly-newline": "off",
+        "object-curly-spacing": [
+            "error",
+            "never"
+        ],
+        "object-property-newline": "off",
+        "object-shorthand": "off",
+        "one-var": "off",
+        "one-var-declaration-per-line": "error",
+        "operator-assignment": [
+            "error",
+            "always"
+        ],
+        "operator-linebreak": "off",
+        "padded-blocks": "off",
+        "prefer-arrow-callback": "off",
+        "prefer-const": "error",
+        "prefer-destructuring": [
+            "error",
+            {
+                "array": false,
+                "object": false
+            }
+        ],
+        "prefer-numeric-literals": "error",
+        "prefer-promise-reject-errors": "error",
+        "prefer-reflect": "off",
+        "prefer-rest-params": "off",
+        "prefer-spread": "off",
+        "prefer-template": "off",
+        "quote-props": "off",
+        "quotes": [
+            "error",
+            "single",
+            {
+                "avoidEscape": true
+            }
+        ],
+        "radix": "error",
+        "require-await": "error",
+        "require-jsdoc": "off",
+        "rest-spread-spacing": "error",
+        "semi": "off",
+        "semi-spacing": [
+            "error",
+            {
+                "after": true,
+                "before": false
+            }
+        ],
+        "sort-imports": "error",
+        "sort-keys": "off",
+        "sort-vars": "error",
+        "space-before-blocks": "error",
+        "space-before-function-paren": "off",
+        "space-in-parens": [
+            "error",
+            "never"
+        ],
+        "space-infix-ops": "error",
+        "space-unary-ops": "error",
+        "spaced-comment": [
+            "error",
+            "always"
+        ],
+        "strict": "off",
+        "symbol-description": "error",
+        "template-curly-spacing": "error",
+        "template-tag-spacing": "error",
+        "unicode-bom": [
+            "error",
+            "never"
+        ],
+        "valid-jsdoc": "off",
+        "vars-on-top": "off",
+        "wrap-iife": "error",
+        "wrap-regex": "off",
+        "yield-star-spacing": "error",
+        "yoda": [
+            "error",
+            "never"
+        ]
+    }
+};

--- a/.jscsrc
+++ b/.jscsrc
@@ -1,8 +1,0 @@
-{
-  "plugins": ["stripe-javascript-style"],
-  "preset": "stripe",
-  "disallowKeywords": ["with"],
-  "requireSpread": false,
-  "requireTemplateStrings": false,
-  "requireCamelCaseOrUpperCaseIdentifiers": false
-}

--- a/examples/webhook-signing/.eslintrc.js
+++ b/examples/webhook-signing/.eslintrc.js
@@ -1,0 +1,9 @@
+module.exports = {
+    "parserOptions": {
+       "ecmaVersion": 6
+     },
+     "rules": {
+        "new-cap": "off",
+        "no-console": "off"
+    }
+};

--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -11,8 +11,8 @@ const Express = require('express');
  * STRIPE_API_KEY=sk_test_XXX WEBHOOK_SECRET=whsec_XXX node express.js
  */
 
-const apiKey = process.env['STRIPE_API_KEY'];
-const webhookSecret = process.env['WEBHOOK_SECRET']
+const apiKey = process.env.STRIPE_API_KEY;
+const webhookSecret = process.env.WEBHOOK_SECRET;
 
 const stripe = Stripe(apiKey);
 

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -33,6 +33,9 @@ function stripeMethod(spec) {
 
     return this.wrapTimeout(new Promise((function(resolve, reject) {
       for (var i = 0, l = urlParams.length; i < l; ++i) {
+        var path
+        var err;
+
         // Note that we shift the args array after every iteration so this just
         // grabs the "next" argument for use as a URL parameter.
         var arg = args[0];
@@ -43,8 +46,8 @@ function stripeMethod(spec) {
         param = param.replace(OPTIONAL_REGEX, '');
 
         if (param == 'id' && typeof arg !== 'string') {
-          var path = this.createResourcePathWithSymbols(spec.path);
-          var err = new Error(
+          path = this.createResourcePathWithSymbols(spec.path);
+          err = new Error(
             'Stripe: "id" must be a string, but got: ' + typeof arg +
             ' (on API request to `' + requestMethod + ' ' + path + '`)'
           );
@@ -58,8 +61,8 @@ function stripeMethod(spec) {
             continue;
           }
 
-          var path = this.createResourcePathWithSymbols(spec.path);
-          var err = new Error(
+          path = this.createResourcePathWithSymbols(spec.path);
+          err = new Error(
             'Stripe: Argument "' + urlParams[i] + '" required, but got: ' + arg +
             ' (on API request to `' + requestMethod + ' ' + path + '`)'
           );
@@ -79,8 +82,8 @@ function stripeMethod(spec) {
       var opts = utils.getOptionsFromArgs(args);
 
       if (args.length) {
-        var path = this.createResourcePathWithSymbols(spec.path);
-        var err = new Error(
+        path = this.createResourcePathWithSymbols(spec.path);
+        err = new Error(
           'Stripe: Unknown arguments (' + args + '). Did you mean to pass an options ' +
           'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.' +
           ' (on API request to ' + requestMethod + ' `' + path + '`)'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ var utils = module.exports = {
     // (the first being args and the second options) and with known
     // option keys in the first so that we can warn the user about it.
     if (optionKeysInArgs.length > 0 && optionKeysInArgs.length !== argKeys.length) {
-      console.warn(
+      console.warn( // eslint-disable-line no-console
         'Stripe: Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
         'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
       );
@@ -154,8 +154,8 @@ var utils = module.exports = {
   * Secure compare, from https://github.com/freewil/scmp
   */
   secureCompare: function(a, b) {
-    var a = Buffer.from(a);
-    var b = Buffer.from(b);
+    a = Buffer.from(a);
+    b = Buffer.from(b);
 
     // return early here if buffer lengths are not equal since timingSafeEqual
     // will throw if buffer lengths are not equal

--- a/package.json
+++ b/package.json
@@ -28,9 +28,9 @@
   "devDependencies": {
     "chai": "~4.1.2",
     "chai-as-promised": "~7.1.1",
-    "jscs": "^2.3.5",
-    "mocha": "~3.5.3",
-    "stripe-javascript-style": "^1.0.1"
+    "eslint": "^4.6.1",
+    "eslint-plugin-chai-friendly": "^0.4.0",
+    "mocha": "~3.5.3"
   },
   "dependencies": {
     "bluebird": "^3.5.0",
@@ -42,6 +42,6 @@
   "scripts": {
     "mocha": "mocha",
     "test": "npm run lint && mocha",
-    "lint": "jscs ."
+    "lint": "eslint ."
   }
 }

--- a/test/.eslintrc.js
+++ b/test/.eslintrc.js
@@ -1,0 +1,14 @@
+module.exports = {
+    "env": {
+        "mocha": true
+    },
+    "plugins": [
+        "chai-friendly"
+    ],
+    "rules": {
+        "no-loop-func": "off",
+        "no-sync": "off",
+        "no-unused-expressions": 0,
+        "chai-friendly/no-unused-expressions": 2
+    }
+};

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -264,7 +264,6 @@ describe('Customers Resource', function() {
       describe('When deleting metadata', function() {
         it('Sends the correct request', function() {
           stripe.customers.setMetadata('customerIdFoo321', null);
-          console.log(stripe.LAST_REQUEST);
           expect(stripe.LAST_REQUEST).to.deep.equal({
             method: 'POST',
             url: '/v1/customers/customerIdFoo321',

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -191,7 +191,7 @@ describe('Stripe Module', function() {
             if (err) {
               resolve('ErrorWasPassed');
             } else {
-              reject('NoErrorPassed');
+              reject(new Error('NoErrorPassed'));
             }
           });
         })).to.eventually.become('ErrorWasPassed');

--- a/test/testUtils.js
+++ b/test/testUtils.js
@@ -18,13 +18,13 @@ var utils = module.exports = {
     // Provide a testable stripe instance
     // That is, with mock-requests built in and hookable
 
-    var Stripe = require('../lib/stripe');
-    var stripeInstance = Stripe('fakeAuthToken');
+    var stripe = require('../lib/stripe');
+    var stripeInstance = stripe('fakeAuthToken');
 
     stripeInstance.REQUESTS = [];
 
     for (var i in stripeInstance) {
-      if (stripeInstance[i] instanceof Stripe.StripeResource) {
+      if (stripeInstance[i] instanceof stripe.StripeResource) {
         // Override each _request method so we can make the params
         // available to consuming tests (revealing requests made on
         // REQUESTS and LAST_REQUEST):
@@ -74,7 +74,7 @@ var utils = module.exports = {
         var cleanups = this._cleanupFns;
         var total = cleanups.length;
         var completed = 0;
-        for (var fn; fn = cleanups.shift();) {
+        for (var fn; (fn = cleanups.shift());) {
           var promise = fn.call(this);
           if (!promise || !promise.then) {
             throw new Error('CleanupUtility expects cleanup functions to return promises!');

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -261,6 +261,7 @@ describe('utils', function() {
   });
 });
 
+/* eslint-disable no-console */
 function handleConsoleWarns(doWithShimmedConsoleWarn, onWarn) {
   // Shim `console.warn`
   var _warn = console.warn;
@@ -272,3 +273,4 @@ function handleConsoleWarns(doWithShimmedConsoleWarn, onWarn) {
   // Un-shim `console.warn`
   console.warn = _warn;
 }
+/* eslint-enable no-console */


### PR DESCRIPTION
This PR is an attempt at fixing #367. It replaces jscs with ESLint.

The main problem is that we were using a custom ruleset for jscs (https://github.com/stripe/javascript-style), which I think is going to be difficult to port to ESLint.

What I did in this PR is use `eslint --init` to create a new configuration file from scratch. ESLint can scan existing code to write a configuration file that more or less matches the style in the current code.

After doing so, there were still ~70 linting errors which I fixed manually. Most of them were legitimate errors (unused variables, unnecessary semicolons), a few were style errors but they were sensible so I fixed them as well.

I'm not sure if this is how we want to handle the switch to ESLint. I'm not a fan of the very long custom configuration file. I also tried using one of the 3 standard rulesets offered by ESLint (Javascript, Google and Airbnb) but all of them resulted in thousands of linting errors.

Flagging as WIP so we can discuss what's the best way forward.

cc @brandur-stripe @jlomas-stripe 