### PR TITLE
Clarify `autoPagingEach` async usage

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -23,7 +23,6 @@ module.exports = {
                 "allowSingleLine": true
             }
         ],
-        "callback-return": "error",
         "camelcase": [
             "error",
             {

--- a/README.md
+++ b/README.md
@@ -31,11 +31,11 @@ available in your [Stripe Dashboard][api-keys]. Require it with the key's
 value:
 
 ``` js
-var stripe = require('stripe')('sk_test_...');
+const stripe = require('stripe')('sk_test_...');
 
-var customer = await stripe.customers.create(
-  { email: 'customer@example.com' }
-);
+const customer = await stripe.customers.create({
+  email: 'customer@example.com'
+});
 ```
 
 Or with versions of Node.js prior to v7.9:
@@ -54,16 +54,16 @@ stripe.customers.create(
 
 Or using ES modules, this looks more like:
 
-``` js
-import stripePackage from 'stripe';
-const stripe = stripePackage('sk_test_...');
+```js
+import Stripe from 'stripe';
+const stripe = Stripe('sk_test_...');
 //…
 ```
 
 
 Or using TypeScript:
 
-``` ts
+```ts
 import * as Stripe from 'stripe';
 const stripe = new Stripe('sk_test_...');
 //…
@@ -74,23 +74,23 @@ const stripe = new Stripe('sk_test_...');
 Every method returns a chainable promise which can be used instead of a regular
 callback:
 
-``` js
+```js
 // Create a new customer and then a new charge for that customer:
 stripe.customers.create({
   email: 'foo-customer@example.com'
-}).then(function(customer) {
+}).then((customer) => {
   return stripe.customers.createSource(customer.id, {
     source: 'tok_visa'
   });
-}).then(function(source) {
+}).then((source) => {
   return stripe.charges.create({
     amount: 1600,
     currency: 'usd',
     customer: source.customer
   });
-}).then(function(charge) {
+}).then((charge) => {
   // New charge created on a new customer
-}).catch(function(err) {
+}).catch((err) => {
   // Deal with an error
 });
 ```
@@ -112,9 +112,9 @@ can be added to any method:
 // Retrieve the balance for a connected account:
 stripe.balance.retrieve({
   stripe_account: 'acct_foo'
-}).then(function(balance) {
+}).then((balance) => {
   // The balance object for the connected account
-}).catch(function(err) {
+}).catch((err) => {
   // Error
 });
 ```
@@ -148,9 +148,9 @@ charge.lastResponse.statusCode
 The Stripe object emits `request` and `response` events.  You can use them like this:
 
 ```js
-var stripe = require('stripe')('sk_test_...');
+const stripe = require('stripe')('sk_test_...');
 
-function onRequest(request) {
+const onRequest = (request) => {
   // Do something.
 }
 
@@ -195,7 +195,7 @@ Please note that you must pass the _raw_ request body, exactly as received from 
 You can find an example of how to use this with [Express](https://expressjs.com/) in the [`examples/webhook-signing`](examples/webhook-signing) folder, but here's what it looks like:
 
 ```js
-event = stripe.webhooks.constructEvent(
+const event = stripe.webhooks.constructEvent(
   webhookRawBody,
   webhookStripeSignatureHeader,
   webhookSecret
@@ -255,13 +255,13 @@ console.log('Done iterating.');
 Equivalently, without `await`, you may return a Promise, which can resolve to `false` to break:
 
 ```js
-stripe.customers.list().autoPagingEach(function onItem(customer) {
-  return doSomething(customer).then(function() {
+stripe.customers.list().autoPagingEach((customer) => {
+  return doSomething(customer).then(() => {
     if (shouldBreak()) {
       return false;
     }
   });
-}).then(function() {
+}).then(() => {
   console.log('Done iterating.');
 }).catch(handleError);
 ```

--- a/lib/autoPagination.js
+++ b/lib/autoPagination.js
@@ -84,14 +84,15 @@ function getDoneCallback(args) {
 }
 
 /**
- * We allow two forms of the `onItem` callback,
+ * We allow four forms of the `onItem` callback (the middle two being equivalent),
  *
  *   1. `.autoPagingEach((item) => { doSomething(item); return false; });`
- *   2. `.autoPagingEach((item, next) => { doSomething(item); next(false); });`
+ *   2. `.autoPagingEach(async (item) => { await doSomething(item); return false; });`
+ *   3. `.autoPagingEach((item) => doSomething(item).then(() => false));`
+ *   4. `.autoPagingEach((item, next) => { doSomething(item); next(false); });`
  *
  * In addition to standard validation, this helper
- * coalesces the former form (which is provided for convenience for simple cases)
- * into the latter form.
+ * coalesces the former forms into the latter form.
  */
 function getItemCallback(args) {
   if (args.length === 0) {
@@ -102,7 +103,7 @@ function getItemCallback(args) {
     throw Error('The first argument to autoPagingEach, if present, must be a callback function; receieved ' + typeof onItem);
   }
 
-  // `.autoPagingEach((item, next) => { doSomething(item); next(); });`
+  // 4. `.autoPagingEach((item, next) => { doSomething(item); next(false); });`
   if (onItem.length === 2) {
     return onItem;
   }
@@ -111,6 +112,10 @@ function getItemCallback(args) {
     throw Error('The `onItem` callback function passed to autoPagingEach must accept at most two arguments; got ' + onItem);
   }
 
+  // This magically handles all three of these usecases (the latter two being functionally identical):
+  // 1. `.autoPagingEach((item) => { doSomething(item); return false; });`
+  // 2. `.autoPagingEach(async (item) => { await doSomething(item); return false; });`
+  // 3. `.autoPagingEach((item) => doSomething(item).then(() => false));`
   return function _onItem(item, next) {
     var shouldContinue = onItem(item);
     next(shouldContinue);
@@ -193,6 +198,7 @@ function wrapAsyncIteratorWithCallback(asyncIteratorNext, onItem) {
       return new Promise(function(next) {
         // Bit confusing, perhaps; we pass a `resolve` fn
         // to the user, so they can decide when and if to continue.
+        // They can return false, or a promise which resolves to false, to break.
         onItem(item, next);
       }).then(function(shouldContinue) {
         if (shouldContinue === false) {

--- a/test/autoPagination.spec.js
+++ b/test/autoPagination.spec.js
@@ -91,6 +91,31 @@ describe('auto pagination', function() {
       })).to.eventually.deep.equal(realCustomerIds.slice(0, LIMIT));
     });
 
+    it('lets you ignore the second arg and return a Promise which returns `false` to break', function() {
+      return expect(new Promise(function(resolve, reject) {
+        var customerIds = [];
+        function onCustomer(customer) {
+          customerIds.push(customer.id);
+          if (customerIds.length === LIMIT) {
+            return Promise.resolve(false);
+          } else {
+            expect(customerIds.length).to.be.lessThan(LIMIT);
+            return Promise.resolve();
+          }
+        }
+        function onDone(err) {
+          if (err) {
+            reject(err);
+          } else {
+            resolve(customerIds);
+          }
+        }
+
+        stripe.customers.list({limit: 3, email: email})
+          .autoPagingEach(onCustomer, onDone);
+      })).to.eventually.deep.equal(realCustomerIds.slice(0, LIMIT));
+    });
+
     it('can use a promise instead of a callback for onDone', function() {
       return expect(new Promise(function(resolve, reject) {
         var customerIds = [];


### PR DESCRIPTION
r? @brandur-stripe 
cc @ob-stripe @remi-stripe @jlomas-stripe 

In https://github.com/stripe/stripe-node/issues/511, @tyscorp asked for support for the following (paraphrased slightly): 

```js
stripe.customers.list().autoPagingEach(async function onItem(customer) {
  const result = await doSomething(customer);
  if (shouldStop(result)) {
    return false;
  }
});
```

It turns out we already have support for this! The only thing better than inventing a new feature is discovering one. 

I have added a test to verify that this works and prevent regressions, and have added docs to clarify. 

Separately, I have also cleaned up the examples on the home page to better reflect current Node usage (that is, a little more modern). 