### PR TITLE
Start testing Node 4.0.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 language: node_js
 node_js:
+  - "4.0.0"
   - "4"
   - "5"
   - "6"


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Starts testing Node 4.0.0.

Currently the earliest version we're testing is `4`, which Travis interprets as "latest 4.x release". Since we want to support all >= 4.0.0 versions, we should also explicitly test Node 4.0.0.
