### PR TITLE
Fix tests

### DIFF
--- a/test/resources/Terminal/ConnectionTokens.spec.js
+++ b/test/resources/Terminal/ConnectionTokens.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var stripe = require('../../testUtils').getSpyableStripe();
+var stripe = require('../../../testUtils').getSpyableStripe();
 
 var expect = require('chai').expect;
 

--- a/test/resources/Terminal/Locations.spec.js
+++ b/test/resources/Terminal/Locations.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var stripe = require('../../testUtils').getSpyableStripe();
+var stripe = require('../../../testUtils').getSpyableStripe();
 
 var expect = require('chai').expect;
 

--- a/test/resources/Terminal/Readers.spec.js
+++ b/test/resources/Terminal/Readers.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var stripe = require('../../testUtils').getSpyableStripe();
+var stripe = require('../../../testUtils').getSpyableStripe();
 
 var expect = require('chai').expect;
 


### PR DESCRIPTION
cc @stripe/api-libraries 

Not quite sure what happened, but it looks like #498 broke the test suite somehow (despite tests in the PR being green). This should fix it.
