### PR TITLE
Fix some code quality issues

### DIFF
--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -54,7 +54,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   }
 
   // Pull request data and options (headers, auth) from args.
-  var dataFromArgs = utils.getDataFromArgs(args)
+  var dataFromArgs = utils.getDataFromArgs(args);
   var data = encode(Object.assign(dataFromArgs, overrideData));
   var options = utils.getOptionsFromArgs(args);
 

--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -39,7 +39,7 @@ module.exports = StripeResource.extend({
         callback(null, buffer);
       }).on('error', function(err) {
         var errorHandler = streamError(callback);
-        errorHandler(err, null);
+        errorHandler(err);
       });
     }
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -92,7 +92,7 @@ var utils = module.exports = {
     var opts = {
       auth: null,
       headers: {},
-    }
+    };
     if (args.length > 0) {
       var arg = args[args.length - 1];
       if (utils.isAuthKey(arg)) {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

- Remove a superfluous argument when calling `errorHandler` (the function only accepts a single argument)
- Add a couple of missing semicolons
