### PR TITLE
Allow network retries and timeout to be set on a per-request basis

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -219,9 +219,9 @@ StripeResource.prototype = {
   },
 
   // For more on when and how to retry API requests, see https://stripe.com/docs/error-handling#safely-retrying-requests-with-idempotency
-  _shouldRetry(res, numRetries) {
+  _shouldRetry(res, numRetries, maxRetries) {
     // Do not retry if we are out of retries.
-    if (numRetries >= this._stripe.getMaxNetworkRetries()) {
+    if (numRetries >= maxRetries) {
       return false;
     }
 
@@ -358,7 +358,7 @@ StripeResource.prototype = {
     }
   },
 
-  _request(method, host, path, data, auth, options, callback) {
+  _request(method, host, path, data, auth, options = {}, callback) {
     let requestData;
 
     const retryRequest = (
@@ -378,7 +378,11 @@ StripeResource.prototype = {
     };
 
     const makeRequest = (apiVersion, headers, numRetries) => {
-      const timeout = this._stripe.getApiField('timeout');
+      // timeout can be set on a per-request basis. Favor that over the global setting
+      const timeout =
+        options.settings && options.settings.timeout
+          ? options.settings.timeout
+          : this._stripe.getApiField('timeout');
       const isInsecureConnection =
         this._stripe.getApiField('protocol') == 'http';
       let agent = this._stripe.getApiField('agent');
@@ -409,6 +413,14 @@ StripeResource.prototype = {
 
       const requestRetries = numRetries || 0;
 
+      // Max retries can be set on a per request basis. Favor those over the global setting
+      const maxRetries =
+        options.settings && Number.isInteger(options.settings.networkRetries)
+          ? options.settings.networkRetries
+          : this._stripe.getMaxNetworkRetries();
+
+      console.log('options: ', options);
+
       req._requestEvent = requestEvent;
 
       req._requestStart = requestStartTime;
@@ -418,7 +430,7 @@ StripeResource.prototype = {
       req.setTimeout(timeout, this._timeoutHandler(timeout, req, callback));
 
       req.once('response', (res) => {
-        if (this._shouldRetry(res, requestRetries)) {
+        if (this._shouldRetry(res, requestRetries, maxRetries)) {
           return retryRequest(
             makeRequest,
             apiVersion,
@@ -432,7 +444,7 @@ StripeResource.prototype = {
       });
 
       req.on('error', (error) => {
-        if (this._shouldRetry(null, requestRetries)) {
+        if (this._shouldRetry(null, requestRetries, maxRetries)) {
           return retryRequest(
             makeRequest,
             apiVersion,

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -394,7 +394,9 @@ StripeResource.prototype = {
     const makeRequest = (apiVersion, headers, numRetries) => {
       // timeout can be set on a per-request basis. Favor that over the global setting
       const timeout =
-        options.settings && options.settings.timeout
+        options.settings &&
+        Number.isInteger(options.settings.timeout) &&
+        options.settings.timeout >= 0
           ? options.settings.timeout
           : this._stripe.getApiField('timeout');
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -291,7 +291,7 @@ StripeResource.prototype = {
       : this._stripe.getMaxNetworkRetries();
   },
 
-  _defaultIdempotencyKey(method, settings = {}) {
+  _defaultIdempotencyKey(method, settings) {
     // If this is a POST and we allow multiple retries, ensure an idempotency key.
     const maxRetries = this._getMaxNetworkRetries(settings);
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -383,6 +383,7 @@ StripeResource.prototype = {
         options.settings && options.settings.timeout
           ? options.settings.timeout
           : this._stripe.getApiField('timeout');
+
       const isInsecureConnection =
         this._stripe.getApiField('protocol') == 'http';
       let agent = this._stripe.getApiField('agent');
@@ -418,8 +419,6 @@ StripeResource.prototype = {
         options.settings && Number.isInteger(options.settings.networkRetries)
           ? options.settings.networkRetries
           : this._stripe.getMaxNetworkRetries();
-
-      console.log('options: ', options);
 
       req._requestEvent = requestEvent;
 

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -283,9 +283,19 @@ StripeResource.prototype = {
     return sleepSeconds * 1000;
   },
 
-  _defaultIdempotencyKey(method) {
+  // Max retries can be set on a per request basis. Favor those over the global setting
+  _getMaxNetworkRetries(settings = {}) {
+    return settings.maxNetworkRetries &&
+      Number.isInteger(settings.maxNetworkRetries)
+      ? settings.maxNetworkRetries
+      : this._stripe.getMaxNetworkRetries();
+  },
+
+  _defaultIdempotencyKey(method, settings = {}) {
     // If this is a POST and we allow multiple retries, ensure an idempotency key.
-    if (method === 'POST' && this._stripe.getMaxNetworkRetries() > 0) {
+    const maxRetries = this._getMaxNetworkRetries(settings);
+
+    if (method === 'POST' && maxRetries > 0) {
       return `stripe-node-retry-${utils.uuid4()}`;
     }
     return null;
@@ -297,7 +307,8 @@ StripeResource.prototype = {
     apiVersion,
     clientUserAgent,
     method,
-    userSuppliedHeaders
+    userSuppliedHeaders,
+    userSuppliedSettings
   ) {
     const defaultHeaders = {
       // Use specified auth token or use default from this stripe instance:
@@ -309,7 +320,10 @@ StripeResource.prototype = {
       'X-Stripe-Client-User-Agent': clientUserAgent,
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
       'Stripe-Version': apiVersion,
-      'Idempotency-Key': this._defaultIdempotencyKey(method),
+      'Idempotency-Key': this._defaultIdempotencyKey(
+        method,
+        userSuppliedSettings
+      ),
     };
 
     return Object.assign(
@@ -414,11 +428,7 @@ StripeResource.prototype = {
 
       const requestRetries = numRetries || 0;
 
-      // Max retries can be set on a per request basis. Favor those over the global setting
-      const maxRetries =
-        options.settings && Number.isInteger(options.settings.networkRetries)
-          ? options.settings.networkRetries
-          : this._stripe.getMaxNetworkRetries();
+      const maxRetries = this._getMaxNetworkRetries(options.settings);
 
       req._requestEvent = requestEvent;
 
@@ -489,7 +499,8 @@ StripeResource.prototype = {
           apiVersion,
           clientUserAgent,
           method,
-          options.headers
+          options.headers,
+          options.settings
         );
 
         makeRequest(apiVersion, headers);

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -58,6 +58,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
     auth: options.auth,
     headers,
     host,
+    settings: options.settings,
   };
 }
 
@@ -90,7 +91,6 @@ function makeRequest(self, requestArgs, spec, overrideData) {
     ].join('');
 
     const {headers, settings} = opts;
-    console.log('opts:', opts);
 
     self._request(
       opts.requestMethod,

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -89,13 +89,16 @@ function makeRequest(self, requestArgs, spec, overrideData) {
       utils.stringifyRequestData(opts.queryData),
     ].join('');
 
+    const {headers, settings} = opts;
+    console.log('opts:', opts);
+
     self._request(
       opts.requestMethod,
       opts.host,
       path,
       opts.bodyData,
       opts.auth,
-      {headers: opts.headers},
+      {headers, settings},
       requestCallback
     );
   });

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -218,10 +218,7 @@ Stripe.prototype = {
   },
 
   _setMaxNetworkRetries(maxNetworkRetries) {
-    if (
-      (maxNetworkRetries && typeof maxNetworkRetries !== 'number') ||
-      arguments.length < 1
-    ) {
+    if (!Number.isInteger(maxNetworkRetries)) {
       throw new Error('maxNetworkRetries must be a number.');
     }
 

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -67,12 +67,14 @@ function Stripe(key, config = {}) {
     port: props.port || Stripe.DEFAULT_PORT,
     basePath: Stripe.DEFAULT_BASE_PATH,
     version: props.apiVersion || Stripe.DEFAULT_API_VERSION,
-    timeout: props.timeout || Stripe.DEFAULT_TIMEOUT,
+    timeout: Number.isInteger(props.timeout)
+      ? props.timeout
+      : Stripe.DEFAULT_TIMEOUT,
     agent: props.httpAgent || null,
     dev: false,
   };
 
-  this._setMaxNetworkRetries(props.maxNetworkRetries || 0);
+  this._setApiNumberField('maxNetworkRetries', props.maxNetworkRetries || 0);
 
   this._prepResources();
   this.setApiKey(key);
@@ -214,15 +216,15 @@ Stripe.prototype = {
    *
    */
   setMaxNetworkRetries(maxNetworkRetries) {
-    this._setMaxNetworkRetries(maxNetworkRetries);
+    this._setApiNumberField('maxNetworkRetries', maxNetworkRetries);
   },
 
-  _setMaxNetworkRetries(maxNetworkRetries) {
-    if (!Number.isInteger(maxNetworkRetries)) {
-      throw new Error('maxNetworkRetries must be a number.');
+  _setApiNumberField(prop, n) {
+    if (!Number.isInteger(n)) {
+      throw new Error(`${prop} must be a number.'`);
     }
 
-    this._setApiField('maxNetworkRetries', maxNetworkRetries);
+    this._setApiField(prop, n);
   },
 
   getMaxNetworkRetryDelay() {

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -67,14 +67,19 @@ function Stripe(key, config = {}) {
     port: props.port || Stripe.DEFAULT_PORT,
     basePath: Stripe.DEFAULT_BASE_PATH,
     version: props.apiVersion || Stripe.DEFAULT_API_VERSION,
-    timeout: Number.isInteger(props.timeout)
-      ? props.timeout
-      : Stripe.DEFAULT_TIMEOUT,
+    timeout: utils.validateInteger(
+      'timeout',
+      props.timeout,
+      Stripe.DEFAULT_TIMEOUT
+    ),
+    maxNetworkRetries: utils.validateInteger(
+      'maxNetworkRetries',
+      props.maxNetworkRetries,
+      0
+    ),
     agent: props.httpAgent || null,
     dev: false,
   };
-
-  this._setApiNumberField('maxNetworkRetries', props.maxNetworkRetries || 0);
 
   this._prepResources();
   this.setApiKey(key);
@@ -219,12 +224,10 @@ Stripe.prototype = {
     this._setApiNumberField('maxNetworkRetries', maxNetworkRetries);
   },
 
-  _setApiNumberField(prop, n) {
-    if (!Number.isInteger(n)) {
-      throw new Error(`${prop} must be a number.'`);
-    }
+  _setApiNumberField(prop, n, defaultVal) {
+    const val = utils.validateInteger(prop, n, defaultVal);
 
-    this._setApiField(prop, n);
+    this._setApiField(prop, val);
   },
 
   getMaxNetworkRetryDelay() {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -163,7 +163,7 @@ const utils = (module.exports = {
           opts.headers['Stripe-Version'] =
             params.stripeVersion || params.stripe_version;
         }
-        if (params.networkRetries) {
+        if (Number.isInteger(params.networkRetries)) {
           opts.settings.networkRetries = params.networkRetries;
         }
         if (params.timeout) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -19,7 +19,7 @@ const OPTIONS_KEYS = [
   'stripeAccount',
   'stripe_version',
   'stripeVersion',
-  'networkRetries',
+  'maxNetworkRetries',
   'timeout',
 ];
 
@@ -163,10 +163,10 @@ const utils = (module.exports = {
           opts.headers['Stripe-Version'] =
             params.stripeVersion || params.stripe_version;
         }
-        if (Number.isInteger(params.networkRetries)) {
-          opts.settings.networkRetries = params.networkRetries;
+        if (Number.isInteger(params.maxNetworkRetries)) {
+          opts.settings.maxNetworkRetries = params.maxNetworkRetries;
         }
-        if (params.timeout) {
+        if (Number.isInteger(params.timeout)) {
           opts.settings.timeout = params.timeout;
         }
       }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -378,6 +378,18 @@ const utils = (module.exports = {
       return v.toString(16);
     });
   },
+
+  validateInteger: (name, n, defaultVal) => {
+    if (!Number.isInteger(n)) {
+      if (defaultVal !== undefined) {
+        return defaultVal;
+      } else {
+        throw new Error(`${name} must be an integer`);
+      }
+    }
+
+    return n;
+  },
 });
 
 function emitWarning(warning) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -7,11 +7,20 @@ const crypto = require('crypto');
 
 const hasOwn = (obj, prop) => Object.prototype.hasOwnProperty.call(obj, prop);
 
+/**
+ * TODO: Remove snake case keys in a future major release
+ */
 const OPTIONS_KEYS = [
   'api_key',
+  'apiKey',
   'idempotency_key',
+  'idempotencyKey',
   'stripe_account',
+  'stripeAccount',
   'stripe_version',
+  'stripeVersion',
+  'networkRetries',
+  'timeout',
 ];
 
 const utils = (module.exports = {
@@ -117,6 +126,7 @@ const utils = (module.exports = {
     const opts = {
       auth: null,
       headers: {},
+      settings: {},
     };
     if (args.length > 0) {
       const arg = args[args.length - 1];
@@ -135,17 +145,29 @@ const utils = (module.exports = {
           );
         }
 
-        if (params.api_key) {
-          opts.auth = params.api_key;
+        /**
+         * TODO: Remove snake case params in next major version
+         */
+        if (params.api_key || params.apiKey) {
+          opts.auth = params.apiKey || params.api_key;
         }
-        if (params.idempotency_key) {
-          opts.headers['Idempotency-Key'] = params.idempotency_key;
+        if (params.idempotency_key || params.idempotencyKey) {
+          opts.headers['Idempotency-Key'] =
+            params.idempotencyKey || params.idempotency_key;
         }
-        if (params.stripe_account) {
-          opts.headers['Stripe-Account'] = params.stripe_account;
+        if (params.stripe_account || params.stripeAccount) {
+          opts.headers['Stripe-Account'] =
+            params.stripeAccount || params.stripe_account;
         }
-        if (params.stripe_version) {
-          opts.headers['Stripe-Version'] = params.stripe_version;
+        if (params.stripe_version || params.stripeVersion) {
+          opts.headers['Stripe-Version'] =
+            params.stripeVersion || params.stripe_version;
+        }
+        if (params.networkRetries) {
+          opts.settings.networkRetries = params.networkRetries;
+        }
+        if (params.timeout) {
+          opts.settings.timeout = params.timeout;
         }
       }
     }

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -148,18 +148,18 @@ const utils = (module.exports = {
         /**
          * TODO: Remove snake case params in next major version
          */
-        if (params.api_key || params.apiKey) {
+        if (params.apiKey || params.api_key) {
           opts.auth = params.apiKey || params.api_key;
         }
-        if (params.idempotency_key || params.idempotencyKey) {
+        if (params.idempotencyKey || params.idempotency_key) {
           opts.headers['Idempotency-Key'] =
             params.idempotencyKey || params.idempotency_key;
         }
-        if (params.stripe_account || params.stripeAccount) {
+        if (params.stripeAccount || params.stripe_account) {
           opts.headers['Stripe-Account'] =
             params.stripeAccount || params.stripe_account;
         }
-        if (params.stripe_version || params.stripeVersion) {
+        if (params.stripeVersion || params.stripe_version) {
           opts.headers['Stripe-Version'] =
             params.stripeVersion || params.stripe_version;
         }

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -141,8 +141,8 @@ describe('StripeResource', () => {
     };
 
     afterEach(() => {
-      realStripe._setMaxNetworkRetries(0);
-      stripe._setMaxNetworkRetries(0);
+      realStripe._setApiNumberField('maxNetworkRetries', 0);
+      stripe._setApiNumberField('maxNetworkRetries', 0);
     });
 
     after(() => {
@@ -169,7 +169,7 @@ describe('StripeResource', () => {
           .post(options.path, options.params)
           .replyWithError('worse stuff');
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err) => {
           const errorMessage = realStripe.invoices._generateConnectionErrorMessage(
@@ -192,7 +192,7 @@ describe('StripeResource', () => {
             amount: 1000,
           });
 
-        realStripe._setMaxNetworkRetries(2);
+        realStripe._setApiNumberField('maxNetworkRetries', 2);
 
         realStripe.charges.create(options.data, (err, charge) => {
           expect(charge.id).to.equal('ch_123');
@@ -215,7 +215,7 @@ describe('StripeResource', () => {
             amount: 1000,
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err, charge) => {
           expect(charge.id).to.equal('ch_123');
@@ -232,7 +232,7 @@ describe('StripeResource', () => {
             },
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err) => {
           expect(err.type).to.equal('StripeCardError');
@@ -253,7 +253,7 @@ describe('StripeResource', () => {
             {'stripe-should-retry': 'false'}
           );
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err) => {
           expect(err.type).to.equal('StripeAPIError');
@@ -276,7 +276,7 @@ describe('StripeResource', () => {
             amount: 1000,
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err, charge) => {
           expect(charge.id).to.equal('ch_123');
@@ -293,7 +293,7 @@ describe('StripeResource', () => {
               'This authorization code has already been used. All tokens issued with this code have been revoked.',
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.oauth.token(options.data, (err) => {
           expect(err.type).to.equal('StripeInvalidGrantError');
@@ -316,7 +316,7 @@ describe('StripeResource', () => {
             amount: 1000,
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err, charge) => {
           expect(charge.id).to.equal('ch_123');
@@ -339,7 +339,7 @@ describe('StripeResource', () => {
             amount: 1000,
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.retrieve('ch_123', (err, charge) => {
           expect(charge.id).to.equal('ch_123');
@@ -368,7 +368,7 @@ describe('StripeResource', () => {
             ]);
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err) => {
           expect(headers).to.have.property('idempotency-key');
@@ -396,7 +396,7 @@ describe('StripeResource', () => {
             ]);
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.retrieve('ch_123', () => {
           expect(headers).to.not.have.property('idempotency-key');
@@ -425,7 +425,7 @@ describe('StripeResource', () => {
             ]);
           });
 
-        realStripe._setMaxNetworkRetries(1);
+        realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, {idempotency_key: key}, () => {
           expect(headers['idempotency-key']).to.equal(key);
@@ -451,7 +451,7 @@ describe('StripeResource', () => {
 
         realStripe.charges.create(
           options.data,
-          {networkRetries: 1},
+          {maxNetworkRetries: 1},
           (err, charge) => {
             expect(charge.id).to.equal('ch_123');
             done();
@@ -460,7 +460,7 @@ describe('StripeResource', () => {
       });
 
       it('should pick the per-request network retry setting if a global setting is set', (done) => {
-        realStripe._setMaxNetworkRetries(0);
+        realStripe._setApiNumberField('maxNetworkRetries', 0);
 
         nock(`https://${options.host}`)
           .post(options.path, options.params)
@@ -479,7 +479,7 @@ describe('StripeResource', () => {
 
         realStripe.charges.create(
           options.data,
-          {networkRetries: 1},
+          {maxNetworkRetries: 1},
           (err, charge) => {
             expect(charge.id).to.equal('ch_123');
             done();
@@ -555,44 +555,19 @@ describe('StripeResource', () => {
   });
 
   describe('Request Timeout', () => {
-    // Use a real instance of stripe as we're mocking the http.request responses.
-    const realStripe = require('../lib/stripe')(utils.getUserStripeKey(), {
-      timeout: 10,
-    });
-
-    const options = {
-      host: stripe.getConstant('DEFAULT_HOST'),
-      path: '/v1/charges',
-      data: {
-        amount: 1000,
-        currency: 'usd',
-        source: 'tok_visa',
-        description: 'test',
-      },
-      params: 'amount=1000&currency=usd&source=tok_visa&description=test',
-    };
-
     it('should allow the setting of a request timeout on a per-request basis', (done) => {
-      nock(`https://${options.host}`)
-        .post(options.path, options.params)
-        .delay(1000)
-        .socketDelay(1000)
-        .reply((uri, requestBody, cb) => {
-          return cb(null, [
-            200,
-            {
-              id: 'ch_123',
-              object: 'charge',
-              amount: 1000,
-            },
-          ]);
-        });
+      stripe.setTimeout(1000);
 
-      realStripe.charges.create(options.data, (err, charge) => {
-        console.log(err);
-        expect(charge.id).to.equal('ch_123');
-        done();
+      stripe.charges.create({});
+
+      expect(stripe.LAST_REQUEST.settings).to.deep.equal({});
+
+      stripe.charges.create({}, {timeout: 10});
+
+      expect(stripe.LAST_REQUEST.settings).to.deep.equal({
+        timeout: 10,
       });
+      done();
     });
   });
 });

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -22,6 +22,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts',
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -34,6 +35,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts/acct_16Tzq6DBahdM4C8s',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -46,6 +48,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts/acct_16Tzq6DBahdM4C8s/reject',
         data: {reason: 'fraud'},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -58,6 +61,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -68,6 +72,7 @@ describe('Account Resource', () => {
         url: '/v1/accounts/foo',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -80,6 +85,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -92,6 +98,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -102,6 +109,7 @@ describe('Account Resource', () => {
         url: '/v1/account',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -115,6 +123,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/capabilities',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -126,6 +135,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -138,6 +148,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/capabilities/acap_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -153,6 +164,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -167,6 +179,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/capabilities/acap_123',
           headers: {},
           data: {first_name: 'John'},
+          settings: {},
         });
       });
 
@@ -185,6 +198,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {first_name: 'John'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -203,6 +217,7 @@ describe('Account Resource', () => {
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -219,6 +234,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -235,6 +251,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/accountIdFoo321/external_accounts',
           headers: {},
           data: {number: '123456', currency: 'usd', country: 'US'},
+          settings: {},
         });
       });
 
@@ -254,6 +271,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {number: '123456', currency: 'usd', country: 'US'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -273,6 +291,7 @@ describe('Account Resource', () => {
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
           data: {default_for_currency: true},
+          settings: {},
         });
       });
     });
@@ -289,6 +308,7 @@ describe('Account Resource', () => {
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -305,6 +325,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -317,6 +338,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/accountIdFoo321/external_accounts',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -328,6 +350,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -342,6 +365,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_EXPRESS/login_links',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -356,6 +380,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -367,6 +392,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -381,6 +407,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons',
           headers: {},
           data: {first_name: 'John'},
+          settings: {},
         });
       });
 
@@ -398,6 +425,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {first_name: 'John'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -412,6 +440,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
           data: {first_name: 'John'},
+          settings: {},
         });
       });
 
@@ -430,6 +459,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {first_name: 'John'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -442,6 +472,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -453,6 +484,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -465,6 +497,7 @@ describe('Account Resource', () => {
           url: '/v1/accounts/acct_123/persons',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -476,6 +509,7 @@ describe('Account Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });

--- a/test/resources/AccountLinks.spec.js
+++ b/test/resources/AccountLinks.spec.js
@@ -23,6 +23,7 @@ describe('AccountLinks Resource', () => {
           success_url: 'https://stripe.com/success',
           type: 'custom_account_verification',
         },
+        settings: {},
       });
     });
   });

--- a/test/resources/ApplePayDomains.spec.js
+++ b/test/resources/ApplePayDomains.spec.js
@@ -12,6 +12,7 @@ describe('ApplePayDomains Resource', () => {
         url: '/v1/apple_pay/domains/apwc_retrieve',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('ApplePayDomains Resource', () => {
         url: '/v1/apple_pay/domains/apwc_delete',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -41,6 +43,7 @@ describe('ApplePayDomains Resource', () => {
         data: {
           domain_name: 'example.com',
         },
+        settings: {},
       });
     });
   });
@@ -53,6 +56,7 @@ describe('ApplePayDomains Resource', () => {
         url: '/v1/apple_pay/domains',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/ApplicationFees.spec.js
+++ b/test/resources/ApplicationFees.spec.js
@@ -12,6 +12,7 @@ describe('ApplicationFee Resource', () => {
         url: '/v1/application_fees',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('ApplicationFee Resource', () => {
           '/v1/application_fees/appFeeIdExample3242/refunds/refundIdExample2312',
         data: {metadata: {key: 'value'}},
         headers: {},
+        settings: {},
       });
     });
 
@@ -39,6 +41,7 @@ describe('ApplicationFee Resource', () => {
         url: '/v1/application_fees/appFeeIdExample3242/refunds',
         data: {amount: 100},
         headers: {},
+        settings: {},
       });
     });
 
@@ -49,6 +52,7 @@ describe('ApplicationFee Resource', () => {
         url: '/v1/application_fees/appFeeIdExample3242/refunds',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -63,6 +67,7 @@ describe('ApplicationFee Resource', () => {
           '/v1/application_fees/appFeeIdExample3242/refunds/refundIdExample2312',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Balance.spec.js
+++ b/test/resources/Balance.spec.js
@@ -12,6 +12,7 @@ describe('Balance Resource', () => {
         url: '/v1/balance',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -23,6 +24,7 @@ describe('Balance Resource', () => {
         data: {},
         auth: 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11',
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/BalanceTransactions.spec.js
+++ b/test/resources/BalanceTransactions.spec.js
@@ -12,6 +12,7 @@ describe('BalanceTransactions Resource', function() {
         url: '/v1/balance_transactions/txn_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('BalanceTransactions Resource', function() {
         url: '/v1/balance_transactions',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/BitcoinReceivers.spec.js
+++ b/test/resources/BitcoinReceivers.spec.js
@@ -12,6 +12,7 @@ describe('BitcoinReceivers Resource', () => {
         url: '/v1/bitcoin/receivers/receiverId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('BitcoinReceivers Resource', () => {
         url: '/v1/bitcoin/receivers',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -38,6 +40,7 @@ describe('BitcoinReceivers Resource', () => {
         url: '/v1/bitcoin/receivers/receiverId/transactions?limit=1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -12,6 +12,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges/chargeIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +41,7 @@ describe('Charge Resource', () => {
           },
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -52,6 +54,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -64,6 +67,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges/chargeIdExample3242/capture',
         headers: {},
         data: {amount: 23},
+        settings: {},
       });
     });
   });
@@ -76,6 +80,7 @@ describe('Charge Resource', () => {
         url: '/v1/charges/chargeIdExample3242',
         headers: {},
         data: {description: 'foo321'},
+        settings: {},
       });
     });
   });

--- a/test/resources/Checkout/Sessions.spec.js
+++ b/test/resources/Checkout/Sessions.spec.js
@@ -34,6 +34,7 @@ describe('Checkout', () => {
           url: '/v1/checkout/sessions',
           headers: {},
           data: params,
+          settings: {},
         });
       });
     });
@@ -46,6 +47,7 @@ describe('Checkout', () => {
           url: '/v1/checkout/sessions/cs_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/CountrySpecs.spec.js
+++ b/test/resources/CountrySpecs.spec.js
@@ -12,6 +12,7 @@ describe('CountrySpecs Resource', () => {
         url: '/v1/country_specs',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -25,6 +26,7 @@ describe('CountrySpecs Resource', () => {
         url: `/v1/country_specs/${country}`,
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Coupons.spec.js
+++ b/test/resources/Coupons.spec.js
@@ -12,6 +12,7 @@ describe('Coupons Resource', () => {
         url: '/v1/coupons/couponId123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Coupons Resource', () => {
         url: '/v1/coupons/couponId123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('Coupons Resource', () => {
         data: {
           metadata: {a: '1234'},
         },
+        settings: {},
       });
     });
   });
@@ -61,6 +64,7 @@ describe('Coupons Resource', () => {
           duration: 'repeating',
           duration_in_months: 4,
         },
+        settings: {},
       });
     });
   });
@@ -73,6 +77,7 @@ describe('Coupons Resource', () => {
         url: '/v1/coupons',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/CreditNotes.spec.js
+++ b/test/resources/CreditNotes.spec.js
@@ -12,6 +12,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes/cn_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -41,6 +43,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes?count=25',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -53,6 +56,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes/cn_123',
         headers: {},
         data: {application_fee: 200},
+        settings: {},
       });
     });
   });
@@ -65,6 +69,7 @@ describe('CreditNotes Resource', () => {
         url: '/v1/credit_notes/cn_123/void',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -14,6 +14,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers/cus_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -25,6 +26,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -37,6 +39,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers',
         headers: {},
         data: {description: 'Some customer'},
+        settings: {},
       });
     });
 
@@ -48,6 +51,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -59,6 +63,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -72,6 +77,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers',
         headers: {'Idempotency-Key': 'foo'},
         data: {description: 'Some customer'},
+        settings: {},
       });
     });
 
@@ -86,6 +92,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -100,6 +107,7 @@ describe('Customers Resource', () => {
         headers: {'Idempotency-Key': 'foo'},
         data: {description: 'Some customer'},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
 
@@ -111,6 +119,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -125,6 +134,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers/cus_123',
         headers: {},
         data: {description: 'Foo "baz"'},
+        settings: {},
       });
     });
   });
@@ -137,6 +147,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers/cus_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -149,6 +160,7 @@ describe('Customers Resource', () => {
         url: '/v1/customers',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -160,6 +172,7 @@ describe('Customers Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -173,6 +186,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/discount',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -187,6 +201,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -198,6 +213,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -214,6 +230,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources',
           headers: {},
           data: {object: 'card', number: '123456', exp_month: '12'},
+          settings: {},
         });
       });
 
@@ -233,6 +250,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {object: 'card', number: '123456', exp_month: '12'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -247,6 +265,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
           data: {name: 'Bob M. Baz'},
+          settings: {},
         });
       });
     });
@@ -259,6 +278,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -270,6 +290,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -282,6 +303,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/sources',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -293,6 +315,7 @@ describe('Customers Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -313,6 +336,7 @@ describe('Customers Resource', () => {
           headers: {},
           data,
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -327,6 +351,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/tax_ids/txi_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -342,6 +367,7 @@ describe('Customers Resource', () => {
           method: 'POST',
           url: '/v1/customers/cus_123/tax_ids',
           headers: {},
+          settings: {},
           data,
         });
       });
@@ -355,6 +381,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/tax_ids/txi_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -367,6 +394,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/tax_ids',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -381,6 +409,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions/cbtxn_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -396,6 +425,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions',
           headers: {},
           data: {amount: 123, currency: 'usd'},
+          settings: {},
         });
       });
     });
@@ -410,6 +440,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions/cbtxn_123',
           headers: {},
           data: {description: 'description'},
+          settings: {},
         });
       });
     });
@@ -422,6 +453,7 @@ describe('Customers Resource', () => {
           url: '/v1/customers/cus_123/balance_transactions',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Disputes.spec.js
+++ b/test/resources/Disputes.spec.js
@@ -12,6 +12,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes/dp_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes/dp_123/close',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -48,6 +51,7 @@ describe('Dispute Resource', () => {
         url: '/v1/disputes/dp_123',
         headers: {},
         data: {evidence: {customer_name: 'Bob'}},
+        settings: {},
       });
     });
   });

--- a/test/resources/EphemeralKeys.spec.js
+++ b/test/resources/EphemeralKeys.spec.js
@@ -24,6 +24,7 @@ function sendsCorrectStripeVersion() {
     headers: {
       'Stripe-Version': '2017-06-05',
     },
+    settings: {},
   });
 }
 
@@ -43,6 +44,7 @@ describe('EphemeralKey Resource', () => {
         headers: {
           'Stripe-Version': '2017-05-25',
         },
+        settings: {},
       });
     });
 
@@ -91,6 +93,7 @@ describe('EphemeralKey Resource', () => {
         url: '/v1/ephemeral_keys/ephkey_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Events.spec.js
+++ b/test/resources/Events.spec.js
@@ -12,6 +12,7 @@ describe('Events Resource', () => {
         url: '/v1/events/eventIdBaz',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Events Resource', () => {
         url: '/v1/events?count=25',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/ExchangeRates.spec.js
+++ b/test/resources/ExchangeRates.spec.js
@@ -12,6 +12,7 @@ describe('ExchangeRates Resource', () => {
         url: '/v1/exchange_rates',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -25,6 +26,7 @@ describe('ExchangeRates Resource', () => {
         url: `/v1/exchange_rates/${currency}`,
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/FileLinks.spec.js
+++ b/test/resources/FileLinks.spec.js
@@ -12,6 +12,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links/link_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links',
         headers: {},
         data: {file: 'file_123'},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links/link_123',
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -48,6 +51,7 @@ describe('FileLinks Resource', () => {
         url: '/v1/file_links',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -16,6 +16,7 @@ describe('Files Resource', () => {
         url: '/v1/files/fil_12345',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -27,6 +28,7 @@ describe('Files Resource', () => {
         headers: {},
         data: {},
         auth: TEST_AUTH_KEY,
+        settings: {},
       });
     });
   });
@@ -39,6 +41,7 @@ describe('Files Resource', () => {
         url: '/v1/files',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/InvoiceItems.spec.js
+++ b/test/resources/InvoiceItems.spec.js
@@ -12,6 +12,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems/invoiceItemIdTesting123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -26,6 +27,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems',
         headers: {},
         data: {customer: 'cust_id_888'},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems/invoiceItemId1',
         headers: {},
         data: {amount: 1900},
+        settings: {},
       });
     });
   });
@@ -52,6 +55,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems/invoiceItemId2',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -64,6 +68,7 @@ describe('InvoiceItems Resource', () => {
         url: '/v1/invoiceitems',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -12,6 +12,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices',
         headers: {},
         data: {application_fee: 111},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices?count=25',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -48,6 +51,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123',
         headers: {},
         data: {application_fee: 200},
+        settings: {},
       });
     });
   });
@@ -60,6 +64,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -72,6 +77,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/lines',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -84,6 +90,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/upcoming/lines',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -101,6 +108,7 @@ describe('Invoices Resource', () => {
           '/v1/invoices/upcoming?customer=cus_abc&subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -119,6 +127,7 @@ describe('Invoices Resource', () => {
           '/v1/invoices/upcoming/lines?customer=cus_abc&subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga&limit=5',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -131,6 +140,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/finalize',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -143,6 +153,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/mark_uncollectible',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -157,6 +168,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/pay',
         headers: {},
         data: {source: 'tok_FooBar'},
+        settings: {},
       });
     });
   });
@@ -169,6 +181,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/send',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -181,6 +194,7 @@ describe('Invoices Resource', () => {
         url: '/v1/invoices/in_123/void',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/IssuerFraudRecords.spec.js
+++ b/test/resources/IssuerFraudRecords.spec.js
@@ -12,6 +12,7 @@ describe('IssuerFraudRecord Resource', () => {
         url: '/v1/issuer_fraud_records/issfr_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('IssuerFraudRecord Resource', () => {
         url: '/v1/issuer_fraud_records',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Issuing/Authorization.spec.js
+++ b/test/resources/Issuing/Authorization.spec.js
@@ -13,6 +13,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations/iauth_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -25,6 +26,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -47,6 +49,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -59,6 +62,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations/iauth_123/approve',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -71,6 +75,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/authorizations/iauth_123/decline',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Cardholders.spec.js
+++ b/test/resources/Issuing/Cardholders.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cardholders/ich_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -35,6 +36,7 @@ describe('Issuing', () => {
             name: 'Tim Testperson',
             type: 'individual',
           },
+          settings: {},
         });
       });
     });
@@ -57,6 +59,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -69,6 +72,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cardholders',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Cards.spec.js
+++ b/test/resources/Issuing/Cards.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cards/ic_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Issuing', () => {
             currency: 'usd',
             type: 'physical',
           },
+          settings: {},
         });
       });
     });
@@ -55,6 +57,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -67,6 +70,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cards',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -82,6 +86,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/cards/ic_123/details',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Disputes.spec.js
+++ b/test/resources/Issuing/Disputes.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/disputes/idp_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -31,6 +32,7 @@ describe('Issuing', () => {
           data: {
             transaction: 'ipi_123',
           },
+          settings: {},
         });
       });
     });
@@ -53,6 +55,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -65,6 +68,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/disputes',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Issuing/Transactions.spec.js
+++ b/test/resources/Issuing/Transactions.spec.js
@@ -15,6 +15,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/transactions/ipi_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -37,6 +38,7 @@ describe('Issuing', () => {
               thing2: 'yes',
             },
           },
+          settings: {},
         });
       });
     });
@@ -49,6 +51,7 @@ describe('Issuing', () => {
           url: '/v1/issuing/transactions',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/OAuth.spec.js
+++ b/test/resources/OAuth.spec.js
@@ -76,6 +76,7 @@ describe('OAuth', () => {
           code: '123abc',
           grant_type: 'authorization_code',
         },
+        settings: {},
       });
     });
   });
@@ -99,6 +100,7 @@ describe('OAuth', () => {
           client_id: stripe.getClientId(),
           stripe_user_id: 'some_user_id',
         },
+        settings: {},
       });
     });
 
