### PR TITLE
Misc. manual formatting

### DIFF
--- a/lib/resources/AccountLinks.js
+++ b/lib/resources/AccountLinks.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'account_links',
+
   includeBasic: ['create'],
 });

--- a/lib/resources/ApplePayDomains.js
+++ b/lib/resources/ApplePayDomains.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'apple_pay/domains',
+
   includeBasic: ['create', 'del', 'list', 'retrieve'],
 });

--- a/lib/resources/ApplicationFeeRefunds.js
+++ b/lib/resources/ApplicationFeeRefunds.js
@@ -16,5 +16,6 @@ const StripeResource = require('../StripeResource');
  */
 module.exports = StripeResource.extend({
   path: 'application_fees/{feeId}/refunds',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/BalanceTransactions.js
+++ b/lib/resources/BalanceTransactions.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'balance/history',
+
   includeBasic: ['list', 'retrieve'],
 });

--- a/lib/resources/Checkout/Sessions.js
+++ b/lib/resources/Checkout/Sessions.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'checkout/sessions',
+
   includeBasic: ['create', 'retrieve'],
 });

--- a/lib/resources/Coupons.js
+++ b/lib/resources/Coupons.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'coupons',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/CreditNotes.js
+++ b/lib/resources/CreditNotes.js
@@ -5,11 +5,12 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'credit_notes',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 
   voidCreditNote: stripeMethod({
     method: 'POST',
-    path: '{id}/void',
+    path: '/{id}/void',
     urlParams: ['id'],
   }),
 });

--- a/lib/resources/Customers.js
+++ b/lib/resources/Customers.js
@@ -5,6 +5,7 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'customers',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 
   /**

--- a/lib/resources/Disputes.js
+++ b/lib/resources/Disputes.js
@@ -8,9 +8,5 @@ module.exports = StripeResource.extend({
 
   includeBasic: ['list', 'retrieve', 'update'],
 
-  close: stripeMethod({
-    method: 'POST',
-    path: '/{id}/close',
-    urlParams: ['id'],
-  }),
+  close: stripeMethod({method: 'POST', path: '/{id}/close', urlParams: ['id']}),
 });

--- a/lib/resources/EphemeralKeys.js
+++ b/lib/resources/EphemeralKeys.js
@@ -4,6 +4,10 @@ const StripeResource = require('../StripeResource');
 const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
+  path: 'ephemeral_keys',
+
+  includeBasic: ['del'],
+
   create: stripeMethod({
     method: 'POST',
     validator: (data, options) => {
@@ -14,8 +18,4 @@ module.exports = StripeResource.extend({
       }
     },
   }),
-
-  path: 'ephemeral_keys',
-
-  includeBasic: ['del'],
 });

--- a/lib/resources/Events.js
+++ b/lib/resources/Events.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'events',
+
   includeBasic: ['list', 'retrieve'],
 });

--- a/lib/resources/FileLinks.js
+++ b/lib/resources/FileLinks.js
@@ -4,5 +4,6 @@ const StripeResource = require('../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'file_links',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -2,12 +2,16 @@
 
 const Buffer = require('safe-buffer').Buffer;
 const utils = require('../utils');
-const StripeResource = require('../StripeResource');
-const stripeMethod = StripeResource.method;
 const multipartDataGenerator = require('../MultipartDataGenerator');
 const Error = require('../Error');
+const StripeResource = require('../StripeResource');
+const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
+  path: 'files',
+
+  includeBasic: ['list', 'retrieve'],
+
   requestDataProcessor(method, data, headers, callback) {
     data = data || {};
 
@@ -66,9 +70,6 @@ module.exports = StripeResource.extend({
       };
     }
   },
-
-  path: 'files',
-  includeBasic: ['list', 'retrieve'],
 
   create: stripeMethod({
     method: 'POST',

--- a/lib/resources/InvoiceItems.js
+++ b/lib/resources/InvoiceItems.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'invoiceitems',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -6,6 +6,7 @@ const utils = require('../utils');
 
 module.exports = StripeResource.extend({
   path: 'invoices',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 
   finalizeInvoice: stripeMethod({

--- a/lib/resources/Issuing/Cardholders.js
+++ b/lib/resources/Issuing/Cardholders.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'issuing/cardholders',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Issuing/Disputes.js
+++ b/lib/resources/Issuing/Disputes.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'issuing/disputes',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Issuing/Transactions.js
+++ b/lib/resources/Issuing/Transactions.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'issuing/transactions',
+
   includeBasic: ['list', 'retrieve', 'update'],
 });

--- a/lib/resources/LoginLinks.js
+++ b/lib/resources/LoginLinks.js
@@ -4,5 +4,6 @@ const StripeResource = require('../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'accounts/{accountId}/login_links',
+
   includeBasic: ['create'],
 });

--- a/lib/resources/Orders.js
+++ b/lib/resources/Orders.js
@@ -8,11 +8,7 @@ module.exports = StripeResource.extend({
 
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 
-  pay: stripeMethod({
-    method: 'POST',
-    path: '/{id}/pay',
-    urlParams: ['id'],
-  }),
+  pay: stripeMethod({method: 'POST', path: '/{id}/pay', urlParams: ['id']}),
 
   returnOrder: stripeMethod({
     method: 'POST',

--- a/lib/resources/PaymentIntents.js
+++ b/lib/resources/PaymentIntents.js
@@ -5,23 +5,24 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'payment_intents',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{id}/cancel',
+    path: '/{id}/cancel',
     urlParams: ['id'],
   }),
 
   capture: stripeMethod({
     method: 'POST',
-    path: '{id}/capture',
+    path: '/{id}/capture',
     urlParams: ['id'],
   }),
 
   confirm: stripeMethod({
     method: 'POST',
-    path: '{id}/confirm',
+    path: '/{id}/confirm',
     urlParams: ['id'],
   }),
 });

--- a/lib/resources/PaymentMethods.js
+++ b/lib/resources/PaymentMethods.js
@@ -5,17 +5,18 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'payment_methods',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 
   attach: stripeMethod({
     method: 'POST',
-    path: '{id}/attach',
+    path: '/{id}/attach',
     urlParams: ['id'],
   }),
 
   detach: stripeMethod({
     method: 'POST',
-    path: '{id}/detach',
+    path: '/{id}/detach',
     urlParams: ['id'],
   }),
 });

--- a/lib/resources/Payouts.js
+++ b/lib/resources/Payouts.js
@@ -10,7 +10,7 @@ module.exports = StripeResource.extend({
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{id}/cancel',
+    path: '/{id}/cancel',
     urlParams: ['id'],
   }),
 });

--- a/lib/resources/Persons.js
+++ b/lib/resources/Persons.js
@@ -2,19 +2,8 @@
 
 const StripeResource = require('../StripeResource');
 
-/**
- * Persons is a unique resource in that, upon instantiation,
- * requires an accountId, and therefore each of its methods only
- * require the personId argument.
- *
- * This streamlines the API specifically for the case of accessing person
- * on a returned transfer object.
- *
- * E.g. accountObject.person.retrieve(personId)
- * (As opposed to the also-supported stripe.accounts.retrievePerson(accountId,
- * personId))
- */
 module.exports = StripeResource.extend({
   path: 'accounts/{accountId}/persons',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Plans.js
+++ b/lib/resources/Plans.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'plans',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Radar/ValueListItems.js
+++ b/lib/resources/Radar/ValueListItems.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'radar/value_list_items',
+
   includeBasic: ['create', 'del', 'list', 'retrieve'],
 });

