### PR TITLE
Remove rate limiting language

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ if (process.env.http_proxy) {
 
 ### Network retries
 
-Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to connection, conflict or rate limiting errors. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
+Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to connection or conflict errors. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
 ```js
 // Retry a request once before giving up

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -223,7 +223,7 @@ StripeResource.prototype = {
       return true;
     }
 
-    // Retry on conflict, rate limit, and availability errors.
+    // Retry on conflict and availability errors.
     if (res.statusCode === 409 || res.statusCode === 503) {
       return true;
     }


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

We removed network retries for rate limiting errors in https://github.com/stripe/stripe-node/pull/559 for now, but accidentally left references to it in the README.md and comments. This fixes that.