### PR TITLE
fix invalid path join #436

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -72,7 +72,7 @@ StripeResource.prototype = {
   createResourcePathWithSymbols: function(pathWithSymbols) {
     return '/' + path.join(
       this.resourcePath,
-      pathWithSymbols
+      pathWithSymbols || ''
     ).replace(/\\/g, '/'); // ugly workaround for Windows
   },
 


### PR DESCRIPTION
pathWithSymbols may be undefined and then an exception is thrown from the path.join method.
bug details: #436