@@ -117,6 +119,7 @@ describe('OAuth', () => {
           client_id: '123abc',
           stripe_user_id: 'some_user_id',
         },
+        settings: {},
       });
     });
   });

--- a/test/resources/OrderReturns.spec.js
+++ b/test/resources/OrderReturns.spec.js
@@ -12,6 +12,7 @@ describe('OrderReturn Resource', () => {
         url: '/v1/order_returns/orderReturnIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -26,6 +27,7 @@ describe('OrderReturn Resource', () => {
         url: '/v1/order_returns?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -38,6 +40,7 @@ describe('OrderReturn Resource', () => {
         url: '/v1/order_returns?order=orderIdFoo123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Orders.spec.js
+++ b/test/resources/Orders.spec.js
@@ -12,6 +12,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -54,6 +55,7 @@ describe('Order Resource', () => {
           email: 'jane@ros.en',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -68,6 +70,7 @@ describe('Order Resource', () => {
         url: '/v1/orders?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -80,6 +83,7 @@ describe('Order Resource', () => {
         url: '/v1/orders?status=active',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -94,6 +98,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo3242/pay',
         headers: {},
         data: {source: 'tok_FooBar'},
+        settings: {},
       });
     });
   });
@@ -108,6 +113,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo3242/returns',
         headers: {},
         data: {items: [{parent: 'sku_123'}]},
