### PR TITLE
Export errors on root Stripe object

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -142,9 +142,12 @@ function Stripe(key, version) {
   this.setApiKey(key);
   this.setApiVersion(version);
 
-  this.errors = require('./Error.js');
+  this.errors = require('./Error');
   this.webhooks = require('./Webhooks');
 }
+
+Stripe.errors = require('./Error');
+Stripe.webhooks = require('./Webhooks');
 
 Stripe.prototype = {
 

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -514,12 +514,6 @@ describe('Flows', function() {
         done();
       });
     });
-
-    it('Exports errors as types', function() {
-      expect(new stripe.errors.StripeInvalidRequestError({
-        message: 'error'
-      }).type).to.equal('StripeInvalidRequestError');
-    });
   });
 
   describe('FileUpload', function() {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -209,4 +209,13 @@ describe('Stripe Module', function() {
       });
     });
   });
+
+  describe('errors', function() {
+    it('Exports errors as types', function() {
+      var Stripe = require('../lib/stripe');
+      expect(new Stripe.errors.StripeInvalidRequestError({
+        message: 'error'
+      }).type).to.equal('StripeInvalidRequestError');
+    });
+  });
 });


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

Export errors on root Stripe object, as suggested in https://github.com/stripe/stripe-node/issues/457#issuecomment-441856552.

Also export webhooks because why not.
