### PR TITLE
Warn on unknown `options`

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,7 +75,7 @@ var utils = module.exports = {
     // (the first being args and the second options) and with known
     // option keys in the first so that we can warn the user about it.
     if (optionKeysInArgs.length > 0 && optionKeysInArgs.length !== argKeys.length) {
-      emitStripeWarning( // eslint-disable-line
+      emitWarning(
         'Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
         'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
       );
@@ -104,7 +104,7 @@ var utils = module.exports = {
         });
 
         if (extraKeys.length) {
-          emitStripeWarning('Invalid options found (' + extraKeys.join(', ') + '); ignoring.');
+          emitWarning('Invalid options found (' + extraKeys.join(', ') + '); ignoring.');
         }
 
         if (params.api_key) {
@@ -205,10 +205,9 @@ var utils = module.exports = {
   },
 };
 
-function emitStripeWarning(warning) {
+function emitWarning(warning) {
   if (typeof process.emitWarning !== 'function') {
-    /* eslint-disable no-console */
-    return console.warn('Stripe: ' + warning);
+    return console.warn('Stripe: ' + warning); /* eslint-disable-line no-console */
   }
 
   return process.emitWarning(warning, 'Stripe');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -75,8 +75,8 @@ var utils = module.exports = {
     // (the first being args and the second options) and with known
     // option keys in the first so that we can warn the user about it.
     if (optionKeysInArgs.length > 0 && optionKeysInArgs.length !== argKeys.length) {
-      console.warn( // eslint-disable-line no-console
-        'Stripe: Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
+      emitStripeWarning( // eslint-disable-line
+        'Options found in arguments (' + optionKeysInArgs.join(', ') + '). Did you mean to pass an options ' +
         'object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
       );
     }
@@ -98,6 +98,15 @@ var utils = module.exports = {
         opts.auth = args.pop();
       } else if (utils.isOptionsHash(arg)) {
         var params = args.pop();
+
+        var extraKeys = Object.keys(params).filter(function(key) {
+          return OPTIONS_KEYS.indexOf(key) == -1;
+        });
+
+        if (extraKeys.length) {
+          emitStripeWarning('Invalid options found (' + extraKeys.join(', ') + '); ignoring.');
+        }
+
         if (params.api_key) {
           opts.auth = params.api_key;
         }
@@ -195,3 +204,12 @@ var utils = module.exports = {
     return obj;
   },
 };
+
+function emitStripeWarning(warning) {
+  if (typeof process.emitWarning !== 'function') {
+    /* eslint-disable no-console */
+    return console.warn('Stripe: ' + warning);
+  }
+
+  return process.emitWarning(warning, 'Stripe');
+}

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -284,10 +284,10 @@ describe('utils', function() {
   });
 });
 
-/* eslint-disable no-console */
 function handleWarnings(doWithShimmedConsoleWarn, onWarn) {
-  /* eslint-disable no-console */
   if (typeof process.emitWarning !== 'function') {
+    /* eslint-disable no-console */
+
     // Shim `console.warn`
     var _warn = console.warn;
     console.warn = onWarn;
@@ -299,8 +299,7 @@ function handleWarnings(doWithShimmedConsoleWarn, onWarn) {
 
     /* eslint-enable no-console */
   } else {
-    /* eslint-disable no-inner-declarations */
-    function onProcessWarn(warning) {
+    function onProcessWarn(warning) { /* eslint-disable-line no-inner-declarations */
       onWarn(warning.name + ': ' + warning.message);
     }
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -296,6 +296,8 @@ function handleWarnings(doWithShimmedConsoleWarn, onWarn) {
 
     // Un-shim `console.warn`,
     console.warn = _warn;
+
+    /* eslint-enable no-console */
   } else {
     /* eslint-disable no-inner-declarations */
     function onProcessWarn(warning) {
@@ -311,4 +313,3 @@ function handleWarnings(doWithShimmedConsoleWarn, onWarn) {
     })
   }
 }
-/* eslint-enable no-console */


### PR DESCRIPTION
I.e., "Do the thing I said I'd do in #375".

I also fixed some tests that weren't running properly (because they were async but didn't include a `done`), and I'm ... also not sure that `emitWarning()` is the right way, and it might be better to just `console.warn()` instead.  Thoughts?

r? @brandur-stripe 
