### PR TITLE
Accept an array of strings or buffers as the header argument for webhooks.constructEvent

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -5,7 +5,14 @@ const https = require('https');
 const path = require('path');
 
 const utils = require('./utils');
-const Error = require('./Error');
+const {
+  StripeConnectionError,
+  StripeAuthenticationError,
+  StripePermissionError,
+  StripeRateLimitError,
+  StripeError,
+  StripeAPIError,
+} = require('./Error');
 
 const defaultHttpAgent = new http.Agent({keepAlive: true});
 const defaultHttpsAgent = new https.Agent({keepAlive: true});
@@ -96,7 +103,7 @@ StripeResource.prototype = {
 
       callback.call(
         this,
-        new Error.StripeConnectionError({
+        new StripeConnectionError({
           message: `Request aborted due to timeout being reached (${timeout}ms)`,
           detail: timeoutErr,
         }),
@@ -159,20 +166,20 @@ StripeResource.prototype = {
             response.error.requestId = res.requestId;
 
             if (res.statusCode === 401) {
-              err = new Error.StripeAuthenticationError(response.error);
+              err = new StripeAuthenticationError(response.error);
             } else if (res.statusCode === 403) {
-              err = new Error.StripePermissionError(response.error);
+              err = new StripePermissionError(response.error);
             } else if (res.statusCode === 429) {
-              err = new Error.StripeRateLimitError(response.error);
+              err = new StripeRateLimitError(response.error);
             } else {
-              err = Error.StripeError.generate(response.error);
+              err = StripeError.generate(response.error);
             }
             return callback.call(this, err, null);
           }
         } catch (e) {
           return callback.call(
             this,
-            new Error.StripeAPIError({
+            new StripeAPIError({
               message: 'Invalid JSON received from the Stripe API',
               response,
               exception: e,
@@ -209,7 +216,7 @@ StripeResource.prototype = {
       }
       callback.call(
         this,
-        new Error.StripeConnectionError({
+        new StripeConnectionError({
           message: this._generateConnectionErrorMessage(requestRetries),
           detail: error,
         }),

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -69,6 +69,21 @@ const signature = {
 
   verifyHeader(payload, header, secret, tolerance) {
     payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
+
+    // Handle array headers because express's TS types claim that the value can be an array,
+    // though in practice we don't expect this.
+    if (Array.isArray(header)) {
+      if (header.length === 1) {
+        header = header[0];
+      } else {
+        throw new Error(
+          `The header arg was an array of length ${
+            header.length
+          }; please pass a string or an array of length 1 instead.`
+        );
+      }
+    }
+
     header = Buffer.isBuffer(header) ? header.toString('utf8') : header;
 
     const details = parseHeader(header, this.EXPECTED_SCHEME);

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -3,7 +3,7 @@
 const crypto = require('crypto');
 
 const utils = require('./utils');
-const Error = require('./Error');
+const {StripeError, StripeSignatureVerificationError} = require('./Error');
 
 const Webhook = {
   DEFAULT_TOLERANCE: 300, // 5 minutes
@@ -32,7 +32,7 @@ const Webhook = {
    */
   generateTestHeaderString: function(opts) {
     if (!opts) {
-      throw new Error.StripeError({
+      throw new StripeError({
         message: 'Options are required',
       });
     }
@@ -74,7 +74,7 @@ const signature = {
     const details = parseHeader(header, this.EXPECTED_SCHEME);
 
     if (!details || details.timestamp === -1) {
-      throw new Error.StripeSignatureVerificationError({
+      throw new StripeSignatureVerificationError({
         message: 'Unable to extract timestamp and signatures from header',
         detail: {
           header,
@@ -84,7 +84,7 @@ const signature = {
     }
 
     if (!details.signatures.length) {
-      throw new Error.StripeSignatureVerificationError({
+      throw new StripeSignatureVerificationError({
         message: 'No signatures found with expected scheme',
         detail: {
           header,
@@ -103,7 +103,7 @@ const signature = {
     ).length;
 
     if (!signatureFound) {
-      throw new Error.StripeSignatureVerificationError({
+      throw new StripeSignatureVerificationError({
         message:
           'No signatures found matching the expected signature for payload.' +
           ' Are you passing the raw request body you received from Stripe?' +
@@ -118,7 +118,7 @@ const signature = {
     const timestampAge = Math.floor(Date.now() / 1000) - details.timestamp;
 
     if (tolerance > 0 && timestampAge > tolerance) {
-      throw new Error.StripeSignatureVerificationError({
+      throw new StripeSignatureVerificationError({
         message: 'Timestamp outside the tolerance zone',
         detail: {
           header,

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -70,18 +70,14 @@ const signature = {
   verifyHeader(payload, header, secret, tolerance) {
     payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
 
-    // Handle array headers because express's TS types claim that the value can be an array,
-    // though in practice we don't expect this.
+    // Express's type for `Request#headers` is `string | []string`
+    // which is because the `set-cookie` header is an array,
+    // but no other headers are an array (docs: https://nodejs.org/api/http.html#http_message_headers)
+    // (Express's Request class is an extension of http.IncomingMessage, and doesn't appear to be relevantly modified: https://github.com/expressjs/express/blob/master/lib/request.js#L31)
     if (Array.isArray(header)) {
-      if (header.length === 1) {
-        header = header[0];
-      } else {
-        throw new Error(
-          `The header arg was an array of length ${
-            header.length
-          }; please pass a string or an array of length 1 instead.`
-        );
-      }
+      throw new Error(
+        'Unexpected: An array was passed as a header, which should not be possible for the stripe-signature header.'
+      );
     }
 
     header = Buffer.isBuffer(header) ? header.toString('utf8') : header;

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -73,6 +73,44 @@ describe('Webhooks', () => {
         stripe.webhooks.constructEvent(EVENT_PAYLOAD_STRING, header, SECRET);
       }).to.throw(/Unable to extract timestamp and signatures from header/);
     });
+
+    it('should allow a singature which is an array of one string', () => {
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: EVENT_PAYLOAD_STRING,
+        secret: SECRET,
+      });
+
+      const event = stripe.webhooks.constructEvent(
+        EVENT_PAYLOAD_STRING,
+        [header],
+        SECRET
+      );
+
+      expect(event.id).to.equal(EVENT_PAYLOAD.id);
+    });
+
+    it('should error if you pass a signature which is an array of length !1', () => {
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: EVENT_PAYLOAD_STRING,
+        secret: SECRET,
+      });
+
+      expect(() => {
+        stripe.webhooks.constructEvent(EVENT_PAYLOAD_STRING, [], SECRET);
+      }).to.throw(
+        'The header arg was an array of length 0; please pass a string or an array of length 1 instead.'
+      );
+
+      expect(() => {
+        stripe.webhooks.constructEvent(
+          EVENT_PAYLOAD_STRING,
+          [header, header],
+          SECRET
+        );
+      }).to.throw(
+        'The header arg was an array of length 2; please pass a string or an array of length 1 instead.'
+      );
+    });
   });
 
   describe('.verifySignatureHeader', () => {

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -74,41 +74,16 @@ describe('Webhooks', () => {
       }).to.throw(/Unable to extract timestamp and signatures from header/);
     });
 
-    it('should allow a singature which is an array of one string', () => {
-      const header = stripe.webhooks.generateTestHeaderString({
-        payload: EVENT_PAYLOAD_STRING,
-        secret: SECRET,
-      });
-
-      const event = stripe.webhooks.constructEvent(
-        EVENT_PAYLOAD_STRING,
-        [header],
-        SECRET
-      );
-
-      expect(event.id).to.equal(EVENT_PAYLOAD.id);
-    });
-
-    it('should error if you pass a signature which is an array of length !1', () => {
+    it('should error if you pass a signature which is an array, even though our types say you can', () => {
       const header = stripe.webhooks.generateTestHeaderString({
         payload: EVENT_PAYLOAD_STRING,
         secret: SECRET,
       });
 
       expect(() => {
-        stripe.webhooks.constructEvent(EVENT_PAYLOAD_STRING, [], SECRET);
+        stripe.webhooks.constructEvent(EVENT_PAYLOAD_STRING, [header], SECRET);
       }).to.throw(
-        'The header arg was an array of length 0; please pass a string or an array of length 1 instead.'
-      );
-
-      expect(() => {
-        stripe.webhooks.constructEvent(
-          EVENT_PAYLOAD_STRING,
-          [header, header],
-          SECRET
-        );
-      }).to.throw(
-        'The header arg was an array of length 2; please pass a string or an array of length 1 instead.'
+        'Unexpected: An array was passed as a header, which should not be possible for the stripe-signature header.'
       );
     });
   });

--- a/types/Webhooks.d.ts
+++ b/types/Webhooks.d.ts
@@ -16,9 +16,15 @@ declare module 'stripe' {
 
         /**
          * Value of the `stripe-signature` header from Stripe.
-         * Typically a string; if it is an array, it must be of length 1.
+         * Typically a string.
+         *
+         * Note that this is typed to accept an array of strings
+         * so that it works seamlessly with express's types,
+         * but will throw if an array is passed in practice
+         * since express should never return this header as an array,
+         * only a string.
          */
-        header: string | Buffer | Array<string> | Array<Buffer>,
+        header: string | Buffer | Array<string>,
 
         /**
          * Your Webhook Signing Secret for this endpoint (e.g., 'whsec_...').

--- a/types/Webhooks.d.ts
+++ b/types/Webhooks.d.ts
@@ -16,8 +16,9 @@ declare module 'stripe' {
 
         /**
          * Value of the `stripe-signature` header from Stripe.
+         * Typically a string; if it is an array, it must be of length 1.
          */
-        header: string,
+        header: string | Buffer | Array<string> | Array<Buffer>,
 
         /**
          * Your Webhook Signing Secret for this endpoint (e.g., 'whsec_...').


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

When trying out the new library, Thor found that express's TS types indicate that a header is typed as `string | []string`. 

This resulted in the following type error:

![image_preview](https://user-images.githubusercontent.com/29717832/72030562-3a8e8000-323e-11ea-862e-20925bcd5706.png)

His workaround was to do a cast:
```tsx
const signature: string = req.headers["stripe-signature"] as string;
event = stripe.webhooks.constructEvent(
  req.body,
  signature,
  process.env.STRIPE_WEBHOOK_SECRET
);
```
but it'd be nice to not have to do that, and have this Just Work:
```tsx
event = stripe.webhooks.constructEvent(
  req.body,
  req.headers["stripe-signature"],
  process.env.STRIPE_WEBHOOK_SECRET
);
```

This turns out to be because express's `Request` class [is a wrapper](https://github.com/expressjs/express/blob/master/lib/request.js#L31) around `http.IncomingMessage`, and `IncomingMessage#headers` [claims](https://nodejs.org/api/http.html#http_message_headers) that:
- set-cookie is always an array. Duplicates are added to the array.
- For all other headers, the values are joined together with ', '.

This means that in practice, _this_ header should never be an array. We shouldn't bother our users with the cast, nor should we handle the array case, which should never occur (at least in `http` and `express`, which is what we're adding this for).

So we type it as accepting an array, but throw an error if one is passed. 