### PR TITLE
Add BalanceTransactions resource

### DIFF
--- a/lib/resources/BalanceTransactions.js
+++ b/lib/resources/BalanceTransactions.js
@@ -1,0 +1,6 @@
+'use strict';
+
+module.exports = require('../StripeResource').extend({
+  path: 'balance/history',
+  includeBasic: ['list', 'retrieve'],
+});

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -39,6 +39,7 @@ var resources = {
   ApplePayDomains: require('./resources/ApplePayDomains'),
   ApplicationFees: require('./resources/ApplicationFees'),
   Balance: require('./resources/Balance'),
+  BalanceTransactions: require('./resources/BalanceTransactions'),
   BitcoinReceivers: require('./resources/BitcoinReceivers'),
   Charges: require('./resources/Charges'),
   CountrySpecs: require('./resources/CountrySpecs'),

--- a/test/resources/BalanceTransactions.spec.js
+++ b/test/resources/BalanceTransactions.spec.js
@@ -1,0 +1,30 @@
+'use strict';
+
+var stripe = require('../../testUtils').getSpyableStripe();
+var expect = require('chai').expect;
+
+describe('BalanceTransactions Resource', function() {
+  describe('retrieve', function() {
+    it('Sends the correct request', function() {
+      stripe.balanceTransactions.retrieve('txn_123');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/balance/history/txn_123',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('list', function() {
+    it('Sends the correct request', function() {
+      stripe.balanceTransactions.list();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/balance/history',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+});


### PR DESCRIPTION
r? @rattrayalex-stripe @remi-stripe 
cc @stripe/api-libraries 

Adds a `stripe.balanceTransactions` resource with `list()` and `retrieve()` methods.

Right now balance transactions can be accessed via `stripe.balance.listTransactions()` / `retrieveTransaction()`, but balance transactions are not really a nested resource, they just have a somewhat weird URL pattern.
