### PR TITLE
Use valid characters when creating plans

### DIFF
--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -153,10 +153,10 @@ describe('Flows', function() {
 
     describe('Plan name variations', function() {
       [
-        '34535 355453' + testUtils.getRandomString(),
-        'TEST 239291' + testUtils.getRandomString(),
+        '34535_355453' + testUtils.getRandomString(),
+        'TEST_239291' + testUtils.getRandomString(),
         'TEST_a-i' + testUtils.getRandomString(),
-        'foobarbazteston###etwothree' + testUtils.getRandomString(),
+        'foobarbazteston___etwothree' + testUtils.getRandomString(),
       ].forEach(function(planID) {
         it('Allows me to create and retrieve plan with ID: ' + planID, function() {
           return expect(


### PR DESCRIPTION
cc @stripe/api-libraries 

As of API version [2018-05-21](https://stripe.com/docs/upgrades#2018-05-21), the character set for plan IDs is now more restricted than it used to be:
> Coupon, SKU, customer, product and plan ids may only contain alphanumeric and `_-` characters on creation.

stripe-node's test suite had a test that created plans with spaces and `#` characters, which caused builds to fail. I updated the tests to use underscores instead.
