### PR TITLE
Do not mutate params when encoding arrays as indexed objects

### DIFF
--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -55,7 +55,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
 
   // Pull request data and options (headers, auth) from args.
   var dataFromArgs = utils.getDataFromArgs(args);
-  var data = encode(Object.assign(dataFromArgs, overrideData));
+  var data = encode(Object.assign({}, dataFromArgs, overrideData));
   var options = utils.getOptionsFromArgs(args);
 
   // Validate that there are no more args.

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -153,6 +153,7 @@ var utils = module.exports = {
    */
   encodeParamWithIntegerIndexes: function(param, data) {
     if (data[param] !== undefined) {
+      data = Object.assign({}, data);
       data[param] = utils.arrayToObject(data[param]);
     }
     return data;

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -264,6 +264,14 @@ describe('utils', function() {
       var partial = utils.encodeParamWithIntegerIndexes.bind(null, 'paramToEncode');
       expect(partial(data)).to.deep.equal(expectedData);
     });
+
+    it('does not mutate input variables', function() {
+      var data = {'paramToEncode': ['value1']};
+      var expectedData = {'paramToEncode': {'0': 'value1'}};
+      expect(utils.encodeParamWithIntegerIndexes('paramToEncode', data)).to.deep.equal(expectedData);
+      expect(data).not.to.deep.equal(expectedData);
+      expect(Array.isArray(data.paramToEncode)).to.equal(true);
+    });
   });
 
   describe('arrayToObject', function() {


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-node/issues/521

Also, for good measure, does a shallow copy of request data in general – I don't think there were any other situations that would have mutated this today, and it also doesn't protect against deep mutations, but I don't think it can hurt much (I wouldn't guess that the extra copy operations would have a meaningful perf impact). 

cc @jperasmus
cc @ob-stripe 
cc @enugent-stripe 