### PR TITLE
Enable request latency telemetry by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,9 @@ See the [Node API docs](https://stripe.com/docs/api/node#intro).
 
 Install the package with:
 
-    npm install stripe --save
+```sh
+npm install stripe --save
+```
 
 ## Usage
 
@@ -377,6 +379,17 @@ Returns a promise of an array of all items across pages for a list request.
 const allNewCustomers = await stripe.customers
   .list({created: {gt: lastMonth}})
   .autoPagingToArray({limit: 10000});
+```
+
+### Request latency telemetry
+
+By default, the library sends request latency telemetry to Stripe. These
+numbers help Stripe improve the overall latency of its API for all users.
+
+You can disable this behavior if you prefer:
+
+```js
+stripe.setTelemetryEnabled(false);
 ```
 
 ## More Information

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -69,7 +69,7 @@ function Stripe(key, version) {
   this.webhooks = require('./Webhooks');
 
   this._prevRequestMetrics = [];
-  this.setTelemetryEnabled(false);
+  this.setTelemetryEnabled(true);
 }
 
 Stripe.errors = require('./Error');

--- a/test/telemetry.spec.js
+++ b/test/telemetry.spec.js
@@ -60,6 +60,7 @@ describe('Client Telemetry', () => {
         const stripe = require('../lib/stripe')(
           'sk_test_FEiILxKZwnmmocJDUjUNO6pa'
         );
+        stripe.setTelemetryEnabled(false);
         stripe.setHost(host, port, 'http');
 
         stripe.balance


### PR DESCRIPTION
r? @brandur-stripe @rattrayalex-stripe
cc @stripe/api-libraries

Cf. https://github.com/stripe/stripe-ruby/pull/800.