### PR TITLE
Retry based on `Stripe-Should-Retry` and `Retry-After` headers

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -228,25 +228,24 @@ StripeResource.prototype = {
       return true;
     }
 
-    if (res.headers['should-retry'] === 'false') {
+    if (res.headers['stripe-should-retry'] === 'false') {
       return false;
     }
-    if (res.headers['should-retry'] === 'true') {
+    if (res.headers['stripe-should-retry'] === 'true') {
       return true;
     }
 
-    // Retry on conflict, rate-limit, and availability errors.
-    if (
-      res.statusCode === 409 ||
-      res.statusCode === 429 ||
-      res.statusCode === 503
-    ) {
+    // Retry on conflict errors.
+    if (res.statusCode === 409) {
       return true;
     }
 
-    // Retry on 5xx's, except POST's, which our idempotency framework
-    // would just replay as 500's again anyway.
-    if (res.statusCode >= 500 && res.req._requestEvent.method !== 'POST') {
+    // Retry on 500, 503, and other internal errors.
+    //
+    // Note that we expect the stripe-should-retry header to be false
+    // in most cases when a 500 is returned, since our idempotency framework
+    // would typically replay it anyway.
+    if (res.statusCode >= 500) {
       return true;
     }
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -253,7 +253,7 @@ StripeResource.prototype = {
     return false;
   },
 
-  _getSleepTimeInMS(numRetries) {
+  _getSleepTimeInMS(numRetries, retryAfter) {
     const initialNetworkRetryDelay = this._stripe.getInitialNetworkRetryDelay();
     const maxNetworkRetryDelay = this._stripe.getMaxNetworkRetryDelay();
 
@@ -272,7 +272,7 @@ StripeResource.prototype = {
     // But never sleep less than the base sleep seconds.
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
 
-    return sleepSeconds * 1000;
+    return Math.max(sleepSeconds * 1000, retryAfter || 0);
   },
 
   _defaultIdempotencyKey(method) {
@@ -353,10 +353,16 @@ StripeResource.prototype = {
   _request(method, host, path, data, auth, options, callback) {
     let requestData;
 
-    const retryRequest = (requestFn, apiVersion, headers, requestRetries) => {
+    const retryRequest = (
+      requestFn,
+      apiVersion,
+      headers,
+      requestRetries,
+      retryAfter
+    ) => {
       return setTimeout(
         requestFn,
-        this._getSleepTimeInMS(requestRetries),
+        this._getSleepTimeInMS(requestRetries, retryAfter),
         apiVersion,
         headers,
         requestRetries + 1
@@ -405,7 +411,13 @@ StripeResource.prototype = {
 
       req.once('response', (res) => {
         if (this._shouldRetry(res, requestRetries)) {
-          return retryRequest(makeRequest, apiVersion, headers, requestRetries);
+          return retryRequest(
+            makeRequest,
+            apiVersion,
+            headers,
+            requestRetries,
+            ((res || {}).headers || {})['retry-after']
+          );
         } else {
           return this._responseHandler(req, callback)(res);
         }
@@ -413,7 +425,13 @@ StripeResource.prototype = {
 
       req.on('error', (error) => {
         if (this._shouldRetry(null, requestRetries)) {
-          return retryRequest(makeRequest, apiVersion, headers, requestRetries);
+          return retryRequest(
+            makeRequest,
+            apiVersion,
+            headers,
+            requestRetries,
+            null
+          );
         } else {
           return this._errorHandler(req, requestRetries, callback)(error);
         }

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -228,8 +228,19 @@ StripeResource.prototype = {
       return true;
     }
 
-    // Retry on conflict and availability errors.
-    if (res.statusCode === 409 || res.statusCode === 503) {
+    if (res.headers['should-retry'] === 'false') {
+      return false;
+    }
+    if (res.headers['should-retry'] === 'true') {
+      return true;
+    }
+
+    // Retry on conflict, rate-limit, and availability errors.
+    if (
+      res.statusCode === 409 ||
+      res.statusCode === 429 ||
+      res.statusCode === 503
+    ) {
       return true;
     }
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -252,7 +252,7 @@ StripeResource.prototype = {
     return false;
   },
 
-  _getSleepTimeInMS(numRetries, retryAfter) {
+  _getSleepTimeInMS(numRetries, retryAfter = null) {
     const initialNetworkRetryDelay = this._stripe.getInitialNetworkRetryDelay();
     const maxNetworkRetryDelay = this._stripe.getMaxNetworkRetryDelay();
 
@@ -271,8 +271,10 @@ StripeResource.prototype = {
     // But never sleep less than the base sleep seconds.
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
 
-    // And never sleep less than the time the API asks us to wait
-    sleepSeconds = Math.max(sleepSeconds, retryAfter || 0);
+    // And never sleep less than the time the API asks us to wait, assuming it's a reasonable ask.
+    if (Number.isInteger(retryAfter) && retryAfter <= 60) {
+      sleepSeconds = Math.max(sleepSeconds, retryAfter);
+    }
 
     return sleepSeconds * 1000;
   },

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -228,10 +228,10 @@ StripeResource.prototype = {
       return true;
     }
 
-    if (res.headers['stripe-should-retry'] === 'false') {
+    if (res.headers && res.headers['stripe-should-retry'] === 'false') {
       return false;
     }
-    if (res.headers['stripe-should-retry'] === 'true') {
+    if (res.headers && res.headers['stripe-should-retry'] === 'true') {
       return true;
     }
 
@@ -271,7 +271,10 @@ StripeResource.prototype = {
     // But never sleep less than the base sleep seconds.
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
 
-    return Math.max(sleepSeconds * 1000, retryAfter || 0);
+    // And never sleep less than the time the API asks us to wait
+    sleepSeconds = Math.max(sleepSeconds, retryAfter || 0);
+
+    return sleepSeconds * 1000;
   },
 
   _defaultIdempotencyKey(method) {

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -18,6 +18,7 @@ StripeResource.method = require('./StripeMethod');
 StripeResource.BASIC_METHODS = require('./StripeMethod.basic');
 
 StripeResource.MAX_BUFFERED_REQUEST_METRICS = 100;
+const MAX_RETRY_AFTER_WAIT = 60;
 
 /**
  * Encapsulates request logic for a Stripe Resource
@@ -217,6 +218,7 @@ StripeResource.prototype = {
     };
   },
 
+  // For more on when and how to retry API requests, see https://stripe.com/docs/error-handling#safely-retrying-requests-with-idempotency
   _shouldRetry(res, numRetries) {
     // Do not retry if we are out of retries.
     if (numRetries >= this._stripe.getMaxNetworkRetries()) {
@@ -228,6 +230,8 @@ StripeResource.prototype = {
       return true;
     }
 
+    // The API may ask us not to retry (eg; if doing so would be a no-op)
+    // or advise us to retry (eg; in cases of lock timeouts); we defer to that.
     if (res.headers && res.headers['stripe-should-retry'] === 'false') {
       return false;
     }
@@ -272,7 +276,7 @@ StripeResource.prototype = {
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
 
     // And never sleep less than the time the API asks us to wait, assuming it's a reasonable ask.
-    if (Number.isInteger(retryAfter) && retryAfter <= 60) {
+    if (Number.isInteger(retryAfter) && retryAfter <= MAX_RETRY_AFTER_WAIT) {
       sleepSeconds = Math.max(sleepSeconds, retryAfter);
     }
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries @paulasjes-stripe @jlomas-stripe

This adds support for the `Stripe-Should-Retry` and `Retry-After` headers. 

This allows the API to specify specific cases when an automatic retry is recommended (such as `lock_timeout` errors) or not recommended (such as when our idempotency framework would replay the request anyway). 

It also allows the API to encourage slower retries.