### PR TITLE
Use test token rather than raw test PAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,13 +59,7 @@ stripe.customers.create({
   email: 'foo-customer@example.com'
 }).then(function(customer){
   return stripe.customers.createSource(customer.id, {
-    source: {
-       object: 'card',
-       exp_month: 10,
-       exp_year: 2018,
-       number: '4242 4242 4242 4242',
-       cvc: 100
-    }
+    source: 'tok_visa'
   });
 }).then(function(source) {
   return stripe.charges.create({


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Updates the sample request in the README file to use the `tok_visa` test token rather than the raw test PAN.
