### PR TITLE
Refactor requestDataProcessor for File out into its own file

### DIFF
--- a/lib/multipart.js
+++ b/lib/multipart.js
@@ -1,11 +1,14 @@
 'use strict';
 
 const utils = require('./utils');
+const {StripeError} = require('./Error');
+
+class StreamProcessingError extends StripeError {}
 
 // Method for formatting HTTP body for the multipart/form-data specification
 // Mostly taken from Fermata.js
 // https://github.com/natevw/fermata/blob/5d9732a33d776ce925013a265935facd1626cc88/fermata.js#L315-L343
-function multipartDataGenerator(method, data, headers) {
+const multipartDataGenerator = (method, data, headers) => {
   const segno = (
     Math.round(Math.random() * 1e16) + Math.round(Math.random() * 1e16)
   ).toString();
@@ -46,6 +49,46 @@ function multipartDataGenerator(method, data, headers) {
   push(`--${segno}--`);
 
   return buffer;
-}
+};
 
-module.exports = multipartDataGenerator;
+const streamProcessor = (method, data, headers, callback) => {
+  const bufferArray = [];
+  data.file.data
+    .on('data', (line) => {
+      bufferArray.push(line);
+    })
+    .once('end', () => {
+      const bufferData = Object.assign({}, data);
+      bufferData.file.data = Buffer.concat(bufferArray);
+      const buffer = multipartDataGenerator(method, bufferData, headers);
+      callback(null, buffer);
+    })
+    .on('error', (err) => {
+      callback(
+        new StreamProcessingError({
+          message:
+            'An error occurred while attempting to process the file for upload.',
+          detail: err,
+        }),
+        null
+      );
+    });
+};
+
+const multipartRequestDataProcessor = (method, data, headers, callback) => {
+  data = data || {};
+
+  if (method !== 'POST') {
+    return callback(null, utils.stringifyRequestData(data));
+  }
+
+  const isStream = utils.checkForStream(data);
+  if (isStream) {
+    return streamProcessor(method, data, headers, callback);
+  }
+
+  const buffer = multipartDataGenerator(method, data, headers);
+  return callback(null, buffer);
+};
+
+module.exports.multipartRequestDataProcessor = multipartRequestDataProcessor;

--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -1,68 +1,15 @@
 'use strict';
 
-const utils = require('../utils');
-const multipartDataGenerator = require('../MultipartDataGenerator');
-const {StripeError} = require('../Error');
+const {multipartRequestDataProcessor} = require('../multipart');
 const StripeResource = require('../StripeResource');
 const stripeMethod = StripeResource.method;
-
-class StreamProcessingError extends StripeError {}
 
 module.exports = StripeResource.extend({
   path: 'files',
 
   includeBasic: ['list', 'retrieve'],
 
-  requestDataProcessor(method, data, headers, callback) {
-    data = data || {};
-
-    if (method === 'POST') {
-      return getProcessorForSourceType(data);
-    } else {
-      return callback(null, utils.stringifyRequestData(data));
-    }
-
-    function getProcessorForSourceType(data) {
-      const isStream = utils.checkForStream(data);
-      if (isStream) {
-        return streamProcessor(multipartDataGenerator);
-      } else {
-        const buffer = multipartDataGenerator(method, data, headers);
-        return callback(null, buffer);
-      }
-    }
-
-    function streamProcessor(fn) {
-      const bufferArray = [];
-      data.file.data
-        .on('data', (line) => {
-          bufferArray.push(line);
-        })
-        .once('end', () => {
-          const bufferData = Object.assign({}, data);
-          bufferData.file.data = Buffer.concat(bufferArray);
-          const buffer = fn(method, bufferData, headers);
-          callback(null, buffer);
-        })
-        .on('error', (err) => {
-          const errorHandler = streamError(callback);
-          errorHandler(err);
-        });
-    }
-
-    function streamError(callback) {
-      return (error) => {
-        callback(
-          new StreamProcessingError({
-            message:
-              'An error occurred while attempting to process the file for upload.',
-            detail: error,
-          }),
-          null
-        );
-      };
-    }
-  },
+  requestDataProcessor: multipartRequestDataProcessor,
 
   create: stripeMethod({
     method: 'POST',


### PR DESCRIPTION
r? @richardm-stripe 
cc @ob-stripe @stripe/api-libraries 

This was in a codegen'd file, which lead to big/ugly diffs; we should ~never have substantial application logic in a codegen'd file.

While I was looking at the code, I refactored to make it a bit more simple/modern/unified.