### PR TITLE
Encode Dates as Unix timestamps

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -27,7 +27,7 @@ var utils = module.exports = {
    * (forming the conventional key 'parent[child]=value')
    */
   stringifyRequestData: function(data) {
-    return qs.stringify(data)
+    return qs.stringify(data, {serializeDate: function (d) { return Math.floor(d.getTime() / 1000); }})
       // Don't use strict form encoding by changing the square bracket control
       // characters back to their literals. This is fine by the server, and
       // makes these parameter strings easier to read.

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -33,6 +33,20 @@ describe('utils', function() {
       })).to.equal('a=1&b=foo');
     });
 
+    it('Handles Dates', function() {
+      expect(utils.stringifyRequestData({
+        date: new Date('2009-02-13T23:31:30Z'),
+        created: {
+          gte: new Date('2009-02-13T23:31:30Z'),
+          lt: new Date('2044-05-01T01:28:21Z'),
+        },
+      })).to.equal([
+        'date=1234567890',
+        'created[gte]=1234567890',
+        'created[lt]=2345678901'
+      ].join('&'));
+    });
+
     it('Handles deeply nested object', function() {
       expect(utils.stringifyRequestData({
         a: {


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 

Encode `Date`s as Unix timestamps, using [`qs`](https://github.com/ljharb/qs)' `serializeDate` option.

Fixes #569.
