### PR TITLE
Updated utils.getDataFromArgs to support mixed options/data hash

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -84,26 +84,16 @@ const utils = (module.exports = {
 
     const argKeys = Object.keys(args[0]);
 
-    const optionKeysInArgs = argKeys.filter((key) =>
-      OPTIONS_KEYS.includes(key)
-    );
-
-    // In some cases options may be the provided as the first argument.
-    // Here we're detecting a case where there are two distinct arguments
-    // (the first being args and the second options) and with known
-    // option keys in the first so that we can warn the user about it.
-    if (
-      optionKeysInArgs.length > 0 &&
-      optionKeysInArgs.length !== argKeys.length
-    ) {
-      emitWarning(
-        `Options found in arguments (${optionKeysInArgs.join(
-          ', '
-        )}). Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.`
-      );
+    const dataKeysInArgs = argKeys.filter((key) => !OPTIONS_KEYS.includes(key));
+    const data = {};
+    const hash = args[0];
+    for (const dataKey of dataKeysInArgs) {
+      const dataValue = hash[dataKey];
+      delete hash[dataKey];
+      data[dataKey] = dataValue;
     }
 
-    return {};
+    return data;
   },
 
   /**

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -155,22 +155,11 @@ describe('utils', () => {
         }
       );
     });
-    it('warns if the hash contains both data and options', (done) => {
+    it('find data if the hash contains both data and options', (done) => {
       const args = [{foo: 'bar', api_key: 'foo', idempotency_key: 'baz'}];
-
-      handleWarnings(
-        () => {
-          utils.getDataFromArgs(args);
-        },
-        (message) => {
-          expect(message).to.equal(
-            'Stripe: Options found in arguments (api_key, idempotency_key).' +
-              ' Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
-          );
-
-          done();
-        }
-      );
+      expect(utils.getDataFromArgs(args)).to.deep.equal({foo: 'bar'});
+      expect(args.length).to.equal(1);
+      done();
     });
     it('finds the data', () => {
       const args = [{foo: 'bar'}, {api_key: 'foo'}];


### PR DESCRIPTION
Mixed options/data hashes may occur when a client is making a request on behalf of a Connect account(aka `stripe_account: "acct_<some account id>"`) and wishing to expand a particular field of the resource(e.g. `expand: ["charges.data.balance_transaction"]`. Meaning the hash would look like this in our figurative example:
```
{
  stripe_account: "acct_<some account id>",
  expand: ["charges.data.balance_transaction"]
}
```
Currently `utils.getDataFromArgs` does not support a mixed options/data hash. Meaning the above hash would result in the `expand` data arg being discarded instead of included. So in order to support mixed options/data hash, we instead look for keys that are not in `OPTIONS_KEYS` and pluck those from the hash. As a part of this plucking, we delete the data properties from the hash object, because they are not options that should be plucked in `utils.getOptionsFromArgs`. This way misleading warnings will not be emitted. We also change a previous `getDataFromArgs` test from warning about a mixed options/data hash to instead finding the data in a mixed options/data hash.