### PR TITLE
Handle errors from the oauth/token endpoint

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -59,6 +59,8 @@ StripeError.generate = function(rawStripeError) {
     return new _Error.StripeAPIError(rawStripeError);
   case 'idempotency_error':
     return new _Error.StripeIdempotencyError(rawStripeError);
+  case 'invalid_grant':
+    return new _Error.StripeInvalidGrantError(rawStripeError);
   }
   return new _Error('Generic', 'Unknown Error');
 };
@@ -73,3 +75,4 @@ _Error.StripeRateLimitError = StripeError.extend({type: 'StripeRateLimitError'})
 _Error.StripeConnectionError = StripeError.extend({type: 'StripeConnectionError'});
 _Error.StripeSignatureVerificationError = StripeError.extend({type: 'StripeSignatureVerificationError'});
 _Error.StripeIdempotencyError = StripeError.extend({type: 'StripeIdempotencyError'});
+_Error.StripeInvalidGrantError = StripeError.extend({type: 'StripeInvalidGrantError'});

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -152,6 +152,15 @@ StripeResource.prototype = {
           if (response.error) {
             var err;
 
+            // Convert OAuth error responses into a standard format
+            // so that the rest of the error logic can be shared
+            if (typeof response.error === 'string') {
+              response.error = {
+                type: response.error,
+                message: response.error_description
+              }
+            }
+
             response.error.headers = headers;
             response.error.statusCode = res.statusCode;
             response.error.requestId = res.requestId;

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -230,6 +230,22 @@ describe('StripeResource', function() {
         });
       });
 
+      it('should handle OAuth errors gracefully', function (done) {
+        nock('https://connect.stripe.com')
+          .post('/oauth/token')
+          .reply(400, {
+            error: 'invalid_grant',
+            error_description: 'This authorization code has already been used. All tokens issued with this code have been revoked.'
+          });
+
+        realStripe.setMaxNetworkRetries(1);
+
+        realStripe.oauth.token(options.data, function (err) {
+          expect(err.type).to.equal('StripeInvalidGrantError');
+          done();
+        });
+      });
+
       it('should retry on a 503 error when the method is POST', function(done) {
         nock('https://' + options.host)
           .post(options.path, options.params)


### PR DESCRIPTION
Before this change, failures from the OAuth API would result in `Invalid JSON received from the Stripe API` errors.

The cause was not a parse error, but an error thrown at https://github.com/stripe/stripe-node/compare/master...mdlavin:handle-oauth-errors?expand=1#diff-404ddfdf655bbca4b088b8c7242d0a3aL155 when the `headers` value was assigned to a string value.

The response body coming back from the oauth/token endpoint is:
```
{
  "error":"invalid_grant",
  "error_description":"This authorization code has already been used. All tokens issued with this code have been revoked."
}
```

As described in https://stripe.com/docs/connect/oauth-reference#post-token-errors

I also added a nicely typed Error for invalid_token responses, and the other OAuth failures will be reported as Generic errors instead of Invalid JSON errors