### PR TITLE
README: imply context of stripe-node

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ client side. This package should not be used for that purpose.
 
 ## Documentation
 
-See the [Node API docs](https://stripe.com/docs/api/node#intro).
+See the [`stripe-node` API docs](https://stripe.com/docs/api/node#intro) for Node.js.
 
 ## Installation
 


### PR DESCRIPTION
This is subjective.
I read it several times as the node API docs (e.g https://nodejs.org/api/),  and somehow skipped it.

Up to you whether this is any better.