### PR TITLE
Extra comma in includeBasic

### DIFF
--- a/lib/resources/Subscriptions.js
+++ b/lib/resources/Subscriptions.js
@@ -7,7 +7,7 @@ var stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
 
   path: 'subscriptions',
-  includeBasic: ['list', 'retrieve', 'del',],
+  includeBasic: ['list', 'retrieve', 'del'],
 
   create: stripeMethod({
     method: 'POST',


### PR DESCRIPTION
Pretty sure this is a typo which adds an empty element to the `includeBasic` array.