### PR TITLE
Remove `safe-buffer` dependency

### DIFF
--- a/lib/MultipartDataGenerator.js
+++ b/lib/MultipartDataGenerator.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const utils = require('./utils');
 
 // Method for formatting HTTP body for the multipart/form-data specification

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const crypto = require('crypto');
 
 const utils = require('./utils');

--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const utils = require('../utils');
 const multipartDataGenerator = require('../MultipartDataGenerator');
 const Error = require('../Error');

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Buffer = require('safe-buffer').Buffer;
 const EventEmitter = require('events').EventEmitter;
 const exec = require('child_process').exec;
 const qs = require('qs');

--- a/package.json
+++ b/package.json
@@ -43,7 +43,6 @@
   "dependencies": {
     "lodash.isplainobject": "^4.0.6",
     "qs": "^6.6.0",
-    "safe-buffer": "^5.1.1",
     "uuid": "^3.3.2"
   },
   "license": "MIT",

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -2,7 +2,6 @@
 
 const stripe = require('../testUtils').getSpyableStripe();
 const expect = require('chai').expect;
-const Buffer = require('safe-buffer').Buffer;
 
 const EVENT_PAYLOAD = {
   id: 'evt_test_webhook',

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -4,7 +4,6 @@ require('../testUtils');
 
 const utils = require('../lib/utils');
 const expect = require('chai').expect;
-const Buffer = require('safe-buffer').Buffer;
 
 describe('utils', () => {
   describe('makeURLInterpolator', () => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1869,7 +1869,7 @@ rxjs@^6.4.0:
   dependencies:
     tslib "^1.9.0"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.1, safe-buffer@^5.1.2, safe-buffer@~5.1.1:
+safe-buffer@^5.0.1, safe-buffer@^5.1.2, safe-buffer@~5.1.1:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==


### PR DESCRIPTION
`safe-buffer` does nothing when native `Buffer.from` API is available and it's available since Nodes.JS 5.10 (https://nodejs.org/api/buffer.html#buffer_class_method_buffer_from_array), so, there is no sense to bring it as production dependency (one of four) when your declared minimum supported Node.JS version is 6.x.