### PR TITLE
Add error handling to User-Agent builder

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -296,21 +296,29 @@ Stripe.prototype = {
   getClientUserAgentSeeded: function(seed, cb) {
     var self = this;
 
-    exec('uname -a', function(err, uname) {
-      var userAgent = {};
-      for (var field in seed) {
-        userAgent[field] = encodeURIComponent(seed[field]);
-      }
+    try {
+      exec('uname -a', function(err, uname) {
+        cb(self._userAgentBuilder(self, seed, uname))
+      });
+    } catch (err) {
+      cb(this._userAgentBuilder(self, seed, 'UNKNOWN'))
+    }
+  },
 
-      // URI-encode in case there are unusual characters in the system's uname.
-      userAgent.uname = encodeURIComponent(uname) || 'UNKNOWN';
+  // Build the User Agent string from a seed and the uname string.
+  _userAgentBuilder: function(self, seed, uname) {
+    var userAgent = {};
+    for (var field in seed) {
+      userAgent[field] = encodeURIComponent(seed[field]);
+    }
 
-      if (self._appInfo) {
-        userAgent.application = self._appInfo;
-      }
+    // URI-encode in case there are unusual characters in the system's uname.
+    userAgent.uname = encodeURIComponent(uname) || 'UNKNOWN';
 
-      cb(JSON.stringify(userAgent));
-    });
+    if (self._appInfo) {
+      userAgent.application = self._appInfo;
+    }
+    return JSON.stringify(userAgent);
   },
 
   getAppInfoAsString: function() {

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -301,7 +301,7 @@ Stripe.prototype = {
         cb(self._userAgentBuilder(self, seed, uname))
       });
     } catch (err) {
-      cb(this._userAgentBuilder(self, seed, 'UNKNOWN'))
+      cb(self._userAgentBuilder(self, seed, 'UNKNOWN'))
     }
   },
 


### PR DESCRIPTION
Currently the User-Agent builder attempts to spawn a sub shell (default of `/bin/sh`) to execute `uname -a`. 

In high security environments where the application runtime is not permitted access to `/bin/sh` (or any external shell), Node will throw a `spawn EACCES` error rather than populating the `error` object. This is a common case when restricting an application with SELinux or AppArmor. 

These errors are not handled gracefully by the library and cause a hard crash. In general, given the myriad of execution environments as well, this call should be fully captured within an error handler. 

This PR adds proper error handling to the child_process execution to prevent shell related errors from breaking the library. 

The main logic for building the UA string is broken into a private helper function to simplify logic.

This PR does not change the format of the UA, and follows the pattern of a uname of "UNKNOWN" in the event of an error.

There's not a consistent way to have the error throw for unit tests without having control of the underlying environment, but I have confirmed that everything works as expected. If needed, any advice on adding additional tests is appreciated. 

Example of the error below:

```
internal/child_process.js:313
    throw errnoException(err, 'spawn');
    ^

Error: spawn EACCES
    at ChildProcess.spawn (internal/child_process.js:313:11)
    at exports.spawn (child_process.js:503:9)
    at Object.exports.execFile (child_process.js:213:15)
    at exports.exec (child_process.js:143:18)
    at Object.<anonymous> (/data/deployd/builds/stripe.js:5:3) // modified lib during testing, ignore line no's
    at Module._compile (module.js:653:30)
    at Object.Module._extensions..js (module.js:664:10)
    at Module.load (module.js:566:32)
    at tryModuleLoad (module.js:506:12)
    at Function.Module._load (module.js:498:3)
```