### PR TITLE
Remove editable bitcoin receiver actions

### DIFF
--- a/lib/resources/BitcoinReceivers.js
+++ b/lib/resources/BitcoinReceivers.js
@@ -8,8 +8,7 @@ module.exports = StripeResource.extend({
   path: 'bitcoin/receivers',
 
   includeBasic: [
-    'create', 'list', 'retrieve',
-    'update', 'setMetadata', 'getMetadata',
+    'list', 'retrieve', 'getMetadata',
   ],
 
   listTransactions: stripeMethod({

--- a/test/resources/BitcoinReceivers.spec.js
+++ b/test/resources/BitcoinReceivers.spec.js
@@ -16,28 +16,6 @@ describe('BitcoinReceivers Resource', function() {
     });
   });
 
-  describe('create', function() {
-    it('Sends the correct request', function() {
-      stripe.bitcoinReceivers.create({
-        amount: 200,
-        currency: 'usd',
-        description: 'some details',
-        email: 'do+fill_now@stripe.com',
-      });
-      expect(stripe.LAST_REQUEST).to.deep.equal({
-        method: 'POST',
-        url: '/v1/bitcoin/receivers',
-        headers: {},
-        data: {
-          amount: 200,
-          currency: 'usd',
-          description: 'some details',
-          email: 'do+fill_now@stripe.com',
-        },
-      });
-    });
-  });
-
   describe('list', function() {
     it('Sends the correct request', function() {
       stripe.bitcoinReceivers.list();
@@ -46,21 +24,6 @@ describe('BitcoinReceivers Resource', function() {
         url: '/v1/bitcoin/receivers',
         headers: {},
         data: {},
-      });
-    });
-  });
-
-  describe('update', function() {
-    it('Sends the correct request to the top-level API', function() {
-      stripe.bitcoinReceivers.update(
-        'btcrcv_123',
-        {metadata: {key: 'value'}}
-      );
-      expect(stripe.LAST_REQUEST).to.deep.equal({
-        method: 'POST',
-        url: '/v1/bitcoin/receivers/btcrcv_123',
-        data: {metadata: {key: 'value'}},
-        headers: {},
       });
     });
   });

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -42,34 +42,6 @@ describe('Charge Resource', function() {
         headers: {},
       });
     });
-
-    it('Sends the correct request for Bitcoin', function() {
-      var receiver = stripe.bitcoinReceivers.create({
-        amount: 100,
-        currency: 'usd',
-        description: 'some details',
-        email: 'do+fill_now@stripe.com',
-      })
-
-      stripe.charges.create({
-        amount: receiver.amount,
-        currency: receiver.currency,
-        description: receiver.description,
-        source: receiver.id,
-      });
-
-      expect(stripe.LAST_REQUEST).to.deep.equal({
-        method: 'POST',
-        url: '/v1/charges',
-        headers: {},
-        data: {
-          amount: receiver.amount,
-          currency: receiver.currency,
-          description: receiver.description,
-          source: receiver.id,
-        },
-      })
-    });
   });
 
   describe('list', function() {


### PR DESCRIPTION
Removes `create`, `update`, and `setMetadata` for bitcoin receivers

Tests passing: `407 passing (47s)`