### PR TITLE
More explicitly call out that `constructEvent` needs the raw body

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,8 @@ stripe.off('request', onRequest);
 
 Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party.  You can read more about it [here](https://stripe.com/docs/webhooks#signatures).
 
+Please note that you must pass the _raw_ request body, exactly as received from Stripe, to the `constructEvent()` function; this will not work with a parsed (i.e., JSON) request body.
+
 You can find an example of how to use this with [Express](https://expressjs.com/) in the [`examples/webhook-signing`](examples/webhook-signing) folder, but here's what it looks like:
 
 ```js

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -55,7 +55,9 @@ var signature = {
 
     if (!signatureFound) {
       throw new Error.StripeSignatureVerificationError({
-        message: 'No signatures found matching the expected signature for payload',
+        message: 'No signatures found matching the expected signature for payload.' +
+          ' Are you passing the raw request body you received from Stripe?' +
+          ' https://github.com/stripe/stripe-node#webhook-signing',
         detail: {
           header: header,
           payload: payload,


### PR DESCRIPTION
Since this is something that comes up a lot, I thought it might be worth calling it out a bit more explicitly, both in the Readme and in the Error we return when the signatures don't match.

r? @brandur-stripe 