### PR TITLE
Remove object-assign package

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var objectAssign = require('object-assign');
 var path = require('path');
 var Promise = require('bluebird');
 var utils = require('./utils');
@@ -87,7 +86,7 @@ function stripeMethod(spec) {
       }
 
       var requestPath = this.createFullPath(commandPath, urlData);
-      var options = {headers: objectAssign(opts.headers, spec.headers)};
+      var options = {headers: Object.assign(opts.headers, spec.headers)};
 
       if (spec.validator) {
         try {

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -2,7 +2,6 @@
 
 var http = require('http');
 var https = require('https');
-var objectAssign = require('object-assign');
 var path = require('path');
 var Promise = require('bluebird');
 
@@ -258,7 +257,7 @@ StripeResource.prototype = {
       headers['X-Stripe-Client-User-Agent'] = cua;
 
       if (options.headers) {
-        objectAssign(headers, options.headers);
+        Object.assign(headers, options.headers);
       }
 
       makeRequest();

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -25,7 +25,6 @@ var APP_INFO_PROPERTIES = ['name', 'version', 'url'];
 
 var EventEmitter = require('events').EventEmitter;
 var exec = require('child_process').exec;
-var objectAssign = require('object-assign');
 var util = require('util');
 
 var resources = {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -5,7 +5,6 @@ var crypto = require('crypto');
 
 var hasOwn = {}.hasOwnProperty;
 var isPlainObject = require('lodash.isplainobject');
-var objectAssign = require('object-assign');
 
 var utils = module.exports = {
 
@@ -107,9 +106,9 @@ var utils = module.exports = {
     // context:
     //
     // https://github.com/stripe/stripe-node/pull/334
-    objectAssign(Constructor, Super);
+    Object.assign(Constructor, Super);
     Constructor.prototype = Object.create(Super.prototype);
-    objectAssign(Constructor.prototype, sub);
+    Object.assign(Constructor.prototype, sub);
 
     return Constructor;
   },

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
   "dependencies": {
     "bluebird": "^2.10.2",
     "lodash.isplainobject": "^4.0.6",
-    "object-assign": "^4.1.0",
     "qs": "~6.0.4"
   },
   "license": "MIT",


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

The [`object-assign`](https://www.npmjs.com/package/object-assign) package is only useful for code targeting Node < 4. Since this is no longer the case for stripe-node, we can safely get rid of it and call `Object.assign` directly.
