### PR TITLE
Allow request retries with 429 lock_timeout errors

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -104,94 +104,92 @@ StripeResource.prototype = {
     };
   },
 
-  _responseHandler(req, callback) {
-    return (res) => {
-      let response = '';
+  _responseHandler(req, res, callback) {
+    let response = '';
 
-      res.setEncoding('utf8');
-      res.on('data', (chunk) => {
-        response += chunk;
+    res.setEncoding('utf8');
+    res.on('data', (chunk) => {
+      response += chunk;
+    });
+    res.once('end', () => {
+      const headers = res.headers || {};
+      // NOTE: Stripe responds with lowercase header names/keys.
+
+      // For convenience, make Request-Id easily accessible on
+      // lastResponse.
+      res.requestId = headers['request-id'];
+
+      const requestEndTime = Date.now();
+      const requestDurationMs = requestEndTime - req._requestStart;
+
+      const responseEvent = utils.removeNullish({
+        api_version: headers['stripe-version'],
+        account: headers['stripe-account'],
+        idempotency_key: headers['idempotency-key'],
+        method: req._requestEvent.method,
+        path: req._requestEvent.path,
+        status: res.statusCode,
+        request_id: res.requestId,
+        elapsed: requestDurationMs,
+        request_start_time: req._requestStart,
+        request_end_time: requestEndTime,
       });
-      res.once('end', () => {
-        const headers = res.headers || {};
-        // NOTE: Stripe responds with lowercase header names/keys.
 
-        // For convenience, make Request-Id easily accessible on
-        // lastResponse.
-        res.requestId = headers['request-id'];
+      this._stripe._emitter.emit('response', responseEvent);
 
-        const requestEndTime = Date.now();
-        const requestDurationMs = requestEndTime - req._requestStart;
+      try {
+        response = JSON.parse(response);
 
-        const responseEvent = utils.removeNullish({
-          api_version: headers['stripe-version'],
-          account: headers['stripe-account'],
-          idempotency_key: headers['idempotency-key'],
-          method: req._requestEvent.method,
-          path: req._requestEvent.path,
-          status: res.statusCode,
-          request_id: res.requestId,
-          elapsed: requestDurationMs,
-          request_start_time: req._requestStart,
-          request_end_time: requestEndTime,
-        });
+        if (response.error) {
+          let err;
 
-        this._stripe._emitter.emit('response', responseEvent);
-
-        try {
-          response = JSON.parse(response);
-
-          if (response.error) {
-            let err;
-
-            // Convert OAuth error responses into a standard format
-            // so that the rest of the error logic can be shared
-            if (typeof response.error === 'string') {
-              response.error = {
-                type: response.error,
-                message: response.error_description,
-              };
-            }
-
-            response.error.headers = headers;
-            response.error.statusCode = res.statusCode;
-            response.error.requestId = res.requestId;
-
-            if (res.statusCode === 401) {
-              err = new Error.StripeAuthenticationError(response.error);
-            } else if (res.statusCode === 403) {
-              err = new Error.StripePermissionError(response.error);
-            } else if (res.statusCode === 429) {
-              err = new Error.StripeRateLimitError(response.error);
-            } else {
-              err = Error.StripeError.generate(response.error);
-            }
-            return callback.call(this, err, null);
+          // Convert OAuth error responses into a standard format
+          // so that the rest of the error logic can be shared
+          if (typeof response.error === 'string') {
+            response.error = {
+              type: response.error,
+              message: response.error_description,
+            };
           }
-        } catch (e) {
-          return callback.call(
-            this,
-            new Error.StripeAPIError({
-              message: 'Invalid JSON received from the Stripe API',
-              response,
-              exception: e,
-              requestId: headers['request-id'],
-            }),
-            null
-          );
+
+          response.error.headers = headers;
+          response.error.statusCode = res.statusCode;
+          response.error.requestId = res.requestId;
+
+          if (res.statusCode === 401) {
+            err = new Error.StripeAuthenticationError(response.error);
+          } else if (res.statusCode === 403) {
+            err = new Error.StripePermissionError(response.error);
+          } else if (res.statusCode === 429) {
+            err = new Error.StripeRateLimitError(response.error);
+          } else {
+            err = Error.StripeError.generate(response.error);
+          }
+          return callback.call(this, err, null);
         }
+      } catch (e) {
+        return callback.call(
+          this,
+          new Error.StripeAPIError({
+            message: 'Invalid JSON received from the Stripe API',
+            response,
+            exception: e,
+            requestId: headers['request-id'],
+          }),
+          null
+        );
+      }
 
-        this._recordRequestMetrics(res.requestId, requestDurationMs);
+      this._recordRequestMetrics(res.requestId, requestDurationMs);
 
-        // Expose res object
-        Object.defineProperty(response, 'lastResponse', {
-          enumerable: false,
-          writable: false,
-          value: res,
-        });
-        callback.call(this, null, response);
+      // Expose res object
+      Object.defineProperty(response, 'lastResponse', {
+        enumerable: false,
+        writable: false,
+        value: res,
       });
-    };
+      callback.call(this, null, response);
+    });
   },
 
   _generateConnectionErrorMessage(requestRetries) {
@@ -236,6 +234,25 @@ StripeResource.prototype = {
     // Retry on 5xx's, except POST's, which our idempotency framework
     // would just replay as 500's again anyway.
     if (res.statusCode >= 500 && res.req._requestEvent.method !== 'POST') {
+      return true;
+    }
+
+    return false;
+  },
+
+  _shouldRetryError(err, numRetries) {
+    // Do not retry if this was not an error.
+    if (!err) {
+      return false;
+    }
+
+    // Do not retry if we are out of retries.
+    if (numRetries >= this._stripe.getMaxNetworkRetries()) {
+      return false;
+    }
+
+    // Retry on lock timeout failures.
+    if (err.statusCode === 429 && err.code === 'lock_timeout') {
       return true;
     }
 
@@ -396,7 +413,18 @@ StripeResource.prototype = {
         if (this._shouldRetry(res, requestRetries)) {
           return retryRequest(makeRequest, apiVersion, headers, requestRetries);
         } else {
-          return this._responseHandler(req, callback)(res);
+          return this._responseHandler(req, res, (err, response) => {
+            if (this._shouldRetryError(err, requestRetries)) {
+              return retryRequest(
+                makeRequest,
+                apiVersion,
+                headers,
+                requestRetries
+              );
+            } else {
+              return callback.call(this, err, response);
+            }
+          });
         }
       });
 


### PR DESCRIPTION
The Stripe client previously didn't attempt to retry requests that failed due to ephemeral locking issues. This seemed like a wasted opportunity, since even the error message itself says that you should attempt to retry the request. :)

For reference, it seems that both the [Ruby client](https://github.com/stripe/stripe-ruby/blob/master/lib/stripe/stripe_client.rb#L99) and the [GoLang client](https://github.com/stripe/stripe-go/blob/369823110ed34bda2ccb1e2b01506631a3098937/stripe.go#L589) (and possibly others) will retry on lock_timeout, similar to this PR.

Note: A large part of the diff is from un-indenting the _responseHandler method. It previously accepted req and callback params, and returned a function that accepted the res. This behavior was never really used, and the single caller just did `this._responseHandler(req, callback)(res)`. I rewrote the thing so that the params are `_responseHandler(req, res, callback)`, since that approach makes interfacing with the error easier.