### PR TITLE
Fix Buffer deprecation warnings

### DIFF
--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -8,12 +8,12 @@ var Buffer = require('safe-buffer').Buffer;
 function multipartDataGenerator(method, data, headers) {
   var segno = (Math.round(Math.random() * 1e16) + Math.round(Math.random() * 1e16)).toString();
   headers['Content-Type'] = ('multipart/form-data; boundary=' + segno);
-  var buffer = new Buffer(0);
+  var buffer = Buffer.alloc(0);
 
   function push(l) {
     var prevBuffer = buffer;
-    var newBuffer = (l instanceof Buffer) ? l : new Buffer(l);
-    buffer = new Buffer(prevBuffer.length + newBuffer.length + 2);
+    var newBuffer = (l instanceof Buffer) ? l : Buffer.from(l);
+    buffer = Buffer.alloc(prevBuffer.length + newBuffer.length + 2);
     prevBuffer.copy(buffer);
     newBuffer.copy(buffer, prevBuffer.length);
     buffer.write('\r\n', buffer.length - 2);

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -132,7 +132,7 @@ describe('Webhooks', function() {
         timestamp: (Date.now() / 1000),
       });
 
-      expect(stripe.webhooks.signature.verifyHeader(new Buffer(EVENT_PAYLOAD_STRING), new Buffer(header), SECRET, 10)).to.equal(true);
+      expect(stripe.webhooks.signature.verifyHeader(Buffer.from(EVENT_PAYLOAD_STRING), Buffer.from(header), SECRET, 10)).to.equal(true);
     });
   });
 });


### PR DESCRIPTION
r? @remi-stripe @rattrayalex-stripe 
cc @stripe/api-libraries 

Using `new Buffer` is deprecated, cf. https://nodejs.org/api/buffer.html#buffer_new_buffer_array. This PR replaces uses of `new Buffer` with `Buffer.alloc(size)` or `Buffer.from(string)` as appropriate.
