### PR TITLE
Add support for retrieving a Checkout Session

### DIFF
--- a/lib/resources/Checkout/Sessions.js
+++ b/lib/resources/Checkout/Sessions.js
@@ -4,5 +4,5 @@ var StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'checkout/sessions',
-  includeBasic: ['create'],
+  includeBasic: ['create', 'retrieve'],
 })

--- a/test/resources/Checkout/Sessions.spec.js
+++ b/test/resources/Checkout/Sessions.spec.js
@@ -39,5 +39,17 @@ describe('Checkout', function () {
         });
       });
     });
+
+    describe('retrieve', function() {
+      it('Sends the correct request', function() {
+        stripe.checkout.sessions.retrieve('cs_123');
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/checkout/sessions/cs_123',
+          data: {},
+          headers: {},
+        });
+      });
+    });
   });
 });


### PR DESCRIPTION
This adds support for retrieving a Checkout Session via the API and also changes the shape of the resource to have more details.

r? @rattrayalex-stripe 
cc @stripe/api-libraries 