--- a/lib/resources/Radar/ValueLists.js
+++ b/lib/resources/Radar/ValueLists.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'radar/value_lists',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Recipients.js
+++ b/lib/resources/Recipients.js
@@ -5,6 +5,7 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'recipients',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 
   /**

--- a/lib/resources/Reporting/ReportRuns.js
+++ b/lib/resources/Reporting/ReportRuns.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'reporting/report_runs',
+
   includeBasic: ['create', 'list', 'retrieve'],
 });

--- a/lib/resources/Reporting/ReportTypes.js
+++ b/lib/resources/Reporting/ReportTypes.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'reporting/report_types',
+
   includeBasic: ['list', 'retrieve'],
 });

--- a/lib/resources/SubscriptionItems.js
+++ b/lib/resources/SubscriptionItems.js
@@ -4,5 +4,6 @@ const StripeResource = require('../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'subscription_items',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/SubscriptionScheduleRevisions.js
+++ b/lib/resources/SubscriptionScheduleRevisions.js
@@ -2,19 +2,8 @@
 
 const StripeResource = require('../StripeResource');
 
-/**
- * SubscriptionScheduleRevisions is a unique resource in that, upon instantiation,
- * requires a subscription schedule id, and therefore each of its methods only
- * require the scheduleId argument.
- *
- * This streamlines the API specifically for the case of accessing a revision
- * on a returned subscription schedule object.
- *
- * E.g. scheduleObject.revisions.retrieve(revisionId)
- * (As opposed to the also-supported stripe.subscriptionSchedules.retrieveRevision(scheduleId,
- * revisionId))
- */
 module.exports = StripeResource.extend({
   path: 'subscription_schedules/{scheduleId}/revisions',
+
   includeBasic: ['list', 'retrieve'],
 });

