### PR TITLE
Fix test suite for latest API version

### DIFF
--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -121,7 +121,7 @@ describe('Flows', function() {
       });
     });
 
-    it('Allows me to: subscribe then cancel with `at_period_end` defined', function() {
+    it('Allows me to: subscribe then update with `cancel_at_period_end` defined', function() {
       return expect(
         Promise.all([
           stripe.plans.create({
@@ -144,10 +144,7 @@ describe('Flows', function() {
 
           return stripe.customers.updateSubscription(customer.id, {
             plan: plan.id,
-          });
-        }).then(function(subscription) {
-          return stripe.customers.cancelSubscription(subscription.customer, {
-            at_period_end: true,
+            cancel_at_period_end: true,
           });
         })
       ).to.eventually.have.property('cancel_at_period_end', true);


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

The test suite is broken because it tries to cancel a subscription with `at_period_end=true`, which is no longer possible with the latest API version. Fixed by changing the request to an update request with `cancel_at_period_end=true`.
