### PR TITLE
Add listLineItems and listUpcomingLineItems methods

### DIFF
--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -27,6 +27,18 @@ module.exports = StripeResource.extend({
     urlParams: ['invoiceId'],
   }),
 
+  listLineItems: stripeMethod({
+    method: 'GET',
+    path: '{invoiceId}/lines',
+    urlParams: ['invoiceId'],
+  }),
+
+  listUpcomingLineItems: stripeMethod({
+    method: 'GET',
+    path: 'upcoming/lines',
+  }),
+
+  // deprecated in favor of `listLineItems`
   retrieveLines: stripeMethod({
     method: 'GET',
     path: '{invoiceId}/lines',

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -64,6 +64,30 @@ describe('Invoices Resource', function() {
     });
   });
 
+  describe('listLineItems', function() {
+    it('Sends the correct request', function() {
+      stripe.invoices.listLineItems('in_123');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/invoices/in_123/lines',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('listUpcomingLineItems', function() {
+    it('Sends the correct request', function() {
+      stripe.invoices.listUpcomingLineItems();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/invoices/upcoming/lines',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
   describe('retrieveLines', function() {
     it('Sends the correct request', function() {
       stripe.invoices.retrieveLines('in_123');


### PR DESCRIPTION
r? @rattrayalex-stripe 
cc @stripe/api-libraries 

We added these two methods in the v7 branch. I'd like to add them to the last 6.x version to make the upgrade path a bit easier, and so that people who need or want to stay on the 6.x branch for a bit can still use these methods (which will be the officially documented ones in the API reference).