+        settings: {},
       });
     });
   });
@@ -120,6 +126,7 @@ describe('Order Resource', () => {
         url: '/v1/orders/orderIdFoo3242',
         headers: {},
         data: {status: 'fulfilled'},
+        settings: {},
       });
     });
   });

--- a/test/resources/PaymentIntents.spec.js
+++ b/test/resources/PaymentIntents.spec.js
@@ -19,6 +19,7 @@ describe('Payment Intents Resource', () => {
         url: '/v1/payment_intents',
         headers: {},
         data: params,
+        settings: {},
       });
     });
   });
@@ -31,6 +32,7 @@ describe('Payment Intents Resource', () => {
         url: '/v1/payment_intents',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -57,6 +60,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}`,
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -69,6 +73,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}/cancel`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -81,6 +86,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}/capture`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -93,6 +99,7 @@ describe('Payment Intents Resource', () => {
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}/confirm`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/PaymentMethods.spec.js
+++ b/test/resources/PaymentMethods.spec.js
@@ -12,6 +12,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -27,6 +28,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods?customer=cus_123&type=card',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -58,6 +61,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -70,6 +74,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123/attach',
         headers: {},
         data: {customer: 'cus_123'},
+        settings: {},
       });
     });
   });
@@ -82,6 +87,7 @@ describe('PaymentMethods Resource', () => {
         url: '/v1/payment_methods/pm_123/detach',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Payouts.spec.js
+++ b/test/resources/Payouts.spec.js
@@ -14,6 +14,7 @@ describe('Payouts Resource', () => {
         url: `/v1/payouts/${PAYOUT_TEST_ID}`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('Payouts Resource', () => {
         url: '/v1/payouts',
         headers: {},
         data: {amount: 200, currency: 'usd'},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Payouts Resource', () => {
         url: `/v1/payouts/${PAYOUT_TEST_ID}`,
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Payouts Resource', () => {
         url: `/v1/payouts/${PAYOUT_TEST_ID}/cancel`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -67,6 +71,7 @@ describe('Payouts Resource', () => {
         url: '/v1/payouts',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Plans.spec.js
+++ b/test/resources/Plans.spec.js
@@ -12,6 +12,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans/planId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -27,6 +28,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans',
         headers: {},
         data: {amount: 200, currency: 'usd'},
+        settings: {},
       });
     });
 
@@ -41,6 +43,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans',
         headers: {},
         data: {amount: 200, currency: 'usd', usage_type: 'metered'},
+        settings: {},
       });
     });
 
