### PR TITLE
Enable persistent connections by default

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -292,6 +292,7 @@ StripeResource.prototype = {
     function makeRequest(apiVersion, headers) {
       var timeout = self._stripe.getApiField('timeout');
       var isInsecureConnection = self._stripe.getApiField('protocol') == 'http';
+      var agent = isInsecureConnection ? self._stripe.getApiField('http_agent') : self._stripe.getApiField('https_agent');
 
       var req = (
         isInsecureConnection ? http : https
@@ -300,7 +301,7 @@ StripeResource.prototype = {
         port: self._stripe.getApiField('port'),
         path: path,
         method: method,
-        agent: self._stripe.getApiField('agent'),
+        agent: agent,
         headers: headers,
         ciphers: 'DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2:!MD5',
       });

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -23,6 +23,9 @@ Stripe.USER_AGENT_SERIALIZED = null;
 
 var APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
+var http = require('http');
+var https = require('https');
+
 var EventEmitter = require('events').EventEmitter;
 var exec = require('child_process').exec;
 var utils = require('./utils');
@@ -140,7 +143,8 @@ function Stripe(key, version) {
     basePath: Stripe.DEFAULT_BASE_PATH,
     version: Stripe.DEFAULT_API_VERSION,
     timeout: Stripe.DEFAULT_TIMEOUT,
-    agent: null,
+    http_agent: this._buildDefaultAgent('http'),
+    https_agent: this._buildDefaultAgent('https'),
     dev: false,
   };
 
@@ -227,7 +231,11 @@ Stripe.prototype = {
   },
 
   setHttpAgent: function(agent) {
-    this._setApiField('agent', agent);
+    if (agent instanceof https.Agent) {
+      this._setApiField('https_agent', agent);
+    } else {
+      this._setApiField('http_agent', agent);
+    }
   },
 
   _setApiField: function(key, value) {
@@ -308,6 +316,11 @@ Stripe.prototype = {
 
   getTelemetryEnabled: function() {
     return this._enableTelemetry;
+  },
+
+  _buildDefaultAgent: function(protocol) {
+    var httpLib = protocol === 'http' ? http : https;
+    return new httpLib.Agent({keepAlive: true});
   },
 
   _prepResources: function() {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -6,6 +6,9 @@ var stripe = require('../lib/stripe')(
   'latest'
 );
 
+var http = require('http');
+var https = require('https');
+
 var expect = require('chai').expect;
 
 var CUSTOMER_DETAILS = {
@@ -20,6 +23,36 @@ describe('Stripe Module', function() {
   describe('setApiKey', function() {
     it('uses Bearer auth', function() {
       expect(stripe.getApiField('auth')).to.equal('Bearer ' + testUtils.getUserStripeKey());
+    });
+  });
+
+  describe('setHttpAgent', function() {
+    var origHttpAgent, origHttpsAgent;
+    beforeEach(function() {
+      origHttpAgent = stripe.getApiField('http_agent');
+      origHttpsAgent = stripe.getApiField('https_agent');
+      stripe._setApiField('http_agent', null);
+      stripe._setApiField('https_agent', null);
+    });
+    afterEach(function() {
+      stripe._setApiField('http_agent', origHttpAgent);
+      stripe._setApiField('https_agent', origHttpsAgent);
+    });
+    describe('when given an https.Agent', function() {
+      it('should save the agent as https_agent', function() {
+        var agent = new https.Agent();
+        stripe.setHttpAgent(agent);
+        expect(stripe.getApiField('https_agent')).to.equal(agent);
+        expect(stripe.getApiField('http_agent')).to.be.null;
+      });
+    });
+    describe('when given an http.Agent', function() {
+      it('should save the agent as http_agent', function() {
+        var agent = new http.Agent();
+        stripe.setHttpAgent(agent);
+        expect(stripe.getApiField('http_agent')).to.equal(agent);
+        expect(stripe.getApiField('https_agent')).to.be.null;
+      });
     });
   });
 
@@ -55,7 +88,7 @@ describe('Stripe Module', function() {
 
   describe('setTimeout', function() {
     it('Should define a default equal to the node default', function() {
-      expect(stripe.getApiField('timeout')).to.equal(require('http').createServer().timeout);
+      expect(stripe.getApiField('timeout')).to.equal(http.createServer().timeout);
     });
     it('Should allow me to set a custom timeout', function() {
       stripe.setTimeout(900);
@@ -63,7 +96,7 @@ describe('Stripe Module', function() {
     });
     it('Should allow me to set null, to reset to the default', function() {
       stripe.setTimeout(null);
-      expect(stripe.getApiField('timeout')).to.equal(require('http').createServer().timeout);
+      expect(stripe.getApiField('timeout')).to.equal(http.createServer().timeout);
     });
   });
 


### PR DESCRIPTION
r? @rattrayalex-stripe 

This PR enables persistent connection by default. From my laptop in Europe, running `test/flows.spec.js` takes 33 seconds with this PR, vs. 1 minute with the master branch.

Tagged as WIP, let me know what you think!