### PR TITLE
Rework error handling around exec

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -27,7 +27,6 @@ Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 var APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
 var EventEmitter = require('events').EventEmitter;
-var exec = require('child_process').exec;
 var utils = require('./utils');
 
 var resourceNamespace = require('./ResourceNamespace');
@@ -296,29 +295,21 @@ Stripe.prototype = {
   getClientUserAgentSeeded: function(seed, cb) {
     var self = this;
 
-    try {
-      exec('uname -a', function(err, uname) {
-        cb(self._userAgentBuilder(self, seed, uname))
-      });
-    } catch (err) {
-      cb(self._userAgentBuilder(self, seed, 'UNKNOWN'))
-    }
-  },
+    utils.safeExec('uname -a', function(err, uname) {
+      var userAgent = {};
+      for (var field in seed) {
+        userAgent[field] = encodeURIComponent(seed[field]);
+      }
 
-  // Build the User Agent string from a seed and the uname string.
-  _userAgentBuilder: function(self, seed, uname) {
-    var userAgent = {};
-    for (var field in seed) {
-      userAgent[field] = encodeURIComponent(seed[field]);
-    }
+      // URI-encode in case there are unusual characters in the system's uname.
+      userAgent.uname = encodeURIComponent(uname || 'UNKNOWN');
 
-    // URI-encode in case there are unusual characters in the system's uname.
-    userAgent.uname = encodeURIComponent(uname) || 'UNKNOWN';
+      if (self._appInfo) {
+        userAgent.application = self._appInfo;
+      }
 
-    if (self._appInfo) {
-      userAgent.application = self._appInfo;
-    }
-    return JSON.stringify(userAgent);
+      cb(JSON.stringify(userAgent))
+    });
   },
 
   getAppInfoAsString: function() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -2,6 +2,7 @@
 
 var Buffer = require('safe-buffer').Buffer;
 var EventEmitter = require('events').EventEmitter;
+var exec = require('child_process').exec;
 var qs = require('qs');
 var crypto = require('crypto');
 
@@ -231,6 +232,24 @@ var utils = module.exports = {
   },
 
   emitWarning: emitWarning,
+
+  /**
+   * Node's built in `exec` function sometimes throws outright,
+   * and sometimes has a callback with an error,
+   * depending on the type of error.
+   *
+   * This unifies that interface.
+   */
+  safeExec: function safeExec(cmd, cb) {
+    try {
+      utils._exec(cmd, cb);
+    } catch (e) {
+      cb(e, null);
+    }
+  },
+
+  // For mocking in tests.
+  _exec: exec,
 };
 
 function emitWarning(warning) {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -283,6 +283,61 @@ describe('utils', function() {
       expect(function() { utils.removeEmpty('potato'); }).to.throw();
     });
   });
+
+  describe('safeExec', function() {
+    var origExec;
+    beforeEach(function() {
+      origExec = utils._exec;
+    });
+    afterEach(function() {
+      utils._exec = origExec;
+    });
+
+    it('runs exec', function() {
+      var calls = [];
+      utils._exec = function(cmd, cb) {
+        calls.push([cmd, cb]);
+      }
+
+      function myCb() {}
+      utils.safeExec('hello', myCb);
+      expect(calls).to.deep.equal([
+        ['hello', myCb],
+      ]);
+    });
+
+    it('passes along normal errors', function() {
+      var myErr = Error('hi');
+      utils._exec = function(cmd, cb) {
+        cb(myErr, null)
+      }
+
+      var calls = [];
+      function myCb(err, x) {
+        calls.push([err, x]);
+      }
+      utils.safeExec('hello', myCb);
+      expect(calls).to.deep.equal([
+        [myErr, null],
+      ]);
+    });
+
+    it('passes along thrown errors as normal callback errors', function() {
+      var myErr = Error('hi');
+      utils._exec = function(cmd, cb) {
+        throw myErr;
+      }
+
+      var calls = [];
+      function myCb(err, x) {
+        calls.push([err, x]);
+      }
+      utils.safeExec('hello', myCb);
+      expect(calls).to.deep.equal([
+        [myErr, null],
+      ]);
+    });
+  })
 });
 
 function handleWarnings(doWithShimmedConsoleWarn, onWarn) {


### PR DESCRIPTION
This is a follow-up to https://github.com/stripe/stripe-node/pull/597 that incorporates [feedback](https://github.com/stripe/stripe-node/pull/597/files#r277846768) from @brandur-stripe 

It also fixes a (small) longstanding bug coming from brandur's hunch; in the `err` case, [this line](https://github.com/stripe/stripe-node/blob/140fd420fbc5407973afff71a578de69e1e1bd3d/lib/stripe.js#L306) would produce `"null"` instead of `"UNKNOWN"`, as intended.

@brennentsmith 's PR introduced no regressions and was minimally-invasive, just taking this opportunity to add some tests for confidence and rework the API a bit (I needed to move things into `utils` anyway for mockability, and figured it was silly _not_ to expose the safer api if I'm already moving things into a utils file – that's what they're for, anyway!). 

r? @brandur-stripe 
cc @stripe/api-libraries 