### PR TITLE
Remove legacy parameter support in invoices.retrieveUpcoming()

### DIFF
--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -2,7 +2,6 @@
 
 const StripeResource = require('../StripeResource');
 const stripeMethod = StripeResource.method;
-const utils = require('../utils');
 
 module.exports = StripeResource.extend({
   path: 'invoices',
@@ -12,6 +11,17 @@ module.exports = StripeResource.extend({
     method: 'POST',
     path: '{id}/finalize',
     urlParams: ['id'],
+  }),
+
+  listLineItems: stripeMethod({
+    method: 'GET',
+    path: '{id}/lines',
+    urlParams: ['id'],
+  }),
+
+  listUpcomingLineItems: stripeMethod({
+    method: 'GET',
+    path: 'upcoming/lines',
   }),
 
   markUncollectible: stripeMethod({
@@ -26,61 +36,9 @@ module.exports = StripeResource.extend({
     urlParams: ['id'],
   }),
 
-  retrieveLines: stripeMethod({
-    method: 'GET',
-    path: '{id}/lines',
-    urlParams: ['id'],
-  }),
-
   retrieveUpcoming: stripeMethod({
     method: 'GET',
-    path(urlData) {
-      let url = 'upcoming?';
-      let hasParam = false;
-
-      // If you pass just a hash with the relevant parameters, including customer id inside.
-      if (
-        urlData.invoiceOptionsOrCustomerId &&
-        typeof urlData.invoiceOptionsOrCustomerId === 'object'
-      ) {
-        return (
-          url + utils.stringifyRequestData(urlData.invoiceOptionsOrCustomerId)
-        );
-      }
-
-      // Legacy implementation where the first parameter is a customer id as a string
-      if (
-        urlData.invoiceOptionsOrCustomerId &&
-        typeof urlData.invoiceOptionsOrCustomerId === 'string'
-      ) {
-        url = `${url}customer=${urlData.invoiceOptionsOrCustomerId}`;
-        hasParam = true;
-      }
-
-      // Legacy support where second argument is the subscription id
-      if (
-        urlData.invoiceOptionsOrSubscriptionId &&
-        typeof urlData.invoiceOptionsOrSubscriptionId === 'string'
-      ) {
-        return `${url + (hasParam ? '&' : '')}subscription=${
-          urlData.invoiceOptionsOrSubscriptionId
-        }`;
-      } else if (
-        urlData.invoiceOptionsOrSubscriptionId &&
-        typeof urlData.invoiceOptionsOrSubscriptionId === 'object'
-      ) {
-        return (
-          url +
-          (hasParam ? '&' : '') +
-          utils.stringifyRequestData(urlData.invoiceOptionsOrSubscriptionId)
-        );
-      }
-      return url;
-    },
-    urlParams: [
-      'optional!invoiceOptionsOrCustomerId',
-      'optional!invoiceOptionsOrSubscriptionId',
-    ],
+    path: 'upcoming',
   }),
 
   sendInvoice: stripeMethod({

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -49,11 +49,12 @@ describe('StripeResource', () => {
     });
 
     describe('_request', () => {
-      it('encodes the query string in GET requests', (done) => {
+      it('encodes the body in GET requests', (done) => {
         const options = {
           host: stripe.getConstant('DEFAULT_HOST'),
           path: '/v1/invoices/upcoming',
           data: {
+            customer: 'cus_123',
             subscription_items: [
               {plan: 'foo', quantity: 2},
               {id: 'si_123', deleted: true},
@@ -62,18 +63,13 @@ describe('StripeResource', () => {
         };
 
         const scope = nock(`https://${options.host}`)
-          .get(options.path)
-          .query(Object.assign({customer: 'cus_123'}, options.data))
+          .get(options.path, options.data)
           .reply(200, '{}');
 
-        realStripe.invoices.retrieveUpcoming(
-          'cus_123',
-          options.data,
-          (err, response) => {
-            done();
-            scope.done();
-          }
-        );
+        realStripe.invoices.retrieveUpcoming(options.data, (err, response) => {
+          done();
+          scope.done();
+        });
       });
 
       it('encodes the body in POST requests', (done) => {

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -64,9 +64,9 @@ describe('Invoices Resource', () => {
     });
   });
 
-  describe('retrieveLines', () => {
+  describe('listLineItems', () => {
     it('Sends the correct request', () => {
-      stripe.invoices.retrieveLines('in_123');
+      stripe.invoices.listLineItems('in_123');
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/invoices/in_123/lines',
@@ -77,101 +77,41 @@ describe('Invoices Resource', () => {
   });
 
   describe('retrieveUpcoming', () => {
-    describe('With just a customer ID', () => {
-      it('Sends the correct request', () => {
-        stripe.invoices.retrieveUpcoming('cus_123');
-        expect(stripe.LAST_REQUEST).to.deep.equal({
-          method: 'GET',
-          url: '/v1/invoices/upcoming?customer=cus_123',
-          headers: {},
-          data: {},
-        });
+    it('Sends the correct request', () => {
+      stripe.invoices.retrieveUpcoming({
+        customer: 'cus_abc',
+        subscription_items: [{plan: 'potato'}, {plan: 'rutabaga'}],
       });
-    });
 
-    describe('With a subscription ID in addition to a customer ID', () => {
-      it('Sends the correct request', () => {
-        stripe.invoices.retrieveUpcoming('cus_123', 'sub_123');
-        expect(stripe.LAST_REQUEST).to.deep.equal({
-          method: 'GET',
-          url: '/v1/invoices/upcoming?customer=cus_123&subscription=sub_123',
-          headers: {},
-          data: {},
-        });
-      });
-    });
-
-    describe('With an options object that includes `subscription_items`', () => {
-      it('Sends the correct request', () => {
-        stripe.invoices.retrieveUpcoming('cus_123', {
-          subscription_items: [{plan: 'potato'}, {plan: 'rutabaga'}],
-        });
-
-        expect(stripe.LAST_REQUEST).to.deep.equal({
-          method: 'GET',
-          url:
-            '/v1/invoices/upcoming?customer=cus_123&' +
-            'subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga',
-          headers: {},
-          data: {},
-        });
-      });
-    });
-
-    describe('Without a customer id but options', () => {
-      it('Sends the correct request', () => {
-        stripe.invoices.retrieveUpcoming({
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/invoices/upcoming',
+        headers: {},
+        data: {
           customer: 'cus_abc',
           subscription_items: [{plan: 'potato'}, {plan: 'rutabaga'}],
-        });
-
-        expect(stripe.LAST_REQUEST).to.deep.equal({
-          method: 'GET',
-          url:
-            '/v1/invoices/upcoming?customer=cus_abc&' +
-            'subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga',
-          headers: {},
-          data: {},
-        });
+        },
       });
     });
+  });
 
-    describe('With an options object that includes `subscription_items` in addition to a subscription ID', () => {
-      it('Sends the correct request', () => {
-        stripe.invoices.retrieveUpcoming('cus_123', 'sub_123', {
-          subscription_items: [
-            {plan: 'potato'},
-            {plan: 'rutabaga'},
-            {id: 'SOME_ID', deleted: true},
-          ],
-          subscription_prorate: true,
-        });
-
-        expect(stripe.LAST_REQUEST).to.deep.equal({
-          method: 'GET',
-          url: '/v1/invoices/upcoming?customer=cus_123&subscription=sub_123',
-          headers: {},
-          data: {
-            subscription_items: [
-              {plan: 'potato'},
-              {plan: 'rutabaga'},
-              {id: 'SOME_ID', deleted: true},
-            ],
-            subscription_prorate: true,
-          },
-        });
+  describe('listUpcomingLineItems', () => {
+    it('Sends the correct request', () => {
+      stripe.invoices.listUpcomingLineItems({
+        customer: 'cus_abc',
+        subscription_items: [{plan: 'potato'}, {plan: 'rutabaga'}],
+        limit: 5,
       });
-    });
 
-    describe('With a options object in addition to a customer ID', () => {
-      it('Sends the correct request', () => {
-        stripe.invoices.retrieveUpcoming('cus_123', {plan: 'planId123'});
-        expect(stripe.LAST_REQUEST).to.deep.equal({
-          method: 'GET',
-          url: '/v1/invoices/upcoming?customer=cus_123&plan=planId123',
-          headers: {},
-          data: {},
-        });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/invoices/upcoming/lines',
+        headers: {},
+        data: {
+          customer: 'cus_abc',
+          subscription_items: [{plan: 'potato'}, {plan: 'rutabaga'}],
+          limit: 5,
+        },
       });
     });
   });


### PR DESCRIPTION
r? @rattrayalex-stripe @remi-stripe 
cc @stripe/api-libraries @irace-stripe 

- Removes support for legacy customer and subscription parameters in `invoices.retrieveUpcoming()`. All parameters must now be provided in a hash.

- While I was at it, I also noticed that `retrieveLines()` should really be called `listLineItems()` because it returns a list object containing a list of `line_item`s.

- I also added `listUpcomingLineItems()` because I think that's much cleaner than telling users to use `listLines()` with `"upcoming"` as the ID.
