### PR TITLE
Add support for radar.early_fraud_warning resource

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -61,6 +61,7 @@ module.exports = {
     Transactions: require('./resources/Issuing/Transactions'),
   }),
   Radar: resourceNamespace('radar', {
+    EarlyFraudWarnings: require('./resources/Radar/EarlyFraudWarnings'),
     ValueLists: require('./resources/Radar/ValueLists'),
     ValueListItems: require('./resources/Radar/ValueListItems'),
   }),

--- a/lib/resources/Radar/EarlyFraudWarnings.js
+++ b/lib/resources/Radar/EarlyFraudWarnings.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const StripeResource = require('../../StripeResource');
+
+module.exports = StripeResource.extend({
+  path: 'radar/early_fraud_warnings',
+
+  includeBasic: ['list', 'retrieve'],
+});

--- a/test/resources/Radar/EarlyFraudWarnings.spec.js
+++ b/test/resources/Radar/EarlyFraudWarnings.spec.js
@@ -1,0 +1,32 @@
+'use strict';
+
+const stripe = require('../../../testUtils').getSpyableStripe();
+const expect = require('chai').expect;
+
+describe('Radar', () => {
+  describe('EarlyFraudWarnings Resource', () => {
+    describe('retrieve', () => {
+      it('Sends the correct request', () => {
+        stripe.radar.earlyFraudWarnings.retrieve('issfr_123');
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/radar/early_fraud_warnings/issfr_123',
+          data: {},
+          headers: {},
+        });
+      });
+    });
+
+    describe('list', () => {
+      it('Sends the correct request', () => {
+        stripe.radar.earlyFraudWarnings.list();
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'GET',
+          url: '/v1/radar/early_fraud_warnings',
+          data: {},
+          headers: {},
+        });
+      });
+    });
+  });
+});


### PR DESCRIPTION
r? @brandur-stripe 
cc @stripe/api-libraries 

Add support for `radar.early_fraud_warning` resource