### PR TITLE
Handle HTTP headers as case insensitive 

### DIFF
--- a/examples/webhook-signing/express.js
+++ b/examples/webhook-signing/express.js
@@ -18,19 +18,21 @@ app.post(
   '/webhooks',
   bodyParser.raw({type: 'application/json'}),
   (req, res) => {
-    const sig = req.headers['stripe-signature'];
-
-    let event;
-
     try {
-      event = stripe.webhooks.constructEvent(req.body, sig, webhookSecret);
+      const sig = req.headers[stripe.headers.STRIPE_SIGNATURE];
+
+      const event = stripe.webhooks.constructEvent(
+        req.body,
+        sig,
+        webhookSecret
+      );
+
+      // Do something with event
+      console.log('Success:', event.id);
     } catch (err) {
       // On error, return the error message
       return res.status(400).send(`Webhook Error: ${err.message}`);
     }
-
-    // Do something with event
-    console.log('Success:', event.id);
 
     // Return a response to acknowledge receipt of the event
     res.json({received: true});

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -341,16 +341,25 @@ StripeResource.prototype = {
 
       // If this is a POST and we allow multiple retries, set a idempotency key if one is not
       // already provided.
+      let idempotencyKey;
       if (method === 'POST' && this._stripe.getMaxNetworkRetries() > 0) {
-        if (!headers.hasOwnProperty('Idempotency-Key')) {
-          headers['Idempotency-Key'] = uuid();
+        if (
+          !Object.keys(headers).find((header) => {
+            if (header.toLowerCase() === 'idempotency-key') {
+              idempotencyKey = header[header];
+              return true;
+            }
+            return false;
+          })
+        ) {
+          headers['Idempotency-Key'] = idempotencyKey = uuid();
         }
       }
 
       const requestEvent = utils.removeEmpty({
         api_version: apiVersion,
         account: headers['Stripe-Account'],
-        idempotency_key: headers['Idempotency-Key'],
+        idempotency_key: idempotencyKey,
         method,
         path,
       });

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -7,6 +7,7 @@ const uuid = require('uuid/v4');
 
 const utils = require('./utils');
 const Error = require('./Error');
+const Headers = require('./http-headers');
 
 const defaultHttpAgent = new http.Agent({keepAlive: true});
 const defaultHttpsAgent = new https.Agent({keepAlive: true});
@@ -119,14 +120,26 @@ StripeResource.prototype = {
 
         // For convenience, make Request-Id easily accessible on
         // lastResponse.
-        res.requestId = headers['request-id'];
+        res.requestId = utils.getCaseInsensitiveProperty(
+          headers,
+          Headers.REQUEST_ID
+        );
 
         const requestDurationMs = Date.now() - req._requestStart;
 
         const responseEvent = utils.removeEmpty({
-          api_version: headers['stripe-version'],
-          account: headers['stripe-account'],
-          idempotency_key: headers['idempotency-key'],
+          api_version: utils.getCaseInsensitiveProperty(
+            headers,
+            Headers.STRIPE_VERSION
+          ),
+          account: utils.getCaseInsensitiveProperty(
+            headers,
+            Headers.STRIPE_ACCOUNT
+          ),
+          idempotency_key: utils.getCaseInsensitiveProperty(
+            headers,
+            Headers.IDEMPOTENCY_KEY
+          ),
           method: req._requestEvent.method,
           path: req._requestEvent.path,
           status: res.statusCode,
@@ -173,7 +186,10 @@ StripeResource.prototype = {
               message: 'Invalid JSON received from the Stripe API',
               response,
               exception: e,
-              requestId: headers['request-id'],
+              requestId: utils.getCaseInsensitiveProperty(
+                headers,
+                Headers.REQUEST_ID
+              ),
             }),
             null
           );
@@ -281,7 +297,7 @@ StripeResource.prototype = {
     };
 
     if (apiVersion) {
-      headers['Stripe-Version'] = apiVersion;
+      headers[Headers.STRIPE_VERSION] = apiVersion;
     }
 
     return headers;
@@ -293,7 +309,7 @@ StripeResource.prototype = {
       this._stripe._prevRequestMetrics.length > 0
     ) {
       const metrics = this._stripe._prevRequestMetrics.shift();
-      headers['X-Stripe-Client-Telemetry'] = JSON.stringify({
+      headers[Headers.STRIPE_TELEMETRY] = JSON.stringify({
         last_request_metrics: metrics,
       });
     }
@@ -343,22 +359,21 @@ StripeResource.prototype = {
       // already provided.
       let idempotencyKey;
       if (method === 'POST' && this._stripe.getMaxNetworkRetries() > 0) {
-        if (
-          !Object.keys(headers).find((header) => {
-            if (header.toLowerCase() === 'idempotency-key') {
-              idempotencyKey = headers[header];
-              return true;
-            }
-            return false;
-          })
-        ) {
-          headers['Idempotency-Key'] = idempotencyKey = uuid();
+        idempotencyKey = utils.getCaseInsensitiveProperty(
+          headers,
+          Headers.IDEMPOTENCY_KEY
+        );
+        if (!idempotencyKey) {
+          headers[Headers.IDEMPOTENCY_KEY] = idempotencyKey = uuid();
         }
       }
 
       const requestEvent = utils.removeEmpty({
         api_version: apiVersion,
-        account: headers['Stripe-Account'],
+        account: utils.getCaseInsensitiveProperty(
+          headers,
+          Headers.STRIPE_ACCOUNT
+        ),
         idempotency_key: idempotencyKey,
         method,
         path,
@@ -419,7 +434,7 @@ StripeResource.prototype = {
       );
 
       this._stripe.getClientUserAgent((cua) => {
-        headers['X-Stripe-Client-User-Agent'] = cua;
+        headers[Headers.STRIPE_CLIENT_UA] = cua;
 
         if (options.headers) {
           Object.assign(headers, options.headers);

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -357,15 +357,16 @@ StripeResource.prototype = {
 
       // If this is a POST and we allow multiple retries, set a idempotency key if one is not
       // already provided.
-      let idempotencyKey;
-      if (method === 'POST' && this._stripe.getMaxNetworkRetries() > 0) {
-        idempotencyKey = utils.getCaseInsensitiveProperty(
-          headers,
-          Headers.IDEMPOTENCY_KEY
-        );
-        if (!idempotencyKey) {
-          headers[Headers.IDEMPOTENCY_KEY] = idempotencyKey = uuid();
-        }
+      let idempotencyKey = utils.getCaseInsensitiveProperty(
+        headers,
+        Headers.IDEMPOTENCY_KEY
+      );
+      if (
+        !idempotencyKey &&
+        method === 'POST' &&
+        this._stripe.getMaxNetworkRetries() > 0
+      ) {
+        headers[Headers.IDEMPOTENCY_KEY] = idempotencyKey = uuid();
       }
 
       const requestEvent = utils.removeEmpty({

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -346,7 +346,7 @@ StripeResource.prototype = {
         if (
           !Object.keys(headers).find((header) => {
             if (header.toLowerCase() === 'idempotency-key') {
-              idempotencyKey = header[header];
+              idempotencyKey = headers[header];
               return true;
             }
             return false;

--- a/lib/http-headers.js
+++ b/lib/http-headers.js
@@ -23,6 +23,8 @@ const STRIPE_ACCOUNT = 'stripe-account';
 /** Stripe Webhook signature */
 const STRIPE_SIGNATURE = 'stripe-signature';
 
+const STRIPE_MANAGE_VERSION = 'stripe-manage-version';
+
 /**
  * Genetic names headers
  */
@@ -43,12 +45,19 @@ const STRIPE_TELEMETRY = 'x-stripe-client-telemetry';
 /** Stripe SDK user-agent */
 const STRIPE_CLIENT_UA = 'x-stripe-client-user-agent';
 
+const STRIPE_EXTERNAL_AUTH_REQUIRED = 'x-stripe-external-auth-required';
+const STRIPE_PRIVILEGED_SESSION_REQUIRED =
+  'x-stripe-privileged-session-required';
+
 module.exports = {
   REQUEST_ID,
   IDEMPOTENCY_KEY,
   STRIPE_VERSION,
+  STRIPE_MANAGE_VERSION,
   STRIPE_ACCOUNT,
   STRIPE_SIGNATURE,
   STRIPE_TELEMETRY,
   STRIPE_CLIENT_UA,
+  STRIPE_EXTERNAL_AUTH_REQUIRED,
+  STRIPE_PRIVILEGED_SESSION_REQUIRED,
 };

--- a/lib/http-headers.js
+++ b/lib/http-headers.js
@@ -1,0 +1,54 @@
+/**
+ * Constants for Stripe HTTP headers
+ *
+ * REMEMBERS: HTTP headers are case insensitive by standard, so, always use lowercase
+ *
+ * Stripe using three types of private headers: prefixed with 'stripe-', prefixed with 'x-stripe-' and just generic names
+ * In June, 2012, Internet Engineering Task Force released a new RFC (https://tools.ietf.org/html/rfc6648),
+ * recommending deprecation of X- prefix.
+ * So, probably correct way for future headers is to be just 'Stripe-' prefixed
+ *
+ */
+
+/**
+ * Company prefixed headers
+ */
+
+/** Stripe API version */
+const STRIPE_VERSION = 'stripe-version';
+
+/** Stripe Account */
+const STRIPE_ACCOUNT = 'stripe-account';
+
+/** Stripe Webhook signature */
+const STRIPE_SIGNATURE = 'stripe-signature';
+
+/**
+ * Genetic names headers
+ */
+
+/** Request ID */
+const REQUEST_ID = 'request-id';
+
+/** Idempotency Key */
+const IDEMPOTENCY_KEY = 'idempotency-key';
+
+/**
+ * X- prefixed headers
+ */
+
+/** Telemetry - typical value JSON.stringify({ last_request_metrics: metrics }) */
+const STRIPE_TELEMETRY = 'x-stripe-client-telemetry';
+
+/** Stripe SDK user-agent */
+const STRIPE_CLIENT_UA = 'x-stripe-client-user-agent';
+
+module.exports = {
+  REQUEST_ID,
+  IDEMPOTENCY_KEY,
+  STRIPE_VERSION,
+  STRIPE_ACCOUNT,
+  STRIPE_SIGNATURE,
+  STRIPE_TELEMETRY,
+  STRIPE_CLIENT_UA,
+};

--- a/lib/resources/EphemeralKeys.js
+++ b/lib/resources/EphemeralKeys.js
@@ -1,6 +1,9 @@
 'use strict';
 
 const StripeResource = require('../StripeResource');
+const {STRIPE_VERSION} = require('../http-headers');
+const {getCaseInsensitiveProperty} = require('../utils');
+
 const stripeMethod = StripeResource.method;
 
 module.exports = StripeResource.extend({
@@ -11,8 +14,8 @@ module.exports = StripeResource.extend({
   create: stripeMethod({
     method: 'POST',
     validator: (data, options) => {
-      if (!options.headers || !options.headers['Stripe-Version']) {
-        throw new Error(
+      if (!getCaseInsensitiveProperty(options.headers, STRIPE_VERSION)) {
+        throw new TypeError(
           'stripe_version must be specified to create an ephemeral key'
         );
       }

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -67,6 +67,7 @@ function Stripe(key, version) {
 
   this.errors = require('./Error');
   this.webhooks = require('./Webhooks');
+  this.headers = require('./http-headers');
 
   this._prevRequestMetrics = [];
   this.setTelemetryEnabled(true);

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -6,8 +6,10 @@ const exec = require('child_process').exec;
 const qs = require('qs');
 const crypto = require('crypto');
 
-const hasOwn = {}.hasOwnProperty;
 const isPlainObject = require('lodash.isplainobject');
+const Headers = require('./http-headers');
+
+const hasOwn = {}.hasOwnProperty;
 
 const OPTIONS_KEYS = [
   'api_key',
@@ -136,13 +138,13 @@ const utils = (module.exports = {
           opts.auth = params.api_key;
         }
         if (params.idempotency_key) {
-          opts.headers['Idempotency-Key'] = params.idempotency_key;
+          opts.headers[Headers.IDEMPOTENCY_KEY] = params.idempotency_key;
         }
         if (params.stripe_account) {
-          opts.headers['Stripe-Account'] = params.stripe_account;
+          opts.headers[Headers.STRIPE_ACCOUNT] = params.stripe_account;
         }
         if (params.stripe_version) {
-          opts.headers['Stripe-Version'] = params.stripe_version;
+          opts.headers[Headers.STRIPE_VERSION] = params.stripe_version;
         }
       }
     }
@@ -312,6 +314,27 @@ const utils = (module.exports = {
     step(data);
 
     return result;
+  },
+
+  /**
+   * Returns value of an object property insensitively of property case
+   * Used at HTTP headers check
+   *
+   * @template T
+   * @param {Record<string, T>} obj
+   * @param {string} propertyName
+   * @returns {T | undefined}
+   */
+  getCaseInsensitiveProperty(obj, propertyName) {
+    if (typeof obj === 'object') {
+      const prop = Object.keys(obj).find(
+        (p) => p.localeCompare(propertyName, 'en', {sensitivity: 'base'}) === 0
+      );
+      if (prop) {
+        return obj[prop];
+      }
+    }
+    return undefined;
   },
 });
 

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -8,6 +8,8 @@ const nock = require('nock');
 const stripe = require('../testUtils').getSpyableStripe();
 const expect = require('chai').expect;
 
+const Headers = require('../lib/http-headers');
+
 describe('StripeResource', () => {
   describe('createResourcePathWithSymbols', () => {
     it('Generates a path', () => {
@@ -32,11 +34,11 @@ describe('StripeResource', () => {
     });
     it('sets the Stripe-Version header if an API version is provided', () => {
       const headers = stripe.invoices._defaultHeaders(null, 0, '1970-01-01');
-      expect(headers['Stripe-Version']).to.equal('1970-01-01');
+      expect(headers[Headers.STRIPE_VERSION]).to.equal('1970-01-01');
     });
     it('does not the set the Stripe-Version header if no API version is provided', () => {
       const headers = stripe.invoices._defaultHeaders(null, 0, null);
-      expect(headers).to.not.include.keys('Stripe-Version');
+      expect(headers).to.not.include.keys(Headers.STRIPE_VERSION);
     });
   });
 
@@ -323,7 +325,7 @@ describe('StripeResource', () => {
         realStripe.setMaxNetworkRetries(1);
 
         realStripe.charges.create(options.data, () => {
-          expect(headers).to.have.property('idempotency-key');
+          expect(headers).to.have.property(Headers.IDEMPOTENCY_KEY);
           done();
         });
       });
@@ -351,7 +353,7 @@ describe('StripeResource', () => {
         realStripe.setMaxNetworkRetries(1);
 
         realStripe.charges.retrieve('ch_123', () => {
-          expect(headers).to.not.have.property('idempotency-key');
+          expect(headers).to.not.have.property(Headers.IDEMPOTENCY_KEY);
           done();
         });
       });
@@ -380,7 +382,7 @@ describe('StripeResource', () => {
         realStripe.setMaxNetworkRetries(1);
 
         realStripe.charges.create(options.data, {idempotency_key: key}, () => {
-          expect(headers['idempotency-key']).to.equal(key);
+          expect(headers[Headers.IDEMPOTENCY_KEY]).to.equal(key);
           done();
         });
       });

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -2,6 +2,7 @@
 
 const stripe = require('../../testUtils').getSpyableStripe();
 const expect = require('chai').expect;
+const Headers = require('../../lib/http-headers');
 
 const TEST_AUTH_KEY = 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11';
 
@@ -70,7 +71,7 @@ describe('Customers Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'POST',
         url: '/v1/customers',
-        headers: {'Idempotency-Key': 'foo'},
+        headers: {[Headers.IDEMPOTENCY_KEY]: 'foo'},
         data: {description: 'Some customer'},
       });
     });
@@ -97,7 +98,7 @@ describe('Customers Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'POST',
         url: '/v1/customers',
-        headers: {'Idempotency-Key': 'foo'},
+        headers: {[Headers.IDEMPOTENCY_KEY]: 'foo'},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
       });

--- a/test/resources/EphemeralKeys.spec.js
+++ b/test/resources/EphemeralKeys.spec.js
@@ -2,6 +2,7 @@
 
 const stripe = require('../../testUtils').getSpyableStripe();
 const expect = require('chai').expect;
+const Headers = require('../../lib/http-headers');
 
 function errorsOnNoStripeVersion() {
   return expect(
@@ -22,7 +23,7 @@ function sendsCorrectStripeVersion() {
       customer: 'cus_123',
     },
     headers: {
-      'Stripe-Version': '2017-06-05',
+      [Headers.STRIPE_VERSION]: '2017-06-05',
     },
   });
 }
@@ -41,7 +42,7 @@ describe('EphemeralKey Resource', () => {
           customer: 'cus_123',
         },
         headers: {
-          'Stripe-Version': '2017-05-25',
+          [Headers.STRIPE_VERSION]: '2017-05-25',
         },
       });
     });

--- a/test/resources/UsageRecordSummaries.spec.js
+++ b/test/resources/UsageRecordSummaries.spec.js
@@ -2,6 +2,7 @@
 
 const stripe = require('../../testUtils').getSpyableStripe();
 const expect = require('chai').expect;
+const Headers = require('../../lib/http-headers');
 
 describe('UsageRecordSummaries Resource', () => {
   describe('list', () => {
@@ -30,7 +31,7 @@ describe('UsageRecordSummaries Resource', () => {
             method: 'GET',
             url: '/v1/subscription_items/si_123/usage_record_summaries',
             headers: {
-              'Stripe-Account': 'acct_456',
+              [Headers.STRIPE_ACCOUNT]: 'acct_456',
             },
             data: {},
           });

--- a/test/resources/UsageRecords.spec.js
+++ b/test/resources/UsageRecords.spec.js
@@ -2,6 +2,7 @@
 
 const stripe = require('../../testUtils').getSpyableStripe();
 const expect = require('chai').expect;
+const Headers = require('../../lib/http-headers');
 
 describe('UsageRecords Resource', () => {
   describe('create', () => {
@@ -42,7 +43,7 @@ describe('UsageRecords Resource', () => {
             method: 'POST',
             url: '/v1/subscription_items/si_123/usage_records',
             headers: {
-              'Stripe-Account': 'acct_456',
+              [Headers.STRIPE_ACCOUNT]: 'acct_456',
             },
             data: {
               quantity: 123,

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -5,6 +5,7 @@ require('../testUtils');
 const utils = require('../lib/utils');
 const expect = require('chai').expect;
 const Buffer = require('safe-buffer').Buffer;
+const Headers = require('../lib/http-headers');
 
 describe('utils', () => {
   describe('makeURLInterpolator', () => {
@@ -223,7 +224,7 @@ describe('utils', () => {
       const args = [{foo: 'bar'}, {idempotency_key: 'foo'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: null,
-        headers: {'Idempotency-Key': 'foo'},
+        headers: {[Headers.IDEMPOTENCY_KEY]: 'foo'},
       });
       expect(args.length).to.equal(1);
     });
@@ -231,7 +232,7 @@ describe('utils', () => {
       const args = [{foo: 'bar'}, {stripe_version: '2003-03-30'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: null,
-        headers: {'Stripe-Version': '2003-03-30'},
+        headers: {[Headers.STRIPE_VERSION]: '2003-03-30'},
       });
       expect(args.length).to.equal(1);
     });
@@ -247,8 +248,8 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
         headers: {
-          'Idempotency-Key': 'foo',
-          'Stripe-Version': '2010-01-10',
+          [Headers.IDEMPOTENCY_KEY]: 'foo',
+          [Headers.STRIPE_VERSION]: '2010-01-10',
         },
       });
       expect(args.length).to.equal(1);
@@ -264,8 +265,8 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
         headers: {
-          'Idempotency-Key': 'foo',
-          'Stripe-Version': 'hunter2',
+          [Headers.IDEMPOTENCY_KEY]: 'foo',
+          [Headers.STRIPE_VERSION]: 'hunter2',
         },
       });
       expect(args.length).to.equal(0);
@@ -432,6 +433,23 @@ describe('utils', () => {
       expect(flattened.buf).to.deep.equal(buf);
       expect(flattened).to.have.property('x[a]');
       expect(flattened['x[a]']).to.equal('1');
+    });
+  });
+
+  describe('getCaseInsensitiveProperty', () => {
+    it('returns undefined for non object', () => {
+      expect(utils.getCaseInsensitiveProperty(false, 'ogogo')).to.be.undefined;
+    });
+    it('return undefined if there is no such property in object', () => {
+      expect(utils.getCaseInsensitiveProperty({a: 'b'}, 'c')).to.be.undefined;
+    });
+    it('returns property value for any case name', () => {
+      expect(
+        utils.getCaseInsensitiveProperty(
+          {thisCaseProperty: 'yeeep'},
+          'THISCASEProperty'
+        )
+      ).to.equal('yeeep');
     });
   });
 });


### PR DESCRIPTION
By HTTP standard headers are case insensitive, so checking for existing `Idempotency-Key` like `headers.hasOwnProperty('Idempotency-Key')` is wrong. Should we fix that?