### PR TITLE
Fix support for HTTPS proxies

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -10,6 +10,9 @@ var Error = require('./Error');
 
 var hasOwn = {}.hasOwnProperty;
 
+var defaultHttpAgent = new http.Agent({keepAlive: true});
+var defaultHttpsAgent = new https.Agent({keepAlive: true});
+
 // Provide extension mechanism for Stripe Resource Sub-Classes
 StripeResource.extend = utils.protoExtend;
 
@@ -356,7 +359,10 @@ StripeResource.prototype = {
     function makeRequest(apiVersion, headers, numRetries) {
       var timeout = self._stripe.getApiField('timeout');
       var isInsecureConnection = self._stripe.getApiField('protocol') == 'http';
-      var agent = isInsecureConnection ? self._stripe.getApiField('http_agent') : self._stripe.getApiField('https_agent');
+      var agent = self._stripe.getApiField('agent');
+      if (agent == null) {
+        agent = isInsecureConnection ? defaultHttpAgent : defaultHttpsAgent;
+      }
 
       var req = (
         isInsecureConnection ? http : https

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -26,9 +26,6 @@ Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 
 var APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
-var http = require('http');
-var https = require('https');
-
 var EventEmitter = require('events').EventEmitter;
 var exec = require('child_process').exec;
 var utils = require('./utils');
@@ -148,8 +145,7 @@ function Stripe(key, version) {
     basePath: Stripe.DEFAULT_BASE_PATH,
     version: Stripe.DEFAULT_API_VERSION,
     timeout: Stripe.DEFAULT_TIMEOUT,
-    http_agent: this._buildDefaultAgent('http'),
-    https_agent: this._buildDefaultAgent('https'),
+    agent: null,
     dev: false,
     maxNetworkRetries: 0,
   };
@@ -237,11 +233,7 @@ Stripe.prototype = {
   },
 
   setHttpAgent: function(agent) {
-    if (agent instanceof https.Agent) {
-      this._setApiField('https_agent', agent);
-    } else {
-      this._setApiField('http_agent', agent);
-    }
+    this._setApiField('agent', agent);
   },
 
   _setApiField: function(key, value) {
@@ -342,11 +334,6 @@ Stripe.prototype = {
 
   getTelemetryEnabled: function() {
     return this._enableTelemetry;
-  },
-
-  _buildDefaultAgent: function(protocol) {
-    var httpLib = protocol === 'http' ? http : https;
-    return new httpLib.Agent({keepAlive: true});
   },
 
   _prepResources: function() {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -7,7 +7,6 @@ var stripe = require('../lib/stripe')(
 );
 
 var http = require('http');
-var https = require('https');
 
 var expect = require('chai').expect;
 
@@ -23,36 +22,6 @@ describe('Stripe Module', function() {
   describe('setApiKey', function() {
     it('uses Bearer auth', function() {
       expect(stripe.getApiField('auth')).to.equal('Bearer ' + testUtils.getUserStripeKey());
-    });
-  });
-
-  describe('setHttpAgent', function() {
-    var origHttpAgent, origHttpsAgent;
-    beforeEach(function() {
-      origHttpAgent = stripe.getApiField('http_agent');
-      origHttpsAgent = stripe.getApiField('https_agent');
-      stripe._setApiField('http_agent', null);
-      stripe._setApiField('https_agent', null);
-    });
-    afterEach(function() {
-      stripe._setApiField('http_agent', origHttpAgent);
-      stripe._setApiField('https_agent', origHttpsAgent);
-    });
-    describe('when given an https.Agent', function() {
-      it('should save the agent as https_agent', function() {
-        var agent = new https.Agent();
-        stripe.setHttpAgent(agent);
-        expect(stripe.getApiField('https_agent')).to.equal(agent);
-        expect(stripe.getApiField('http_agent')).to.be.null;
-      });
-    });
-    describe('when given an http.Agent', function() {
-      it('should save the agent as http_agent', function() {
-        var agent = new http.Agent();
-        stripe.setHttpAgent(agent);
-        expect(stripe.getApiField('http_agent')).to.equal(agent);
-        expect(stripe.getApiField('https_agent')).to.be.null;
-      });
     });
   });
 


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

When I enabled persistent connections in #560, I broke support for HTTPS proxies: instances of `HttpsProxyAgent` are not instances of `https.Agent`, so they are assigned to `http_agent` instead of `https_agent`.

Rather than try to store all possible agent types in the correct variable, this PR reverts to the previous behavior of storing the agent in `agent` regardless of its type. If `agent` is null,`StripeResource` will use a default agent of the correct type depending on whether the request uses HTTP or HTTPS.

Fixes #579.
