### PR TITLE
Define 'type' as a property on errors rather than a getter

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -11,11 +11,7 @@ class StripeError extends Error {
     super(raw.message);
     // This splat is here for back-compat and should be removed in the next major version.
     this.populate(...arguments);
-  }
-
-  // Allow `new StripeFooError(raw).type === 'StripeFooError'`
-  get type() {
-    return this.constructor.name;
+    this.type = this.constructor.name;
   }
 
   /**
@@ -71,12 +67,10 @@ class StripeError extends Error {
    */
   static extend(options) {
     const type = options.type;
-    class CustomError extends StripeError {
-      // eslint-disable-next-line class-methods-use-this
-      get type() {
-        return type;
-      }
-    }
+    class CustomError extends StripeError {}
+    Object.defineProperty(CustomError, 'name', {
+      value: type,
+    });
     delete options.type;
     Object.assign(CustomError.prototype, options);
     return CustomError;


### PR DESCRIPTION
cc @rattrayalex-stripe for discussion:

I don't have a full understanding of why it was originally important for 'type' to be implemented as a getter -- or if we should do this -- but this PR both
1. Passes the existing `test/Error.spec.js`
2. Fulfills the ask in https://github.com/stripe/stripe-node/issues/718
```javascript
      class Foo extends Error.StripeError {}
      const err = new Foo({message: 'hi'});
      console.log(err);
```
outputs
```
...
  {
  raw: { message: 'hi' },
  rawType: undefined,
  code: undefined,
  param: undefined,
  detail: undefined,
  headers: undefined,
  requestId: undefined,
  statusCode: undefined,
  charge: undefined,
  decline_code: undefined,
  payment_intent: undefined,
  payment_method: undefined,
  setup_intent: undefined,
  source: undefined,
  type: 'Foo'
}
```

and
```
      const Custom = Error.StripeError.extend({type: 'Foo'});
      const err = new Custom({message: 'hi'});
      console.log(err);
```
outputs the same.
