### PR TITLE
Remove old 3DS test to ensure test suite keep working

### DIFF
--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -407,19 +407,6 @@ describe('Flows', function() {
     });
   });
 
-  describe('Creating a ThreeDSecure object', function() {
-    it('Allows me to do so', function() {
-      return expect(
-        stripe.threeDSecure.create({
-          card: 'tok_visa',
-          amount: 1500,
-          currency: 'usd',
-          return_url: 'https://example.org/3d-secure-result',
-        })
-      ).to.eventually.have.property('object', 'three_d_secure');
-    });
-  });
-
   describe('Request/Response Events', function() {
     var connectedAccountId;
 


### PR DESCRIPTION
As we're actively deprecating the old and undocumented /v1/3d_secure endpoint, we need to remove the test so that the test suite does not break.

r? @ob-stripe 
cc @stripe/api-libraries 