### PR TITLE
Allow trailing undefined or null argument as empty options object

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -110,6 +110,8 @@ var utils = module.exports = {
         if (params.stripe_version) {
           opts.headers['Stripe-Version'] = params.stripe_version;
         }
+      } else if (arg === undefined || arg === null) {
+        args.pop();
       }
     }
     return opts;

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -158,6 +158,22 @@ describe('utils', function() {
       });
       expect(args.length).to.equal(1);
     });
+    it('parses and drops an undefined parameter', function() {
+      var args = [undefined];
+      expect(utils.getOptionsFromArgs(args)).to.deep.equal({
+        auth: null,
+        headers: {},
+      });
+      expect(args.length).to.equal(0);
+    });
+    it('parses and drops a null parameter', function() {
+      var args = [null];
+      expect(utils.getOptionsFromArgs(args)).to.deep.equal({
+        auth: null,
+        headers: {},
+      });
+      expect(args.length).to.equal(0);
+    });
     it('parses an api key', function() {
       var args = ['sk_test_iiiiiiiiiiiiiiiiiiiiiiii'];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({


### PR DESCRIPTION
I'm unaware of whether or not there are deeper implications to dropping trailing null/undefined arguments, but if there are please let me know.

This PR is to allow `null` or `undefined` as an argument in place of the Stripe options object (e.g., `stripe_account`, `stripe_version`, etc). Currently, if you provide `null`, `undefined` as an options argument, stripe-node will reject since there are unknown arguments left over. See here: https://github.com/stripe/stripe-node/blob/a22a89c2e765d2548929d3d42dc0d7c4c4f6c19c/lib/StripeMethod.js#L84

With this simple change in place, stripe-node will ignore a trailing `null` or `undefined`.

For context, we have our own wrapper around stripe-node. Certain functions operate on both our platform account and connected accounts, so optionally allow a `stripeAccountId` argument. In that case we want to include an options argument.

With stripe-node rejecting a trailing `null` or `undefined`, we have been building arrays of arguments and only if `stripeAccountId` is included do we push it into our argument array.

A simple example of our workaround to this problem:
```
async getSubscription(subscriptionId, stripeAccountId) {
  return await this.stripe.subscriptions.retrieve(subscriptionId, {
    expand: ["customer"]
  }, stripUndefined({
    stripe_account: stripeAccountId // stripeAccountId can be undefined
  })
}
```
where `stripeUndefined` returns undefined if `stripeAccountId` is not provided.

We are internally working on converting our sources to typescript, which makes the variadic arguments approach a little messier to deal with. If this PR is merged, we can much more easily do something like this (and strongly type arguments):
```
async getSubscription(subscriptionId, stripeAccountId) {
  return await this.stripe.subscriptions.retrieve(subscriptionId, {
    expand: ["customer"]
  }, stripeAccountId ? {
    stripe_account: stripeAccountId
  } : undefined);
}
```

Any feedback greatly appreciated. Thanks!

--EDIT--

My teammate just pointed out that this actually works fine too as a workaround to the problem:
```
async getSubscription(subscriptionId, stripeAccountId) {
  return await this.stripe.subscriptions.retrieve(subscriptionId, {
    expand: ["customer"]
  }, {
    stripe_account: stripeAccountId // stripeAccountId can be undefined
  }
}
```