### PR TITLE
New config object

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,36 @@ const stripe = Stripe('sk_test_...');
 On older versions of Node, you can use [promises](#using-promises)
 or [callbacks](#using-callbacks) instead of `async`/`await`.
 
+## Initialize with config object
+
+The package can be initialized with several options:
+
+```js
+import ProxyAgent from 'https-proxy-agent';
+
+const stripe = Stripe('sk_test_...', {
+  apiVersion: '2019-08-08',
+  maxNetworkRetries: 1,
+  httpAgent: new ProxyAgent(process.env.http_proxy),
+  timeout: 1000,
+  host: 'api.example.com',
+  port: 123,
+  telemetry: true,
+});
+```
+
+| Option              | Default                       | Description                                                                           |
+| ------------------- | ----------------------------- | ------------------------------------------------------------------------------------- |
+| `apiVersion`        | `null`                        | Stripe API version to be used. If not set the account's default version will be used. |
+| `maxNetworkRetries` | 0                             | The amount of times a request should be [retried](#network-retries).                  |
+| `httpAgent`         | `null`                        | [Proxy](#configuring-a-proxy) agent to be used by the library.                        |
+| `timeout`           | 120000 (Node default timeout) | [Maximum time each request can take in ms.](#configuring-timeout)                     |
+| `host`              | `'api.stripe.com'`            | Host that requests are made to.                                                       |
+| `port`              | 443                           | Port that requests are made to.                                                       |
+| `telemetry`         | `true`                        | Allow Stripe to send latency [telemetry](#request-latency-telemetry)                  |
+
+Note: Both `maxNetworkRetries` and `timeout` can be overridden on a per-request basis. `timeout` can be updated at any time with [`stripe.setTimeout`](#configuring-timeout).
+
 ### Usage with TypeScript
 
 Stripe does not currently maintain typings for this package, but there are
@@ -135,6 +165,29 @@ Request timeout is configurable (the default is Node's default of 120 seconds):
 stripe.setTimeout(20000); // in ms (this is 20 seconds)
 ```
 
+Timeout can also be set globally via the config object:
+
+```js
+const stripe = Stripe('sk_test_...', {
+  timeout: 2000,
+});
+```
+
+And on a per-request basis:
+
+```js
+stripe.customers.create(
+  {
+    email: 'customer@example.com',
+  },
+  {
+    timeout: 1000,
+  }
+);
+```
+
+If `timeout` is set globally via the config object, the value set in a per-request basis will be favored.
+
 ### Configuring For Connect
 
 A per-request `Stripe-Account` header for use with [Stripe Connect][connect]
@@ -144,7 +197,7 @@ can be added to any method:
 // Retrieve the balance for a connected account:
 stripe.balance
   .retrieve({
-    stripe_account: 'acct_foo',
+    stripeAccount: 'acct_foo',
   })
   .then((balance) => {
     // The balance object for the connected account
@@ -159,24 +212,41 @@ stripe.balance
 An [https-proxy-agent][https-proxy-agent] can be configured with
 `setHttpAgent`.
 
-To use stripe behind a proxy you can pass to sdk:
+To use stripe behind a proxy you can pass to sdk on initialization:
 
 ```js
 if (process.env.http_proxy) {
   const ProxyAgent = require('https-proxy-agent');
-  stripe.setHttpAgent(new ProxyAgent(process.env.http_proxy));
+
+  const stripe = Stripe('sk_test_...', {
+    httpProxy: new ProxyAgent(process.env.http_proxy),
+  });
 }
 ```
 
 ### Network retries
 
-Automatic network retries can be enabled with `setMaxNetworkRetries`.
+Automatic network retries can be enabled with the `maxNetworkRetries` config option.
 This will retry requests `n` times with exponential backoff if they fail due to an intermittent network problem.
 [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
 ```js
-// Retry a request twice before giving up
-stripe.setMaxNetworkRetries(2);
+const stripe = Stripe('sk_test_...', {
+  maxNetworkRetries: 2, // Retry a request twice before giving up
+});
+```
+
+Network retries can also be set on a per-request basis:
+
+```js
+stripe.customers.create(
+  {
+    email: 'customer@example.com',
+  },
+  {
+    maxNetworkRetries: 2, // Retry this specific request twice before giving up
+  }
+);
 ```
 
 ### Examining Responses
@@ -185,7 +255,7 @@ Some information about the response which generated a resource is available
 with the `lastResponse` property:
 
 ```js
-charge.lastResponse.requestId; // see: https://stripe.com/docs/api/node#request_ids
+charge.lastResponse.requestId; // see: https://stripe.com/docs/api/request_ids?lang=node
 charge.lastResponse.statusCode;
 ```
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -219,9 +219,9 @@ StripeResource.prototype = {
   },
 
   // For more on when and how to retry API requests, see https://stripe.com/docs/error-handling#safely-retrying-requests-with-idempotency
-  _shouldRetry(res, numRetries) {
+  _shouldRetry(res, numRetries, maxRetries) {
     // Do not retry if we are out of retries.
-    if (numRetries >= this._stripe.getMaxNetworkRetries()) {
+    if (numRetries >= maxRetries) {
       return false;
     }
 
@@ -283,9 +283,19 @@ StripeResource.prototype = {
     return sleepSeconds * 1000;
   },
 
-  _defaultIdempotencyKey(method) {
+  // Max retries can be set on a per request basis. Favor those over the global setting
+  _getMaxNetworkRetries(settings = {}) {
+    return settings.maxNetworkRetries &&
+      Number.isInteger(settings.maxNetworkRetries)
+      ? settings.maxNetworkRetries
+      : this._stripe.getMaxNetworkRetries();
+  },
+
+  _defaultIdempotencyKey(method, settings) {
     // If this is a POST and we allow multiple retries, ensure an idempotency key.
-    if (method === 'POST' && this._stripe.getMaxNetworkRetries() > 0) {
+    const maxRetries = this._getMaxNetworkRetries(settings);
+
+    if (method === 'POST' && maxRetries > 0) {
       return `stripe-node-retry-${utils.uuid4()}`;
     }
     return null;
@@ -297,7 +307,8 @@ StripeResource.prototype = {
     apiVersion,
     clientUserAgent,
     method,
-    userSuppliedHeaders
+    userSuppliedHeaders,
+    userSuppliedSettings
   ) {
     const defaultHeaders = {
       // Use specified auth token or use default from this stripe instance:
@@ -309,7 +320,10 @@ StripeResource.prototype = {
       'X-Stripe-Client-User-Agent': clientUserAgent,
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
       'Stripe-Version': apiVersion,
-      'Idempotency-Key': this._defaultIdempotencyKey(method),
+      'Idempotency-Key': this._defaultIdempotencyKey(
+        method,
+        userSuppliedSettings
+      ),
     };
 
     return Object.assign(
@@ -358,7 +372,7 @@ StripeResource.prototype = {
     }
   },
 
-  _request(method, host, path, data, auth, options, callback) {
+  _request(method, host, path, data, auth, options = {}, callback) {
     let requestData;
 
     const retryRequest = (
@@ -378,7 +392,14 @@ StripeResource.prototype = {
     };
 
     const makeRequest = (apiVersion, headers, numRetries) => {
-      const timeout = this._stripe.getApiField('timeout');
+      // timeout can be set on a per-request basis. Favor that over the global setting
+      const timeout =
+        options.settings &&
+        Number.isInteger(options.settings.timeout) &&
+        options.settings.timeout >= 0
+          ? options.settings.timeout
+          : this._stripe.getApiField('timeout');
+
       const isInsecureConnection =
         this._stripe.getApiField('protocol') == 'http';
       let agent = this._stripe.getApiField('agent');
@@ -409,6 +430,8 @@ StripeResource.prototype = {
 
       const requestRetries = numRetries || 0;
 
+      const maxRetries = this._getMaxNetworkRetries(options.settings);
+
       req._requestEvent = requestEvent;
 
       req._requestStart = requestStartTime;
@@ -418,7 +441,7 @@ StripeResource.prototype = {
       req.setTimeout(timeout, this._timeoutHandler(timeout, req, callback));
 
       req.once('response', (res) => {
-        if (this._shouldRetry(res, requestRetries)) {
+        if (this._shouldRetry(res, requestRetries, maxRetries)) {
           return retryRequest(
             makeRequest,
             apiVersion,
@@ -432,7 +455,7 @@ StripeResource.prototype = {
       });
 
       req.on('error', (error) => {
-        if (this._shouldRetry(null, requestRetries)) {
+        if (this._shouldRetry(null, requestRetries, maxRetries)) {
           return retryRequest(
             makeRequest,
             apiVersion,
@@ -478,7 +501,8 @@ StripeResource.prototype = {
           apiVersion,
           clientUserAgent,
           method,
-          options.headers
+          options.headers,
+          options.settings
         );
 
         makeRequest(apiVersion, headers);

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -58,6 +58,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
     auth: options.auth,
     headers,
     host,
+    settings: options.settings,
   };
 }
 
@@ -89,13 +90,15 @@ function makeRequest(self, requestArgs, spec, overrideData) {
       utils.stringifyRequestData(opts.queryData),
     ].join('');
 
+    const {headers, settings} = opts;
+
     self._request(
       opts.requestMethod,
       opts.host,
       path,
       opts.bodyData,
       opts.auth,
-      {headers: opts.headers},
+      {headers, settings},
       requestCallback
     );
   });

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -27,6 +27,15 @@ Stripe.MAX_NETWORK_RETRY_DELAY_SEC = 2;
 Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 
 const APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
+const ALLOWED_CONFIG_PROPERTIES = [
+  'apiVersion',
+  'maxNetworkRetries',
+  'httpAgent',
+  'timeout',
+  'host',
+  'port',
+  'telemetry',
+];
 
 const EventEmitter = require('events').EventEmitter;
 const utils = require('./utils');
@@ -34,10 +43,12 @@ const utils = require('./utils');
 Stripe.StripeResource = require('./StripeResource');
 Stripe.resources = resources;
 
-function Stripe(key, version) {
+function Stripe(key, config = {}) {
   if (!(this instanceof Stripe)) {
-    return new Stripe(key, version);
+    return new Stripe(key, config);
   }
+
+  const props = this._getPropsFromConfig(config);
 
   Object.defineProperty(this, '_emitter', {
     value: new EventEmitter(),
@@ -52,25 +63,32 @@ function Stripe(key, version) {
 
   this._api = {
     auth: null,
-    host: Stripe.DEFAULT_HOST,
-    port: Stripe.DEFAULT_PORT,
+    host: props.host || Stripe.DEFAULT_HOST,
+    port: props.port || Stripe.DEFAULT_PORT,
     basePath: Stripe.DEFAULT_BASE_PATH,
-    version: Stripe.DEFAULT_API_VERSION,
-    timeout: Stripe.DEFAULT_TIMEOUT,
-    agent: null,
+    version: props.apiVersion || Stripe.DEFAULT_API_VERSION,
+    timeout: utils.validateInteger(
+      'timeout',
+      props.timeout,
+      Stripe.DEFAULT_TIMEOUT
+    ),
+    maxNetworkRetries: utils.validateInteger(
+      'maxNetworkRetries',
+      props.maxNetworkRetries,
+      0
+    ),
+    agent: props.httpAgent || null,
     dev: false,
-    maxNetworkRetries: 0,
   };
 
   this._prepResources();
   this.setApiKey(key);
-  this.setApiVersion(version);
 
   this.errors = require('./Error');
   this.webhooks = require('./Webhooks');
 
   this._prevRequestMetrics = [];
-  this.setTelemetryEnabled(true);
+  this.setTelemetryEnabled(props.telemetry !== false);
 }
 
 Stripe.errors = require('./Error');
@@ -91,10 +109,26 @@ Stripe.prototype = {
     this._setApiField('protocol', protocol.toLowerCase());
   },
 
+  /**
+   * @deprecated will be removed in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   port: 3000,
+   * });
+   *
+   */
   setPort(port) {
     this._setApiField('port', port);
   },
 
+  /**
+   * @deprecated will be removed in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   apiVersion: API_VERSION,
+   * });
+   *
+   */
   setApiVersion(version) {
     if (version) {
       this._setApiField('version', version);
@@ -141,6 +175,15 @@ Stripe.prototype = {
     this._appInfo = appInfo;
   },
 
+  /**
+   * @deprecated will be removed in a future major version. Use the config object instead:
+   *
+   * const ProxyAgent = require('https-proxy-agent');
+   * const stripe = new Stripe(API_KEY, {
+   *   httpAgent: new ProxyAgent(process.env.http_proxy),
+   * });
+   *
+   */
   setHttpAgent(agent) {
     this._setApiField('agent', agent);
   },
@@ -169,15 +212,22 @@ Stripe.prototype = {
     return this.getApiField('maxNetworkRetries');
   },
 
+  /**
+   * @deprecated will be removed in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   maxNetworkRetries: 2,
+   * });
+   *
+   */
   setMaxNetworkRetries(maxNetworkRetries) {
-    if (
-      (maxNetworkRetries && typeof maxNetworkRetries !== 'number') ||
-      arguments.length < 1
-    ) {
-      throw new Error('maxNetworkRetries must be a number.');
-    }
+    this._setApiNumberField('maxNetworkRetries', maxNetworkRetries);
+  },
 
-    this._setApiField('maxNetworkRetries', maxNetworkRetries);
+  _setApiNumberField(prop, n, defaultVal) {
+    const val = utils.validateInteger(prop, n, defaultVal);
+
+    this._setApiField(prop, val);
   },
 
   getMaxNetworkRetryDelay() {
@@ -250,6 +300,43 @@ Stripe.prototype = {
     for (const name in resources) {
       this[utils.pascalToCamelCase(name)] = new resources[name](this);
     }
+  },
+
+  _getPropsFromConfig(config) {
+    // If config is null or undefined, just bail early with no props
+    if (!config) {
+      return {};
+    }
+
+    // config can be an object or a string
+    const isString = typeof config === 'string';
+    const isObject = config === Object(config) && !Array.isArray(config);
+
+    if (!isObject && !isString) {
+      throw new Error('Config must either be an object or a string');
+    }
+
+    // If config is a string, we assume the old behavior of passing in a string representation of the api version
+    if (isString) {
+      return {
+        apiVersion: config,
+      };
+    }
+
+    // If config is an object, we assume the new behavior and make sure it doesn't contain any unexpected values
+    const values = Object.keys(config).filter(
+      (value) => !ALLOWED_CONFIG_PROPERTIES.includes(value)
+    );
+
+    if (values.length > 0) {
+      throw new Error(
+        `Config object may only contain the following: ${ALLOWED_CONFIG_PROPERTIES.join(
+          ', '
+        )}`
+      );
+    }
+
+    return config;
   },
 };
 

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,11 +7,20 @@ const crypto = require('crypto');
 
 const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
 
+/**
+ * TODO: Remove snake case keys in a future major release
+ */
 const OPTIONS_KEYS = [
   'api_key',
+  'apiKey',
   'idempotency_key',
+  'idempotencyKey',
   'stripe_account',
+  'stripeAccount',
   'stripe_version',
+  'stripeVersion',
+  'maxNetworkRetries',
+  'timeout',
 ];
 
 const utils = (module.exports = {
@@ -117,6 +126,7 @@ const utils = (module.exports = {
     const opts = {
       auth: null,
       headers: {},
+      settings: {},
     };
     if (args.length > 0) {
       const arg = args[args.length - 1];
@@ -135,17 +145,29 @@ const utils = (module.exports = {
           );
         }
 
-        if (params.api_key) {
-          opts.auth = params.api_key;
+        /**
+         * TODO: Remove snake case params in next major version
+         */
+        if (params.apiKey || params.api_key) {
+          opts.auth = params.apiKey || params.api_key;
         }
-        if (params.idempotency_key) {
-          opts.headers['Idempotency-Key'] = params.idempotency_key;
+        if (params.idempotencyKey || params.idempotency_key) {
+          opts.headers['Idempotency-Key'] =
+            params.idempotencyKey || params.idempotency_key;
         }
-        if (params.stripe_account) {
-          opts.headers['Stripe-Account'] = params.stripe_account;
+        if (params.stripeAccount || params.stripe_account) {
+          opts.headers['Stripe-Account'] =
+            params.stripeAccount || params.stripe_account;
         }
-        if (params.stripe_version) {
-          opts.headers['Stripe-Version'] = params.stripe_version;
+        if (params.stripeVersion || params.stripe_version) {
+          opts.headers['Stripe-Version'] =
+            params.stripeVersion || params.stripe_version;
+        }
+        if (Number.isInteger(params.maxNetworkRetries)) {
+          opts.settings.maxNetworkRetries = params.maxNetworkRetries;
+        }
+        if (Number.isInteger(params.timeout)) {
+          opts.settings.timeout = params.timeout;
         }
       }
     }
@@ -355,6 +377,18 @@ const utils = (module.exports = {
       const v = c === 'x' ? r : (r & 0x3) | 0x8;
       return v.toString(16);
     });
+  },
+
+  validateInteger: (name, n, defaultVal) => {
+    if (!Number.isInteger(n)) {
+      if (defaultVal !== undefined) {
+        return defaultVal;
+      } else {
+        throw new Error(`${name} must be an integer`);
+      }
+    }
+
+    return n;
   },
 });
 

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -22,6 +22,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts',
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -34,6 +35,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts/acct_16Tzq6DBahdM4C8s',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -46,6 +48,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts/acct_16Tzq6DBahdM4C8s/reject',
         data: {reason: 'fraud'},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -58,6 +61,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -68,6 +72,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts/foo',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -80,6 +85,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -92,6 +98,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -102,6 +109,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -115,6 +123,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/capabilities',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -126,6 +135,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -138,6 +148,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/capabilities/acap_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -153,6 +164,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -167,6 +179,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/capabilities/acap_123',
           headers: {},
           data: {first_name: 'John'},
+          settings: {},
         });
       });
 
@@ -185,6 +198,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {first_name: 'John'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -203,6 +217,7 @@ describe('Account Resource', () => {
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -219,6 +234,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -235,6 +251,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/accountIdFoo321/external_accounts',
           headers: {},
           data: {number: '123456', currency: 'usd', country: 'US'},
+          settings: {},
         });
       });
 
@@ -254,6 +271,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {number: '123456', currency: 'usd', country: 'US'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -273,6 +291,7 @@ describe('Account Resource', () => {
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
           data: {default_for_currency: true},
+          settings: {},
         });
       });
     });
@@ -289,6 +308,7 @@ describe('Account Resource', () => {
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -305,6 +325,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -317,6 +338,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/accountIdFoo321/external_accounts',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -328,6 +350,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -342,6 +365,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_EXPRESS/login_links',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -356,6 +380,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -367,6 +392,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -381,6 +407,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons',
           headers: {},
           data: {first_name: 'John'},
+          settings: {},
         });
       });
 
@@ -398,6 +425,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {first_name: 'John'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -412,6 +440,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
           data: {first_name: 'John'},
+          settings: {},
         });
       });
 
@@ -430,6 +459,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {first_name: 'John'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -442,6 +472,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -453,6 +484,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -465,6 +497,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -476,6 +509,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });

--- a/test/resources/AccountLinks.spec.js
+++ b/test/resources/AccountLinks.spec.js
@@ -23,6 +23,7 @@ describe('AccountLinks Resource', () => {
           success_url: 'https://stripe.com/success',
           type: 'custom_account_verification',
         },
+        settings: {},
       });
     });
   });

--- a/test/resources/ApplePayDomains.spec.js
+++ b/test/resources/ApplePayDomains.spec.js
@@ -12,6 +12,7 @@ describe('ApplePayDomains Resource', () => {
         url: '/v1/apple_pay/domains/apwc_retrieve',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('ApplePayDomains Resource', () => {
         url: '/v1/apple_pay/domains/apwc_delete',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -41,6 +43,7 @@ describe('ApplePayDomains Resource', () => {
         data: {
           domain_name: 'example.com',
         },
+        settings: {},
       });
     });
   });
@@ -53,6 +56,7 @@ describe('ApplePayDomains Resource', () => {
         url: '/v1/apple_pay/domains',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/ApplicationFees.spec.js
+++ b/test/resources/ApplicationFees.spec.js
@@ -12,6 +12,7 @@ describe('ApplicationFee Resource', () => {
         url: '/v1/application_fees',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('ApplicationFee Resource', () => {
           '/v1/application_fees/appFeeIdExample3242/refunds/refundIdExample2312',
         data: {metadata: {key: 'value'}},
         headers: {},
+        settings: {},
       });
     });
 
@@ -39,6 +41,7 @@ describe('ApplicationFee Resource', () => {
         url: '/v1/application_fees/appFeeIdExample3242/refunds',
         data: {amount: 100},
         headers: {},
+        settings: {},
       });
     });
 
@@ -49,6 +52,7 @@ describe('ApplicationFee Resource', () => {
         url: '/v1/application_fees/appFeeIdExample3242/refunds',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -63,6 +67,7 @@ describe('ApplicationFee Resource', () => {
           '/v1/application_fees/appFeeIdExample3242/refunds/refundIdExample2312',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Balance.spec.js
+++ b/test/resources/Balance.spec.js
@@ -12,6 +12,7 @@ describe('Balance Resource', () => {
         url: '/v1/balance',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -23,6 +24,7 @@ describe('Balance Resource', () => {
         data: {},
         auth: 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11',
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/BalanceTransactions.spec.js
+++ b/test/resources/BalanceTransactions.spec.js
@@ -12,6 +12,7 @@ describe('BalanceTransactions Resource', function() {
         url: '/v1/balance_transactions/txn_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('BalanceTransactions Resource', function() {
         url: '/v1/balance_transactions',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/BitcoinReceivers.spec.js
+++ b/test/resources/BitcoinReceivers.spec.js
@@ -12,6 +12,7 @@ describe('BitcoinReceivers Resource', () => {
         url: '/v1/bitcoin/receivers/receiverId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('BitcoinReceivers Resource', () => {
         url: '/v1/bitcoin/receivers',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -38,6 +40,7 @@ describe('BitcoinReceivers Resource', () => {
         url: '/v1/bitcoin/receivers/receiverId/transactions?limit=1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -12,6 +12,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges/chargeIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +41,7 @@ describe('Charge Resource', () => {
           },
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -52,6 +54,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -64,6 +67,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges/chargeIdExample3242/capture',
         headers: {},
         data: {amount: 23},
+        settings: {},
       });
     });
   });
@@ -76,6 +80,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges/chargeIdExample3242',
         headers: {},
         data: {description: 'foo321'},
+        settings: {},
       });
     });
   });

--- a/test/resources/Checkout/Sessions.spec.js
+++ b/test/resources/Checkout/Sessions.spec.js
@@ -34,6 +34,7 @@ describe('Checkout', () => {
           url: '/v1/checkout/sessions',
           headers: {},
           data: params,
+          settings: {},
         });
       });
     });
@@ -46,6 +47,7 @@ describe('Checkout', () => {
           url: '/v1/checkout/sessions/cs_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/CountrySpecs.spec.js
+++ b/test/resources/CountrySpecs.spec.js
@@ -12,6 +12,7 @@ describe('CountrySpecs Resource', () => {
         url: '/v1/country_specs',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -25,6 +26,7 @@ describe('CountrySpecs Resource', () => {
         url: `/v1/country_specs/${country}`,
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Coupons.spec.js
+++ b/test/resources/Coupons.spec.js
@@ -12,6 +12,7 @@ describe('Coupons Resource', () => {
         url: '/v1/coupons/couponId123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Coupons Resource', () => {
         url: '/v1/coupons/couponId123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('Coupons Resource', () => {
         data: {
           metadata: {a: '1234'},
         },
+        settings: {},
       });
     });
   });
@@ -61,6 +64,7 @@ describe('Coupons Resource', () => {
           duration: 'repeating',
           duration_in_months: 4,
         },
+        settings: {},
       });
     });
   });
@@ -73,6 +77,7 @@ describe('Coupons Resource', () => {
         url: '/v1/coupons',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/CreditNotes.spec.js
+++ b/test/resources/CreditNotes.spec.js
@@ -12,6 +12,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes/cn_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -41,6 +43,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes?count=25',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -53,6 +56,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes/cn_123',
         headers: {},
         data: {application_fee: 200},
+        settings: {},
       });
     });
   });
@@ -65,6 +69,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes/cn_123/void',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -14,6 +14,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers/cus_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -25,6 +26,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -37,6 +39,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers',
         headers: {},
         data: {description: 'Some customer'},
+        settings: {},
       });
     });
 
@@ -48,6 +51,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -59,6 +63,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -72,6 +77,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers',
         headers: {'Idempotency-Key': 'foo'},
         data: {description: 'Some customer'},
+        settings: {},
       });
     });
 
@@ -86,6 +92,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -100,6 +107,7 @@ describe('Customers Resource', () => {
         headers: {'Idempotency-Key': 'foo'},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -111,6 +119,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -125,6 +134,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers/cus_123',
         headers: {},
         data: {description: 'Foo "baz"'},
+        settings: {},
       });
     });
   });
@@ -137,6 +147,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers/cus_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -149,6 +160,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -160,6 +172,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -173,6 +186,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/discount',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -187,6 +201,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -198,6 +213,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -214,6 +230,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources',
           headers: {},
           data: {object: 'card', number: '123456', exp_month: '12'},
+          settings: {},
         });
       });
 
@@ -233,6 +250,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {object: 'card', number: '123456', exp_month: '12'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -247,6 +265,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
           data: {name: 'Bob M. Baz'},
+          settings: {},
         });
       });
     });
@@ -259,6 +278,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -270,6 +290,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -282,6 +303,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -293,6 +315,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -313,6 +336,7 @@ describe('Customers Resource', () => {
           headers: {},
           data,
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -327,6 +351,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/tax_ids/txi_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -342,6 +367,7 @@ describe('Customers Resource', () => {
           method: 'POST',
           url: '/v1/customers/cus_123/tax_ids',
           headers: {},
+          settings: {},
           data,
         });
       });
@@ -355,6 +381,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/tax_ids/txi_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -367,6 +394,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/tax_ids',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -381,6 +409,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions/cbtxn_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -396,6 +425,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions',
           headers: {},
           data: {amount: 123, currency: 'usd'},
+          settings: {},
         });
       });
     });
@@ -410,6 +440,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions/cbtxn_123',
           headers: {},
           data: {description: 'description'},
+          settings: {},
         });
       });
     });
@@ -422,6 +453,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Disputes.spec.js
+++ b/test/resources/Disputes.spec.js
@@ -12,6 +12,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes/dp_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes/dp_123/close',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -48,6 +51,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes/dp_123',
         headers: {},
         data: {evidence: {customer_name: 'Bob'}},
+        settings: {},
       });
     });
   });

--- a/test/resources/EphemeralKeys.spec.js
+++ b/test/resources/EphemeralKeys.spec.js
@@ -24,6 +24,7 @@ function sendsCorrectStripeVersion() {
     headers: {
       'Stripe-Version': '2017-06-05',
     },
+    settings: {},
   });
 }
 
@@ -43,6 +44,7 @@ describe('EphemeralKey Resource', () => {
         headers: {
           'Stripe-Version': '2017-05-25',
         },
+        settings: {},
       });
     });
 
@@ -91,6 +93,7 @@ describe('EphemeralKey Resource', () => {
         url: '/v1/ephemeral_keys/ephkey_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Events.spec.js
+++ b/test/resources/Events.spec.js
@@ -12,6 +12,7 @@ describe('Events Resource', () => {
         url: '/v1/events/eventIdBaz',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Events Resource', () => {
         url: '/v1/events?count=25',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/ExchangeRates.spec.js
+++ b/test/resources/ExchangeRates.spec.js
@@ -12,6 +12,7 @@ describe('ExchangeRates Resource', () => {
         url: '/v1/exchange_rates',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -25,6 +26,7 @@ describe('ExchangeRates Resource', () => {
         url: `/v1/exchange_rates/${currency}`,
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/FileLinks.spec.js
+++ b/test/resources/FileLinks.spec.js
@@ -12,6 +12,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links/link_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links',
         headers: {},
         data: {file: 'file_123'},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links/link_123',
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -48,6 +51,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -16,6 +16,7 @@ describe('Files Resource', () => {
         url: '/v1/files/fil_12345',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -27,6 +28,7 @@ describe('Files Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -39,6 +41,7 @@ describe('Files Resource', () => {
         url: '/v1/files',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/InvoiceItems.spec.js
+++ b/test/resources/InvoiceItems.spec.js
@@ -12,6 +12,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems/invoiceItemIdTesting123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -26,6 +27,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems',
         headers: {},
         data: {customer: 'cust_id_888'},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems/invoiceItemId1',
         headers: {},
         data: {amount: 1900},
+        settings: {},
       });
     });
   });
@@ -52,6 +55,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems/invoiceItemId2',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -64,6 +68,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -12,6 +12,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices',
         headers: {},
         data: {application_fee: 111},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices?count=25',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -48,6 +51,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123',
         headers: {},
         data: {application_fee: 200},
+        settings: {},
       });
     });
   });
@@ -60,6 +64,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -72,6 +77,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/lines',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -84,6 +90,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/upcoming/lines',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -101,6 +108,7 @@ describe('Invoices Resource', () => {
           '/v1/invoices/upcoming?customer=cus_abc&subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -119,6 +127,7 @@ describe('Invoices Resource', () => {
           '/v1/invoices/upcoming/lines?customer=cus_abc&subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga&limit=5',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -131,6 +140,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/finalize',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -143,6 +153,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/mark_uncollectible',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -157,6 +168,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/pay',
         headers: {},
         data: {source: 'tok_FooBar'},
+        settings: {},
       });
     });
   });
@@ -169,6 +181,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/send',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -181,6 +194,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/void',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/IssuerFraudRecords.spec.js
+++ b/test/resources/IssuerFraudRecords.spec.js
@@ -12,6 +12,7 @@ describe('IssuerFraudRecord Resource', () => {
         url: '/v1/issuer_fraud_records/issfr_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('IssuerFraudRecord Resource', () => {
         url: '/v1/issuer_fraud_records',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Issuing/Authorization.spec.js
+++ b/test/resources/Issuing/Authorization.spec.js
@@ -13,6 +13,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations/iauth_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -25,6 +26,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -47,6 +49,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -59,6 +62,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations/iauth_123/approve',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -71,6 +75,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations/iauth_123/decline',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Cardholders.spec.js
+++ b/test/resources/Issuing/Cardholders.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cardholders/ich_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -35,6 +36,7 @@ describe('Issuing', () => {
             name: 'Tim Testperson',
             type: 'individual',
           },
+          settings: {},
         });
       });
     });
@@ -57,6 +59,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -69,6 +72,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cardholders',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Cards.spec.js
+++ b/test/resources/Issuing/Cards.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cards/ic_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Issuing', () => {
             currency: 'usd',
             type: 'physical',
           },
+          settings: {},
         });
       });
     });
@@ -55,6 +57,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -67,6 +70,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cards',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -82,6 +86,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cards/ic_123/details',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Disputes.spec.js
+++ b/test/resources/Issuing/Disputes.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/disputes/idp_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -31,6 +32,7 @@ describe('Issuing', () => {
           data: {
             transaction: 'ipi_123',
           },
+          settings: {},
         });
       });
     });
@@ -53,6 +55,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -65,6 +68,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/disputes',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Transactions.spec.js
+++ b/test/resources/Issuing/Transactions.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/transactions/ipi_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -37,6 +38,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -49,6 +51,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/transactions',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/OAuth.spec.js
+++ b/test/resources/OAuth.spec.js
@@ -76,6 +76,7 @@ describe('OAuth', () => {
           code: '123abc',
           grant_type: 'authorization_code',
         },
+        settings: {},
       });
     });
   });
@@ -99,6 +100,7 @@ describe('OAuth', () => {
           client_id: stripe.getClientId(),
           stripe_user_id: 'some_user_id',
         },
+        settings: {},
       });
     });
 
@@ -117,6 +119,7 @@ describe('OAuth', () => {
           client_id: '123abc',
           stripe_user_id: 'some_user_id',
         },
+        settings: {},
       });
     });
   });

--- a/test/resources/OrderReturns.spec.js
+++ b/test/resources/OrderReturns.spec.js
@@ -12,6 +12,7 @@ describe('OrderReturn Resource', () => {
         url: '/v1/order_returns/orderReturnIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -26,6 +27,7 @@ describe('OrderReturn Resource', () => {
         url: '/v1/order_returns?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -38,6 +40,7 @@ describe('OrderReturn Resource', () => {
         url: '/v1/order_returns?order=orderIdFoo123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Orders.spec.js
+++ b/test/resources/Orders.spec.js
@@ -12,6 +12,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -54,6 +55,7 @@ describe('Order Resource', () => {
           email: 'jane@ros.en',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -68,6 +70,7 @@ describe('Order Resource', () => {
         url: '/v1/orders?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -80,6 +83,7 @@ describe('Order Resource', () => {
         url: '/v1/orders?status=active',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -94,6 +98,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo3242/pay',
         headers: {},
         data: {source: 'tok_FooBar'},
+        settings: {},
       });
     });
   });
@@ -108,6 +113,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo3242/returns',
         headers: {},
         data: {items: [{parent: 'sku_123'}]},
+        settings: {},
       });
     });
   });
@@ -120,6 +126,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo3242',
         headers: {},
         data: {status: 'fulfilled'},
+        settings: {},
       });
     });
   });

--- a/test/resources/PaymentIntents.spec.js
+++ b/test/resources/PaymentIntents.spec.js
@@ -19,6 +19,7 @@ describe('Payment Intents Resource', () => {
         url: '/v1/payment_intents',
         headers: {},
         data: params,
+        settings: {},
       });
     });
   });
@@ -31,6 +32,7 @@ describe('Payment Intents Resource', () => {
         url: '/v1/payment_intents',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -57,6 +60,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}`,
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -69,6 +73,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}/cancel`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -81,6 +86,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}/capture`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -93,6 +99,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}/confirm`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/PaymentMethods.spec.js
+++ b/test/resources/PaymentMethods.spec.js
@@ -12,6 +12,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -27,6 +28,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods?customer=cus_123&type=card',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -58,6 +61,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -70,6 +74,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123/attach',
         headers: {},
         data: {customer: 'cus_123'},
+        settings: {},
       });
     });
   });
@@ -82,6 +87,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123/detach',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Payouts.spec.js
+++ b/test/resources/Payouts.spec.js
@@ -14,6 +14,7 @@ describe('Payouts Resource', () => {
         url: `/v1/payouts/${PAYOUT_TEST_ID}`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('Payouts Resource', () => {
         url: '/v1/payouts',
         headers: {},
         data: {amount: 200, currency: 'usd'},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Payouts Resource', () => {
         url: `/v1/payouts/${PAYOUT_TEST_ID}`,
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Payouts Resource', () => {
         url: `/v1/payouts/${PAYOUT_TEST_ID}/cancel`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -67,6 +71,7 @@ describe('Payouts Resource', () => {
         url: '/v1/payouts',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Plans.spec.js
+++ b/test/resources/Plans.spec.js
@@ -12,6 +12,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans/planId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -27,6 +28,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans',
         headers: {},
         data: {amount: 200, currency: 'usd'},
+        settings: {},
       });
     });
 
@@ -41,6 +43,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans',
         headers: {},
         data: {amount: 200, currency: 'usd', usage_type: 'metered'},
+        settings: {},
       });
     });
 
@@ -61,6 +64,7 @@ describe('Plans Resource', () => {
           tiers: [{up_to: 123, amount: 100}, {up_to: 'inf', amount: 200}],
           tiers_mode: 'volume',
         },
+        settings: {},
       });
     });
 
@@ -79,6 +83,7 @@ describe('Plans Resource', () => {
           currency: 'usd',
           transform_usage: {divide_by: 123, round: 'up'},
         },
+        settings: {},
       });
     });
   });
@@ -94,6 +99,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans/planId3',
         headers: {},
         data: {amount: 1900, currency: 'usd'},
+        settings: {},
       });
     });
   });
@@ -106,6 +112,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans/planId4',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -118,6 +125,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Products.spec.js
+++ b/test/resources/Products.spec.js
@@ -12,6 +12,7 @@ describe('Product Resource', () => {
         url: '/v1/products/productIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -32,6 +33,7 @@ describe('Product Resource', () => {
           type: 'good',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -46,6 +48,7 @@ describe('Product Resource', () => {
         url: '/v1/products?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -58,6 +61,7 @@ describe('Product Resource', () => {
         url: '/v1/products?shippable=true',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -70,6 +74,7 @@ describe('Product Resource', () => {
         url: '/v1/products/productIdFoo3242',
         headers: {},
         data: {caption: 'test'},
+        settings: {},
       });
     });
   });
@@ -82,6 +87,7 @@ describe('Product Resource', () => {
         url: '/v1/products/productIdFoo3242',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Radar/EarlyFraudWarnings.spec.js
+++ b/test/resources/Radar/EarlyFraudWarnings.spec.js
@@ -13,6 +13,7 @@ describe('Radar', () => {
           url: '/v1/radar/early_fraud_warnings/issfr_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -25,6 +26,7 @@ describe('Radar', () => {
           url: '/v1/radar/early_fraud_warnings',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Radar/ValueListItems.spec.js
+++ b/test/resources/Radar/ValueListItems.spec.js
@@ -15,6 +15,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_list_items/rsli_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Radar', () => {
             value_list: 'rsl_123',
             value: 'value',
           },
+          settings: {},
         });
       });
     });
@@ -47,6 +49,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_list_items?value_list=rsl_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -59,6 +62,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_list_items/rsli_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Radar/ValueLists.spec.js
+++ b/test/resources/Radar/ValueLists.spec.js
@@ -15,6 +15,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_lists/rsl_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Radar', () => {
             alias: 'alias',
             name: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -45,6 +47,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_lists',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -57,6 +60,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_lists/rsl_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -73,6 +77,7 @@ describe('Radar', () => {
           data: {
             metadata: {a: '1234'},
           },
+          settings: {},
         });
       });
     });

--- a/test/resources/Recipients.spec.js
+++ b/test/resources/Recipients.spec.js
@@ -14,6 +14,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients/recipientId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients',
         headers: {},
         data: {name: 'Bob', type: 'individual'},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients/recipientId3',
         headers: {},
         data: {name: 'Bob Smith'},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients/recipientId4',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -67,6 +71,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -80,6 +85,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards/cardIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -95,6 +101,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -110,6 +117,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards',
           headers: {},
           data: {number: '123456', exp_month: '12'},
+          settings: {},
         });
       });
 
@@ -128,6 +136,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {number: '123456', exp_month: '12'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -142,6 +151,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards/cardIdFoo456',
           headers: {},
           data: {name: 'Bob M. Baz'},
+          settings: {},
         });
       });
     });
@@ -154,6 +164,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards/cardIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -169,6 +180,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -181,6 +193,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -192,6 +205,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });

--- a/test/resources/Refunds.spec.js
+++ b/test/resources/Refunds.spec.js
@@ -19,6 +19,7 @@ describe('Refund Resource', () => {
           amount: '300',
           charge: 'ch_123',
         },
+        settings: {},
       });
     });
   });
@@ -31,6 +32,7 @@ describe('Refund Resource', () => {
         url: '/v1/refunds/re_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Refund Resource', () => {
         url: '/v1/refunds',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Refund Resource', () => {
         url: '/v1/refunds/re_123',
         headers: {},
         data: {metadata: {key: 'abcd'}},
+        settings: {},
       });
     });
   });

--- a/test/resources/Reporting/ReportRuns.spec.js
+++ b/test/resources/Reporting/ReportRuns.spec.js
@@ -15,6 +15,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_runs/frr_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -37,6 +38,7 @@ describe('Reporting', () => {
             },
             report_type: 'activity.summary.1',
           },
+          settings: {},
         });
       });
     });
@@ -49,6 +51,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_runs',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Reporting/ReportTypes.spec.js
+++ b/test/resources/Reporting/ReportTypes.spec.js
@@ -15,6 +15,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_types/activity.summary.1',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -27,6 +28,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_types',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Reviews.spec.js
+++ b/test/resources/Reviews.spec.js
@@ -12,6 +12,7 @@ describe('Review Resource', () => {
         url: '/v1/reviews/prv_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Review Resource', () => {
         url: '/v1/reviews',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('Review Resource', () => {
         url: '/v1/reviews/prv_123/approve',
         headers: {},
         data: {amount: 23},
+        settings: {},
       });
     });
   });

--- a/test/resources/SKUs.spec.js
+++ b/test/resources/SKUs.spec.js
@@ -12,6 +12,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus/skuIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +37,7 @@ describe('SKU Resource', () => {
           product: 'prodIdTest123',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -50,6 +52,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -62,6 +65,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus?product=prodId123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -74,6 +78,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus/skuIdFoo3242',
         headers: {},
         data: {caption: 'test'},
+        settings: {},
       });
     });
   });
@@ -86,6 +91,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus/skuIdFoo3242',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/SetupIntents.spec.js
+++ b/test/resources/SetupIntents.spec.js
@@ -17,6 +17,7 @@ describe('Setup Intents Resource', () => {
         url: '/v1/setup_intents',
         headers: {},
         data: params,
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('Setup Intents Resource', () => {
         url: '/v1/setup_intents',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -41,6 +43,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -67,6 +71,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}/cancel`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -79,6 +84,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}/confirm`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Sigma/ScheduledQueryRuns.spec.js
+++ b/test/resources/Sigma/ScheduledQueryRuns.spec.js
@@ -13,6 +13,7 @@ describe('Sigma', () => {
           url: '/v1/sigma/scheduled_query_runs/sqr_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -25,6 +26,7 @@ describe('Sigma', () => {
           url: '/v1/sigma/scheduled_query_runs',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Sources.spec.js
+++ b/test/resources/Sources.spec.js
@@ -12,6 +12,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/sourceId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -42,6 +43,7 @@ describe('Sources Resource', () => {
             refund_address: 'refundAddress1',
           },
         },
+        settings: {},
       });
     });
   });
@@ -56,6 +58,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/src_foo',
         headers: {},
         data: {metadata: {foo: 'bar'}},
+        settings: {},
       });
     });
   });
@@ -68,6 +71,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/src_foo/source_transactions',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -80,6 +84,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/src_foo/verify',
         headers: {},
         data: {values: [32, 45]},
+        settings: {},
       });
     });
   });

--- a/test/resources/SubscriptionItems.spec.js
+++ b/test/resources/SubscriptionItems.spec.js
@@ -12,6 +12,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items/test_sub_item',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items/test_sub_item',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('SubscriptionItems Resource', () => {
         data: {
           plan: 'gold',
         },
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('SubscriptionItems Resource', () => {
           subscription: 'test_sub',
           plan: 'gold',
         },
+        settings: {},
       });
     });
   });
@@ -74,6 +78,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items?limit=3&subscription=test_sub',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -91,6 +96,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items/si_123/usage_records',
         headers: {},
         data,
+        settings: {},
       });
     });
   });

--- a/test/resources/SubscriptionSchedule.spec.js
+++ b/test/resources/SubscriptionSchedule.spec.js
@@ -17,6 +17,7 @@ describe('Subscription Schedule Resource', () => {
         url: `/v1/subscription_schedules/${SCHEDULE_TEST_ID}/cancel`,
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -32,6 +33,7 @@ describe('Subscription Schedule Resource', () => {
         url: '/v1/subscription_schedules',
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -44,6 +46,7 @@ describe('Subscription Schedule Resource', () => {
         url: '/v1/subscription_schedules',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('Subscription Schedule Resource', () => {
         url: `/v1/subscription_schedules/${SCHEDULE_TEST_ID}/release`,
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -71,6 +75,7 @@ describe('Subscription Schedule Resource', () => {
         url: '/v1/subscription_schedules/sub_sched_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -84,6 +89,7 @@ describe('Subscription Schedule Resource', () => {
         url: `/v1/subscription_schedules/${SCHEDULE_TEST_ID}`,
         data,
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Subscriptions.spec.js
+++ b/test/resources/Subscriptions.spec.js
@@ -12,6 +12,7 @@ describe('subscriptions Resource', () => {
         url: '/v1/subscriptions/test_sub',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('subscriptions Resource', () => {
         url: '/v1/subscriptions/test_sub',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('subscriptions Resource', () => {
         data: {
           metadata: {a: '1234'},
         },
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('subscriptions Resource', () => {
           customer: 'test_cus',
           plan: 'gold',
         },
+        settings: {},
       });
     });
   });
@@ -85,6 +89,7 @@ describe('subscriptions Resource', () => {
             },
           ],
         },
+        settings: {},
       });
     });
   });
@@ -112,6 +117,7 @@ describe('subscriptions Resource', () => {
             },
           ],
         },
+        settings: {},
       });
     });
   });
@@ -138,6 +144,7 @@ describe('subscriptions Resource', () => {
             },
           },
         },
+        settings: {},
       });
     });
   });
@@ -165,6 +172,7 @@ describe('subscriptions Resource', () => {
             },
           },
         },
+        settings: {},
       });
     });
   });
@@ -181,6 +189,7 @@ describe('subscriptions Resource', () => {
         url: '/v1/subscriptions?limit=3&customer=test_cus&plan=gold',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -194,6 +203,7 @@ describe('subscriptions Resource', () => {
           url: '/v1/subscriptions/test_sub/discount',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/TaxRates.spec.js
+++ b/test/resources/TaxRates.spec.js
@@ -12,6 +12,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates/txr_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -27,6 +28,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates/txr_123',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -45,6 +47,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -57,6 +60,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Terminal/ConnectionTokens.spec.js
+++ b/test/resources/Terminal/ConnectionTokens.spec.js
@@ -14,6 +14,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/connection_tokens',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Terminal/Locations.spec.js
+++ b/test/resources/Terminal/Locations.spec.js
@@ -15,6 +15,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/locations/loc_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -45,6 +46,7 @@ describe('Terminal', () => {
               city: 'San Francisco',
             },
           },
+          settings: {},
         });
       });
     });
@@ -57,6 +59,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/locations/loc_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -73,6 +76,7 @@ describe('Terminal', () => {
           data: {
             display_name: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -85,6 +89,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/locations',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Terminal/Readers.spec.js
+++ b/test/resources/Terminal/Readers.spec.js
@@ -15,6 +15,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/readers/rdr_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Terminal', () => {
             registration_code: 'a-b-c',
             label: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -45,6 +47,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/readers/rdr_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -61,6 +64,7 @@ describe('Terminal', () => {
           data: {
             label: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -73,6 +77,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/readers',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/ThreeDSecure.spec.js
+++ b/test/resources/ThreeDSecure.spec.js
@@ -12,6 +12,7 @@ describe('ThreeDSecure Resource', () => {
         url: '/v1/3d_secure/tdsrc_id',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -35,6 +36,7 @@ describe('ThreeDSecure Resource', () => {
           currency: 'usd',
           return_url: 'https://example.org/3d-secure-result',
         },
+        settings: {},
       });
     });
   });

--- a/test/resources/Tokens.spec.js
+++ b/test/resources/Tokens.spec.js
@@ -14,6 +14,7 @@ describe('Tokens Resource', () => {
         url: '/v1/tokens',
         headers: {},
         data: {card: {number: 123}},
+        settings: {},
       });
     });
   });
@@ -26,6 +27,7 @@ describe('Tokens Resource', () => {
         url: '/v1/tokens/tokenId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Topups.spec.js
+++ b/test/resources/Topups.spec.js
@@ -12,6 +12,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups/tu_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +37,7 @@ describe('Topup Resource', () => {
           statement_descriptor: 'creating a topup',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -48,6 +50,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -60,6 +63,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups/tu_123/cancel',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -72,6 +76,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups/tu_123',
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });

--- a/test/resources/Transfers.spec.js
+++ b/test/resources/Transfers.spec.js
@@ -12,6 +12,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers/transferId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -28,6 +29,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers',
         headers: {},
         data: {amount: 200, currency: 'usd', recipient: {}},
+        settings: {},
       });
     });
   });
@@ -42,6 +44,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers/transferId6654',
         headers: {},
         data: {amount: 300},
+        settings: {},
       });
     });
   });
@@ -54,6 +57,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/UsageRecordSummaries.spec.js
+++ b/test/resources/UsageRecordSummaries.spec.js
@@ -13,6 +13,7 @@ describe('UsageRecordSummaries Resource', () => {
         url: '/v1/subscription_items/si_123/usage_record_summaries',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -33,6 +34,7 @@ describe('UsageRecordSummaries Resource', () => {
               'Stripe-Account': 'acct_456',
             },
             data: {},
+            settings: {},
           });
 
           done();

--- a/test/resources/UsageRecords.spec.js
+++ b/test/resources/UsageRecords.spec.js
@@ -21,6 +21,7 @@ describe('UsageRecords Resource', () => {
           timestamp: 123321,
           action: 'increment',
         },
+        settings: {},
       });
     });
 
@@ -49,6 +50,7 @@ describe('UsageRecords Resource', () => {
               timestamp: 123321,
               action: 'increment',
             },
+            settings: {},
           });
 
           done();

--- a/test/resources/WebhookEndpoints.spec.js
+++ b/test/resources/WebhookEndpoints.spec.js
@@ -12,6 +12,7 @@ describe('WebhookEndpoints Resource', () => {
         url: '/v1/webhook_endpoints/we_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('WebhookEndpoints Resource', () => {
         url: '/v1/webhook_endpoints/we_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('WebhookEndpoints Resource', () => {
         data: {
           enabled_events: ['charge.succeeded'],
         },
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('WebhookEndpoints Resource', () => {
           enabled_events: ['charge.succeeded'],
           url: 'https://stripe.com',
         },
+        settings: {},
       });
     });
   });
@@ -71,6 +75,7 @@ describe('WebhookEndpoints Resource', () => {
         url: '/v1/webhook_endpoints',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -135,13 +135,15 @@ describe('utils', () => {
     it('handles an empty list', () => {
       expect(utils.getDataFromArgs([])).to.deep.equal({});
     });
+
     it('handles a list with no object', () => {
       const args = [1, 3];
       expect(utils.getDataFromArgs(args)).to.deep.equal({});
       expect(args.length).to.equal(2);
     });
+
     it('ignores a hash with only options', (done) => {
-      const args = [{api_key: 'foo'}];
+      const args = [{apiKey: 'foo'}];
 
       handleWarnings(
         () => {
@@ -155,8 +157,9 @@ describe('utils', () => {
         }
       );
     });
+
     it('warns if the hash contains both data and options', (done) => {
-      const args = [{foo: 'bar', api_key: 'foo', idempotency_key: 'baz'}];
+      const args = [{foo: 'bar', apiKey: 'foo', idempotencyKey: 'baz'}];
 
       handleWarnings(
         () => {
@@ -164,7 +167,7 @@ describe('utils', () => {
         },
         (message) => {
           expect(message).to.equal(
-            'Stripe: Options found in arguments (api_key, idempotency_key).' +
+            'Stripe: Options found in arguments (apiKey, idempotencyKey).' +
               ' Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
           );
 
@@ -172,8 +175,9 @@ describe('utils', () => {
         }
       );
     });
+
     it('finds the data', () => {
-      const args = [{foo: 'bar'}, {api_key: 'foo'}];
+      const args = [{foo: 'bar'}, {apiKey: 'foo'}];
       expect(utils.getDataFromArgs(args)).to.deep.equal({foo: 'bar'});
       expect(args.length).to.equal(1);
     });
@@ -184,63 +188,77 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs([])).to.deep.equal({
         auth: null,
         headers: {},
+        settings: {},
       });
     });
+
     it('handles an list with no object', () => {
       const args = [1, 3];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: null,
         headers: {},
+        settings: {},
       });
       expect(args.length).to.equal(2);
     });
+
     it('ignores a non-options object', () => {
       const args = [{foo: 'bar'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: null,
         headers: {},
+        settings: {},
       });
       expect(args.length).to.equal(1);
     });
+
     it('parses an api key', () => {
       const args = ['sk_test_iiiiiiiiiiiiiiiiiiiiiiii'];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
         headers: {},
+        settings: {},
       });
       expect(args.length).to.equal(0);
     });
+
     it('assumes any string is an api key', () => {
       const args = ['yolo'];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: 'yolo',
         headers: {},
+        settings: {},
       });
       expect(args.length).to.equal(0);
     });
+
     it('parses an idempotency key', () => {
-      const args = [{foo: 'bar'}, {idempotency_key: 'foo'}];
+      const args = [{foo: 'bar'}, {idempotencyKey: 'foo'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: null,
         headers: {'Idempotency-Key': 'foo'},
+        settings: {},
       });
       expect(args.length).to.equal(1);
     });
+
     it('parses an api version', () => {
-      const args = [{foo: 'bar'}, {stripe_version: '2003-03-30'}];
+      const args = [{foo: 'bar'}, {stripeVersion: '2003-03-30'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         auth: null,
         headers: {'Stripe-Version': '2003-03-30'},
+        settings: {},
       });
       expect(args.length).to.equal(1);
     });
+
     it('parses an idempotency key and api key and api version (with data)', () => {
       const args = [
         {foo: 'bar'},
         {
-          api_key: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
-          idempotency_key: 'foo',
-          stripe_version: '2010-01-10',
+          apiKey: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
+          idempotencyKey: 'foo',
+          stripeVersion: '2010-01-10',
         },
       ];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
@@ -249,15 +267,17 @@ describe('utils', () => {
           'Idempotency-Key': 'foo',
           'Stripe-Version': '2010-01-10',
         },
+        settings: {},
       });
       expect(args.length).to.equal(1);
     });
+
     it('parses an idempotency key and api key and api version', () => {
       const args = [
         {
-          api_key: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
-          idempotency_key: 'foo',
-          stripe_version: 'hunter2',
+          apiKey: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
+          idempotencyKey: 'foo',
+          stripeVersion: 'hunter2',
         },
       ];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
@@ -266,16 +286,57 @@ describe('utils', () => {
           'Idempotency-Key': 'foo',
           'Stripe-Version': 'hunter2',
         },
+        settings: {},
       });
       expect(args.length).to.equal(0);
     });
+
+    it('parses additional per-request settings', () => {
+      const args = [
+        {
+          maxNetworkRetries: 5,
+          timeout: 1000,
+        },
+      ];
+
+      expect(utils.getOptionsFromArgs(args)).to.deep.equal({
+        auth: null,
+        headers: {},
+        settings: {
+          maxNetworkRetries: 5,
+          timeout: 1000,
+        },
+      });
+    });
+
+    it('parses snake case for backwards compatibility', () => {
+      const args = [
+        {
+          api_key: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
+          idempotency_key: 'key',
+          stripe_account: 'acct_123',
+          stripe_version: '2019-08-08',
+        },
+      ];
+
+      expect(utils.getOptionsFromArgs(args)).to.deep.equal({
+        auth: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
+        headers: {
+          'Idempotency-Key': 'key',
+          'Stripe-Version': '2019-08-08',
+          'Stripe-Account': 'acct_123',
+        },
+        settings: {},
+      });
+    });
+
     it('warns if the hash contains something that does not belong', (done) => {
       const args = [
         {foo: 'bar'},
         {
-          api_key: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
-          idempotency_key: 'foo',
-          stripe_version: '2010-01-10',
+          apiKey: 'sk_test_iiiiiiiiiiiiiiiiiiiiiiii',
+          idempotencyKey: 'foo',
+          stripeVersion: '2010-01-10',
           fishsticks: true,
           custard: true,
         },
@@ -431,6 +492,41 @@ describe('utils', () => {
       expect(flattened.buf).to.deep.equal(buf);
       expect(flattened).to.have.property('x[a]');
       expect(flattened['x[a]']).to.equal('1');
+    });
+  });
+
+  describe('validateInteger', () => {
+    it("Returns the given value if it's a valid integer", () => {
+      const cases = [1, 0x123, 1e3, Number.MAX_SAFE_INTEGER];
+
+      cases.forEach((int) => {
+        expect(utils.validateInteger('magicNumber', int)).to.equal(int);
+      });
+    });
+
+    it('Throws an error if the value is not an integer', () => {
+      const cases = ['foo', 1.2, Number.POSITIVE_INFINITY];
+
+      cases.forEach((val) => {
+        expect(() => {
+          utils.validateInteger('magicNumber', val);
+        }).to.throw();
+      });
+    });
+
+    it('Returns a default value if n is not provided', () => {
+      const expected = 1000;
+      [null, undefined].forEach((t) => {
+        expect(utils.validateInteger('magicNumber', t, expected)).to.equal(
+          expected
+        );
+      });
+    });
+
+    it('Throws if neither value nor default is set', () => {
+      expect(() => {
+        utils.validateInteger('magicNumber');
+      }).to.throw();
     });
   });
 });

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -48,6 +48,7 @@ const utils = (module.exports = {
           url,
           data,
           headers: options.headers || {},
+          settings: options.settings || {},
         });
         if (auth) {
           req.auth = auth;


### PR DESCRIPTION
This is a long running branch for the changes outlined in https://github.com/stripe/stripe-node/issues/640

Steps to complete before this can be merged:

- [x] Move `setApiVersion` to be set via a config object in the Stripe object initialization, with the intention of deprecating `stripe.setApiVersion`
- [x] Move other setters like `setMaxNetworkRetires` to be set via the config object
- [x] Allow certain properties (e.g. network retries, timeout) to be set on a per-request basis as well as a global setting
- [x] Update documentation and README to reflect new config object

~I'll open this up for review once the previous steps are completed.~

This is now ready for review! All the code in the PR was previously reviewed (see branches that were merged into this one). This should theoretically be an easy thumbs up.

r? @rattrayalex-stripe @ob-stripe 
cc: @stripe/api-libraries 
