### PR TITLE
Remove old CHANGELOG

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -1,2 +1,0 @@
-We've moved the CHANGELOG that was at this location to CHANGELOG.md at
-https://github.com/stripe/stripe-node/blob/master/CHANGELOG.md for better formatting and deep linking in github.


### PR DESCRIPTION
We initially had this in place so that old links would still have
somewhere to point to, but I think it's been long enough at this point
(we've shipped *many* releases with the proper link since then). Worst
case scenario is that people just go up to the repository and find
`CHANGELOG.md` manually.