### PR TITLE
Add support for /v1/topups endpoints

### DIFF
--- a/lib/resources/Topups.js
+++ b/lib/resources/Topups.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
+  path: 'topups',
+  includeBasic: ['create', 'list', 'retrieve', 'update', 'setMetadata', 'getMetadata'],
+});

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -49,6 +49,7 @@ var resources = {
   Recipients: require('./resources/Recipients'),
   Refunds: require('./resources/Refunds'),
   Tokens: require('./resources/Tokens'),
+  Topups: require('./resources/Topups'),
   Transfers: require('./resources/Transfers'),
   ApplicationFees: require('./resources/ApplicationFees'),
   FileUploads: require('./resources/FileUploads'),

--- a/test/resources/Topups.spec.js
+++ b/test/resources/Topups.spec.js
@@ -1,0 +1,66 @@
+'use strict';
+
+var stripe = require('../testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+
+describe('Topup Resource', function() {
+  describe('retrieve', function() {
+    it('Sends the correct request', function() {
+      stripe.topups.retrieve('tu_123');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/topups/tu_123',
+        data: {},
+        headers: {},
+      });
+    });
+  });
+
+  describe('create', function() {
+    it('Sends the correct request', function() {
+      stripe.topups.create({
+        source: 'src_123',
+        amount: '1500',
+        currency: 'usd',
+        description: 'a topup',
+        statement_descriptor: 'creating a topup',
+      });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/topups',
+        data: {
+          source: 'src_123',
+          amount: '1500',
+          currency: 'usd',
+          description: 'a topup',
+          statement_descriptor: 'creating a topup',
+        },
+        headers: {},
+      });
+    });
+  });
+
+  describe('list', function() {
+    it('Sends the correct request', function() {
+      stripe.topups.list();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/topups',
+        data: {},
+        headers: {},
+      });
+    });
+  });
+
+  describe('update', function() {
+    it('Sends the correct request', function() {
+      stripe.topups.update('tu_123', {metadata: {'key': 'value'}});
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/topups/tu_123',
+        headers: {},
+        data: {metadata: {'key': 'value'}},
+      });
+    });
+  });
+});


### PR DESCRIPTION
This add standard retrieve, create and update client support for the new `/v1/topups` endpoint.