### PR TITLE
Update subscriptions tests to pass with new API changes

### DIFF
--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -43,7 +43,10 @@ describe('Flows', function() {
             amount: 1700,
             currency: CURRENCY,
             interval: 'month',
-            name: 'Gold Super Amazing Tier',
+            nickname: 'Gold Super Amazing Tier',
+            product: {
+              name: 'product' + testUtils.getRandomString(),
+            },
           }),
           stripe.customers.create(CUSTOMER_DETAILS)
         ).then(function(j) {
@@ -71,7 +74,10 @@ describe('Flows', function() {
               amount: 1700,
               currency: CURRENCY,
               interval: 'month',
-              name: 'Gold Super Amazing Tier',
+              nickname: 'Gold Super Amazing Tier',
+              product: {
+                name: 'product' + testUtils.getRandomString(),
+              },
             }),
             stripe.customers.create(CUSTOMER_DETAILS)
           ).then(function(j) {
@@ -122,7 +128,10 @@ describe('Flows', function() {
             amount: 1700,
             currency: CURRENCY,
             interval: 'month',
-            name: 'Silver Super Amazing Tier',
+            nickname: 'Silver Super Amazing Tier',
+            product: {
+              name: 'product' + testUtils.getRandomString(),
+            },
           }),
           stripe.customers.create(CUSTOMER_DETAILS)
         ).then(function(j) {
@@ -157,7 +166,10 @@ describe('Flows', function() {
               amount: 1700,
               currency: CURRENCY,
               interval: 'month',
-              name: 'generic',
+              nickname: 'generic',
+              product: {
+                name: 'product' + testUtils.getRandomString(),
+              },
             }).then(function() {
               cleanup.deletePlan(planID);
               return stripe.plans.retrieve(planID);

--- a/test/resources/Products.spec.js
+++ b/test/resources/Products.spec.js
@@ -21,6 +21,7 @@ describe('Product Resource', function() {
       stripe.products.create({
         name: 'Llamas',
         active: true,
+        type: 'good',
       });
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'POST',
@@ -28,6 +29,7 @@ describe('Product Resource', function() {
         data: {
           name: 'Llamas',
           active: true,
+          type: 'good',
         },
         headers: {},
       });


### PR DESCRIPTION
Version 2018-02-05 came with a major change to plans and products:

* Products now have a `type` which is `service` or `good`.
* Plans have `name` change to `nickname`.
* Plans now take a product (of `type=service`) on creation.

Testing on `master` is currently broken. This patch updates some test suites to
allow for the new API changes and fixes the suite.

r? @ob-stripe 