@@ -61,6 +64,7 @@ describe('Plans Resource', () => {
           tiers: [{up_to: 123, amount: 100}, {up_to: 'inf', amount: 200}],
           tiers_mode: 'volume',
         },
+        settings: {},
       });
     });
 
@@ -79,6 +83,7 @@ describe('Plans Resource', () => {
           currency: 'usd',
           transform_usage: {divide_by: 123, round: 'up'},
         },
+        settings: {},
       });
     });
   });
@@ -94,6 +99,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans/planId3',
         headers: {},
         data: {amount: 1900, currency: 'usd'},
+        settings: {},
       });
     });
   });
@@ -106,6 +112,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans/planId4',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -118,6 +125,7 @@ describe('Plans Resource', () => {
         url: '/v1/plans',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Products.spec.js
+++ b/test/resources/Products.spec.js
@@ -12,6 +12,7 @@ describe('Product Resource', () => {
         url: '/v1/products/productIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -32,6 +33,7 @@ describe('Product Resource', () => {
           type: 'good',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -46,6 +48,7 @@ describe('Product Resource', () => {
         url: '/v1/products?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -58,6 +61,7 @@ describe('Product Resource', () => {
         url: '/v1/products?shippable=true',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -70,6 +74,7 @@ describe('Product Resource', () => {
         url: '/v1/products/productIdFoo3242',
         headers: {},
         data: {caption: 'test'},
+        settings: {},
       });
     });
   });
