### PR TITLE
Network retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ const stripe = Stripe('sk_test_...');
 
 ### Usage with TypeScript
 
-Stripe does not currently maintain typings for this package, but there are 
-community typings available from DefinitelyTyped. 
+Stripe does not currently maintain typings for this package, but there are
+community typings available from DefinitelyTyped.
 
 To install:
 
@@ -144,6 +144,17 @@ if (process.env.http_proxy) {
   stripe.setHttpAgent(new ProxyAgent(process.env.http_proxy));
 }
 ```
+
+### Network retries
+
+Network retry amount can be added with `setMaxNetworkRetries`. This will automatically retry a request `n` amount of times if it failed due to a connection, conflict or rate limiting error.
+
+```js
+// Retry a request once before giving up
+stripe.setMaxNetworkRetries(1);
+```
+
+For POST requests, this will automatically add a [idempotency key](https://stripe.com/docs/api/idempotent_requests) if one is not already set to prevent duplication.
 
 ### Examining Responses
 

--- a/README.md
+++ b/README.md
@@ -147,14 +147,12 @@ if (process.env.http_proxy) {
 
 ### Network retries
 
-Network retry amount can be added with `setMaxNetworkRetries`. This will automatically retry a request `n` amount of times if it failed due to a connection, conflict or rate limiting error.
+Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to connection, conflict or rate limiting errors. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
 ```js
 // Retry a request once before giving up
 stripe.setMaxNetworkRetries(1);
 ```
-
-For POST requests, this will automatically add a [idempotency key](https://stripe.com/docs/api/idempotent_requests) if one is not already set to prevent duplication.
 
 ### Examining Responses
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -206,14 +206,25 @@ StripeResource.prototype = {
   },
 
   _shouldRetry: function(res, numRetries) {
-    // Retry on connection error, if we have retries left.
-    if (!res) {
-      return numRetries < this._stripe.getMaxNetworkRetries();
+    // Do not retry if we are out of retries.
+    if (numRetries >= this._stripe.getMaxNetworkRetries()) {
+      return false;
     }
 
-    // Retry on conflict or rate limit error, if we have retries left.
-    if (res.statusCode === 409 || res.statusCode === 429) {
-      return numRetries < this._stripe.getMaxNetworkRetries();
+    // Retry on connection error.
+    if (!res) {
+      return true;
+    }
+
+    // Retry on conflict, rate limit, and availability errors.
+    if (res.statusCode === 409 || res.statusCode === 429 || res.statusCode === 503) {
+      return true;
+    }
+
+    // Retry on 5xx's, except POST's, which our idempotency framework
+    // would just replay as 500's again anyway.
+    if (res.statusCode >= 500 && res.req._requestEvent.method !== 'POST') {
+      return true;
     }
 
     return false;

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -200,13 +200,18 @@ StripeResource.prototype = {
     }
   },
 
-  _shouldRetry: function(err, numRetries) {
+  _shouldRetry: function(error, numRetries) {
     if (numRetries >= this._stripe.getMaxNetworkRetries()) {
       return false;
     }
 
-    if (err.type === 'StripeConnectionError' || err.type === 'StripeApiError') {
+    if (error.type === 'StripeConnectionError' || error.type === 'StripeApiError') {
       return true;
+    }
+
+    // conflict or rate limiting
+    if (error.code === 409 || error.code === 429) {
+      return false;
     }
 
     return false;
@@ -328,6 +333,13 @@ StripeResource.prototype = {
       req.on('error', function(error) {
         if (self._shouldRetry(error, requestRetries)) {
           requestRetries += 1;
+
+          // if it's a POST request, add an idempotency key
+          if (method === 'POST') {
+            if (!headers.hasOwnProperty('Idempotency-Key')) {
+              headers['Idempotency-Key'] = utils.getUUID();
+            }
+          }
 
           return setTimeout(
             makeRequest,

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -206,12 +206,12 @@ StripeResource.prototype = {
   },
 
   _shouldRetry: function(res, numRetries) {
-    // retry on conflict or rate limit error, if we have retries left
+    // Retry on conflict or rate limit error, if we have retries left.
     if (res && (res.statusCode === 409 || res.statusCode === 429)) {
       return numRetries < this._stripe.getMaxNetworkRetries();
     }
 
-    // retry on connection error, if we have retries left
+    // Retry on connection error, if we have retries left.
     if (!res && (numRetries < this._stripe.getMaxNetworkRetries())) {
       return true;
     }
@@ -231,10 +231,10 @@ StripeResource.prototype = {
       maxNetworkRetryDelay
     );
 
-    // Apply some jitter
+    // Apply some jitter.
     sleepSeconds *= 0.5 * (1 + Math.random());
 
-    // Never sleep more than the max allowed
+    // Never sleep more than the max allowed.
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
 
     return sleepSeconds;
@@ -301,13 +301,6 @@ StripeResource.prototype = {
     function retryRequest(requestFn, apiVersion, headers, requestRetries) {
       requestRetries += 1;
 
-      // if it's a POST request, add an idempotency key
-      if (method === 'POST') {
-        if (!headers.hasOwnProperty('Idempotency-Key')) {
-          headers['Idempotency-Key'] = uuid();
-        }
-      }
-
       return setTimeout(
         requestFn,
         self._getSleepTime(requestRetries) * 1000,
@@ -332,6 +325,14 @@ StripeResource.prototype = {
         headers: headers,
         ciphers: 'DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2:!MD5',
       });
+
+      // If this is a POST and we allow multiple retries, set a idempotency key if one is not
+      // already provided.
+      if (method === 'POST' && self._stripe.getMaxNetworkRetries() > 0) {
+        if (!headers.hasOwnProperty('Idempotency-Key')) {
+          headers['Idempotency-Key'] = uuid();
+        }
+      }
 
       var requestEvent = utils.removeEmpty({
         api_version: apiVersion,

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -182,19 +182,6 @@ StripeResource.prototype = {
     };
   },
 
-  _parseResponse: function(res, cb) {
-    var response = '';
-
-    res.setEncoding('utf8');
-    res.on('data', function(chunk) {
-      response += chunk;
-    });
-
-    res.on('end', function() {
-      cb(response);
-    });
-  },
-
   _errorHandler: function(req, requestRetries, callback) {
     var self = this;
     return function(error) {
@@ -213,13 +200,13 @@ StripeResource.prototype = {
     }
   },
 
-  _shouldRetry: function(error, numRetries) {
+  _shouldRetry: function(res, numRetries) {
     if (numRetries >= this._stripe.getMaxNetworkRetries()) {
       return false;
     }
 
     // conflict or rate limiting
-    if (error.code === 409 || error.code === 429) {
+    if (res && (res.statusCode === 409 || res.statusCode === 429)) {
       return false;
     }
 
@@ -305,6 +292,14 @@ StripeResource.prototype = {
       makeRequestWithData(null, utils.stringifyRequestData(data || {}));
     }
 
+    function addIdempotentKey(headerObj) {
+      if (!headerObj.hasOwnProperty('Idempotency-Key')) {
+        headerObj['Idempotency-Key'] = utils.getUUID();
+      }
+
+      return headerObj;
+    }
+
     function makeRequest(apiVersion, headers, numRetries) {
       var timeout = self._stripe.getApiField('timeout');
       var isInsecureConnection = self._stripe.getApiField('protocol') == 'http';
@@ -338,41 +333,35 @@ StripeResource.prototype = {
       self._stripe._emitter.emit('request', requestEvent);
 
       req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));
-      // req.on('response', self._responseHandler(req, callback));
-      req.on('reponse', function(res) {
-        self._parseResponse(res, function(parsedResponse) {
-          if (self._shouldRetry(parsedResponse, requestRetries)) {
-            requestRetries += 1;
 
-            // if it's a POST request, add an idempotency key
-            if (method === 'POST') {
-              if (!headers.hasOwnProperty('Idempotency-Key')) {
-                headers['Idempotency-Key'] = utils.getUUID();
-              }
-            }
-
-            return setTimeout(
-              makeRequest,
-              self._getSleepTime(requestRetries) * 1000,
-              apiVersion,
-              headers,
-              requestRetries
-            );
-          } else {
-            return self._responseHandler(req, callback)(res);
-          }
-        });
-      });
-
-      req.on('error', function(error) {
-        if (self._shouldRetry(error, requestRetries)) {
+      req.on('response', function(res) {
+        if (self._shouldRetry(res, requestRetries)) {
           requestRetries += 1;
 
           // if it's a POST request, add an idempotency key
           if (method === 'POST') {
-            if (!headers.hasOwnProperty('Idempotency-Key')) {
-              headers['Idempotency-Key'] = utils.getUUID();
-            }
+            headers = addIdempotentKey(headers);
+          }
+
+          return setTimeout(
+            makeRequest,
+            self._getSleepTime(requestRetries) * 1000,
+            apiVersion,
+            headers,
+            requestRetries
+          );
+        } else {
+          return self._responseHandler(req, callback)(res);
+        }
+      });
+
+      req.on('error', function(error) {
+        if (self._shouldRetry(null, requestRetries)) {
+          requestRetries += 1;
+
+          // if it's a POST request, add an idempotency key
+          if (method === 'POST') {
+            headers = addIdempotentKey(headers);
           }
 
           return setTimeout(
@@ -402,7 +391,6 @@ StripeResource.prototype = {
       });
     }
   },
-
 };
 
 module.exports = StripeResource;

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -206,20 +206,20 @@ StripeResource.prototype = {
   },
 
   _shouldRetry: function(res, numRetries) {
-    // Retry on conflict or rate limit error, if we have retries left.
-    if (res && (res.statusCode === 409 || res.statusCode === 429)) {
+    // Retry on connection error, if we have retries left.
+    if (!res) {
       return numRetries < this._stripe.getMaxNetworkRetries();
     }
 
-    // Retry on connection error, if we have retries left.
-    if (!res && (numRetries < this._stripe.getMaxNetworkRetries())) {
-      return true;
+    // Retry on conflict or rate limit error, if we have retries left.
+    if (res.statusCode === 409 || res.statusCode === 429) {
+      return numRetries < this._stripe.getMaxNetworkRetries();
     }
 
     return false;
   },
 
-  _getSleepTime: function(numRetries) {
+  _getSleepTimeInMS: function(numRetries) {
     var initialNetworkRetryDelay = this._stripe.getInitialNetworkRetryDelay();
     var maxNetworkRetryDelay = this._stripe.getMaxNetworkRetryDelay();
 
@@ -231,13 +231,14 @@ StripeResource.prototype = {
       maxNetworkRetryDelay
     );
 
-    // Apply some jitter.
+    // Apply some jitter by randomizing the value in the range of
+    // (sleepSeconds / 2) to (sleepSeconds).
     sleepSeconds *= 0.5 * (1 + Math.random());
 
-    // Never sleep more than the max allowed.
+    // But never sleep less than the base sleep seconds.
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
 
-    return sleepSeconds;
+    return sleepSeconds * 1000;
   },
 
   _defaultHeaders: function(auth, contentLength, apiVersion) {
@@ -303,7 +304,7 @@ StripeResource.prototype = {
 
       return setTimeout(
         requestFn,
-        self._getSleepTime(requestRetries) * 1000,
+        self._getSleepTimeInMS(requestRetries),
         apiVersion,
         headers,
         requestRetries
@@ -354,7 +355,7 @@ StripeResource.prototype = {
 
       req.on('response', function(res) {
         if (self._shouldRetry(res, requestRetries)) {
-          retryRequest(makeRequest, apiVersion, headers, requestRetries);
+          return retryRequest(makeRequest, apiVersion, headers, requestRetries);
         } else {
           return self._responseHandler(req, callback)(res);
         }
@@ -362,7 +363,7 @@ StripeResource.prototype = {
 
       req.on('error', function(error) {
         if (self._shouldRetry(null, requestRetries)) {
-          retryRequest(makeRequest, apiVersion, headers, requestRetries);
+          return retryRequest(makeRequest, apiVersion, headers, requestRetries);
         } else {
           return self._errorHandler(req, requestRetries, callback)(error);
         }

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -217,7 +217,7 @@ StripeResource.prototype = {
     }
 
     // Retry on conflict, rate limit, and availability errors.
-    if (res.statusCode === 409 || res.statusCode === 429 || res.statusCode === 503) {
+    if (res.statusCode === 409 || res.statusCode === 503) {
       return true;
     }
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -200,6 +200,18 @@ StripeResource.prototype = {
     }
   },
 
+  _shouldRetry: function(err, numRetries) {
+    if (numRetries >= this._stripe.getMaxNetworkRetries()) {
+      return false;
+    }
+
+    if (err.type === 'StripeConnectionError' || err.type === 'StripeApiError') {
+      return true;
+    }
+
+    return false;
+  },
+
   _defaultHeaders: function(auth, contentLength, apiVersion) {
     var userAgentString = 'Stripe/v1 NodeBindings/' + this._stripe.getConstant('PACKAGE_VERSION');
 
@@ -285,6 +297,8 @@ StripeResource.prototype = {
       req._requestEvent = requestEvent;
 
       req._requestStart = Date.now();
+
+      req._requestRetries = 0;
 
       self._stripe._emitter.emit('request', requestEvent);
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -3,6 +3,7 @@
 var http = require('http');
 var https = require('https');
 var path = require('path');
+var uuid = require('uuid/v4');
 
 var utils = require('./utils');
 var Error = require('./Error');
@@ -182,6 +183,10 @@ StripeResource.prototype = {
     };
   },
 
+  _generateConnectionErrorMessage: function(requestRetries) {
+    return 'An error occurred with our connection to Stripe.' + (requestRetries > 0 ? ' Request was retried ' + requestRetries + ' times.' : '');
+  },
+
   _errorHandler: function(req, requestRetries, callback) {
     var self = this;
     return function(error) {
@@ -192,7 +197,7 @@ StripeResource.prototype = {
       callback.call(
         self,
         new Error.StripeConnectionError({
-          message: 'An error occurred with our connection to Stripe. Request was retried ' + requestRetries + ' times.',
+          message: self._generateConnectionErrorMessage(requestRetries),
           detail: error,
         }),
         null
@@ -299,7 +304,7 @@ StripeResource.prototype = {
       // if it's a POST request, add an idempotency key
       if (method === 'POST') {
         if (!headers.hasOwnProperty('Idempotency-Key')) {
-          headers['Idempotency-Key'] = utils.getUUID();
+          headers['Idempotency-Key'] = uuid();
         }
       }
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -329,7 +329,6 @@ StripeResource.prototype = {
         if (self._shouldRetry(error, requestRetries)) {
           requestRetries += 1;
 
-          // TODO: add idempotency key to headers when retrying
           return setTimeout(
             makeRequest,
             self._getSleepTime(requestRetries) * 1000,

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -201,21 +201,17 @@ StripeResource.prototype = {
   },
 
   _shouldRetry: function(res, numRetries) {
-    if (numRetries >= this._stripe.getMaxNetworkRetries()) {
-      return false;
-    }
-
-    // conflict or rate limiting
+    // retry on conflict or rate limit error, if we have retries left
     if (res && (res.statusCode === 409 || res.statusCode === 429)) {
-      return false;
+      return numRetries < this._stripe.getMaxNetworkRetries();
     }
 
-    // don't retry if everything succeeded
-    if (res && res.statusCode === 200) {
-      return false;
+    // retry on connection error, if we have retries left
+    if (!res && (numRetries < this._stripe.getMaxNetworkRetries())) {
+      return true;
     }
 
-    return true;
+    return false;
   },
 
   _getSleepTime: function(numRetries) {
@@ -297,13 +293,23 @@ StripeResource.prototype = {
       makeRequestWithData(null, utils.stringifyRequestData(data || {}));
     }
 
-    // add idempotency key if we're retrying the request
-    function addIdempotentKey(headerObj) {
-      if (!headerObj.hasOwnProperty('Idempotency-Key')) {
-        headerObj['Idempotency-Key'] = utils.getUUID();
+    function retryRequest(requestFn, apiVersion, headers, requestRetries) {
+      requestRetries += 1;
+
+      // if it's a POST request, add an idempotency key
+      if (method === 'POST') {
+        if (!headers.hasOwnProperty('Idempotency-Key')) {
+          headers['Idempotency-Key'] = utils.getUUID();
+        }
       }
 
-      return headerObj;
+      return setTimeout(
+        requestFn,
+        self._getSleepTime(requestRetries) * 1000,
+        apiVersion,
+        headers,
+        requestRetries
+      );
     }
 
     function makeRequest(apiVersion, headers, numRetries) {
@@ -342,20 +348,7 @@ StripeResource.prototype = {
 
       req.on('response', function(res) {
         if (self._shouldRetry(res, requestRetries)) {
-          requestRetries += 1;
-
-          // if it's a POST request, add an idempotency key
-          if (method === 'POST') {
-            headers = addIdempotentKey(headers);
-          }
-
-          return setTimeout(
-            makeRequest,
-            self._getSleepTime(requestRetries) * 1000,
-            apiVersion,
-            headers,
-            requestRetries
-          );
+          retryRequest(makeRequest, apiVersion, headers, requestRetries);
         } else {
           return self._responseHandler(req, callback)(res);
         }
@@ -363,20 +356,7 @@ StripeResource.prototype = {
 
       req.on('error', function(error) {
         if (self._shouldRetry(null, requestRetries)) {
-          requestRetries += 1;
-
-          // if it's a POST request, add an idempotency key
-          if (method === 'POST') {
-            headers = addIdempotentKey(headers);
-          }
-
-          return setTimeout(
-            makeRequest,
-            self._getSleepTime(requestRetries) * 1000,
-            apiVersion,
-            headers,
-            requestRetries
-          );
+          retryRequest(makeRequest, apiVersion, headers, requestRetries);
         } else {
           return self._errorHandler(req, requestRetries, callback)(error);
         }

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -182,7 +182,7 @@ StripeResource.prototype = {
     };
   },
 
-  _errorHandler: function(req, callback) {
+  _errorHandler: function(req, requestRetries, callback) {
     var self = this;
     return function(error) {
       if (req._isAborted) {
@@ -192,7 +192,7 @@ StripeResource.prototype = {
       callback.call(
         self,
         new Error.StripeConnectionError({
-          message: 'An error occurred with our connection to Stripe',
+          message: 'An error occurred with our connection to Stripe. Request was retried ' + requestRetries + ' times.',
           detail: error,
         }),
         null
@@ -210,6 +210,27 @@ StripeResource.prototype = {
     }
 
     return false;
+  },
+
+  _getSleepTime: function(numRetries) {
+    var initialNetworkRetryDelay = this._stripe.getInitialNetworkRetryDelay();
+    var maxNetworkRetryDelay = this._stripe.getMaxNetworkRetryDelay();
+
+    // Apply exponential backoff with initialNetworkRetryDelay on the
+    // number of numRetries so far as inputs. Do not allow the number to exceed
+    // maxNetworkRetryDelay.
+    var sleepSeconds = Math.min(
+      initialNetworkRetryDelay * Math.pow(numRetries - 1, 2),
+      maxNetworkRetryDelay
+    );
+
+    // Apply some jitter
+    sleepSeconds *= 0.5 * (1 + Math.random());
+
+    // Never sleep more than the max allowed
+    sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
+
+    return sleepSeconds;
   },
 
   _defaultHeaders: function(auth, contentLength, apiVersion) {
@@ -270,7 +291,7 @@ StripeResource.prototype = {
       makeRequestWithData(null, utils.stringifyRequestData(data || {}));
     }
 
-    function makeRequest(apiVersion, headers) {
+    function makeRequest(apiVersion, headers, numRetries) {
       var timeout = self._stripe.getApiField('timeout');
       var isInsecureConnection = self._stripe.getApiField('protocol') == 'http';
 
@@ -294,17 +315,32 @@ StripeResource.prototype = {
         path: path,
       });
 
+      var requestRetries = numRetries || 0;
+
       req._requestEvent = requestEvent;
 
       req._requestStart = Date.now();
-
-      req._requestRetries = 0;
 
       self._stripe._emitter.emit('request', requestEvent);
 
       req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));
       req.on('response', self._responseHandler(req, callback));
-      req.on('error', self._errorHandler(req, callback));
+      req.on('error', function(error) {
+        if (self._shouldRetry(error, requestRetries)) {
+          requestRetries += 1;
+
+          // TODO: add idempotency key to headers when retrying
+          return setTimeout(
+            makeRequest,
+            self._getSleepTime(requestRetries) * 1000,
+            apiVersion,
+            headers,
+            requestRetries
+          );
+        } else {
+          return self._errorHandler(req, requestRetries, callback)(error);
+        }
+      });
 
       req.on('socket', function(socket) {
         if (socket.connecting) {

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -210,6 +210,11 @@ StripeResource.prototype = {
       return false;
     }
 
+    // don't retry if everything succeeded
+    if (res && res.statusCode === 200) {
+      return false;
+    }
+
     return true;
   },
 
@@ -292,6 +297,7 @@ StripeResource.prototype = {
       makeRequestWithData(null, utils.stringifyRequestData(data || {}));
     }
 
+    // add idempotency key if we're retrying the request
     function addIdempotentKey(headerObj) {
       if (!headerObj.hasOwnProperty('Idempotency-Key')) {
         headerObj['Idempotency-Key'] = utils.getUUID();

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -182,6 +182,19 @@ StripeResource.prototype = {
     };
   },
 
+  _parseResponse: function(res, cb) {
+    var response = '';
+
+    res.setEncoding('utf8');
+    res.on('data', function(chunk) {
+      response += chunk;
+    });
+
+    res.on('end', function() {
+      cb(response);
+    });
+  },
+
   _errorHandler: function(req, requestRetries, callback) {
     var self = this;
     return function(error) {
@@ -205,16 +218,12 @@ StripeResource.prototype = {
       return false;
     }
 
-    if (error.type === 'StripeConnectionError' || error.type === 'StripeApiError') {
-      return true;
-    }
-
     // conflict or rate limiting
     if (error.code === 409 || error.code === 429) {
       return false;
     }
 
-    return false;
+    return true;
   },
 
   _getSleepTime: function(numRetries) {
@@ -329,7 +338,32 @@ StripeResource.prototype = {
       self._stripe._emitter.emit('request', requestEvent);
 
       req.setTimeout(timeout, self._timeoutHandler(timeout, req, callback));
-      req.on('response', self._responseHandler(req, callback));
+      // req.on('response', self._responseHandler(req, callback));
+      req.on('reponse', function(res) {
+        self._parseResponse(res, function(parsedResponse) {
+          if (self._shouldRetry(parsedResponse, requestRetries)) {
+            requestRetries += 1;
+
+            // if it's a POST request, add an idempotency key
+            if (method === 'POST') {
+              if (!headers.hasOwnProperty('Idempotency-Key')) {
+                headers['Idempotency-Key'] = utils.getUUID();
+              }
+            }
+
+            return setTimeout(
+              makeRequest,
+              self._getSleepTime(requestRetries) * 1000,
+              apiVersion,
+              headers,
+              requestRetries
+            );
+          } else {
+            return self._responseHandler(req, callback)(res);
+          }
+        });
+      });
+
       req.on('error', function(error) {
         if (self._shouldRetry(error, requestRetries)) {
           requestRetries += 1;

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -21,6 +21,9 @@ Stripe.USER_AGENT = {
 
 Stripe.USER_AGENT_SERIALIZED = null;
 
+Stripe.MAX_NETWORK_RETRY_DELAY = 2;
+Stripe.INITIAL_NETWORK_RETRY_DELAY = 0.5;
+
 var APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
 var EventEmitter = require('events').EventEmitter;
@@ -142,6 +145,7 @@ function Stripe(key, version) {
     timeout: Stripe.DEFAULT_TIMEOUT,
     agent: null,
     dev: false,
+    maxNetworkRetries: 0,
   };
 
   this._prepResources();
@@ -245,6 +249,26 @@ Stripe.prototype = {
 
   getConstant: function(c) {
     return Stripe[c];
+  },
+
+  getMaxNetworkRetries: function() {
+    return this.getApiField('maxNetworkRetries');
+  },
+
+  setMaxNetworkRetries: function(maxNetworkRetries) {
+    if ((maxNetworkRetries && typeof maxNetworkRetries !== 'number') || arguments.length < 1) {
+      throw new Error('maxNetworkRetries must be a number.');
+    }
+
+    this._setApiField('maxNetworkRetries', maxNetworkRetries);
+  },
+
+  getMaxNetworkRetryDelay: function() {
+    return this.getConstant('MAX_NETWORK_RETRY_DELAY');
+  },
+
+  getInitialNetworkRetryDelay: function() {
+    return this.getConstant('INITIAL_NETWORK_RETRY_DELAY');
   },
 
   // Gets a JSON version of a User-Agent and uses a cached version for a slight

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -21,8 +21,8 @@ Stripe.USER_AGENT = {
 
 Stripe.USER_AGENT_SERIALIZED = null;
 
-Stripe.MAX_NETWORK_RETRY_DELAY = 2;
-Stripe.INITIAL_NETWORK_RETRY_DELAY = 0.5;
+Stripe.MAX_NETWORK_RETRY_DELAY_SEC = 2;
+Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 
 var APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
@@ -264,11 +264,11 @@ Stripe.prototype = {
   },
 
   getMaxNetworkRetryDelay: function() {
-    return this.getConstant('MAX_NETWORK_RETRY_DELAY');
+    return this.getConstant('MAX_NETWORK_RETRY_DELAY_SEC');
   },
 
   getInitialNetworkRetryDelay: function() {
-    return this.getConstant('INITIAL_NETWORK_RETRY_DELAY');
+    return this.getConstant('INITIAL_NETWORK_RETRY_DELAY_SEC');
   },
 
   // Gets a JSON version of a User-Agent and uses a cached version for a slight

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,6 +4,7 @@ var Buffer = require('safe-buffer').Buffer;
 var EventEmitter = require('events').EventEmitter;
 var qs = require('qs');
 var crypto = require('crypto');
+var uuid = require('uuid/v4');
 
 var hasOwn = {}.hasOwnProperty;
 var isPlainObject = require('lodash.isplainobject');
@@ -252,6 +253,12 @@ var utils = module.exports = {
       return name[0].toLowerCase() + name.substring(1);
     }
   },
+
+  /**
+   * Return UUID for idempotency
+   */
+  getUUID: uuid,
+
 };
 
 function emitWarning(warning) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -253,12 +253,6 @@ var utils = module.exports = {
       return name[0].toLowerCase() + name.substring(1);
     }
   },
-
-  /**
-   * Return UUID for idempotency
-   */
-  getUUID: uuid,
-
 };
 
 function emitWarning(warning) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -4,7 +4,6 @@ var Buffer = require('safe-buffer').Buffer;
 var EventEmitter = require('events').EventEmitter;
 var qs = require('qs');
 var crypto = require('crypto');
-var uuid = require('uuid/v4');
 
 var hasOwn = {}.hasOwnProperty;
 var isPlainObject = require('lodash.isplainobject');

--- a/package.json
+++ b/package.json
@@ -33,13 +33,13 @@
     "eslint-plugin-chai-friendly": "^0.4.0",
     "mocha": "~5.0.5",
     "nock": "^9.0.0",
-    "nyc": "^11.3.0",
-    "uuid": "^3.3.2"
+    "nyc": "^11.3.0"
   },
   "dependencies": {
     "lodash.isplainobject": "^4.0.6",
     "qs": "~6.5.1",
-    "safe-buffer": "^5.1.1"
+    "safe-buffer": "^5.1.1",
+    "uuid": "^3.3.2"
   },
   "license": "MIT",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-chai-friendly": "^0.4.0",
     "mocha": "~5.0.5",
+    "nock": "^10.0.6",
     "nyc": "^11.3.0"
   },
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "eslint": "^4.19.1",
     "eslint-plugin-chai-friendly": "^0.4.0",
     "mocha": "~5.0.5",
-    "nock": "^10.0.6",
+    "nock": "^9.0.0",
     "nyc": "^11.3.0",
     "uuid": "^3.3.2"
   },

--- a/package.json
+++ b/package.json
@@ -33,7 +33,8 @@
     "eslint-plugin-chai-friendly": "^0.4.0",
     "mocha": "~5.0.5",
     "nock": "^10.0.6",
-    "nyc": "^11.3.0"
+    "nyc": "^11.3.0",
+    "uuid": "^3.3.2"
   },
   "dependencies": {
     "lodash.isplainobject": "^4.0.6",

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -186,7 +186,7 @@ describe('StripeResource', function() {
       });
 
       it('should return false if the status is 200', function() {
-        stripe.setMaxNetworkRetries(1);
+        stripe.setMaxNetworkRetries(2);
 
         // mocking that we're on our 2nd request
         var res = stripe.invoices._shouldRetry({

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -174,13 +174,24 @@ describe('StripeResource', function() {
         stripe.setMaxNetworkRetries(1);
         var res = stripe.invoices._shouldRetry({
           statusCode: 409
-        }, 0)
+        }, 0);
 
         expect(res).to.equal(false);
 
         res = stripe.invoices._shouldRetry({
           statusCode: 429
-        }, 0)
+        }, 0);
+
+        expect(res).to.equal(false);
+      });
+
+      it('should return false if the status is 200', function() {
+        stripe.setMaxNetworkRetries(1);
+
+        // mocking that we're on our 2nd request
+        var res = stripe.invoices._shouldRetry({
+          statusCode: 200
+        }, 1);
 
         expect(res).to.equal(false);
       });

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -35,30 +35,66 @@ describe('StripeResource', function() {
     });
   });
 
-  describe('_request', function() {
-    it('throws an error on connection failure', function() {
-      var stripe = require('../lib/stripe')(utils.getUserStripeKey());
+  describe('Retry Network Requests', function() {
+    // use a real instance of stripe as we're mocking the http.request responses
+    var realStripe = require('../lib/stripe')(utils.getUserStripeKey());
+    var options = {
+      host: stripe.getConstant('DEFAULT_HOST'),
+      path: '/v1/charges',
+      data: {
+        amount: 1000,
+        currency: 'usd',
+        source: 'tok_visa',
+        description: 'test'
+      }
+    };
 
-      var options = {
-        method: 'POST',
-        host: stripe.getConstant('DEFAULT_HOST'),
-        path: '/v1/charges',
-        data: {
-          amount: 1000,
-          currency: 'usd',
-          source: 'tok_visa',
-          description: 'test'
-        }
-      };
+    afterEach(function() {
+      nock.cleanAll();
+    });
 
+    describe('_request', function() {
+      // mock the 500
       nock('https://' + options.host)
-        .get(options.path)
-        .reply(500, {
-          error: 'foo errors'
+        .post(options.path, options.data)
+        .replyWithError({
+          type: 'StripeConnectionError'
         });
 
-      stripe.charges.create(options.data, function(err, charge) {
-        expect(err.message).to.equal('An error occurred with our connection to Stripe');
+      it('throws an error on connection failure', function(done) {
+        realStripe.charges.create(options.data, function(err, charge) {
+          expect(err.detail).to.deep.equal({
+            type: 'StripeConnectionError'
+          });
+
+          done();
+        });
+      });
+    });
+
+    describe('_shouldRetry', function() {
+      it('should return false if we\'ve reached maximum retries', function() {
+        var res = stripe.invoices._shouldRetry({}, 0);
+
+        expect(res).to.equal(false);
+      });
+
+      it('should return true if we have more retries available', function() {
+        stripe.setMaxNetworkRetries(1);
+        var res = stripe.invoices._shouldRetry({
+          type: 'StripeConnectionError'
+        }, 0);
+
+        expect(res).to.equal(true);
+      });
+
+      it('should return false if the error is not an API or connection error', function() {
+        stripe.setMaxNetworkRetries(1);
+        var res = stripe.invoices._shouldRetry({
+          type: 'foo'
+        }, 0);
+
+        expect(res).to.equal(false);
       });
     });
   });

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -37,7 +37,7 @@ describe('StripeResource', function() {
   });
 
   describe('Retry Network Requests', function() {
-    // use a real instance of stripe as we're mocking the http.request responses
+    // Use a real instance of stripe as we're mocking the http.request responses.
     var realStripe = require('../lib/stripe')(utils.getUserStripeKey());
     var options = {
       host: stripe.getConstant('DEFAULT_HOST'),
@@ -62,7 +62,7 @@ describe('StripeResource', function() {
 
     describe('_request', function() {
       it('throws an error on connection failure', function(done) {
-        // mock the connection error
+        // Mock the connection error.
         nock('https://' + options.host)
           .post(options.path, options.params)
           .replyWithError('bad stuff');
@@ -166,7 +166,7 @@ describe('StripeResource', function() {
       it('should add an idempotency key for retries using the POST method', function(done) {
         var headers;
 
-        // fail the first request but succeed on the 2nd
+        // Fail the first request but succeed on the 2nd.
         nock('https://' + options.host)
           .post(options.path, options.params)
           .replyWithError('bad stuff')

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -39,6 +39,12 @@ describe('StripeResource', function() {
   describe('Retry Network Requests', function() {
     // Use a real instance of stripe as we're mocking the http.request responses.
     var realStripe = require('../lib/stripe')(utils.getUserStripeKey());
+
+    // Override the sleep timer to speed up tests
+    realStripe.charges._getSleepTimeInMS = function() {
+      return 0;
+    };
+
     var options = {
       host: stripe.getConstant('DEFAULT_HOST'),
       path: '/v1/charges',

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -54,6 +54,10 @@ describe('StripeResource', function() {
       stripe.setMaxNetworkRetries(0);
     });
 
+    after(function() {
+      nock.cleanAll();
+    })
+
     describe('_request', function() {
       // mock the 500
       nock('https://' + options.host)

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -115,12 +115,12 @@ describe('StripeResource', function() {
         });
       });
 
-      it('should retry on rate limit error', function(done) {
+      it('should retry on a 409 error', function(done) {
         nock('https://' + options.host)
           .post(options.path, options.params)
-          .reply(429, {
+          .reply(409, {
             error: {
-              message: 'Rate limited'
+              message: 'Conflict'
             }
           })
           .post(options.path, options.params)
@@ -300,7 +300,7 @@ describe('StripeResource', function() {
       it('should return false if we\'ve reached maximum retries', function() {
         stripe.setMaxNetworkRetries(1);
         var res = stripe.invoices._shouldRetry({
-          statusCode: 429
+          statusCode: 409
         }, 1);
 
         expect(res).to.equal(false);
@@ -309,13 +309,13 @@ describe('StripeResource', function() {
       it('should return true if we have more retries available', function() {
         stripe.setMaxNetworkRetries(1);
         var res = stripe.invoices._shouldRetry({
-          statusCode: 429
+          statusCode: 409
         }, 0);
 
         expect(res).to.equal(true);
       });
 
-      it('should return true if the error code is either 409 or 429', function() {
+      it('should return true if the error code is either 409 or 503', function() {
         stripe.setMaxNetworkRetries(1);
         var res = stripe.invoices._shouldRetry({
           statusCode: 409
@@ -324,7 +324,7 @@ describe('StripeResource', function() {
         expect(res).to.equal(true);
 
         res = stripe.invoices._shouldRetry({
-          statusCode: 429
+          statusCode: 503
         }, 0);
 
         expect(res).to.equal(true);

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var utils = require('../testUtils');
-var uuid = require('../lib/utils').getUUID;
+var uuid = require('uuid/v4');
 
 var nock = require('nock');
 
@@ -67,7 +67,7 @@ describe('StripeResource', function() {
           .post(options.path, options.params)
           .replyWithError('bad stuff');
 
-        realStripe.charges.create(options.data, function(err, charge) {
+        realStripe.charges.create(options.data, function(err) {
           expect(err.detail.message).to.deep.equal('bad stuff');
           done();
         });
@@ -82,8 +82,9 @@ describe('StripeResource', function() {
 
         realStripe.setMaxNetworkRetries(1);
 
-        realStripe.charges.create(options.data, function(err, charge) {
-          expect(err.message).to.equal('An error occurred with our connection to Stripe. Request was retried 1 times.');
+        realStripe.charges.create(options.data, function(err) {
+          var errorMessage = realStripe.invoices._generateConnectionErrorMessage(1);
+          expect(err.message).to.equal(errorMessage);
           done();
         });
       });
@@ -141,7 +142,7 @@ describe('StripeResource', function() {
 
         realStripe.setMaxNetworkRetries(1);
 
-        realStripe.charges.create(options.data, function(err, charge) {
+        realStripe.charges.create(options.data, function(err) {
           expect(err).to.not.be.null;
           done();
         });
@@ -156,7 +157,7 @@ describe('StripeResource', function() {
             }
           });
 
-        realStripe.charges.create(options.data, function(err, charge) {
+        realStripe.charges.create(options.data, function(err) {
           expect(err).to.not.be.null;
           done();
         });
@@ -182,7 +183,7 @@ describe('StripeResource', function() {
 
         realStripe.setMaxNetworkRetries(1);
 
-        realStripe.charges.create(options.data, function(err, charge) {
+        realStripe.charges.create(options.data, function() {
           expect(headers).to.have.property('idempotency-key');
           done();
         });
@@ -208,7 +209,7 @@ describe('StripeResource', function() {
 
         realStripe.setMaxNetworkRetries(1);
 
-        realStripe.charges.create(options.data, {idempotency_key: key}, function(err, charge) {
+        realStripe.charges.create(options.data, {idempotency_key: key}, function() {
           expect(headers['idempotency-key']).to.equal(key);
           done();
         });

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -261,14 +261,14 @@ describe('StripeResource', function() {
       });
     });
 
-    describe('_getSleepTime', function() {
+    describe('_getSleepTimeInMS', function() {
       it('should not exceed the maximum or minimum values', function() {
         var sleepSeconds;
         var max = stripe.getMaxNetworkRetryDelay();
         var min = stripe.getInitialNetworkRetryDelay();
 
         for (var i = 0; i < 10; i++) {
-          sleepSeconds = stripe.invoices._getSleepTime(i);
+          sleepSeconds = stripe.invoices._getSleepTimeInMS(i) / 1000;
 
           expect(sleepSeconds).to.be.at.most(max);
           expect(sleepSeconds).to.be.at.least(min);

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -218,4 +218,18 @@ describe('Stripe Module', function() {
       }).type).to.equal('StripeInvalidRequestError');
     });
   });
+
+  describe('setMaxNetworkRetries', function() {
+    describe('when given an empty or non-number variable', function() {
+      it('should error', function() {
+        expect(function() {
+          stripe.setMaxNetworkRetries('foo');
+        }).to.throw(/maxNetworkRetries must be a number/);
+
+        expect(function() {
+          stripe.setMaxNetworkRetries();
+        }).to.throw(/maxNetworkRetries must be a number/);
+      });
+    });
+  });
 });


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

Fixes https://github.com/stripe/stripe-node/issues/558

Adds network retry functionality. The default retry amount is 0 but can be changed via `stripe.setMaxNetworkRetries(n)`. I modeled this after a similar change in `stripe-php`: https://github.com/stripe/stripe-php/pull/428/files

In the case of a `POST` request, an idempotency key is generated if not already provided.

This also adds the `uuid` and `nock` libraries. The former is for generating idempotency keys, there already is a similar function used in testing however according to our docs \[0\] `uuid/v4` should ideally be used for real requests. I use `nock` to mock API responses and failures.

\[0\]: https://stripe.com/docs/api/idempotent_requests