### PR TITLE
Use native promises

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,7 @@
 module.exports = {
     "env": {
-        "node": true
+        "node": true,
+        "es6": true
     },
     "extends": "eslint:recommended",
     "rules": {

--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
 var isPlainObject = require('lodash.isplainobject');
 var stripeMethod = require('./StripeMethod');
 

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var Promise = require('bluebird');
 var utils = require('./utils');
 var OPTIONAL_REGEX = /^optional!/;
 

--- a/package.json
+++ b/package.json
@@ -29,13 +29,12 @@
     "chai": "~4.1.2",
     "chai-as-promised": "~7.1.1",
     "coveralls": "^3.0.0",
-    "eslint": "^4.6.1",
+    "eslint": "^4.19.1",
     "eslint-plugin-chai-friendly": "^0.4.0",
-    "mocha": "~3.5.3",
+    "mocha": "~5.0.5",
     "nyc": "^11.3.0"
   },
   "dependencies": {
-    "bluebird": "^3.5.0",
     "lodash.isplainobject": "^4.0.6",
     "qs": "~6.5.1",
     "safe-buffer": "^5.1.1"

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -2,7 +2,6 @@
 
 var testUtils = require('./testUtils');
 var chai = require('chai');
-var Promise = require('bluebird');
 var stripe = require('../lib/stripe')(
   testUtils.getUserStripeKey(),
   'latest'
@@ -37,7 +36,7 @@ describe('Flows', function() {
   describe('Plan+Subscription flow', function() {
     it('Allows me to: Create a plan and subscribe a customer to it', function() {
       return expect(
-        Promise.join(
+        Promise.all([
           stripe.plans.create({
             id: 'plan' + testUtils.getRandomString(),
             amount: 1700,
@@ -49,7 +48,7 @@ describe('Flows', function() {
             },
           }),
           stripe.customers.create(CUSTOMER_DETAILS)
-        ).then(function(j) {
+        ]).then(function(j) {
           var plan = j[0];
           var customer = j[1];
 
@@ -68,7 +67,7 @@ describe('Flows', function() {
       function() {
         var plan;
         return expect(
-          Promise.join(
+          Promise.all([
             stripe.plans.create({
               id: 'plan' + testUtils.getRandomString(),
               amount: 1700,
@@ -80,7 +79,7 @@ describe('Flows', function() {
               },
             }),
             stripe.customers.create(CUSTOMER_DETAILS)
-          ).then(function(j) {
+          ]).then(function(j) {
             plan = j[0];
             var customer = j[1];
 
@@ -122,7 +121,7 @@ describe('Flows', function() {
 
     it('Allows me to: subscribe then cancel with `at_period_end` defined', function() {
       return expect(
-        Promise.join(
+        Promise.all([
           stripe.plans.create({
             id: 'plan' + testUtils.getRandomString(),
             amount: 1700,
@@ -134,7 +133,7 @@ describe('Flows', function() {
             },
           }),
           stripe.customers.create(CUSTOMER_DETAILS)
-        ).then(function(j) {
+        ]).then(function(j) {
           var plan = j[0];
           var customer = j[1];
 
@@ -187,13 +186,13 @@ describe('Flows', function() {
     describe('When I create a coupon & customer', function() {
       it('Does so', function() {
         return expect(
-          Promise.join(
+          Promise.all([
             stripe.coupons.create({
               percent_off: 20,
               duration: 'once',
             }),
             stripe.customers.create(CUSTOMER_DETAILS)
-          ).then(function(joined) {
+          ]).then(function(joined) {
             coupon = joined[0];
             customer = joined[1];
           })

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -2,7 +2,6 @@
 
 var stripe = require('../testUtils').getSpyableStripe();
 var expect = require('chai').expect;
-var Promise = require('bluebird');
 
 var TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
 

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -1,7 +1,6 @@
 'use strict';
 
 var testUtils = require('./testUtils');
-var Promise = require('bluebird');
 var stripe = require('../lib/stripe')(
   testUtils.getUserStripeKey(),
   'latest'
@@ -37,20 +36,20 @@ describe('Stripe Module', function() {
   describe('GetClientUserAgentSeeded', function() {
     it('Should return a user-agent serialized JSON object', function() {
       var userAgent = {lang: 'node'};
-      var d = Promise.defer();
-      stripe.getClientUserAgentSeeded(userAgent, function(c) {
-        d.resolve(JSON.parse(c));
-      });
-      return expect(d.promise).to.eventually.have.property('lang', 'node');
+      return expect(new Promise(function(resolve, reject) {
+        stripe.getClientUserAgentSeeded(userAgent, function(c) {
+          resolve(JSON.parse(c));
+        });
+      })).to.eventually.have.property('lang', 'node');
     });
 
     it('Should URI-encode user-agent fields', function() {
       var userAgent = {lang: 'ï'};
-      var d = Promise.defer();
-      stripe.getClientUserAgentSeeded(userAgent, function(c) {
-        d.resolve(JSON.parse(c));
-      });
-      return expect(d.promise).to.eventually.have.property('lang', '%C3%AF');
+      return expect(new Promise(function(resolve, reject) {
+        stripe.getClientUserAgentSeeded(userAgent, function(c) {
+          resolve(JSON.parse(c));
+        });
+      })).to.eventually.have.property('lang', '%C3%AF');
     })
   });
 


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries @OrKoN

- Use native ES6 promises instead of Bluebird promises
- ~Add a `setPromise` configuration option for users to provide their own `Promise` implementation~

Fixes #438.
