### PR TITLE
Add ExchangeRates API methods

### DIFF
--- a/lib/resources/ExchangeRates.js
+++ b/lib/resources/ExchangeRates.js
@@ -1,0 +1,12 @@
+'use strict';
+
+var StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
+
+  path: 'exchange_rates',
+
+  includeBasic: [
+    'list', 'retrieve',
+  ],
+});

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -39,6 +39,7 @@ var resources = {
   Disputes: require('./resources/Disputes'),
   EphemeralKeys: require('./resources/EphemeralKeys'),
   Events: require('./resources/Events'),
+  ExchangeRates: require('./resources/ExchangeRates'),
   Invoices: require('./resources/Invoices'),
   InvoiceItems: require('./resources/InvoiceItems'),
   LoginLinks: require('./resources/LoginLinks'),

--- a/test/resources/ExchangeRates.spec.js
+++ b/test/resources/ExchangeRates.spec.js
@@ -1,0 +1,31 @@
+'use strict';
+
+var stripe = require('../testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+
+describe('ExchangeRates Resource', function() {
+  describe('list', function() {
+    it('Sends the correct request', function() {
+      stripe.exchangeRates.list();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/exchange_rates',
+        data: {},
+        headers: {},
+      });
+    });
+  });
+
+  describe('retrieve', function() {
+    it('Sends the correct request', function() {
+      var currency = 'USD';
+      stripe.exchangeRates.retrieve(currency);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/exchange_rates/' + currency,
+        data: {},
+        headers: {},
+      });
+    });
+  });
+});


### PR DESCRIPTION
r? @brandur-stripe
cc @stripe/api-libraries @alixander-stripe

Adds support for the new `/v1/exchange_rates` endpoints.