### PR TITLE
Adds support for an optional 'partner_id' parameter in 'setAppInfo'

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -21,7 +21,7 @@ Stripe.USER_AGENT = {
 
 Stripe.USER_AGENT_SERIALIZED = null;
 
-var APP_INFO_PROPERTIES = ['name', 'version', 'url'];
+var APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
 var EventEmitter = require('events').EventEmitter;
 var exec = require('child_process').exec;

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -96,7 +96,7 @@ describe('Stripe Module', function() {
     });
 
     describe('when given at least a `name`', function() {
-      it('should set name, version and url of stripe._appInfo', function() {
+      it('should set name, partner ID, url, and version of stripe._appInfo', function() {
         stripe.setAppInfo({
           name: 'MyAwesomeApp',
         });
@@ -121,17 +121,29 @@ describe('Stripe Module', function() {
           name: 'MyAwesomeApp',
           url: 'https://myawesomeapp.info',
         });
+
+        stripe.setAppInfo({
+          name: 'MyAwesomeApp',
+          partner_id: 'partner_1234',
+        });
+        expect(stripe._appInfo).to.eql({
+          name: 'MyAwesomeApp',
+          partner_id: 'partner_1234',
+        });
+
       });
 
       it('should ignore any invalid properties', function() {
         stripe.setAppInfo({
           name: 'MyAwesomeApp',
+          partner_id: 'partner_1234',
           version: '1.2.345',
           url: 'https://myawesomeapp.info',
           countOfRadishes: 512,
         });
         expect(stripe._appInfo).to.eql({
           name: 'MyAwesomeApp',
+          partner_id: 'partner_1234',
           version: '1.2.345',
           url: 'https://myawesomeapp.info',
         });


### PR DESCRIPTION
This adds support for an optional partner_id attribute in the SetAppInfo hash.