### PR TITLE
Override host per method instead of per resource

### DIFF
--- a/lib/StripeMethod.basic.js
+++ b/lib/StripeMethod.basic.js
@@ -65,7 +65,7 @@ module.exports = {
         sendMetadata(metadata, auth);
       } else {
         // Set entire metadata object after resetting it:
-        this._request('POST', path, {
+        this._request('POST', null, path, {
           metadata: null,
         }, auth, {}, function(err, response) {
           if (err) {
@@ -76,7 +76,7 @@ module.exports = {
       }
 
       function sendMetadata(metadata, auth) {
-        self._request('POST', path, {
+        self._request('POST', null, path, {
           metadata: metadata,
         }, auth, {}, function(err, response) {
           if (err) {
@@ -99,7 +99,7 @@ module.exports = {
     var path = this.createFullPath('/' + id, urlData);
 
     return utils.callbackifyPromiseWithTimeout(new Promise((function(resolve, reject) {
-      this._request('GET', path, {}, auth, {}, function(err, response) {
+      this._request('GET', null, path, {}, auth, {}, function(err, response) {
         if (err) {
           reject(err);
         } else {

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -14,8 +14,9 @@ var makeAutoPaginationMethods = require('./autoPagination').makeAutoPaginationMe
  *  must be passed by the consumer of the API. Subsequent optional arguments are
  *  optionally passed through a hash (Object) as the penultimate argument
  *  (preceding the also-optional callback argument
-  * @param [spec.encode] Function for mutating input parameters to a method.
+ * @param [spec.encode] Function for mutating input parameters to a method.
  *  Usefully for applying transforms to data on a per-method basis.
+ * @param [spec.host] Hostname for the request.
  */
 function stripeMethod(spec) {
   return function() {

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -48,11 +48,6 @@ StripeResource.prototype = {
   // take method name, data, and headers as arguments.
   requestDataProcessor: null,
 
-  // String that overrides the base API endpoint. If `overrideHost` is not null
-  // then all requests for a particular resource will be sent to a base API
-  // endpoint as defined by `overrideHost`.
-  overrideHost: null,
-
   // Function to add a validation checks before sending the request, errors should
   // be thrown, and they will be passed to the callback/promise.
   validateRequest: null,
@@ -227,7 +222,7 @@ StripeResource.prototype = {
     return headers;
   },
 
-  _request: function(method, path, data, auth, options, callback) {
+  _request: function(method, host, path, data, auth, options, callback) {
     var self = this;
     var requestData;
 
@@ -264,12 +259,10 @@ StripeResource.prototype = {
       var timeout = self._stripe.getApiField('timeout');
       var isInsecureConnection = self._stripe.getApiField('protocol') == 'http';
 
-      var host = self.overrideHost || self._stripe.getApiField('host');
-
       var req = (
         isInsecureConnection ? http : https
       ).request({
-        host: host,
+        host: host || self._stripe.getApiField('host'),
         port: self._stripe.getApiField('port'),
         path: path,
         method: method,

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -10,6 +10,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   var requestMethod = (spec.method || 'GET').toUpperCase();
   var urlParams = spec.urlParams || [];
   var encode = spec.encode || function(data) {return data;};
+  var host = spec.host;
 
   // Don't mutate args externally.
   var args = [].slice.call(requestArgs);
@@ -80,6 +81,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
     data: data,
     auth: options.auth,
     headers: headers,
+    host: host,
   };
 }
 
@@ -104,7 +106,7 @@ function makeRequest(self, requestArgs, spec, overrideData) {
       }
     }
 
-    self._request(opts.requestMethod, opts.requestPath, opts.data, opts.auth, {headers: opts.headers}, requestCallback);
+    self._request(opts.requestMethod, opts.host, opts.requestPath, opts.data, opts.auth, {headers: opts.headers}, requestCallback);
   });
 }
 

--- a/lib/resources/FileUploads.js
+++ b/lib/resources/FileUploads.js
@@ -9,8 +9,6 @@ var Error = require('../Error');
 
 module.exports = StripeResource.extend({
 
-  overrideHost: 'uploads.stripe.com',
-
   requestDataProcessor: function(method, data, headers, callback) {
     data = data || {};
 
@@ -68,15 +66,23 @@ module.exports = StripeResource.extend({
 
   path: 'files',
 
-  includeBasic: [
-    'retrieve',
-    'list',
-  ],
-
   create: stripeMethod({
     method: 'POST',
     headers: {
       'Content-Type': 'multipart/form-data',
     },
+    host: 'uploads.stripe.com',
+  }),
+
+  list: stripeMethod({
+    method: 'GET',
+    host: 'uploads.stripe.com',
+  }),
+
+  retrieve: stripeMethod({
+    method: 'GET',
+    path: '/{id}',
+    urlParams: ['id'],
+    host: 'uploads.stripe.com',
   }),
 });

--- a/test/resources/FileUploads.spec.js
+++ b/test/resources/FileUploads.spec.js
@@ -16,6 +16,7 @@ describe('File Uploads Resource', function() {
         url: '/v1/files/fil_12345',
         headers: {},
         data: {},
+        host: 'uploads.stripe.com',
       });
     });
 
@@ -27,6 +28,7 @@ describe('File Uploads Resource', function() {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        host: 'uploads.stripe.com',
       });
     });
   });
@@ -39,6 +41,7 @@ describe('File Uploads Resource', function() {
         url: '/v1/files',
         headers: {},
         data: {},
+        host: 'uploads.stripe.com',
       });
     });
   });
@@ -57,6 +60,7 @@ describe('File Uploads Resource', function() {
         },
       });
 
+      expect(stripe.LAST_REQUEST).to.deep.property('host', 'uploads.stripe.com');
       expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
       expect(stripe.LAST_REQUEST).to.deep.property('url', '/v1/files');
     });
@@ -74,6 +78,7 @@ describe('File Uploads Resource', function() {
         },
       }, TEST_AUTH_KEY);
 
+      expect(stripe.LAST_REQUEST).to.deep.property('host', 'uploads.stripe.com');
       expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
       expect(stripe.LAST_REQUEST).to.deep.property('url', '/v1/files');
       expect(stripe.LAST_REQUEST).to.deep.property('auth', TEST_AUTH_KEY);
@@ -91,6 +96,7 @@ describe('File Uploads Resource', function() {
           type: 'application/octet-stream',
         },
       }).then(function() {
+        expect(stripe.LAST_REQUEST).to.deep.property('host', 'uploads.stripe.com');
         expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
         expect(stripe.LAST_REQUEST).to.deep.property('url', '/v1/files');
       });
@@ -108,6 +114,7 @@ describe('File Uploads Resource', function() {
           type: 'application/octet-stream',
         },
       }, TEST_AUTH_KEY).then(function() {
+        expect(stripe.LAST_REQUEST).to.deep.property('host', 'uploads.stripe.com');
         expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
         expect(stripe.LAST_REQUEST).to.deep.property('url', '/v1/files');
         expect(stripe.LAST_REQUEST).to.deep.property('auth', TEST_AUTH_KEY);

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -42,7 +42,7 @@ var utils = module.exports = {
     }
 
     function patchRequest(stripeInstance, instance) {
-      instance._request = function(method, url, data, auth, options, cb) {
+      instance._request = function(method, host, url, data, auth, options, cb) {
         var req = stripeInstance.LAST_REQUEST = {
           method: method,
           url: url,
@@ -51,6 +51,9 @@ var utils = module.exports = {
         };
         if (auth) {
           req.auth = auth;
+        }
+        if (host) {
+          req.host = host;
         }
         stripeInstance.REQUESTS.push(req);
         cb.call(this, null, {});


### PR DESCRIPTION
r? @brandur-stripe @jlomas-stripe @remi-stripe 
cc @stripe/api-libraries 

Replaces the `overrideHost` key in `StripeResource` with a `host` key in the `stripeMethod` spec argument. This allows for overriding the host per method instead of per resource.
