### PR TITLE
Handle Buffer instances in Webhook.constructEvent

### DIFF
--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -1,16 +1,18 @@
+'use strict';
+
+var Buffer = require('safe-buffer').Buffer;
 var crypto = require('crypto');
 
 var utils = require('./utils');
 var Error = require('./Error');
 
 var Webhook = {
-  DEFAULT_TOLERANCE: 300,
+  DEFAULT_TOLERANCE: 300, // 5 minutes
 
   constructEvent: function(payload, header, secret, tolerance) {
-    var jsonPayload = JSON.parse(payload);
-
     this.signature.verifyHeader(payload, header, secret, tolerance || Webhook.DEFAULT_TOLERANCE);
 
+    var jsonPayload = JSON.parse(payload);
     return jsonPayload;
   },
 };
@@ -25,6 +27,9 @@ var signature = {
   },
 
   verifyHeader: function(payload, header, secret, tolerance) {
+    payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
+    header = Buffer.isBuffer(header) ? header.toString('utf8') : header;
+
     var details = parseHeader(header, this.EXPECTED_SCHEME);
 
     if (!details || details.timestamp === -1) {

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -2,6 +2,7 @@
 
 var stripe = require('../testUtils').getSpyableStripe();
 var expect = require('chai').expect;
+var Buffer = require('safe-buffer').Buffer;
 
 var EVENT_PAYLOAD = {
   id: 'evt_test_webhook',
@@ -124,6 +125,14 @@ describe('Webhooks', function() {
       });
 
       expect(stripe.webhooks.signature.verifyHeader(EVENT_PAYLOAD_STRING, header, SECRET)).to.equal(true);
+    });
+
+    it('should accept Buffer instances for the payload and header', function() {
+      var header = generateHeaderString({
+        timestamp: (Date.now() / 1000),
+      });
+
+      expect(stripe.webhooks.signature.verifyHeader(new Buffer(EVENT_PAYLOAD_STRING), new Buffer(header), SECRET, 10)).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
r? @jlomas-stripe 
cc @stripe/api-libraries 

Handle `Buffer` instances in `Webhook.constructEvent`, by silently converting them to strings.

Firebase returns the raw body as a `Buffer` instance, so this lets users directly pass `request.rawBody` to the `constructEvent` method, without having to do the string conversion themselves.

(What happens currently is that the buffer is coerced into a string when we compute the signed payload with the timestamp, but since no explicit encoding is applied, this can apparently cause issues in some cases, cf. https://github.com/stripe/stripe-node/issues/341#issuecomment-441278062).