@@ -82,6 +87,7 @@ describe('Product Resource', () => {
         url: '/v1/products/productIdFoo3242',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Radar/EarlyFraudWarnings.spec.js
+++ b/test/resources/Radar/EarlyFraudWarnings.spec.js
@@ -13,6 +13,7 @@ describe('Radar', () => {
           url: '/v1/radar/early_fraud_warnings/issfr_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -25,6 +26,7 @@ describe('Radar', () => {
           url: '/v1/radar/early_fraud_warnings',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Radar/ValueListItems.spec.js
+++ b/test/resources/Radar/ValueListItems.spec.js
@@ -15,6 +15,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_list_items/rsli_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Radar', () => {
             value_list: 'rsl_123',
             value: 'value',
           },
+          settings: {},
         });
       });
     });
@@ -47,6 +49,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_list_items?value_list=rsl_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -59,6 +62,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_list_items/rsli_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Radar/ValueLists.spec.js
+++ b/test/resources/Radar/ValueLists.spec.js
@@ -15,6 +15,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_lists/rsl_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Radar', () => {
             alias: 'alias',
             name: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -45,6 +47,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_lists',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -57,6 +60,7 @@ describe('Radar', () => {
           url: '/v1/radar/value_lists/rsl_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -73,6 +77,7 @@ describe('Radar', () => {
           data: {
             metadata: {a: '1234'},
           },
