### PR TITLE
Add Stripe client telemetry to request headers

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -174,7 +174,7 @@ StripeResource.prototype = {
           );
         }
 
-        if (res.requestId) {
+        if (self._stripe.telemetryEnabled() && res.requestId) {
           self._stripe._prevRequestMetrics.push({
             'request_id': res.requestId,
             'request_duration_ms': requestDuration,
@@ -258,7 +258,7 @@ StripeResource.prototype = {
           Object.assign(headers, options.headers);
         }
 
-        if (self._stripe._prevRequestMetrics.length > 0) {
+        if (self._stripe.telemetryEnabled() && self._stripe._prevRequestMetrics.length > 0) {
           var metrics = self._stripe._prevRequestMetrics.pop();
           headers['X-Stripe-Client-Telemetry'] = JSON.stringify({
             'last_request_metrics': metrics

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -125,6 +125,8 @@ StripeResource.prototype = {
         // lastResponse.
         res.requestId = headers['request-id'];
 
+        var requestDuration = Date.now() - req._requestStart;
+
         var responseEvent = utils.removeEmpty({
           api_version: headers['stripe-version'],
           account: headers['stripe-account'],
@@ -133,7 +135,7 @@ StripeResource.prototype = {
           path: req._requestEvent.path,
           status: res.statusCode,
           request_id: res.requestId,
-          elapsed: Date.now() - req._requestStart,
+          elapsed: requestDuration,
         });
 
         self._stripe._emitter.emit('response', responseEvent);
@@ -171,6 +173,14 @@ StripeResource.prototype = {
             null
           );
         }
+
+        if (res.requestId) {
+          self._stripe._prevRequestMetrics.push({
+            'request_id': res.requestId,
+            'request_duration_ms': requestDuration,
+          });
+        }
+
         // Expose res object
         Object.defineProperty(response, 'lastResponse', {
           enumerable: false,
@@ -246,6 +256,13 @@ StripeResource.prototype = {
 
         if (options.headers) {
           Object.assign(headers, options.headers);
+        }
+
+        if (self._stripe._prevRequestMetrics.length > 0) {
+          var metrics = self._stripe._prevRequestMetrics.pop();
+          headers['X-Stripe-Client-Telemetry'] = JSON.stringify({
+            'last_request_metrics': metrics
+          });
         }
 
         makeRequest(apiVersion, headers);

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -150,6 +150,8 @@ function Stripe(key, version) {
 
   this.errors = require('./Error');
   this.webhooks = require('./Webhooks');
+
+  this._prevRequestMetrics = [];
 }
 
 Stripe.errors = require('./Error');

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -152,6 +152,7 @@ function Stripe(key, version) {
   this.webhooks = require('./Webhooks');
 
   this._prevRequestMetrics = [];
+  this.setTelemetryEnabled(false);
 }
 
 Stripe.errors = require('./Error');
@@ -301,12 +302,19 @@ Stripe.prototype = {
     return formatted;
   },
 
+  setTelemetryEnabled: function(enableTelemetry) {
+    this._enableTelemetry = enableTelemetry;
+  },
+
+  telemetryEnabled: function() {
+    return this._enableTelemetry;
+  },
+
   _prepResources: function() {
     for (var name in resources) {
       this[utils.pascalToCamelCase(name)] = new resources[name](this);
     }
   },
-
 };
 
 module.exports = Stripe;

--- a/test/telemetry.spec.js
+++ b/test/telemetry.spec.js
@@ -6,6 +6,24 @@ var http = require('http');
 var expect = require('chai').expect;
 var testServer = null;
 
+function createTestServer(handlerFunc, cb) {
+  var host = '127.0.0.1';
+  testServer = http.createServer(function(req, res) {
+    try {
+      handlerFunc(req, res);
+    } catch (e) {
+      res.writeHead(400, {'Content-Type': 'application/json'});
+      res.end(JSON.stringify({
+        error: {type: 'invalid_request_error', message: e.message}
+      }));
+    }
+  });
+  testServer.listen(0, host, function() {
+    var port = testServer.address().port;
+    cb(host, port);
+  });
+}
+
 describe('Client Telemetry', function() {
   afterEach(function() {
     if (testServer) {
@@ -14,20 +32,18 @@ describe('Client Telemetry', function() {
     }
   });
 
-  it('Sends client telemetry on the second request', function(done) {
+  it('Does not send telemetry when disabled', function(done) {
     var numRequests = 0;
-    testServer = http.createServer(function (req, res) {
+
+    createTestServer(function (req, res) {
       numRequests += 1;
 
       var telemetry = req.headers['x-stripe-client-telemetry'];
+
       switch (numRequests) {
       case 1:
-        expect(telemetry).to.not.exist;
-        break;
       case 2:
-        expect(telemetry).to.exist;
-        expect(JSON.parse(telemetry).last_request_metrics.request_id)
-          .to.eql('req_1');
+        expect(telemetry).to.not.exist;
         break;
       default:
         expect.fail(`Should not have reached request ${numRequests}`);
@@ -36,17 +52,98 @@ describe('Client Telemetry', function() {
       res.setHeader('Request-Id', `req_${numRequests}`);
       res.writeHead(200, {'Content-Type': 'application/json'});
       res.end('{}');
-    });
-
-    testServer.listen(0, '127.0.0.1', function() {
+    }, function(host, port) {
       const stripe = require('../lib/stripe')('sk_test_FEiILxKZwnmmocJDUjUNO6pa')
-
-      stripe.setHost('127.0.0.1', testServer.address().port, 'http');
+      stripe.setHost(host, port, 'http');
 
       stripe.balance.retrieve().then(function (res) {
         return stripe.balance.retrieve();
       }).then(function (res) {
         expect(numRequests).to.equal(2);
+        done();
+      }).catch(done);
+    });
+  });
+
+  it('Sends client telemetry on the second request when enabled', function(done) {
+    var numRequests = 0;
+
+    createTestServer(function (req, res) {
+      numRequests += 1;
+
+      var telemetry = req.headers['x-stripe-client-telemetry'];
+
+      switch (numRequests) {
+      case 1:
+        expect(telemetry).to.not.exist;
+        break;
+      case 2:
+        expect(telemetry).to.exist;
+        expect(JSON.parse(telemetry).last_request_metrics.request_id)
+          .to.equal('req_1');
+        break;
+      default:
+        expect.fail(`Should not have reached request ${numRequests}`);
+      }
+
+      res.setHeader('Request-Id', `req_${numRequests}`);
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end('{}');
+    }, function(host, port) {
+      const stripe = require('../lib/stripe')('sk_test_FEiILxKZwnmmocJDUjUNO6pa')
+      stripe.setTelemetryEnabled(true);
+      stripe.setHost(host, port, 'http');
+
+      stripe.balance.retrieve().then(function (res) {
+        return stripe.balance.retrieve();
+      }).then(function (res) {
+        expect(numRequests).to.equal(2);
+        done();
+      }).catch(done);
+    });
+  });
+
+  it('Buffers metrics on concurrent requests', function(done) {
+    var numRequests = 0;
+
+    createTestServer(function (req, res) {
+      numRequests += 1;
+
+      var telemetry = req.headers['x-stripe-client-telemetry'];
+
+      switch (numRequests) {
+      case 1:
+      case 2:
+        expect(telemetry).to.not.exist;
+        break;
+      case 3:
+      case 4:
+        expect(telemetry).to.exist;
+        expect(JSON.parse(telemetry).last_request_metrics.request_id)
+          .to.be.oneOf(['req_1', 'req_2']);
+        break;
+      default:
+        expect.fail(`Should not have reached request ${numRequests}`);
+      }
+
+      res.setHeader('Request-Id', `req_${numRequests}`);
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end('{}');
+    }, function(host, port) {
+      const stripe = require('../lib/stripe')('sk_test_FEiILxKZwnmmocJDUjUNO6pa')
+      stripe.setTelemetryEnabled(true);
+      stripe.setHost(host, port, 'http');
+
+      Promise.all([
+        stripe.balance.retrieve(),
+        stripe.balance.retrieve()
+      ]).then(function() {
+        return Promise.all([
+          stripe.balance.retrieve(),
+          stripe.balance.retrieve()
+        ]);
+      }).then(function() {
+        expect(numRequests).to.equal(4);
         done();
       }).catch(done);
     });

--- a/test/telemetry.spec.js
+++ b/test/telemetry.spec.js
@@ -1,0 +1,54 @@
+'use strict';
+
+require('../testUtils');
+var http = require('http');
+
+var expect = require('chai').expect;
+var testServer = null;
+
+describe('Client Telemetry', function() {
+  afterEach(function() {
+    if (testServer) {
+      testServer.close();
+      testServer = null;
+    }
+  });
+
+  it('Sends client telemetry on the second request', function(done) {
+    var numRequests = 0;
+    testServer = http.createServer(function (req, res) {
+      numRequests += 1;
+
+      var telemetry = req.headers['x-stripe-client-telemetry'];
+      switch (numRequests) {
+      case 1:
+        expect(telemetry).to.not.exist;
+        break;
+      case 2:
+        expect(telemetry).to.exist;
+        expect(JSON.parse(telemetry).last_request_metrics.request_id)
+          .to.eql('req_1');
+        break;
+      default:
+        expect.fail(`Should not have reached request ${numRequests}`);
+      }
+
+      res.setHeader('Request-Id', `req_${numRequests}`);
+      res.writeHead(200, {'Content-Type': 'application/json'});
+      res.end('{}');
+    });
+
+    testServer.listen(0, '127.0.0.1', function() {
+      const stripe = require('../lib/stripe')('sk_test_FEiILxKZwnmmocJDUjUNO6pa')
+
+      stripe.setHost('127.0.0.1', testServer.address().port, 'http');
+
+      stripe.balance.retrieve().then(function (res) {
+        return stripe.balance.retrieve();
+      }).then(function (res) {
+        expect(numRequests).to.equal(2);
+        done();
+      }).catch(done);
+    });
+  });
+});


### PR DESCRIPTION
r? @brandur-stripe @ob-stripe 
cc @stripe/api-libraries @dcarney @akropp-stripe 

Replicates https://github.com/stripe/stripe-go/pull/766, adding request duration metrics to subsequent requests in the `X-Stripe-Client-Telemetry` header.

Since node.js is concurrent but only runs on one thread, I've used a buffering approach similar to the go implementation but without explicit mutual exclusion. Right now the buffer is unbounded, so it's size is proportional to the maximum number of successful, concurrent requests.

Instead of mocking out the server, I spin up a real http server on a random port for each test, and add assertions on the server side. This may be unconventional, but it allows me to be absolutely sure that the metrics are reaching the server. I used a similar approach in the [Go implementation](https://github.com/jameshageman-stripe/stripe-go/blob/d87ed19be3d9d9f25e26ee112a1f3a9ed6c98415/stripe_test.go#L229).