--- a/lib/resources/SubscriptionSchedules.js
+++ b/lib/resources/SubscriptionSchedules.js
@@ -8,21 +8,17 @@ module.exports = StripeResource.extend({
 
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 
-  release: stripeMethod({
-    method: 'POST',
-    path: '/{id}/release',
-    urlParams: ['id'],
-  }),
-
   cancel: stripeMethod({
     method: 'POST',
     path: '/{id}/cancel',
     urlParams: ['id'],
   }),
 
-  /**
-   * SubscriptionSchedules: SubscriptionScheduleRevisions methods
-   */
+  release: stripeMethod({
+    method: 'POST',
+    path: '/{id}/release',
+    urlParams: ['id'],
+  }),
 
   listRevisions: stripeMethod({
     method: 'GET',

--- a/lib/resources/Subscriptions.js
+++ b/lib/resources/Subscriptions.js
@@ -5,11 +5,9 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'subscriptions',
+
   includeBasic: ['create', 'list', 'retrieve', 'update', 'del'],
 
-  /**
-   * Subscription: Discount methods
-   */
   deleteDiscount: stripeMethod({
     method: 'DELETE',
     path: '/{id}/discount',

--- a/lib/resources/TaxIds.js
+++ b/lib/resources/TaxIds.js
@@ -2,18 +2,8 @@
 
 const StripeResource = require('../StripeResource');
 
-/**
- * TaxIds is a unique resource in that, upon instantiation,
- * requires a customerId, and therefore each of its methods only
- * require the taxId argument.
- *
- * This streamlines the API specifically for the case of accessing a tax id
- * on a returned customer object.
- *
- * E.g. customerObject.tax_ids.retrieve(taxIdId)
- * (As opposed to the also-supported stripe.customers.retrieveTaxId(customerId, taxIdId))
- */
 module.exports = StripeResource.extend({
   path: 'customers/{customerId}/tax_ids',
+
   includeBasic: ['create', 'del', 'list', 'retrieve'],
 });

--- a/lib/resources/TaxRates.js
+++ b/lib/resources/TaxRates.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'tax_rates',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Terminal/ConnectionTokens.js
+++ b/lib/resources/Terminal/ConnectionTokens.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'terminal/connection_tokens',
+
   includeBasic: ['create'],
 });

--- a/lib/resources/Terminal/Locations.js
+++ b/lib/resources/Terminal/Locations.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'terminal/locations',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Terminal/Readers.js
+++ b/lib/resources/Terminal/Readers.js
@@ -4,5 +4,6 @@ const StripeResource = require('../../StripeResource');
 
 module.exports = StripeResource.extend({
   path: 'terminal/readers',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/Tokens.js
+++ b/lib/resources/Tokens.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'tokens',
+
   includeBasic: ['create', 'retrieve'],
 });

--- a/lib/resources/Topups.js
+++ b/lib/resources/Topups.js
@@ -5,11 +5,12 @@ const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
   path: 'topups',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 
   cancel: stripeMethod({
     method: 'POST',
-    path: '{id}/cancel',
+    path: '/{id}/cancel',
     urlParams: ['id'],
   }),
 });

--- a/lib/resources/TransferReversals.js
+++ b/lib/resources/TransferReversals.js
@@ -2,19 +2,8 @@
 
 const StripeResource = require('../StripeResource');
 
-/**
- * TransferReversals is a unique resource in that, upon instantiation,
- * requires a transferId, and therefore each of its methods only
- * require the reversalId argument.
- *
- * This streamlines the API specifically for the case of accessing reversals
- * on a returned transfer object.
- *
- * E.g. transferObject.reversals.retrieve(reversalId)
- * (As opposed to the also-supported stripe.transfers.retrieveReversal(transferId,
- * reversalId))
- */
 module.exports = StripeResource.extend({
   path: 'transfers/{transferId}/reversals',
+
   includeBasic: ['create', 'list', 'retrieve', 'update'],
 });

--- a/lib/resources/UsageRecords.js
+++ b/lib/resources/UsageRecords.js
@@ -8,7 +8,7 @@ module.exports = StripeResource.extend({
 
   create: stripeMethod({
     method: 'POST',
-    path: '{id}/usage_records',
+    path: '/{id}/usage_records',
     urlParams: ['id'],
   }),
 });

--- a/lib/resources/WebhookEndpoints.js
+++ b/lib/resources/WebhookEndpoints.js
@@ -1,6 +1,9 @@
 'use strict';
 
-module.exports = require('../StripeResource').extend({
+const StripeResource = require('../StripeResource');
+
+module.exports = StripeResource.extend({
   path: 'webhook_endpoints',
+
   includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 });


### PR DESCRIPTION
Some misc. manual formatting to get us closer to the code style that we’re striving for:

- No chained method calls on `require` statements
- Paths start with `/`
- Line break between `path` and `includeBasic` entries in object literals
- Alphabetical method ordering
- Remove misc. comments

r? @rattrayalex-stripe 
r? @ob-stripe 