### PR TITLE
Bump dependencies versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,16 +26,16 @@
   },
   "main": "lib/stripe.js",
   "devDependencies": {
-    "chai": "~1.10.0",
-    "chai-as-promised": "~4.1.1",
+    "chai": "~4.1.2",
+    "chai-as-promised": "~7.1.1",
     "jscs": "^2.3.5",
-    "mocha": "~2.1.0",
+    "mocha": "~3.5.3",
     "stripe-javascript-style": "^1.0.1"
   },
   "dependencies": {
-    "bluebird": "^2.10.2",
+    "bluebird": "^3.5.0",
     "lodash.isplainobject": "^4.0.6",
-    "qs": "~6.0.4"
+    "qs": "~6.5.1"
   },
   "license": "MIT",
   "scripts": {

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -33,7 +33,7 @@ describe('Flows', function() {
           CURRENCY = acct.default_currency;
           return acct;
         })
-    ).to.eventually.have.deep.property('default_currency');
+    ).to.eventually.have.property('default_currency');
   });
 
   describe('Plan+Subscription flow', function() {
@@ -201,7 +201,7 @@ describe('Flows', function() {
         it('Can be retrieved from that customer', function() {
           return expect(
             stripe.customers.retrieve(customer.id)
-          ).to.eventually.have.deep.property('discount.coupon.id', coupon.id);
+          ).to.eventually.have.nested.property('discount.coupon.id', coupon.id);
         });
         describe('The resulting discount', function() {
           it('Can be removed', function() {
@@ -213,7 +213,7 @@ describe('Flows', function() {
             it('Does indeed indicate that it is deleted', function() {
               return expect(
                 stripe.customers.retrieve(customer.id)
-              ).to.eventually.have.deep.property('discount', null);
+              ).to.eventually.have.property('discount', null);
             });
           });
         });
@@ -344,7 +344,7 @@ describe('Flows', function() {
                 expand: ['customer'],
               });
             })
-        ).to.eventually.have.deep.property('customer.created');
+        ).to.eventually.have.nested.property('customer.created');
       });
     });
     describe('A customer\'s default source', function() {
@@ -360,7 +360,7 @@ describe('Flows', function() {
               return cust;
             })
         // Confirm it's expanded by checking that some prop (e.g. exp_year) exists:
-        ).to.eventually.have.deep.property('default_source.exp_year');
+        ).to.eventually.have.nested.property('default_source.exp_year');
       });
     });
   });
@@ -381,7 +381,7 @@ describe('Flows', function() {
         }).then(null, function(error) {
           return error;
         })
-      ).to.eventually.have.deep.property('raw.charge');
+      ).to.eventually.have.nested.property('raw.charge');
     });
   });
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

While working on #383, I noticed that npm was complaining about some deprecated packages, so I thought I'd just bump all dependencies to their latest versions. Should probably have done this at the same time as #382, sorry!

I had to modify some tests to account for a breaking change in chai 4.x (cf. https://github.com/chaijs/chai/issues/781).