### PR TITLE
Clarify that automatic network retries occur for most api errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ if (process.env.http_proxy) {
 
 ### Network retries
 
-Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to connection errors or most api errors. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
+Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to an intermittent network problem. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
 ```js
 // Retry a request once before giving up

--- a/README.md
+++ b/README.md
@@ -147,7 +147,7 @@ if (process.env.http_proxy) {
 
 ### Network retries
 
-Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to connection or conflict errors. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
+Automatic network retries can be enabled with `setMaxNetworkRetries`. This will retry requests `n` times with exponential backoff if they fail due to connection errors or most api errors. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
 ```js
 // Retry a request once before giving up


### PR DESCRIPTION
r? @remi-stripe 
cc @paulasjes-stripe 
cc @brandur-stripe 
cc @stripe/api-libraries 
Follows https://github.com/stripe/stripe-node/pull/566 which follows https://github.com/stripe/stripe-node/pull/559