### PR TITLE
Add testUtils to npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@
 !/VERSION
 !/package.json
 !/lib/**/*
+!/testUtils/*


### PR DESCRIPTION
Should fix https://github.com/stripe/stripe-node/issues/616

Let me know if we want to only specify `index` here or if the whole folder is okay.

r? @remi-stripe @rattrayalex-stripe 