### PR TITLE
Fix the comparison for the args/options warnings

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,7 +70,10 @@ var utils = module.exports = {
       return OPTIONS_KEYS.indexOf(key) > -1;
     });
 
-    if (optionKeysInArgs.length > 0) {
+    // We need to be sure that it's not _both_ an options and args object:
+    // If the args keys and options keys are not the same length,
+    // then it contains both arguments and options, and that's not good.
+    if (argKeys.length !== optionKeysInArgs.length) {
       console.warn(
         'Stripe: Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
         'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -70,10 +70,11 @@ var utils = module.exports = {
       return OPTIONS_KEYS.indexOf(key) > -1;
     });
 
-    // We need to be sure that it's not _both_ an options and args object:
-    // If the args keys and options keys are not the same length,
-    // then it contains both arguments and options, and that's not good.
-    if (argKeys.length !== optionKeysInArgs.length) {
+    // In some cases options may be the provided as the first argument.
+    // Here we're detecting a case where there are two distinct arguments
+    // (the first being args and the second options) and with known
+    // option keys in the first so that we can warn the user about it.
+    if (optionKeysInArgs.length > 0 && optionKeysInArgs.length !== argKeys.length) {
       console.warn(
         'Stripe: Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
         'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'


### PR DESCRIPTION
Fixes #393.  The initial change (#306) didn't properly handle the case where the object was all `options` - it was `console.warn`ing in that case - but now it handles it properly.