### PR TITLE
Flatten parameters in multipart requests

### DIFF
--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Buffer = require('safe-buffer').Buffer;
+var utils = require('./utils');
 
 // Method for formatting HTTP body for the multipart/form-data specification
 // Mostly taken from Fermata.js
@@ -23,7 +24,7 @@ function multipartDataGenerator(method, data, headers) {
     return '"' + s.replace(/"|"/g, '%22').replace(/\r\n|\r|\n/g, ' ') + '"';
   }
 
-  for (var k in data) {
+  for (var k in utils.flattenAndStringify(data)) {
     var v = data[k];
     push('--' + segno);
     if (v.hasOwnProperty('data')) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -250,6 +250,41 @@ var utils = module.exports = {
 
   // For mocking in tests.
   _exec: exec,
+
+  isObject: function isObject(obj) {
+    var type = typeof obj;
+    return (type === 'function' || type === 'object') && !!obj;
+  },
+
+  // For use in multipart requests
+  flattenAndStringify: function flattenAndStringify(data) {
+    var result = {};
+
+    function step(obj, prevKey) {
+      Object.keys(obj).forEach(function (key) {
+        var value = obj[key];
+
+        var newKey = prevKey ? `${prevKey}[${key}]` : key;
+
+        if (utils.isObject(value)) {
+          if (!Buffer.isBuffer(value) && !value.hasOwnProperty('data')) {
+            // Non-buffer non-file Objects are recursively flattened
+            return step(value, newKey);
+          } else {
+            // Buffers and file objects are stored without modification
+            result[newKey] = value;
+          }
+        } else {
+          // Primitives are converted to strings
+          result[newKey] = String(value);
+        }
+      })
+    }
+
+    step(data);
+
+    return result;
+  },
 };
 
 function emitWarning(warning) {

--- a/test/resources/FileUploads.spec.js
+++ b/test/resources/FileUploads.spec.js
@@ -55,6 +55,7 @@ describe('File Uploads Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       });
 
       expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
@@ -73,6 +74,7 @@ describe('File Uploads Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       }, TEST_AUTH_KEY);
 
       expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
@@ -92,6 +94,7 @@ describe('File Uploads Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       }).then(function() {
         expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
         expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
@@ -110,6 +113,7 @@ describe('File Uploads Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       }, TEST_AUTH_KEY).then(function() {
         expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
         expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -55,6 +55,7 @@ describe('Files Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       });
 
       expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
@@ -73,6 +74,7 @@ describe('Files Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       }, TEST_AUTH_KEY);
 
       expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
@@ -92,6 +94,7 @@ describe('Files Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       }).then(function() {
         expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
         expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');
@@ -110,6 +113,7 @@ describe('Files Resource', function() {
           name: 'minimal.pdf',
           type: 'application/octet-stream',
         },
+        file_link_data: {create: true},
       }, TEST_AUTH_KEY).then(function() {
         expect(stripe.LAST_REQUEST).to.deep.property('host', 'files.stripe.com');
         expect(stripe.LAST_REQUEST).to.deep.property('method', 'POST');


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

Allows for nested parameters in multipart requests (i.e. file creation requests).
