### PR TITLE
Temporary user-agent change to track typescript usage

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -339,7 +339,7 @@ StripeResource.prototype = {
       ? this._stripe.getAppInfoAsString()
       : '';
 
-    return `Stripe/v1 NodeBindings/${packageVersion} ${appInfo}`.trim();
+    return `Stripe/v1 NodeBindings/${packageVersion}/typescript-beta ${appInfo}`.trim();
   },
 
   _getTelemetryHeader() {


### PR DESCRIPTION
Changing the user-agent temporarily to append a  custom tag for the beta so that we can better track who is using it and reach out for feedback or once the production version is ready.

My main worry here is that changing the user agent format could break our parsing scripts though I hope not. cc @ob-stripe 

r? @rattrayalex-stripe 
cc @stripe/api-libraries 