### PR TITLE
Interpret any string in options as an API Key instead of using a regex

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -22,13 +22,6 @@ const utils = (module.exports = {
   },
 
   /**
-   * DEPRECATED. This is not reliable and will be removed in a future version.
-   */
-  isAuthKey: (key) => {
-    return typeof key == 'string' && /^(?:[a-z]{2}_)?[A-z0-9]{32}$/.test(key);
-  },
-
-  /**
    * Stringifies an Object, accommodating nested objects
    * (forming the conventional key 'parent[child]=value')
    */

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -17,12 +17,15 @@ const OPTIONS_KEYS = [
 ];
 
 const utils = (module.exports = {
-  isAuthKey: (key) => {
-    return typeof key == 'string' && /^(?:[a-z]{2}_)?[A-z0-9]{32}$/.test(key);
-  },
-
   isOptionsHash: (o) => {
     return isPlainObject(o) && OPTIONS_KEYS.some((key) => hasOwn.call(o, key));
+  },
+
+  /**
+   * DEPRECATED. This is not reliable and will be removed in a future version.
+   */
+  isAuthKey: (key) => {
+    return typeof key == 'string' && /^(?:[a-z]{2}_)?[A-z0-9]{32}$/.test(key);
   },
 
   /**
@@ -121,7 +124,7 @@ const utils = (module.exports = {
     };
     if (args.length > 0) {
       const arg = args[args.length - 1];
-      if (utils.isAuthKey(arg)) {
+      if (typeof arg === 'string') {
         opts.auth = args.pop();
       } else if (utils.isOptionsHash(arg)) {
         const params = args.pop();

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -211,6 +211,14 @@ describe('utils', () => {
       });
       expect(args.length).to.equal(0);
     });
+    it('assumes any string is an api key', () => {
+      const args = ['yolo'];
+      expect(utils.getOptionsFromArgs(args)).to.deep.equal({
+        auth: 'yolo',
+        headers: {},
+      });
+      expect(args.length).to.equal(0);
+    });
     it('parses an idempotency key', () => {
       const args = [{foo: 'bar'}, {idempotency_key: 'foo'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries @jlomas-stripe @paulasjes-stripe @remi-stripe 

`isAuthKey` relies on a regex which assumes a fixed length of a secret key token. This assumption recently broke. 

Looking at the code, passing a string which does not fit the regex currently noops completely, so I chose to simply check whether it is a non-empty string and if so, assume it is an auth key. 

Note that you could maybe interpret this to be a breaking change, because you could have previously written this: 

```js
stripe.customers.retrieve('cus_123', 'garbage');
```
which would have been equivalent to `stripe.customers.retrieve('cus_123')` and worked fine, but with this change would fail with a bad secret key. 

I think that's fine, but not sure and want to check with others. 

Relatedly, I moved `isAuthKey` from `utils` but that didn't seem to be publicly exported so I think that's fine. 