+          settings: {},
         });
       });
     });

--- a/test/resources/Recipients.spec.js
+++ b/test/resources/Recipients.spec.js
@@ -14,6 +14,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients/recipientId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients',
         headers: {},
         data: {name: 'Bob', type: 'individual'},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients/recipientId3',
         headers: {},
         data: {name: 'Bob Smith'},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients/recipientId4',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -67,6 +71,7 @@ describe('Recipients Resource', () => {
         url: '/v1/recipients',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -80,6 +85,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards/cardIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -95,6 +101,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -110,6 +117,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards',
           headers: {},
           data: {number: '123456', exp_month: '12'},
+          settings: {},
         });
       });
 
@@ -128,6 +136,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {number: '123456', exp_month: '12'},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -142,6 +151,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards/cardIdFoo456',
           headers: {},
           data: {name: 'Bob M. Baz'},
+          settings: {},
         });
       });
     });
@@ -154,6 +164,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards/cardIdFoo456',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -169,6 +180,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });
@@ -181,6 +193,7 @@ describe('Recipients Resource', () => {
           url: '/v1/recipients/recipientIdFoo321/cards',
           headers: {},
           data: {},
+          settings: {},
         });
       });
 
@@ -192,6 +205,7 @@ describe('Recipients Resource', () => {
           headers: {},
           data: {},
           auth: TEST_AUTH_KEY,
+          settings: {},
         });
       });
     });

--- a/test/resources/Refunds.spec.js
+++ b/test/resources/Refunds.spec.js
@@ -19,6 +19,7 @@ describe('Refund Resource', () => {
           amount: '300',
           charge: 'ch_123',
         },
+        settings: {},
       });
     });
   });
@@ -31,6 +32,7 @@ describe('Refund Resource', () => {
         url: '/v1/refunds/re_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -43,6 +45,7 @@ describe('Refund Resource', () => {
         url: '/v1/refunds',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Refund Resource', () => {
         url: '/v1/refunds/re_123',
         headers: {},
         data: {metadata: {key: 'abcd'}},
+        settings: {},
       });
     });
   });

--- a/test/resources/Reporting/ReportRuns.spec.js
+++ b/test/resources/Reporting/ReportRuns.spec.js
@@ -15,6 +15,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_runs/frr_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -37,6 +38,7 @@ describe('Reporting', () => {
             },
             report_type: 'activity.summary.1',
           },
+          settings: {},
         });
       });
     });
@@ -49,6 +51,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_runs',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Reporting/ReportTypes.spec.js
+++ b/test/resources/Reporting/ReportTypes.spec.js
@@ -15,6 +15,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_types/activity.summary.1',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -27,6 +28,7 @@ describe('Reporting', () => {
           url: '/v1/reporting/report_types',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Reviews.spec.js
+++ b/test/resources/Reviews.spec.js
@@ -12,6 +12,7 @@ describe('Review Resource', () => {
         url: '/v1/reviews/prv_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('Review Resource', () => {
         url: '/v1/reviews',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +38,7 @@ describe('Review Resource', () => {
         url: '/v1/reviews/prv_123/approve',
         headers: {},
         data: {amount: 23},
+        settings: {},
       });
     });
   });

--- a/test/resources/SKUs.spec.js
+++ b/test/resources/SKUs.spec.js
@@ -12,6 +12,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus/skuIdFoo123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +37,7 @@ describe('SKU Resource', () => {
           product: 'prodIdTest123',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -50,6 +52,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus?limit=3',
         data: {},
         headers: {},
+        settings: {},
       });
     });
 
@@ -62,6 +65,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus?product=prodId123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -74,6 +78,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus/skuIdFoo3242',
         headers: {},
         data: {caption: 'test'},
+        settings: {},
       });
     });
   });
@@ -86,6 +91,7 @@ describe('SKU Resource', () => {
         url: '/v1/skus/skuIdFoo3242',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/SetupIntents.spec.js
+++ b/test/resources/SetupIntents.spec.js
@@ -17,6 +17,7 @@ describe('Setup Intents Resource', () => {
         url: '/v1/setup_intents',
         headers: {},
         data: params,
+        settings: {},
       });
     });
   });
@@ -29,6 +30,7 @@ describe('Setup Intents Resource', () => {
         url: '/v1/setup_intents',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -41,6 +43,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -55,6 +58,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });
@@ -67,6 +71,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}/cancel`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -79,6 +84,7 @@ describe('Setup Intents Resource', () => {
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}/confirm`,
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Sigma/ScheduledQueryRuns.spec.js
+++ b/test/resources/Sigma/ScheduledQueryRuns.spec.js
@@ -13,6 +13,7 @@ describe('Sigma', () => {
           url: '/v1/sigma/scheduled_query_runs/sqr_123',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });
