### PR TITLE
Add request-specific fields from raw error to top level error

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -36,6 +36,13 @@ class StripeError extends Error {
     this.requestId = raw.requestId;
     this.statusCode = raw.statusCode;
     this.message = raw.message;
+
+    this.charge = raw.decline_code;
+    this.decline_code = raw.decline_code;
+    this.payment_intent = raw.payment_intent;
+    this.payment_method = raw.payment_method;
+    this.setup_intent = raw.setup_intent;
+    this.source = raw.source;
   }
 
   /**

--- a/lib/Error.js
+++ b/lib/Error.js
@@ -37,7 +37,7 @@ class StripeError extends Error {
     this.statusCode = raw.statusCode;
     this.message = raw.message;
 
-    this.charge = raw.decline_code;
+    this.charge = raw.charge;
     this.decline_code = raw.decline_code;
     this.payment_intent = raw.payment_intent;
     this.payment_method = raw.payment_method;

--- a/test/Error.spec.js
+++ b/test/Error.spec.js
@@ -60,6 +60,15 @@ describe('Error', () => {
       ).to.be.instanceOf(Error.StripeIdempotencyError);
     });
 
+    it('copies whitelisted properties', () => {
+      const e = new Error.StripeError({
+        charge: 'foo',
+        unknown_prop: 'bar',
+      });
+      expect(e).to.have.property('charge', 'foo');
+      expect(e).not.to.have.property('unknown_prop', 'bar');
+    });
+
     it('Pulls in headers', () => {
       const headers = {'Request-Id': '123'};
       const e = Error.StripeError.generate({

--- a/test/Error.spec.js
+++ b/test/Error.spec.js
@@ -67,6 +67,7 @@ describe('Error', () => {
       });
       expect(e).to.have.property('charge', 'foo');
       expect(e).not.to.have.property('unknown_prop', 'bar');
+      expect(e).not.to.have.property('decline_code', 'xyzzy');
     });
 
     it('Pulls in headers', () => {


### PR DESCRIPTION
Per request of @remi-stripe (https://jira.corp.stripe.com/secure/RapidBoard.jspa?rapidView=1346&projectKey=DX&view=planning&selectedIssue=DX-4753&quickFilter=3988)
It is sometimes important to access properties such as `error.raw.payment_intent`, `error.raw.payment_method`, etc. But "raw" means "here be dragons, don't rely on anything here". This PR copies these properties from `raw` to the top level error object, to indicate that they are properly part of our interface and remove the need for users to access "raw".

