### PR TITLE
Add support for the Reporting resources

### DIFF
--- a/lib/resources/Reporting/ReportRuns.js
+++ b/lib/resources/Reporting/ReportRuns.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var StripeResource = require('../../StripeResource');
+
+module.exports = StripeResource.extend({
+  path: 'reporting/report_runs',
+  includeBasic: ['create', 'list', 'retrieve'],
+});

--- a/lib/resources/Reporting/ReportTypes.js
+++ b/lib/resources/Reporting/ReportTypes.js
@@ -1,0 +1,8 @@
+'use strict';
+
+var StripeResource = require('../../StripeResource');
+
+module.exports = StripeResource.extend({
+  path: 'reporting/report_types',
+  includeBasic: ['list', 'retrieve'],
+});

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -84,6 +84,10 @@ var resources = {
     Disputes: require('./resources/Issuing/Disputes'),
     Transactions: require('./resources/Issuing/Transactions'),
   }),
+  Reporting: resourceNamespace('reporting', {
+    ReportRuns: require('./resources/Reporting/ReportRuns'),
+    ReportTypes: require('./resources/Reporting/ReportTypes'),
+  }),
   Sigma: resourceNamespace('sigma', {
     ScheduledQueryRuns: require('./resources/Sigma/ScheduledQueryRuns'),
   }),

--- a/test/resources/Reporting/ReportRuns.spec.js
+++ b/test/resources/Reporting/ReportRuns.spec.js
@@ -1,0 +1,56 @@
+'use strict';
+
+var stripe = require('../../testUtils').getSpyableStripe();
+
+var expect = require('chai').expect;
+
+describe('Reporting', function () {
+  describe('ReportRuns Resource', function () {
+    describe('retrieve', function () {
+      it('Sends the correct request', function () {
+        stripe.reporting.reportRuns.retrieve('frr_123');
+
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/reporting/report_runs/frr_123',
+          headers: {},
+          data: {},
+        });
+      });
+    });
+
+    describe('create', function () {
+      it('Sends the correct request', function () {
+        stripe.reporting.reportRuns.create({
+          parameters: {
+            connected_account: 'acct_123',
+          },
+          report_type: 'activity.summary.1',
+        });
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'POST',
+          url: '/v1/reporting/report_runs',
+          headers: {},
+          data: {
+            parameters: {
+              connected_account: 'acct_123',
+            },
+            report_type: 'activity.summary.1',
+          },
+        });
+      });
+    });
+
+    describe('list', function () {
+      it('Sends the correct request', function () {
+        stripe.reporting.reportRuns.list();
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/reporting/report_runs',
+          headers: {},
+          data: {},
+        });
+      });
+    });
+  });
+});

--- a/test/resources/Reporting/ReportTypes.spec.js
+++ b/test/resources/Reporting/ReportTypes.spec.js
@@ -1,0 +1,34 @@
+'use strict';
+
+var stripe = require('../../testUtils').getSpyableStripe();
+
+var expect = require('chai').expect;
+
+describe('Reporting', function () {
+  describe('ReportTypes Resource', function () {
+    describe('retrieve', function () {
+      it('Sends the correct request', function () {
+        stripe.reporting.reportTypes.retrieve('activity.summary.1');
+
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/reporting/report_types/activity.summary.1',
+          headers: {},
+          data: {},
+        });
+      });
+    });
+
+    describe('list', function () {
+      it('Sends the correct request', function () {
+        stripe.reporting.reportTypes.list();
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/reporting/report_types',
+          headers: {},
+          data: {},
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Adding support for the new Reporting resources. Those are in OpenAPI but not yet public but since they are starting to be used and are stable we should merge them.

It's WIP for now while I get some feedback on the implementation and the shape of the resources.

cc @stripe/api-libraries
cc @brahn-stripe