@@ -25,6 +26,7 @@ describe('Sigma', () => {
           url: '/v1/sigma/scheduled_query_runs',
           data: {},
           headers: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Sources.spec.js
+++ b/test/resources/Sources.spec.js
@@ -12,6 +12,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/sourceId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -42,6 +43,7 @@ describe('Sources Resource', () => {
             refund_address: 'refundAddress1',
           },
         },
+        settings: {},
       });
     });
   });
@@ -56,6 +58,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/src_foo',
         headers: {},
         data: {metadata: {foo: 'bar'}},
+        settings: {},
       });
     });
   });
@@ -68,6 +71,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/src_foo/source_transactions',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -80,6 +84,7 @@ describe('Sources Resource', () => {
         url: '/v1/sources/src_foo/verify',
         headers: {},
         data: {values: [32, 45]},
+        settings: {},
       });
     });
   });

--- a/test/resources/SubscriptionItems.spec.js
+++ b/test/resources/SubscriptionItems.spec.js
@@ -12,6 +12,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items/test_sub_item',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items/test_sub_item',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('SubscriptionItems Resource', () => {
         data: {
           plan: 'gold',
         },
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('SubscriptionItems Resource', () => {
           subscription: 'test_sub',
           plan: 'gold',
         },
+        settings: {},
       });
     });
   });
@@ -74,6 +78,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items?limit=3&subscription=test_sub',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -91,6 +96,7 @@ describe('SubscriptionItems Resource', () => {
         url: '/v1/subscription_items/si_123/usage_records',
         headers: {},
         data,
+        settings: {},
       });
     });
   });

--- a/test/resources/SubscriptionSchedule.spec.js
+++ b/test/resources/SubscriptionSchedule.spec.js
@@ -17,6 +17,7 @@ describe('Subscription Schedule Resource', () => {
         url: `/v1/subscription_schedules/${SCHEDULE_TEST_ID}/cancel`,
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -32,6 +33,7 @@ describe('Subscription Schedule Resource', () => {
         url: '/v1/subscription_schedules',
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -44,6 +46,7 @@ describe('Subscription Schedule Resource', () => {
         url: '/v1/subscription_schedules',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('Subscription Schedule Resource', () => {
         url: `/v1/subscription_schedules/${SCHEDULE_TEST_ID}/release`,
         data,
         headers: {},
+        settings: {},
       });
     });
   });
@@ -71,6 +75,7 @@ describe('Subscription Schedule Resource', () => {
         url: '/v1/subscription_schedules/sub_sched_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -84,6 +89,7 @@ describe('Subscription Schedule Resource', () => {
         url: `/v1/subscription_schedules/${SCHEDULE_TEST_ID}`,
         data,
         headers: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Subscriptions.spec.js
+++ b/test/resources/Subscriptions.spec.js
@@ -12,6 +12,7 @@ describe('subscriptions Resource', () => {
         url: '/v1/subscriptions/test_sub',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('subscriptions Resource', () => {
         url: '/v1/subscriptions/test_sub',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('subscriptions Resource', () => {
         data: {
           metadata: {a: '1234'},
         },
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('subscriptions Resource', () => {
           customer: 'test_cus',
           plan: 'gold',
         },
+        settings: {},
       });
     });
   });
@@ -85,6 +89,7 @@ describe('subscriptions Resource', () => {
             },
           ],
         },
+        settings: {},
       });
     });
   });
@@ -112,6 +117,7 @@ describe('subscriptions Resource', () => {
             },
           ],
         },
+        settings: {},
       });
     });
   });
@@ -138,6 +144,7 @@ describe('subscriptions Resource', () => {
             },
           },
         },
+        settings: {},
       });
     });
   });
@@ -165,6 +172,7 @@ describe('subscriptions Resource', () => {
             },
           },
         },
+        settings: {},
       });
     });
   });
@@ -181,6 +189,7 @@ describe('subscriptions Resource', () => {
         url: '/v1/subscriptions?limit=3&customer=test_cus&plan=gold',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -194,6 +203,7 @@ describe('subscriptions Resource', () => {
           url: '/v1/subscriptions/test_sub/discount',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/TaxRates.spec.js
+++ b/test/resources/TaxRates.spec.js
@@ -12,6 +12,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates/txr_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -27,6 +28,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates/txr_123',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -45,6 +47,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates',
         headers: {},
         data,
+        settings: {},
       });
     });
   });
@@ -57,6 +60,7 @@ describe('TaxRates Resource', () => {
         url: '/v1/tax_rates',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Terminal/ConnectionTokens.spec.js
+++ b/test/resources/Terminal/ConnectionTokens.spec.js
@@ -14,6 +14,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/connection_tokens',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Terminal/Locations.spec.js
+++ b/test/resources/Terminal/Locations.spec.js
@@ -15,6 +15,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/locations/loc_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -45,6 +46,7 @@ describe('Terminal', () => {
               city: 'San Francisco',
             },
           },
+          settings: {},
         });
       });
     });
@@ -57,6 +59,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/locations/loc_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -73,6 +76,7 @@ describe('Terminal', () => {
           data: {
             display_name: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -85,6 +89,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/locations',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/Terminal/Readers.spec.js
+++ b/test/resources/Terminal/Readers.spec.js
@@ -15,6 +15,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/readers/rdr_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -33,6 +34,7 @@ describe('Terminal', () => {
             registration_code: 'a-b-c',
             label: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -45,6 +47,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/readers/rdr_123',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });
@@ -61,6 +64,7 @@ describe('Terminal', () => {
           data: {
             label: 'name',
           },
+          settings: {},
         });
       });
     });
@@ -73,6 +77,7 @@ describe('Terminal', () => {
           url: '/v1/terminal/readers',
           headers: {},
           data: {},
+          settings: {},
         });
       });
     });

--- a/test/resources/ThreeDSecure.spec.js
+++ b/test/resources/ThreeDSecure.spec.js
@@ -12,6 +12,7 @@ describe('ThreeDSecure Resource', () => {
         url: '/v1/3d_secure/tdsrc_id',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -35,6 +36,7 @@ describe('ThreeDSecure Resource', () => {
           currency: 'usd',
           return_url: 'https://example.org/3d-secure-result',
         },
+        settings: {},
       });
     });
   });

--- a/test/resources/Tokens.spec.js
+++ b/test/resources/Tokens.spec.js
@@ -14,6 +14,7 @@ describe('Tokens Resource', () => {
         url: '/v1/tokens',
         headers: {},
         data: {card: {number: 123}},
+        settings: {},
       });
     });
   });
@@ -26,6 +27,7 @@ describe('Tokens Resource', () => {
         url: '/v1/tokens/tokenId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/Topups.spec.js
+++ b/test/resources/Topups.spec.js
@@ -12,6 +12,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups/tu_123',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -36,6 +37,7 @@ describe('Topup Resource', () => {
           statement_descriptor: 'creating a topup',
         },
         headers: {},
+        settings: {},
       });
     });
   });
@@ -48,6 +50,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups',
         data: {},
         headers: {},
+        settings: {},
       });
     });
   });
@@ -60,6 +63,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups/tu_123/cancel',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -72,6 +76,7 @@ describe('Topup Resource', () => {
         url: '/v1/topups/tu_123',
         headers: {},
         data: {metadata: {key: 'value'}},
+        settings: {},
       });
     });
   });

--- a/test/resources/Transfers.spec.js
+++ b/test/resources/Transfers.spec.js
@@ -12,6 +12,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers/transferId1',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -28,6 +29,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers',
         headers: {},
         data: {amount: 200, currency: 'usd', recipient: {}},
+        settings: {},
       });
     });
   });
@@ -42,6 +44,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers/transferId6654',
         headers: {},
         data: {amount: 300},
+        settings: {},
       });
     });
   });
@@ -54,6 +57,7 @@ describe('Transfers Resource', () => {
         url: '/v1/transfers',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/resources/UsageRecordSummaries.spec.js
+++ b/test/resources/UsageRecordSummaries.spec.js
@@ -13,6 +13,7 @@ describe('UsageRecordSummaries Resource', () => {
         url: '/v1/subscription_items/si_123/usage_record_summaries',
         headers: {},
         data: {},
+        settings: {},
       });
     });
 
