### PR TITLE
Add properties to new config object

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -81,7 +81,7 @@ function Stripe(key, config = {}) {
   this.webhooks = require('./Webhooks');
 
   this._prevRequestMetrics = [];
-  this.setTelemetryEnabled(props.telemetry || true);
+  this.setTelemetryEnabled(props.telemetry !== false);
 }
 
 Stripe.errors = require('./Error');
@@ -103,7 +103,7 @@ Stripe.prototype = {
   },
 
   /**
-   * @deprecated in a future major version. Use the config object instead:
+   * @deprecated will be removed in a future major version. Use the config object instead:
    *
    * const stripe = new Stripe(API_KEY, {
    *   port: 3000,
@@ -115,7 +115,7 @@ Stripe.prototype = {
   },
 
   /**
-   * @deprecated in a future major version. Use the config object instead:
+   * @deprecated will be removed in a future major version. Use the config object instead:
    *
    * const stripe = new Stripe(API_KEY, {
    *   apiVersion: API_VERSION,
@@ -169,7 +169,7 @@ Stripe.prototype = {
   },
 
   /**
-   * @deprecated in a future major version. Use the config object instead:
+   * @deprecated will be removed in a future major version. Use the config object instead:
    *
    * const ProxyAgent = require('https-proxy-agent');
    * const stripe = new Stripe(API_KEY, {
@@ -206,7 +206,7 @@ Stripe.prototype = {
   },
 
   /**
-   * @deprecated in a future major version. Use the config object instead:
+   * @deprecated will be removed in a future major version. Use the config object instead:
    *
    * const stripe = new Stripe(API_KEY, {
    *   maxNetworkRetries: 2,

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -27,7 +27,7 @@ Stripe.MAX_NETWORK_RETRY_DELAY_SEC = 2;
 Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 
 const APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
-const ALLOWED_CONFIG_PROPERTIES = ['apiVersion'];
+const ALLOWED_CONFIG_PROPERTIES = ['apiVersion', 'maxNetworkRetries'];
 
 const EventEmitter = require('events').EventEmitter;
 const utils = require('./utils');
@@ -62,8 +62,9 @@ function Stripe(key, config = {}) {
     timeout: Stripe.DEFAULT_TIMEOUT,
     agent: null,
     dev: false,
-    maxNetworkRetries: 0,
   };
+
+  this.setMaxNetworkRetries(props.maxNetworkRetries || 0);
 
   this._prepResources();
   this.setApiKey(key);
@@ -179,6 +180,15 @@ Stripe.prototype = {
     return this.getApiField('maxNetworkRetries');
   },
 
+  /**
+   * @deprecated in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   maxNetworkRetries: 2,
+   * });
+   *
+   * TODO: Make this a private function to be used for maxNetworkRetries validation
+   */
   setMaxNetworkRetries(maxNetworkRetries) {
     if (
       (maxNetworkRetries && typeof maxNetworkRetries !== 'number') ||

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -34,6 +34,7 @@ const ALLOWED_CONFIG_PROPERTIES = [
   'timeout',
   'host',
   'port',
+  'telemetry',
 ];
 
 const EventEmitter = require('events').EventEmitter;
@@ -80,7 +81,7 @@ function Stripe(key, config = {}) {
   this.webhooks = require('./Webhooks');
 
   this._prevRequestMetrics = [];
-  this.setTelemetryEnabled(true);
+  this.setTelemetryEnabled(props.telemetry || true);
 }
 
 Stripe.errors = require('./Error');
@@ -101,6 +102,14 @@ Stripe.prototype = {
     this._setApiField('protocol', protocol.toLowerCase());
   },
 
+  /**
+   * @deprecated in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   port: 3000,
+   * });
+   *
+   */
   setPort(port) {
     this._setApiField('port', port);
   },
@@ -125,14 +134,6 @@ Stripe.prototype = {
     }
   },
 
-  /**
-   * @deprecated in a future major version. Use the config object instead:
-   *
-   * const stripe = new Stripe(API_KEY, {
-   *   timeout: TIMEOUT,
-   * });
-   *
-   */
   setTimeout(timeout) {
     this._setApiField(
       'timeout',

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -173,7 +173,7 @@ Stripe.prototype = {
    *
    * const ProxyAgent = require('https-proxy-agent');
    * const stripe = new Stripe(API_KEY, {
-   *   httpAgent: new ProxyAgent(process.env.http_proxy,
+   *   httpAgent: new ProxyAgent(process.env.http_proxy),
    * });
    *
    */

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -27,7 +27,14 @@ Stripe.MAX_NETWORK_RETRY_DELAY_SEC = 2;
 Stripe.INITIAL_NETWORK_RETRY_DELAY_SEC = 0.5;
 
 const APP_INFO_PROPERTIES = ['name', 'version', 'url', 'partner_id'];
-const ALLOWED_CONFIG_PROPERTIES = ['apiVersion', 'maxNetworkRetries'];
+const ALLOWED_CONFIG_PROPERTIES = [
+  'apiVersion',
+  'maxNetworkRetries',
+  'httpAgent',
+  'timeout',
+  'host',
+  'port',
+];
 
 const EventEmitter = require('events').EventEmitter;
 const utils = require('./utils');
@@ -55,16 +62,16 @@ function Stripe(key, config = {}) {
 
   this._api = {
     auth: null,
-    host: Stripe.DEFAULT_HOST,
-    port: Stripe.DEFAULT_PORT,
+    host: props.host || Stripe.DEFAULT_HOST,
+    port: props.port || Stripe.DEFAULT_PORT,
     basePath: Stripe.DEFAULT_BASE_PATH,
     version: props.apiVersion || Stripe.DEFAULT_API_VERSION,
-    timeout: Stripe.DEFAULT_TIMEOUT,
-    agent: null,
+    timeout: props.timeout || Stripe.DEFAULT_TIMEOUT,
+    agent: props.httpAgent || null,
     dev: false,
   };
 
-  this.setMaxNetworkRetries(props.maxNetworkRetries || 0);
+  this._setMaxNetworkRetries(props.maxNetworkRetries || 0);
 
   this._prepResources();
   this.setApiKey(key);
@@ -118,6 +125,14 @@ Stripe.prototype = {
     }
   },
 
+  /**
+   * @deprecated in a future major version. Use the config object instead:
+   *
+   * const stripe = new Stripe(API_KEY, {
+   *   timeout: TIMEOUT,
+   * });
+   *
+   */
   setTimeout(timeout) {
     this._setApiField(
       'timeout',
@@ -152,6 +167,15 @@ Stripe.prototype = {
     this._appInfo = appInfo;
   },
 
+  /**
+   * @deprecated in a future major version. Use the config object instead:
+   *
+   * const ProxyAgent = require('https-proxy-agent');
+   * const stripe = new Stripe(API_KEY, {
+   *   httpAgent: new ProxyAgent(process.env.http_proxy,
+   * });
+   *
+   */
   setHttpAgent(agent) {
     this._setApiField('agent', agent);
   },
@@ -187,9 +211,12 @@ Stripe.prototype = {
    *   maxNetworkRetries: 2,
    * });
    *
-   * TODO: Make this a private function to be used for maxNetworkRetries validation
    */
   setMaxNetworkRetries(maxNetworkRetries) {
+    this._setMaxNetworkRetries(maxNetworkRetries);
+  },
+
+  _setMaxNetworkRetries(maxNetworkRetries) {
     if (
       (maxNetworkRetries && typeof maxNetworkRetries !== 'number') ||
       arguments.length < 1

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -52,6 +52,7 @@ describe('Stripe Module', function() {
       expect(() => {
         Stripe(testUtils.getUserStripeKey(), {
           apiVersion: '2019-12-12',
+          maxNetworkRetries: 2,
         });
       }).to.not.throw();
     });
@@ -349,6 +350,38 @@ describe('Stripe Module', function() {
         expect(() => {
           stripe.setMaxNetworkRetries();
         }).to.throw(/maxNetworkRetries must be a number/);
+      });
+    });
+
+    describe('when passed in via the config object', () => {
+      it('should only accept numbers', () => {
+        expect(() => {
+          Stripe(testUtils.getUserStripeKey(), {
+            maxNetworkRetries: 'foo',
+          });
+        }).to.throw(/maxNetworkRetries must be a number/);
+
+        expect(() => {
+          Stripe(testUtils.getUserStripeKey(), {
+            maxNetworkRetries: 2,
+          });
+        }).to.not.throw();
+      });
+
+      it('should correctly set the amount of network retries', () => {
+        const newStripe = Stripe(testUtils.getUserStripeKey(), {
+          maxNetworkRetries: 5,
+        });
+
+        expect(newStripe.getMaxNetworkRetries()).to.equal(5);
+      });
+    });
+
+    describe('when not set', () => {
+      it('should use the default', () => {
+        const newStripe = Stripe(testUtils.getUserStripeKey());
+
+        expect(newStripe.getMaxNetworkRetries()).to.equal(0);
       });
     });
   });

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -75,6 +75,31 @@ describe('Stripe Module', function() {
         expect(stripe.getApiField('version')).to.equal(null);
       });
     });
+
+    it('should enable telemetry if not explicitly set', () => {
+      const newStripe = Stripe(testUtils.getUserStripeKey());
+
+      expect(newStripe.getTelemetryEnabled()).to.equal(true);
+    });
+
+    it('should enable telemetry if anything but "false" is set', () => {
+      const vals = ['foo', null, undefined];
+      let newStripe;
+
+      vals.forEach((val) => {
+        newStripe = Stripe(testUtils.getUserStripeKey(), {
+          telemetry: val,
+        });
+
+        expect(newStripe.getTelemetryEnabled()).to.equal(true);
+      });
+
+      newStripe = Stripe(testUtils.getUserStripeKey(), {
+        telemetry: false,
+      });
+
+      expect(newStripe.getTelemetryEnabled()).to.equal(false);
+    });
   });
 
   describe('setApiKey', () => {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -182,6 +182,12 @@ describe('Stripe Module', function() {
       });
     });
 
