### PR TITLE
Update SubscriptionSchedules.Phase.Plan.plan to use correct type

### DIFF
--- a/types/2019-12-03/SubscriptionSchedules.d.ts
+++ b/types/2019-12-03/SubscriptionSchedules.d.ts
@@ -231,7 +231,7 @@ declare module 'stripe' {
           /**
            * ID of the plan to which the customer should be subscribed.
            */
-          plan: string | Plan | DeletedPlan;
+          plan: string | Stripe.Plan | DeletedPlan;
 
           /**
            * Quantity of the plan to which the customer should be subscribed.


### PR DESCRIPTION
`SubscriptionSchedules.Phase.Plan.plan` was incorrectly using type `SubscriptionSchedules.Phase.Plan` so I changed it to use type `Stripe.Plan` as described [here](https://stripe.com/docs/api/subscription_schedules/object#subscription_schedule_object-phases-plans-plan)