@@ -33,6 +34,7 @@ describe('UsageRecordSummaries Resource', () => {
               'Stripe-Account': 'acct_456',
             },
             data: {},
+            settings: {},
           });
 
           done();

--- a/test/resources/UsageRecords.spec.js
+++ b/test/resources/UsageRecords.spec.js
@@ -21,6 +21,7 @@ describe('UsageRecords Resource', () => {
           timestamp: 123321,
           action: 'increment',
         },
+        settings: {},
       });
     });
 
@@ -49,6 +50,7 @@ describe('UsageRecords Resource', () => {
               timestamp: 123321,
               action: 'increment',
             },
+            settings: {},
           });
 
           done();

--- a/test/resources/WebhookEndpoints.spec.js
+++ b/test/resources/WebhookEndpoints.spec.js
@@ -12,6 +12,7 @@ describe('WebhookEndpoints Resource', () => {
         url: '/v1/webhook_endpoints/we_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -24,6 +25,7 @@ describe('WebhookEndpoints Resource', () => {
         url: '/v1/webhook_endpoints/we_123',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });
@@ -40,6 +42,7 @@ describe('WebhookEndpoints Resource', () => {
         data: {
           enabled_events: ['charge.succeeded'],
         },
+        settings: {},
       });
     });
   });
@@ -59,6 +62,7 @@ describe('WebhookEndpoints Resource', () => {
           enabled_events: ['charge.succeeded'],
           url: 'https://stripe.com',
         },
+        settings: {},
       });
     });
   });
@@ -71,6 +75,7 @@ describe('WebhookEndpoints Resource', () => {
         url: '/v1/webhook_endpoints',
         headers: {},
         data: {},
+        settings: {},
       });
     });
   });

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -379,11 +379,11 @@ describe('Stripe Module', function() {
     describe('when given an empty or non-number variable', () => {
       it('should error', () => {
         expect(() => {
-          stripe._setMaxNetworkRetries('foo');
+          stripe._setApiNumberField('maxNetworkRetries', 'foo');
         }).to.throw(/maxNetworkRetries must be a number/);
 
         expect(() => {
-          stripe._setMaxNetworkRetries();
+          stripe._setApiNumberField('maxNetworkRetries');
         }).to.throw(/maxNetworkRetries must be a number/);
       });
     });

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -380,21 +380,21 @@ describe('Stripe Module', function() {
       it('should error', () => {
         expect(() => {
           stripe._setApiNumberField('maxNetworkRetries', 'foo');
-        }).to.throw(/maxNetworkRetries must be a number/);
+        }).to.throw(/maxNetworkRetries must be an integer/);
 
         expect(() => {
           stripe._setApiNumberField('maxNetworkRetries');
-        }).to.throw(/maxNetworkRetries must be a number/);
+        }).to.throw(/maxNetworkRetries must be an integer/);
       });
     });
 
     describe('when passed in via the config object', () => {
-      it('should only accept numbers', () => {
-        expect(() => {
-          Stripe(testUtils.getUserStripeKey(), {
-            maxNetworkRetries: 'foo',
-          });
-        }).to.throw(/maxNetworkRetries must be a number/);
+      it('should default to 0 if a non-integer is passed', () => {
+        const newStripe = Stripe(testUtils.getUserStripeKey(), {
+          maxNetworkRetries: 'foo',
+        });
+
+        expect(newStripe.getMaxNetworkRetries()).to.equal(0);
 
         expect(() => {
           Stripe(testUtils.getUserStripeKey(), {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -143,7 +143,7 @@ describe('utils', () => {
     });
 
     it('ignores a hash with only options', (done) => {
-      const args = [{api_key: 'foo'}];
+      const args = [{apiKey: 'foo'}];
 
       handleWarnings(
         () => {
@@ -159,7 +159,7 @@ describe('utils', () => {
     });
 
     it('warns if the hash contains both data and options', (done) => {
-      const args = [{foo: 'bar', api_key: 'foo', idempotency_key: 'baz'}];
+      const args = [{foo: 'bar', apiKey: 'foo', idempotencyKey: 'baz'}];
 
       handleWarnings(
         () => {
@@ -167,7 +167,7 @@ describe('utils', () => {
         },
         (message) => {
           expect(message).to.equal(
-            'Stripe: Options found in arguments (api_key, idempotency_key).' +
+            'Stripe: Options found in arguments (apiKey, idempotencyKey).' +
               ' Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options.'
           );
 

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -294,7 +294,7 @@ describe('utils', () => {
     it('parses additional per-request settings', () => {
       const args = [
         {
-          networkRetries: 5,
+          maxNetworkRetries: 5,
           timeout: 1000,
         },
       ];
@@ -303,7 +303,7 @@ describe('utils', () => {
         auth: null,
         headers: {},
         settings: {
-          networkRetries: 5,
+          maxNetworkRetries: 5,
           timeout: 1000,
         },
       });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -494,6 +494,41 @@ describe('utils', () => {
       expect(flattened['x[a]']).to.equal('1');
     });
   });
+
+  describe('validateInteger', () => {
+    it("Returns the given value if it's a valid integer", () => {
+      const cases = [1, 0x123, 1e3, Number.MAX_SAFE_INTEGER];
+
+      cases.forEach((int) => {
+        expect(utils.validateInteger('magicNumber', int)).to.equal(int);
+      });
+    });
+
+    it('Throws an error if the value is not an integer', () => {
+      const cases = ['foo', 1.2, Number.POSITIVE_INFINITY];
+
+      cases.forEach((val) => {
+        expect(() => {
+          utils.validateInteger('magicNumber', val);
+        }).to.throw();
+      });
+    });
+
+    it('Returns a default value if n is not provided', () => {
+      const expected = 1000;
+      [null, undefined].forEach((t) => {
+        expect(utils.validateInteger('magicNumber', t, expected)).to.equal(
+          expected
+        );
+      });
+    });
+
+    it('Throws if neither value nor default is set', () => {
+      expect(() => {
+        utils.validateInteger('magicNumber');
+      }).to.throw();
+    });
+  });
 });
 
 function handleWarnings(doWithShimmedConsoleWarn, onWarn) {

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -48,6 +48,7 @@ const utils = (module.exports = {
           url,
           data,
           headers: options.headers || {},
+          settings: options.settings || {},
         });
         if (auth) {
           req.auth = auth;


### PR DESCRIPTION
Added network retries/timeout to be set on per-request basis and some general cleanup.

# Per-request settings

This now works:

```js
const charge = await stripe.charges.create({
  amount: 1000,
  currency: 'usd',
  source: 'tok_visa',
}, { 
  maxNetworkRetries: 1,
  timeout: 500,
});
```

`maxNetworkRetries` and `timeout` can still be set globally via the config object:

```js
const stripe = Stripe('sk_test_123', {
  maxNetworkRetries: 2,
  timeout: 1000,
});
```

Additionally `timeout` can still be globally set at any time:
```js
stripe.setTimeout(1000);
```

If set, a per-request value will get priority over a globally set value.

I had to make a bunch of very annoying small changes to tests, as our request object now includes a `settings` object. This is because the previously per-request values were always something that we'd include in the header object, which seemed like the wrong place for `timeout` and `maxNetworkRetries`.

# General cleanup
Previously you'd set per-request settings using snake case:

```js
const charge = await stripe.charges.create({...}, {
  idempotency_key: 'key',
});
```

This was odd since the rest of the library prefers snake case. Plus for header values we prefer the format `Idempotency-Key` when setting them for a request.

For new per-request values, I've only added camel case keys. For existing values, I've added camel case keys but left the old snake case ones for backwards compatibility. The idea being that we'd remove the snake case values entirely in a future major version.

```js
const charge = await stripe.charges.create({...}, {
  idempotencyKey: 'key', // this now works
  stripe_version: '2019-09-09', // this will still work even though "stripeVersion" exists
});
```

r? @rattrayalex-stripe @jlomas-stripe 
cc @stripe/api-libraries 