### PR TITLE
Add TypeScript usage to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,15 @@ const stripe = stripePackage('sk_test_...');
 //…
 ```
 
+
+Or using TypeScript:
+
+``` ts
+import * as Stripe from 'stripe';
+const stripe = new Stripe('sk_test_...');
+//…
+```
+
 ### Using Promises
 
 Every method returns a chainable promise which can be used instead of a regular


### PR DESCRIPTION
The ES modules usage fails to compile in TS, so this should help TS users get started.