### PR TITLE
Updated webhook signing example

### DIFF
--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -13,20 +13,21 @@ const bodyParser = require('body-parser');
 const webhookSecret = process.env.WEBHOOK_SECRET;
 const app = express();
 
-app.use(bodyParser.raw({type: '*/*'}));
-
-app.post('/webhooks', (req, res) => {
+// Stripe requires the raw body to construct the event
+app.post('/webhooks', bodyParser.raw({type: 'application/json'}), (req, res) => {
   const sig = req.headers['stripe-signature'];
 
+  let event;
+
   try {
-    const event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
-
-    // Do something with event
-
+    event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
   } catch (err) {
     // On error, return the error message
     return res.status(400).send(`Webhook Error: ${err.message}`);
   }
+
+  // Do something with event
+  console.log('Success:', event.id);
 
   // Return a response to acknowledge receipt of the event
   res.json({received: true});

--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -1,7 +1,6 @@
-'use strict';
-
-const Stripe = require('stripe');
-const Express = require('express');
+const stripe = require('stripe')(process.env.STRIPE_API_KEY);
+const express = require('express');
+const bodyParser = require('body-parser');
 
 /**
  * You'll need to make sure this is externally accessible.  ngrok (https://ngrok.com/)
@@ -11,66 +10,28 @@ const Express = require('express');
  * STRIPE_API_KEY=sk_test_XXX WEBHOOK_SECRET=whsec_XXX node express.js
  */
 
-const apiKey = process.env.STRIPE_API_KEY;
 const webhookSecret = process.env.WEBHOOK_SECRET;
+const app = express();
 
-const stripe = Stripe(apiKey);
+app.use(bodyParser.raw({type: '*/*'}));
 
-const router = Express.Router();
-
-// Add the raw text body of the request to the `request` object
-function addRawBody(req, res, next) {
-  req.setEncoding('utf8');
-
-  var data = '';
-
-  req.on('data', function(chunk) {
-    data += chunk;
-  });
-
-  req.on('end', function() {
-    req.rawBody = data;
-
-    next();
-  });
-}
-
-/**
- * You can either `use()` addRawBody on the Router...
- */
-// router.use(addRawBody);
-
-/**
- * ...or add it directly as middleware to the route.
- */
-router.post('/webhooks', addRawBody, function(request, response) {
-  var event;
+app.post('/webhooks', (req, res) => {
+  const sig = req.headers['stripe-signature'];
 
   try {
-    // Try adding the Event as `request.event`
-    event = stripe.webhooks.constructEvent(
-      request.rawBody,
-      request.headers['stripe-signature'],
-      webhookSecret
-    );
-  } catch (e) {
-    // If `constructEvent` throws an error, respond with the message and return.
-    console.log('Error', e.message);
+    const event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
 
-    return response.status(400).send('Webhook Error:' + e.message);
+    // Do something with event
+
+  } catch (err) {
+    // On error, return the error message
+    return res.status(400).send(`Webhook Error: ${err.message}`);
   }
 
-  console.log('Success', event.id);
-
-  // Event was 'constructed', so we can respond with a 200 OK
-  response.status(200).send('Signed Webhook Received: ' + event.id);
+  // Return a response to acknowledge receipt of the event
+  res.json({received: true});
 });
 
-// You could either create this app, or just return the `Router` for use in an
-// existing Express app - up to you!
-
-const app = Express();
-app.use(router);
 app.listen(3000, function() {
   console.log('Example app listening on port 3000!')
 });

--- a/examples/webhook-signing/package.json
+++ b/examples/webhook-signing/package.json
@@ -2,14 +2,12 @@
   "name": "webhook-signing-example-express",
   "version": "1.0.0",
   "description": "",
-  "main": "index.js",
-  "scripts": {  },
+  "main": "express.js",
+  "scripts": {},
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "body-parser": "^1.17.1",
-    "express": "^4.15.2",
-    "morgan": "^1.8.1",
-    "stripe": "^4.18.0"
+    "express": "^4.16.4",
+    "stripe": "^6.30.0"
   }
 }


### PR DESCRIPTION
Old example was from 2017 and was confusing people. Particularly since `body-parser` is now included automatically with Express and no longer needs to be installed by NPM/Yarn. 

New example is now more in line to what the official docs say: https://stripe.com/docs/webhooks/signatures

Alternatively, we could just remove the examples folder entirely and direct people to the docs instead.

cc @stripe/api-libraries 

r? @rattrayalex-stripe 