### PR TITLE
Upcoming invoices now have proper integer-index-encoded params

### DIFF
--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -25,19 +25,19 @@ module.exports = StripeResource.extend({
     method: 'GET',
     path: function(urlData) {
       var url = 'upcoming?customer=' + urlData.customerId;
-      // Legacy support where second argument is a the subscription id
+      // Legacy support where second argument is the subscription id
       if (urlData.invoiceOptions && typeof urlData.invoiceOptions === 'string') {
         return url + '&subscription=' + urlData.invoiceOptions;
       } else if (urlData.invoiceOptions && typeof urlData.invoiceOptions === 'object') {
         if (urlData.invoiceOptions.subscription_items !== undefined) {
           urlData.invoiceOptions.subscription_items = utils.arrayToObject(urlData.invoiceOptions.subscription_items);
         }
-
         return url + '&' + utils.stringifyRequestData(urlData.invoiceOptions);
       }
       return url;
     },
     urlParams: ['customerId', 'optional!invoiceOptions'],
+    encode: utils.encodeParamWithIntegerIndexes.bind(null, 'subscription_items'),
   }),
 
 });

--- a/lib/resources/Subscriptions.js
+++ b/lib/resources/Subscriptions.js
@@ -4,13 +4,6 @@ var StripeResource = require('../StripeResource');
 var utils = require('../utils');
 var stripeMethod = StripeResource.method;
 
-function encode(data) {
-  if (data.items !== undefined) {
-    data.items = utils.arrayToObject(data.items);
-  }
-  return data;
-}
-
 module.exports = StripeResource.extend({
 
   path: 'subscriptions',
@@ -18,14 +11,14 @@ module.exports = StripeResource.extend({
 
   create: stripeMethod({
     method: 'POST',
-    encode: encode,
+    encode: utils.encodeParamWithIntegerIndexes.bind(null, 'items'),
   }),
 
   update: stripeMethod({
     method: 'POST',
     path: '{id}',
     urlParams: ['id'],
-    encode: encode,
+    encode: utils.encodeParamWithIntegerIndexes.bind(null, 'items'),
   }),
 
   /**

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -146,6 +146,18 @@ var utils = module.exports = {
   },
 
   /**
+   * Encodes a particular param of data, whose value is an array, as an
+   * object with integer string attributes. Returns the entirety of data
+   * with just that param modified.
+   */
+  encodeParamWithIntegerIndexes: function(param, data) {
+    if (data[param] !== undefined) {
+      data[param] = utils.arrayToObject(data[param]);
+    }
+    return data;
+  },
+
+  /**
    * Convert an array into an object with integer string attributes
    */
   arrayToObject: function(arr) {

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -77,7 +77,7 @@ describe('Invoices Resource', function() {
       });
     });
 
-    describe('With a options object that includes `subscription_items`', function() {
+    describe('With an options object that includes `subscription_items`', function() {
       it('Sends the correct request', function() {
         stripe.invoices.retrieveUpcoming('customerId1', {
           subscription_items: [
@@ -92,6 +92,41 @@ describe('Invoices Resource', function() {
             'subscription_items%5B0%5D%5Bplan%5D=potato&subscription_items%5B1%5D%5Bplan%5D=rutabaga',
           headers: {},
           data: {},
+        });
+      });
+    });
+
+    describe('With an options object that includes `subscription_items` in addition to a subscription ID', function() {
+      it('Sends the correct request', function() {
+        stripe.invoices.retrieveUpcoming('customerId1', 'subscriptionID1',
+          {
+            subscription_items: [
+              {plan: 'potato'},
+              {plan: 'rutabaga'},
+              {id: 'SOME_ID', deleted: true},
+            ],
+            subscription_prorate: true,
+          });
+
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/invoices/upcoming?customer=customerId1&subscription=subscriptionID1',
+          headers: {},
+          data: {
+            subscription_items: {
+              0: {
+                plan: 'potato',
+              },
+              1: {
+                plan: 'rutabaga',
+              },
+              2: {
+                deleted: true,
+                id: 'SOME_ID',
+              },
+            },
+            subscription_prorate: true,
+          },
         });
       });
     });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -54,6 +54,15 @@ describe('utils', function() {
       }))).to.equal('a[][b]=c&a[][b]=d');
     })
 
+    it('Handles indexed arrays', function() {
+      expect(decodeURI(utils.stringifyRequestData({
+        a: {
+          0: 'c',
+          1: 'd',
+        },
+      }))).to.equal('a[0]=c&a[1]=d');
+    })
+
     it('Creates a string from an object, handling shallow nested objects', function() {
       expect(utils.stringifyRequestData({
         test: 1,
@@ -234,6 +243,26 @@ describe('utils', function() {
 
         done();
       });
+    });
+  });
+
+  describe('encodeParamWithIntegerIndexes', function() {
+    it('handles param not existing in data', function() {
+      var data = {'someParam': ['foo']};
+      expect(utils.encodeParamWithIntegerIndexes('anotherParam', data)).to.deep.equal(data);
+    });
+
+    it('encodes just the specified param with integer indexes', function() {
+      var data = {'paramToEncode': ['value1', 'value2'], 'anotherParam': ['foo']};
+      var expectedData = {'paramToEncode': {'0': 'value1', '1': 'value2'}, 'anotherParam': ['foo']};
+      expect(utils.encodeParamWithIntegerIndexes('paramToEncode', data)).to.deep.equal(expectedData);
+    });
+
+    it('encodes just the specified param with integer indexes when used via partial application', function() {
+      var data = {'paramToEncode': ['value1', 'value2'], 'anotherParam': ['foo']};
+      var expectedData = {'paramToEncode': {'0': 'value1', '1': 'value2'}, 'anotherParam': ['foo']};
+      var partial = utils.encodeParamWithIntegerIndexes.bind(null, 'paramToEncode');
+      expect(partial(data)).to.deep.equal(expectedData);
     });
   });
 


### PR DESCRIPTION
r? @brandur (But brandur already approved internally, so I'm going to go ahead and self-approve)

This ended up being a bit tricky to figure out where the problem was. It appears the upcoming invoices resource at some point took two URL params, `customerID` and `invoiceOptions`, where `invoiceOptions` was an object with a bunch of parameters. At some point we scrapped `invoiceOptions` and promoted all of its options to be optional top-level fields in the request. 

So now we handle requests in one of two ways:
1. If <=2 parameters, [customerID, {other_stuff}]: customerID and other_stuff appear directly in the URL and are index-encoded properly for array things.
2. If >2 parameters, [customerID, one_field, other_stuff]: customerID and one_field appear directly in the URL. `other_stuff` is in the request body. `subscription_items` were not getting integer-index-encoded in the request body for requests with three parameters like: [customerID, one_field, subscription_items]. This fixes that by generalizing the existing `encode` method used by subscriptions.

I didn't touch the param-handling in case 1 (for backwards-compatibility, also because it works). And I guess we probably want to continue including the `subscription_items` in the request body in case 2 to skirt URL length limits.