### PR TITLE
Use `id` for single positional arguments

### DIFF
--- a/lib/resources/BitcoinReceivers.js
+++ b/lib/resources/BitcoinReceivers.js
@@ -10,8 +10,8 @@ module.exports = StripeResource.extend({
 
   listTransactions: stripeMethod({
     method: 'GET',
-    path: '/{receiverId}/transactions',
-    urlParams: ['receiverId'],
+    path: '/{id}/transactions',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 });

--- a/lib/resources/Charges.js
+++ b/lib/resources/Charges.js
@@ -45,14 +45,14 @@ module.exports = StripeResource.extend({
    */
   createRefund: stripeMethod({
     method: 'POST',
-    path: '/{chargeId}/refunds',
-    urlParams: ['chargeId'],
+    path: '/{id}/refunds',
+    urlParams: ['id'],
   }),
 
   listRefunds: stripeMethod({
     method: 'GET',
-    path: '/{chargeId}/refunds',
-    urlParams: ['chargeId'],
+    path: '/{id}/refunds',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 

--- a/lib/resources/CreditNotes.js
+++ b/lib/resources/CreditNotes.js
@@ -9,7 +9,7 @@ module.exports = StripeResource.extend({
 
   voidCreditNote: stripeMethod({
     method: 'POST',
-    path: '{creditNoteId}/void',
-    urlParams: ['creditNoteId'],
+    path: '{id}/void',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/Customers.js
+++ b/lib/resources/Customers.js
@@ -22,8 +22,8 @@ module.exports = StripeResource.extend({
 
   _legacyUpdateSubscription: stripeMethod({
     method: 'POST',
-    path: '{customerId}/subscription',
-    urlParams: ['customerId'],
+    path: '{id}/subscription',
+    urlParams: ['id'],
   }),
 
   _newstyleUpdateSubscription: stripeMethod({
@@ -34,8 +34,8 @@ module.exports = StripeResource.extend({
 
   _legacyCancelSubscription: stripeMethod({
     method: 'DELETE',
-    path: '{customerId}/subscription',
-    urlParams: ['customerId'],
+    path: '{id}/subscription',
+    urlParams: ['id'],
   }),
 
   _newstyleCancelSubscription: stripeMethod({
@@ -46,14 +46,14 @@ module.exports = StripeResource.extend({
 
   createSubscription: stripeMethod({
     method: 'POST',
-    path: '/{customerId}/subscriptions',
-    urlParams: ['customerId'],
+    path: '/{id}/subscriptions',
+    urlParams: ['id'],
   }),
 
   listSubscriptions: stripeMethod({
     method: 'GET',
-    path: '/{customerId}/subscriptions',
-    urlParams: ['customerId'],
+    path: '/{id}/subscriptions',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 

--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -10,26 +10,26 @@ module.exports = StripeResource.extend({
 
   finalizeInvoice: stripeMethod({
     method: 'POST',
-    path: '{invoiceId}/finalize',
-    urlParams: ['invoiceId'],
+    path: '{id}/finalize',
+    urlParams: ['id'],
   }),
 
   markUncollectible: stripeMethod({
     method: 'POST',
-    path: '{invoiceId}/mark_uncollectible',
-    urlParams: ['invoiceId'],
+    path: '{id}/mark_uncollectible',
+    urlParams: ['id'],
   }),
 
   pay: stripeMethod({
     method: 'POST',
-    path: '{invoiceId}/pay',
-    urlParams: ['invoiceId'],
+    path: '{id}/pay',
+    urlParams: ['id'],
   }),
 
   retrieveLines: stripeMethod({
     method: 'GET',
-    path: '{invoiceId}/lines',
-    urlParams: ['invoiceId'],
+    path: '{id}/lines',
+    urlParams: ['id'],
   }),
 
   retrieveUpcoming: stripeMethod({
@@ -88,13 +88,13 @@ module.exports = StripeResource.extend({
 
   sendInvoice: stripeMethod({
     method: 'POST',
-    path: '{invoiceId}/send',
-    urlParams: ['invoiceId'],
+    path: '{id}/send',
+    urlParams: ['id'],
   }),
 
   voidInvoice: stripeMethod({
     method: 'POST',
-    path: '{invoiceId}/void',
-    urlParams: ['invoiceId'],
+    path: '{id}/void',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/Orders.js
+++ b/lib/resources/Orders.js
@@ -10,13 +10,13 @@ module.exports = StripeResource.extend({
 
   pay: stripeMethod({
     method: 'POST',
-    path: '/{orderId}/pay',
-    urlParams: ['orderId'],
+    path: '/{id}/pay',
+    urlParams: ['id'],
   }),
 
   returnOrder: stripeMethod({
     method: 'POST',
-    path: '/{orderId}/returns',
-    urlParams: ['orderId'],
+    path: '/{id}/returns',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/PaymentIntents.js
+++ b/lib/resources/PaymentIntents.js
@@ -9,19 +9,19 @@ module.exports = StripeResource.extend({
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{paymentIntentId}/cancel',
-    urlParams: ['paymentIntentId'],
+    path: '{id}/cancel',
+    urlParams: ['id'],
   }),
 
   capture: stripeMethod({
     method: 'POST',
-    path: '{paymentIntentId}/capture',
-    urlParams: ['paymentIntentId'],
+    path: '{id}/capture',
+    urlParams: ['id'],
   }),
 
   confirm: stripeMethod({
     method: 'POST',
-    path: '{paymentIntentId}/confirm',
-    urlParams: ['paymentIntentId'],
+    path: '{id}/confirm',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/PaymentMethods.js
+++ b/lib/resources/PaymentMethods.js
@@ -9,13 +9,13 @@ module.exports = StripeResource.extend({
 
   attach: stripeMethod({
     method: 'POST',
-    path: '{paymentMethodId}/attach',
-    urlParams: ['paymentMethodId'],
+    path: '{id}/attach',
+    urlParams: ['id'],
   }),
 
   detach: stripeMethod({
     method: 'POST',
-    path: '{paymentMethodId}/detach',
-    urlParams: ['paymentMethodId'],
+    path: '{id}/detach',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/Payouts.js
+++ b/lib/resources/Payouts.js
@@ -17,14 +17,14 @@ module.exports = StripeResource.extend({
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{payoutId}/cancel',
-    urlParams: ['payoutId'],
+    path: '{id}/cancel',
+    urlParams: ['id'],
   }),
 
   listTransactions: stripeMethod({
     method: 'GET',
-    path: '{payoutId}/transactions',
-    urlParams: ['payoutId'],
+    path: '{id}/transactions',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 });

--- a/lib/resources/Recipients.js
+++ b/lib/resources/Recipients.js
@@ -17,14 +17,14 @@ module.exports = StripeResource.extend({
 
   createCard: stripeMethod({
     method: 'POST',
-    path: '/{recipientId}/cards',
-    urlParams: ['recipientId'],
+    path: '/{id}/cards',
+    urlParams: ['id'],
   }),
 
   listCards: stripeMethod({
     method: 'GET',
-    path: '/{recipientId}/cards',
-    urlParams: ['recipientId'],
+    path: '/{id}/cards',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 

--- a/lib/resources/Subscriptions.js
+++ b/lib/resources/Subscriptions.js
@@ -12,7 +12,7 @@ module.exports = StripeResource.extend({
    */
   deleteDiscount: stripeMethod({
     method: 'DELETE',
-    path: '/{subscriptionId}/discount',
-    urlParams: ['subscriptionId'],
+    path: '/{id}/discount',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/Topups.js
+++ b/lib/resources/Topups.js
@@ -16,7 +16,7 @@ module.exports = StripeResource.extend({
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{topupId}/cancel',
-    urlParams: ['topupId'],
+    path: '{id}/cancel',
+    urlParams: ['id'],
   }),
 });

--- a/lib/resources/Transfers.js
+++ b/lib/resources/Transfers.js
@@ -1,4 +1,4 @@
-'use strict';
+id'use strict';
 
 var StripeResource = require('../StripeResource');
 var stripeMethod = StripeResource.method;
@@ -17,20 +17,20 @@ module.exports = StripeResource.extend({
 
   reverse: stripeMethod({
     method: 'POST',
-    path: '/{transferId}/reversals',
-    urlParams: ['transferId'],
+    path: '/{id}/reversals',
+    urlParams: ['id'],
   }),
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{transferId}/cancel',
-    urlParams: ['transferId'],
+    path: '{id}/cancel',
+    urlParams: ['id'],
   }),
 
   listTransactions: stripeMethod({
     method: 'GET',
-    path: '{transferId}/transactions',
-    urlParams: ['transferId'],
+    path: '{id}/transactions',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 
@@ -39,14 +39,14 @@ module.exports = StripeResource.extend({
    */
   createReversal: stripeMethod({
     method: 'POST',
-    path: '/{transferId}/reversals',
-    urlParams: ['transferId'],
+    path: '/{id}/reversals',
+    urlParams: ['id'],
   }),
 
   listReversals: stripeMethod({
     method: 'GET',
-    path: '/{transferId}/reversals',
-    urlParams: ['transferId'],
+    path: '/{id}/reversals',
+    urlParams: ['id'],
     methodType: 'list',
   }),
 

--- a/lib/resources/Transfers.js
+++ b/lib/resources/Transfers.js
@@ -1,4 +1,4 @@
-id'use strict';
+'use strict';
 
 var StripeResource = require('../StripeResource');
 var stripeMethod = StripeResource.method;

--- a/lib/resources/UsageRecords.js
+++ b/lib/resources/UsageRecords.js
@@ -8,7 +8,7 @@ module.exports = StripeResource.extend({
 
   create: stripeMethod({
     method: 'POST',
-    path: '{subscriptionItem}/usage_records',
-    urlParams: ['subscriptionItem'],
+    path: '{id}/usage_records',
+    urlParams: ['id'],
   }),
 });


### PR DESCRIPTION
Use `id` for single resource method positional arguments, e.g.:

```javascript
cancel: stripeMethod({
  method: 'POST',
  path: '{id}/cancel',
  urlParams: ['id'],
})
```

Instead of:

```javascript
cancel: stripeMethod({
  method: 'POST',
  path: '{paymentIntentId}/cancel',
  urlParams: ['paymentIntentId'],
})
```

### This PR does _not_:

1. Modify argument names for methods with multiple positional arguments, e.g.

```javascript
updateRefund: stripeMethod({
  method: 'POST',
  path: '/{chargeId}/refunds/{refundId}',
  urlParams: ['chargeId', 'refundId'],
}),
```

2. Modify argument names in resource paths, e.g.

```javascript
module.exports = StripeResource.extend({
  path: 'application_fees/{feeId}/refunds',
  includeBasic: ['create', 'list', 'retrieve', 'update'],
});
```