### PR TITLE
Update README retry code sample to use two retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -176,7 +176,7 @@ This will retry requests `n` times with exponential backoff if they fail due to 
 
 ```js
 // Retry a request once before giving up
-stripe.setMaxNetworkRetries(1);
+stripe.setMaxNetworkRetries(2);
 ```
 
 ### Examining Responses

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ This will retry requests `n` times with exponential backoff if they fail due to 
 [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
 ```js
-// Retry a request once before giving up
+ // Retry a request twice before giving up
 stripe.setMaxNetworkRetries(2);
 ```
 


### PR DESCRIPTION
While looking at retry code samples across client libraries recently, we
happened to notice that all the other ones use two retries as an example
while stripe-node uses one.

Definitely not adverse to changing this number everywhere at some point
if we think it's right move, but for now just doing the incremental
improvement of making stripe-node consistent with the other libraries.

r? @brandur-stripe (Tiny change. Going to self-approve this one.)