### PR TITLE
Fix iterating on files.list method

### DIFF
--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -65,6 +65,7 @@ module.exports = StripeResource.extend({
   },
 
   path: 'files',
+  includeBasic: ['list', 'retrieve'],
 
   create: stripeMethod({
     method: 'POST',
@@ -72,15 +73,5 @@ module.exports = StripeResource.extend({
       'Content-Type': 'multipart/form-data',
     },
     host: 'files.stripe.com',
-  }),
-
-  list: stripeMethod({
-    method: 'GET',
-  }),
-
-  retrieve: stripeMethod({
-    method: 'GET',
-    path: '/{id}',
-    urlParams: ['id'],
   }),
 });


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

The `retrieve` and `list` methods were manually defined on `files` because they used to hit a different host (`files.stripe.com` vs. `api.stripe.com`). Now `files.stripe.com` is only used for upload and download requests and `api.stripe.com` is used for retrieving / listing file objects, so we can use the standard methods.

Fixes #533.
