### PR TITLE
Expose and use `once`

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -113,7 +113,7 @@ StripeResource.prototype = {
       res.on('data', (chunk) => {
         response += chunk;
       });
-      res.on('end', () => {
+      res.once('end', () => {
         const headers = res.headers || {};
         // NOTE: Stripe responds with lowercase header names/keys.
 
@@ -365,7 +365,7 @@ StripeResource.prototype = {
 
       req.setTimeout(timeout, this._timeoutHandler(timeout, req, callback));
 
-      req.on('response', (res) => {
+      req.once('response', (res) => {
         if (this._shouldRetry(res, requestRetries)) {
           return retryRequest(makeRequest, apiVersion, headers, requestRetries);
         } else {
@@ -381,13 +381,16 @@ StripeResource.prototype = {
         }
       });
 
-      req.on('socket', (socket) => {
+      req.once('socket', (socket) => {
         if (socket.connecting) {
-          socket.on(isInsecureConnection ? 'connect' : 'secureConnect', () => {
-            // Send payload; we're safe:
-            req.write(requestData);
-            req.end();
-          });
+          socket.once(
+            isInsecureConnection ? 'connect' : 'secureConnect',
+            () => {
+              // Send payload; we're safe:
+              req.write(requestData);
+              req.end();
+            }
+          );
         } else {
           // we're already connected
           req.write(requestData);

--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -36,7 +36,7 @@ module.exports = StripeResource.extend({
         .on('data', (line) => {
           bufferArray.push(line);
         })
-        .on('end', () => {
+        .once('end', () => {
           const bufferData = Object.assign({}, data);
           bufferData.file.data = Buffer.concat(bufferArray);
           const buffer = fn(method, bufferData, headers);

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -43,10 +43,11 @@ function Stripe(key, version) {
     value: new EventEmitter(),
     enumerable: false,
     configurable: false,
-    writeable: false,
+    writable: false,
   });
 
   this.on = this._emitter.on.bind(this._emitter);
+  this.once = this._emitter.once.bind(this._emitter);
   this.off = this._emitter.removeListener.bind(this._emitter);
 
   this._api = {

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -339,7 +339,7 @@ describe('Flows', function() {
         done();
       }
 
-      stripe.on('request', onRequest);
+      stripe.once('request', onRequest);
 
       stripe.charges
         .create(
@@ -386,7 +386,7 @@ describe('Flows', function() {
         done();
       }
 
-      stripe.on('response', onResponse);
+      stripe.once('response', onResponse);
 
       stripe.charges
         .create(
@@ -411,7 +411,7 @@ describe('Flows', function() {
         done(new Error('How did you get here?'));
       }
 
-      stripe.on('response', onResponse);
+      stripe.once('response', onResponse);
       stripe.off('response', onResponse);
 
       stripe.charges

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -370,6 +370,8 @@ describe('Flows', function() {
           return;
         }
 
+        stripe.off('response', onResponse);
+
         expect(response.api_version).to.equal(apiVersion);
         expect(response.idempotency_key).to.equal(idempotencyKey);
         expect(response.account).to.equal(connectedAccountId);
@@ -382,7 +384,7 @@ describe('Flows', function() {
         done();
       }
 
-      stripe.once('response', onResponse);
+      stripe.on('response', onResponse);
 
       stripe.charges
         .create(
@@ -408,6 +410,7 @@ describe('Flows', function() {
       }
 
       stripe.once('response', onResponse);
+      stripe.off('response', onResponse);
 
       stripe.charges
         .create({

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -412,7 +412,6 @@ describe('Flows', function() {
       }
 
       stripe.once('response', onResponse);
-      stripe.off('response', onResponse);
 
       stripe.charges
         .create({

--- a/test/flows.spec.js
+++ b/test/flows.spec.js
@@ -326,8 +326,6 @@ describe('Flows', function() {
         .slice(2);
 
       function onRequest(request) {
-        stripe.off('request', onRequest);
-
         expect(request).to.eql({
           api_version: 'latest',
           idempotency_key: idempotencyKey,
@@ -371,8 +369,6 @@ describe('Flows', function() {
         if (response.idempotency_key !== idempotencyKey) {
           return;
         }
-
-        stripe.off('response', onResponse);
 
         expect(response.api_version).to.equal(apiVersion);
         expect(response.idempotency_key).to.equal(idempotencyKey);


### PR DESCRIPTION
Fixes a misspelling in EventEmitter property declaration, exposes `once` method and uses `once` where it's more appropriate than `on`