### PR TITLE
Separate super-deprecated errors from base errors, fix type override, and remove name override

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -1,82 +1,33 @@
 'use strict';
 
-/**
- *  @typedef {{ message?: string, type?: string, code?: number, param?: string, detail?: string, headers?: Record<string, string>, requestId?: string, statusCode?: number }} ErrorParams
- */
-/**
- * Generic Error class to wrap any errors returned by stripe-node
- */
-class GenericError extends Error {
-  /**
-   *
-   * @param  {string} type
-   * @param {string} message
-   */
-  constructor(type, message) {
-    super(message);
-    this.type = type || this.constructor.name;
-    // Saving class name in the property of our custom error as a shortcut.
-    this.name = this.constructor.name;
+const utils = require('./utils');
 
-    // Capturing stack trace, excluding constructor call from it.
-    Error.captureStackTrace(this, this.constructor);
+/**
+ * StripeError is the base error from which all other more specific Stripe errors derive.
+ * Specifically for errors returned from Stripe's REST API.
+ */
+class StripeError extends Error {
+  constructor(raw = {}) {
+    super(raw.message);
+    // This splat is here for back-compat and should be removed in the next major version.
+    this.populate(...arguments);
   }
 
-  /**
-   *
-   * @param {string} [type] - error type name
-   * @param {string} [message]
-   */
-  populate(type, message) {
-    this.type = type;
-    this.message = message;
+  // Allow `new StripeFooError(raw).type === 'StripeFooError'`
+  get type() {
+    return this.constructor.name;
   }
 
   /**
    * DEPRECATED
-   * Please use ES6 class inheritance instead.
-   * @param {{ type: string, message?: string, [k:string]: any }} options
+   * This will be inlined in the constructor in the future.
    */
-  static extend(options) {
-    class customError extends StripeError {
-      /**
-       * @see {@link https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Function/name#Function_names_in_classes}
-       */
-      // @ts-ignore
-      static get name() {
-        return options.type;
-      }
-    }
-    Object.assign(customError.prototype, options);
-    return customError;
-  }
-}
-
-/**
- * StripeError is the base error from which all other more specific Stripe
- * errors derive.
- * (Specifically for errors returned from Stripe's REST API)
- *
- */
-class StripeError extends GenericError {
-  /**
-   *
-   * @param {ErrorParams} [raw]
-   */
-  constructor(raw = {}) {
-    super(undefined, raw.message);
-    this.populate(raw);
-  }
-  /**
-   *
-   * @param {ErrorParams} raw
-   */
-  // @ts-ignore
   populate(raw) {
-    if (!raw || typeof raw !== 'object' || Object.keys(raw).length < 1) {
+    this.raw = raw;
+    if (!raw || typeof raw !== 'object') {
       return;
     }
-    this.raw = raw;
+
     this.rawType = raw.type;
     this.code = raw.code;
     this.param = raw.param;
@@ -89,8 +40,6 @@ class StripeError extends GenericError {
 
   /**
    * Helper factory which takes raw stripe errors and outputs wrapping instances
-   *
-   * @param {ErrorParams} rawStripeError
    */
   static generate(rawStripeError) {
     switch (rawStripeError.type) {
@@ -107,6 +56,23 @@ class StripeError extends GenericError {
       default:
         return new GenericError('Generic', 'Unknown Error');
     }
+  }
+
+  /**
+   * DEPRECATED
+   * Please use class inheritance instead.
+   */
+  static extend(options) {
+    const type = options.type;
+    class CustomError extends StripeError {
+      // eslint-disable-next-line class-methods-use-this
+      get type() {
+        return type;
+      }
+    }
+    delete options.type;
+    Object.assign(CustomError.prototype, options);
+    return CustomError;
   }
 }
 
@@ -179,10 +145,26 @@ class StripeIdempotencyError extends StripeError {}
 class StripeInvalidGrantError extends StripeError {}
 
 /**
- * DEPRECATED: Default import from this module is deprecated and
- * will be removed in the next major version
+ * DEPRECATED
+ * This is here for backwards compatibility and will be removed in the next major version.
  */
-module.exports = GenericError;
+function _Error(raw) {
+  this.populate(...arguments);
+  this.stack = new Error(this.message).stack;
+}
+_Error.prototype = Object.create(Error.prototype);
+_Error.prototype.type = 'GenericError';
+_Error.prototype.populate = function(type, message) {
+  this.type = type;
+  this.message = message;
+};
+_Error.extend = utils.protoExtend;
+
+/**
+ * DEPRECATED.
+ * Do not use the default export; it may be removed or change in a future version.
+ */
+module.exports = _Error;
 
 module.exports.StripeError = StripeError;
 module.exports.StripeCardError = StripeCardError;


### PR DESCRIPTION
This is a follow-on to https://github.com/stripe/stripe-node/pull/661

It makes several small changes but the most consequential are:

1) Adding `get type()` support on `StripeError`, so subclasses have the property `new StripeFooClass({}).type === 'StripeFooClass'`, which is an important property to uphold. We missed this in #661 because our `StripeError` tests had actually been testing `GenericError` on accident, oops!
2) Remove support for magical `.name`, which turned out not to be important for backcompat (previously `.name` was just `'Error'`) – was a mistake for me to ask for that.
3) Have `StripeError` inherit directly from `Error`, and have the default export of `Error.js` be an "old-school class" to maximize backcompat without any complexity leaking into our proper base class, and to emphasize that it is totally deprecated and will be going completely away. Users should not be relying on the stripe library to extend Error.

r? @richardm-stripe
cc @stripe/api-libraries 