### PR TITLE
Add support for the `SetupIntent` resource and APIs

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -37,6 +37,7 @@ module.exports = {
   Recipients: require('./resources/Recipients'),
   Refunds: require('./resources/Refunds'),
   Reviews: require('./resources/Reviews'),
+  SetupIntents: require('./resources/SetupIntents'),
   Skus: require('./resources/SKUs'),
   Sources: require('./resources/Sources'),
   Subscriptions: require('./resources/Subscriptions'),

--- a/lib/resources/SetupIntents.js
+++ b/lib/resources/SetupIntents.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const StripeResource = require('../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'setup_intents',
+
+  includeBasic: ['create', 'list', 'retrieve', 'update'],
+
+  cancel: stripeMethod({
+    method: 'POST',
+    path: '/{intent}/cancel',
+  }),
+
+  confirm: stripeMethod({
+    method: 'POST',
+    path: '/{intent}/confirm',
+  }),
+});

--- a/test/resources/SetupIntents.spec.js
+++ b/test/resources/SetupIntents.spec.js
@@ -1,0 +1,85 @@
+'use strict';
+
+const stripe = require('../../testUtils').getSpyableStripe();
+const expect = require('chai').expect;
+
+const SETUP_INTENT_TEST_ID = 'seti_123';
+
+describe('Setup Intents Resource', () => {
+  describe('create', () => {
+    it('Sends the correct request', () => {
+      const params = {
+        payment_method_types: ['card'],
+      };
+      stripe.setupIntents.create(params);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: '/v1/setup_intents',
+        headers: {},
+        data: params,
+      });
+    });
+  });
+
+  describe('list', () => {
+    it('Sends the correct request', () => {
+      stripe.setupIntents.list();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/setup_intents',
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('retrieve', () => {
+    it('Sends the correct request', () => {
+      stripe.setupIntents.retrieve(SETUP_INTENT_TEST_ID);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('update', () => {
+    it('Sends the correct request', () => {
+      stripe.setupIntents.update(SETUP_INTENT_TEST_ID, {
+        metadata: {key: 'value'},
+      });
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
+        headers: {},
+        data: {metadata: {key: 'value'}},
+      });
+    });
+  });
+
+  describe('cancel', () => {
+    it('Sends the correct request', () => {
+      stripe.setupIntents.cancel(SETUP_INTENT_TEST_ID);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}/cancel`,
+        headers: {},
+        data: {},
+      });
+    });
+  });
+
+  describe('confirm', () => {
+    it('Sends the correct request', () => {
+      stripe.setupIntents.confirm(SETUP_INTENT_TEST_ID);
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'POST',
+        url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}/confirm`,
+        headers: {},
+        data: {},
+      });
+    });
+  });
+});


### PR DESCRIPTION
I used the autogen tool to generate the code. I just manually removed the changes to Customers.js as those were incorrect 

r? @rattrayalex-stripe 
cc @stripe/api-libraries 
