### PR TITLE
Fix UsageRecords so it passes through the rest of the arguments

### DIFF
--- a/lib/resources/UsageRecords.js
+++ b/lib/resources/UsageRecords.js
@@ -4,13 +4,19 @@ var stripeMethod = require('../StripeMethod');
 
 module.exports = require('../StripeResource').extend({
   path: 'subscription_items',
-  create: function(args) {
-    var requestPath = args.subscription_item + '/usage_records';
-    var reqArgs = Object.assign({}, args);
+  create: function() {
+    var args = Array.prototype.slice.call(arguments);
+
+    var reqArgs = args.shift();
+    var requestPath = reqArgs.subscription_item + '/usage_records';
+
     delete reqArgs.subscription_item;
+
+    args.unshift(reqArgs);
+
     return stripeMethod({
       method: 'POST',
       path: requestPath
-    }).bind(this)(reqArgs);
+    }).apply(this, args);
   }
 });

--- a/lib/resources/UsageRecords.js
+++ b/lib/resources/UsageRecords.js
@@ -1,22 +1,14 @@
 'use strict';
 
-var stripeMethod = require('../StripeMethod');
+var StripeResource = require('../StripeResource');
+var stripeMethod = StripeResource.method;
 
-module.exports = require('../StripeResource').extend({
+module.exports = StripeResource.extend({
   path: 'subscription_items',
-  create: function() {
-    var args = Array.prototype.slice.call(arguments);
 
-    var reqArgs = args.shift();
-    var requestPath = reqArgs.subscription_item + '/usage_records';
-
-    delete reqArgs.subscription_item;
-
-    args.unshift(reqArgs);
-
-    return stripeMethod({
-      method: 'POST',
-      path: requestPath
-    }).apply(this, args);
-  }
+  create: stripeMethod({
+    method: 'POST',
+    path: '{subscriptionItem}/usage_records',
+    urlParams: ['subscriptionItem'],
+  }),
 });

--- a/test/resources/UsageRecords.spec.js
+++ b/test/resources/UsageRecords.spec.js
@@ -9,18 +9,56 @@ describe('UsageRecords Resource', function() {
       stripe.usageRecords.create({
         subscription_item: 'si_123',
         quantity: 123,
-        timestmap: 123321,
+        timestamp: 123321,
         action: 'increment'
       });
+
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'POST',
         url: '/v1/subscription_items/si_123/usage_records',
         headers: {},
         data: {
           quantity: 123,
-          timestmap: 123321,
+          timestamp: 123321,
           action: 'increment'
         }
+      });
+    });
+
+    it('Includes any options that were provided', function(done) {
+      stripe.usageRecords.create({
+        subscription_item: 'si_123',
+        quantity: 123,
+        timestamp: 123321,
+        action: 'increment'
+      }, {
+        stripe_account: 'acct_456',
+      }).then(function(record) {
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'POST',
+          url: '/v1/subscription_items/si_123/usage_records',
+          headers: {
+            'Stripe-Account': 'acct_456'
+          },
+          data: {
+            quantity: 123,
+            timestamp: 123321,
+            action: 'increment'
+          }
+        });
+
+        done();
+      });
+    });
+
+    it('Calls a given callback', function(done) {
+      stripe.usageRecords.create({
+        subscription_item: 'si_123',
+        quantity: 123,
+        timestamp: 123321,
+        action: 'increment'
+      }, function(error, record) {
+        done(error);
       });
     });
   });

--- a/test/resources/UsageRecords.spec.js
+++ b/test/resources/UsageRecords.spec.js
@@ -6,8 +6,7 @@ var expect = require('chai').expect;
 describe('UsageRecords Resource', function() {
   describe('create', function() {
     it('Sends the correct request', function() {
-      stripe.usageRecords.create({
-        subscription_item: 'si_123',
+      stripe.usageRecords.create('si_123', {
         quantity: 123,
         timestamp: 123321,
         action: 'increment'
@@ -26,8 +25,7 @@ describe('UsageRecords Resource', function() {
     });
 
     it('Includes any options that were provided', function(done) {
-      stripe.usageRecords.create({
-        subscription_item: 'si_123',
+      stripe.usageRecords.create('si_123', {
         quantity: 123,
         timestamp: 123321,
         action: 'increment'
@@ -52,8 +50,7 @@ describe('UsageRecords Resource', function() {
     });
 
     it('Calls a given callback', function(done) {
-      stripe.usageRecords.create({
-        subscription_item: 'si_123',
+      stripe.usageRecords.create('si_123', {
         quantity: 123,
         timestamp: 123321,
         action: 'increment'


### PR DESCRIPTION
Makes sure that all of the elements of the original `arguments` array - with the first one being modified to extract and remove the SubscriptionItem ID - are passed through to the `stripeMethod()` call.

Fixes #451.

r? @brandur-stripe 
