### PR TITLE
Rename `FileUploads` to `Files`

### DIFF
--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -71,18 +71,16 @@ module.exports = StripeResource.extend({
     headers: {
       'Content-Type': 'multipart/form-data',
     },
-    host: 'uploads.stripe.com',
+    host: 'files.stripe.com',
   }),
 
   list: stripeMethod({
     method: 'GET',
-    host: 'uploads.stripe.com',
   }),
 
   retrieve: stripeMethod({
     method: 'GET',
     path: '/{id}',
     urlParams: ['id'],
-    host: 'uploads.stripe.com',
   }),
 });

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -44,8 +44,8 @@ var resources = {
   EphemeralKeys: require('./resources/EphemeralKeys'),
   Events: require('./resources/Events'),
   ExchangeRates: require('./resources/ExchangeRates'),
+  Files: require('./resources/Files'),
   FileLinks: require('./resources/FileLinks'),
-  FileUploads: require('./resources/FileUploads'),
   InvoiceItems: require('./resources/InvoiceItems'),
   Invoices: require('./resources/Invoices'),
   IssuerFraudRecords: require('./resources/IssuerFraudRecords'),
@@ -93,6 +93,9 @@ var resources = {
     ScheduledQueryRuns: require('./resources/Sigma/ScheduledQueryRuns'),
   }),
 };
+
+// For backwards compatibility, `Files` is aliased to `FileUploads`
+resources.FileUploads = resources.Files;
 
 Stripe.StripeResource = require('./StripeResource');
 Stripe.resources = resources;

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -7,10 +7,10 @@ var path = require('path');
 
 var TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
 
-describe('File Uploads Resource', function() {
+describe('Files Resource', function() {
   describe('retrieve', function() {
     it('Sends the correct request', function() {
-      stripe.fileUploads.retrieve('fil_12345');
+      stripe.files.retrieve('fil_12345');
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/files/fil_12345',
@@ -20,7 +20,7 @@ describe('File Uploads Resource', function() {
     });
 
     it('Sends the correct request [with specified auth]', function() {
-      stripe.fileUploads.retrieve('fil_12345', TEST_AUTH_KEY);
+      stripe.files.retrieve('fil_12345', TEST_AUTH_KEY);
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/files/fil_12345',
@@ -33,7 +33,7 @@ describe('File Uploads Resource', function() {
 
   describe('list', function() {
     it('Sends the correct request', function() {
-      stripe.fileUploads.list();
+      stripe.files.list();
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/files',
@@ -48,7 +48,7 @@ describe('File Uploads Resource', function() {
       var testFilename = path.join(__dirname, 'data/minimal.pdf');
       var f = fs.readFileSync(testFilename);
 
-      stripe.fileUploads.create({
+      stripe.files.create({
         purpose: 'dispute_evidence',
         file: {
           data: f,
@@ -66,7 +66,7 @@ describe('File Uploads Resource', function() {
       var testFilename = path.join(__dirname, 'data/minimal.pdf');
       var f = fs.readFileSync(testFilename);
 
-      stripe.fileUploads.create({
+      stripe.files.create({
         purpose: 'dispute_evidence',
         file: {
           data: f,
@@ -85,7 +85,7 @@ describe('File Uploads Resource', function() {
       var testFilename = path.join(__dirname, 'data/minimal.pdf');
       var f = fs.createReadStream(testFilename);
 
-      return stripe.fileUploads.create({
+      return stripe.files.create({
         purpose: 'dispute_evidence',
         file: {
           data: f,
@@ -103,7 +103,7 @@ describe('File Uploads Resource', function() {
       var testFilename = path.join(__dirname, 'data/minimal.pdf');
       var f = fs.createReadStream(testFilename);
 
-      return stripe.fileUploads.create({
+      return stripe.files.create({
         purpose: 'dispute_evidence',
         file: {
           data: f,


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

- Rename `stripe.fileUploads` to `stripe.files` (but keep `stripe.fileUploads` as an alias for BC)
- Have the retrieve and list requests hit `api.stripe.com` instead of `uploads.stripe.com`
- Have the create request hit `files.stripe.com` instead of `uploads.stripe.com` (this is actually the same host, but `files.stripe.com` is the new canonical name)
