### PR TITLE
Add config object

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -112,7 +112,12 @@ Stripe.prototype = {
   },
 
   /**
-   * @deprecated in a future major version
+   * @deprecated in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   apiVersion: API_VERSION,
+   * });
+   *
    */
   setApiVersion(version) {
     if (version) {

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -28,15 +28,33 @@ Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 
 const APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
 
+const ALLOWED_CONFIG_PROPERTIES = ['apiVersion'];
+
 const EventEmitter = require('events').EventEmitter;
 const utils = require('./utils');
 
 Stripe.StripeResource = require('./StripeResource');
 Stripe.resources = resources;
 
-function Stripe(key, version) {
+function Stripe(key, config = {}) {
   if (!(this instanceof Stripe)) {
-    return new Stripe(key, version);
+    return new Stripe(key, config);
+  }
+
+  if (!(config === Object(config))) {
+    throw new Error('Config must be an object');
+  }
+
+  const props = Object.keys(config).filter((prop) => {
+    return !ALLOWED_CONFIG_PROPERTIES.includes(prop);
+  });
+
+  if (props.length > 0) {
+    throw new Error(
+      `Config object may only contain the following: ${ALLOWED_CONFIG_PROPERTIES.join(
+        ', '
+      )}`
+    );
   }
 
   Object.defineProperty(this, '_emitter', {
@@ -63,7 +81,8 @@ function Stripe(key, version) {
 
   this._prepResources();
   this.setApiKey(key);
-  this.setApiVersion(version);
+
+  this._setApiField('version', config.apiVersion || Stripe.DEFAULT_API_VERSION);
 
   this.errors = require('./Error');
   this.webhooks = require('./Webhooks');
@@ -94,6 +113,7 @@ Stripe.prototype = {
     this._setApiField('port', port);
   },
 
+  // DEPRECATED
   setApiVersion(version) {
     if (version) {
       this._setApiField('version', version);

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -120,6 +120,9 @@ Stripe.prototype = {
     }
   },
 
+  /**
+   * @deprecated in a future major version
+   */
   setApiKey(key) {
     if (key) {
       this._setApiField('auth', `Bearer ${key}`);

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -72,7 +72,7 @@ function Stripe(key, config = {}) {
     host: Stripe.DEFAULT_HOST,
     port: Stripe.DEFAULT_PORT,
     basePath: Stripe.DEFAULT_BASE_PATH,
-    version: Stripe.DEFAULT_API_VERSION,
+    version: config.apiVersion || Stripe.DEFAULT_API_VERSION,
     timeout: Stripe.DEFAULT_TIMEOUT,
     agent: null,
     dev: false,
@@ -81,8 +81,6 @@ function Stripe(key, config = {}) {
 
   this._prepResources();
   this.setApiKey(key);
-
-  this._setApiField('version', config.apiVersion || Stripe.DEFAULT_API_VERSION);
 
   this.errors = require('./Error');
   this.webhooks = require('./Webhooks');

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -111,16 +111,15 @@ Stripe.prototype = {
     this._setApiField('port', port);
   },
 
-  // DEPRECATED
+  /**
+   * @deprecated in a future major version
+   */
   setApiVersion(version) {
     if (version) {
       this._setApiField('version', version);
     }
   },
 
-  /**
-   * @deprecated in a future major version
-   */
   setApiKey(key) {
     if (key) {
       this._setApiField('auth', `Bearer ${key}`);

--- a/test/autoPagination.spec.js
+++ b/test/autoPagination.spec.js
@@ -3,7 +3,9 @@
 /* eslint-disable callback-return */
 
 const testUtils = require('../testUtils');
-const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), 'latest');
+const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), {
+  apiVersion: 'latest',
+});
 
 const expect = require('chai').expect;
 

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -2,7 +2,9 @@
 
 const testUtils = require('../testUtils');
 const chai = require('chai');
-const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), 'latest');
+const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), {
+  apiVersion: 'latest',
+});
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -47,6 +47,15 @@ describe('Stripe Module', function() {
         Stripe.DEFAULT_API_VERSION
       );
     });
+
+    it('should use the options set in the config object', () => {
+      const version = '2019-02-11';
+      const optionsStripe = new Stripe(testUtils.getUserStripeKey(), {
+        apiVersion: version,
+      });
+
+      expect(optionsStripe.getApiField('version')).to.equal(version);
+    });
   });
 
   describe('setApiKey', () => {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -2,7 +2,10 @@
 
 const testUtils = require('../testUtils');
 const utils = require('../lib/utils');
-const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), 'latest');
+const Stripe = require('../lib/stripe');
+const stripe = new Stripe(testUtils.getUserStripeKey(), {
+  apiVersion: 'latest',
+});
 
 const http = require('http');
 
@@ -16,6 +19,27 @@ const CUSTOMER_DETAILS = {
 describe('Stripe Module', function() {
   const cleanup = new testUtils.CleanupUtility();
   this.timeout(20000);
+
+  describe('config object', () => {
+    it('should only accept an object', () => {
+      expect(() => {
+        /* eslint-disable new-cap */
+        Stripe(testUtils.getUserStripeKey(), 'latest');
+        /* eslint-enable new-cap */
+      }).to.throw(/Config must be an object/);
+    });
+
+    it('should only contain allowed properties', () => {
+      expect(() => {
+        /* eslint-disable new-cap */
+        Stripe(testUtils.getUserStripeKey(), {
+          foo: 'bar',
+          apiVersion: 'latest',
+        });
+        /* eslint-enable new-cap */
+      }).to.throw(/Config object may only contain the following:/);
+    });
+  });
 
   describe('setApiKey', () => {
     it('uses Bearer auth', () => {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -39,6 +39,14 @@ describe('Stripe Module', function() {
         /* eslint-enable new-cap */
       }).to.throw(/Config object may only contain the following:/);
     });
+
+    it('should use defaults when no config object is provided', () => {
+      const defaultStripe = new Stripe(testUtils.getUserStripeKey());
+
+      expect(defaultStripe.getApiField('version')).to.equal(
+        Stripe.DEFAULT_API_VERSION
+      );
+    });
   });
 
   describe('setApiKey', () => {

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -74,10 +74,9 @@ const utils = (module.exports = {
     function CleanupUtility(timeout) {
       const self = this;
       this._cleanupFns = [];
-      this._stripe = require('../lib/stripe')(
-        utils.getUserStripeKey(),
-        'latest'
-      );
+      this._stripe = require('../lib/stripe')(utils.getUserStripeKey(), {
+        apiVersion: 'latest',
+      });
       afterEach(function(done) {
         this.timeout(timeout || CleanupUtility.DEFAULT_TIMEOUT);
         return self.doCleanup(done);


### PR DESCRIPTION
# What
Partially fixes https://github.com/stripe/stripe-node/issues/640

Changes how the API version is set, making it part of the initial constructor instead of a separate function.

Old: 
```js
const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
stripe.setApiVersion('2019-02-19');
```

New:
```js
const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
  apiVersion: '2019-01-01',
});
```

`stripe.setApiVersion` will still work as before, but now has a 'deprecated' JSDOC attached to it. Intention is to eventually remove the `setApiVersion` function altogether in a future major version.

# Future work
Move other config properties into the config object (e.g. network retries, host, protocol etc). Make some of these (all?) able to be set on a per-request basis.

r? @rattrayalex-stripe @ob-stripe @brandur-stripe 
cc @stripe/api-libraries 