### PR TITLE
Support custom agent with keepAlive: true

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -299,12 +299,17 @@ StripeResource.prototype = {
       req.on('error', self._errorHandler(req, callback));
 
       req.on('socket', function(socket) {
-        socket.on((isInsecureConnection ? 'connect' : 'secureConnect'), function() {
-          // Send payload; we're safe:
+        if (socket.connecting) {
+          socket.on((isInsecureConnection ? 'connect' : 'secureConnect'), function() {
+            // Send payload; we're safe:
+            req.write(requestData);
+              req.end();
+          });
+        } else {
+          // we're already connected
           req.write(requestData);
-
           req.end();
-        });
+        }
       });
     }
   },


### PR DESCRIPTION
When using a custom http agent and keepAlive is set the request won't create new sockets, meaning that the `'connect'` or `'secureConnect'` events won't run.

This fixes that.