### PR TITLE
Use safe-buffer package

### DIFF
--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -1,5 +1,7 @@
 'use strict';
 
+var Buffer = require('safe-buffer').Buffer;
+
 // Method for formatting HTTP body for the multipart/form-data specification
 // Mostly taken from Fermata.js
 // https://github.com/natevw/fermata/blob/5d9732a33d776ce925013a265935facd1626cc88/fermata.js#L315-L343

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,5 +1,6 @@
 'use strict';
 
+var Buffer = require('safe-buffer').Buffer;
 var qs = require('qs');
 var crypto = require('crypto');
 
@@ -131,8 +132,8 @@ var utils = module.exports = {
   * Secure compare, from https://github.com/freewil/scmp
   */
   secureCompare: function(a, b) {
-    var a = asBuffer(a);
-    var b = asBuffer(b);
+    var a = Buffer.from(a);
+    var b = Buffer.from(b);
 
     // return early here if buffer lengths are not equal since timingSafeEqual
     // will throw if buffer lengths are not equal
@@ -172,24 +173,3 @@ var utils = module.exports = {
     return obj;
   },
 };
-
-function asBuffer(thing) {
-  if (Buffer.isBuffer(thing)) {
-    return thing;
-  }
-
-  if (Buffer.from) {
-    // Buffer.from fix for node versions prior to 4.5.x
-    try {
-      return Buffer.from(thing);
-    } catch (e) {
-      if (e instanceof TypeError) {
-        return new Buffer(thing);
-      } else {
-        throw e;
-      }
-    }
-  } else {
-    return new Buffer(thing);
-  }
-}

--- a/package.json
+++ b/package.json
@@ -35,7 +35,8 @@
   "dependencies": {
     "bluebird": "^3.5.0",
     "lodash.isplainobject": "^4.0.6",
-    "qs": "~6.5.1"
+    "qs": "~6.5.1",
+    "safe-buffer": "^5.1.1"
   },
   "license": "MIT",
   "scripts": {


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

ESLint recommends using the `safe-buffer` package for Node <= 4.5, and it also lets us get rid of some code that we added to manually handle this (cf. #365).

Let's wait until #387 is merged and this PR is rebased to make sure everything's still working as expected!
