### PR TITLE
Update docs to take advantage of Node 8's `await`

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,16 @@ value:
 ``` js
 var stripe = require('stripe')('sk_test_...');
 
+var customer = await stripe.customers.create(
+  { email: 'customer@example.com' }
+);
+```
+
+Or with versions of Node.js prior to v7.9:
+
+``` js
+var stripe = require('stripe')('sk_test_...');
+
 stripe.customers.create(
   { email: 'customer@example.com' },
   function(err, customer) {
@@ -41,11 +51,12 @@ stripe.customers.create(
 );
 ```
 
-On ES6, this looks more like:
+Or using ES modules, this looks more like:
 
 ``` js
 import stripePackage from 'stripe';
 const stripe = stripePackage('sk_test_...');
+//…
 ```
 
 ### Using Promises


### PR DESCRIPTION
Now that Node 8 is LTS, it might be nice to show `await` syntax first  (here's some [reasoning](https://gist.github.com/mikermcneil/c1028d000cc0cc8bce995a2a82b29245) on that)