+    describe('when not set', () => {
+      it('should return empty string', () => {
+        expect(stripe.getAppInfoAsString()).to.equal('');
+      });
+    });
+
     describe('when given a non-object variable', () => {
       it('should throw an error', () => {
         expect(() => {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -53,6 +53,10 @@ describe('Stripe Module', function() {
         Stripe(testUtils.getUserStripeKey(), {
           apiVersion: '2019-12-12',
           maxNetworkRetries: 2,
+          httpAgent: 'agent',
+          timeout: 123,
+          host: 'foo.stripe.com',
+          port: 321,
         });
       }).to.not.throw();
     });
@@ -344,11 +348,11 @@ describe('Stripe Module', function() {
     describe('when given an empty or non-number variable', () => {
       it('should error', () => {
         expect(() => {
-          stripe.setMaxNetworkRetries('foo');
+          stripe._setMaxNetworkRetries('foo');
         }).to.throw(/maxNetworkRetries must be a number/);
 
         expect(() => {
-          stripe.setMaxNetworkRetries();
+          stripe._setMaxNetworkRetries();
         }).to.throw(/maxNetworkRetries must be a number/);
       });
     });


### PR DESCRIPTION
Adds the following properties to the config object:
```
'maxNetworkRetries',
'httpAgent',
'timeout',
'host',
'port',
'telemetry'
```

Means you can now set these properties like so:

```js
const stripe = new Stripe('sk_test_123', {
  maxNetworkRetries: 2,
  httpAgent: new ProxyAgent(process.env.http_proxy),
  timeout: 1000,
  host: 'api.stripe.zonks',
  port: 123,
  telemetry: false,
});
```

Properties that I expect to only be set once (e.g. httpAgent and host) I added a deprecated warning to their old setter functions. Properties which you could possibly want to change after initialization (e.g. telemetry and timeout) I left the setters as is.

For network retries, does it make sense to remove the setter and favor set on initialization/override per request or should we leave the setter in? I changed it to a private function but am happy to revert back to a public one.

r? @rattrayalex-stripe @richardm-stripe @jlomas-stripe 
