### PR TITLE
Improve markdown links in TS comments

### DIFF
--- a/types/2019-12-03/Accounts.d.ts
+++ b/types/2019-12-03/Accounts.d.ts
@@ -320,7 +320,7 @@ declare module 'stripe' {
         namespace Verification {
           interface Document {
             /**
-             * The back of a document returned by a [file upload](#create_file) with a `purpose` value of `additional_verification`.
+             * The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`.
              */
             back: string | Stripe.File | null;
 
@@ -335,7 +335,7 @@ declare module 'stripe' {
             details_code: string | null;
 
             /**
-             * The front of a document returned by a [file upload](#create_file) with a `purpose` value of `additional_verification`.
+             * The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`.
              */
             front: string | Stripe.File | null;
           }
@@ -769,12 +769,12 @@ declare module 'stripe' {
         namespace Verification {
           interface Document {
             /**
-             * The back of a document returned by a [file upload](#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of a document returned by a [file upload](#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }
@@ -935,24 +935,24 @@ declare module 'stripe' {
         namespace Verification {
           interface AdditionalDocument {
             /**
-             * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }
 
           interface Document {
             /**
-             * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }
@@ -1361,12 +1361,12 @@ declare module 'stripe' {
         namespace Verification {
           interface Document {
             /**
-             * The back of a document returned by a [file upload](#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of a document returned by a [file upload](#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `additional_verification`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }
@@ -1527,24 +1527,24 @@ declare module 'stripe' {
         namespace Verification {
           interface AdditionalDocument {
             /**
-             * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }
 
           interface Document {
             /**
-             * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }

--- a/types/2019-12-03/Balance.d.ts
+++ b/types/2019-12-03/Balance.d.ts
@@ -10,7 +10,7 @@ declare module 'stripe' {
       object: 'balance';
 
       /**
-       * Funds that are available to be transferred or paid out, whether automatically by Stripe or explicitly via the [Transfers API](#transfers) or [Payouts API](#payouts). The available balance for each currency and payment type can be found in the `source_types` property.
+       * Funds that are available to be transferred or paid out, whether automatically by Stripe or explicitly via the [Transfers API](https://stripe.com/docs/api#transfers) or [Payouts API](https://stripe.com/docs/api#payouts). The available balance for each currency and payment type can be found in the `source_types` property.
        */
       available: Array<Balance.Available>;
 

--- a/types/2019-12-03/Charges.d.ts
+++ b/types/2019-12-03/Charges.d.ts
@@ -1163,7 +1163,7 @@ declare module 'stripe' {
       application_fee_amount?: number;
 
       /**
-       * Whether to immediately capture the charge. Defaults to `true`. When `false`, the charge issues an authorization (or pre-authorization), and will need to be [captured](#capture_charge) later. Uncaptured charges expire in _seven days_. For more information, see the [authorizing charges and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation.
+       * Whether to immediately capture the charge. Defaults to `true`. When `false`, the charge issues an authorization (or pre-authorization), and will need to be [captured](https://stripe.com/docs/api#capture_charge) later. Uncaptured charges expire in _seven days_. For more information, see the [authorizing charges and settling later](https://stripe.com/docs/charges/placing-a-hold) documentation.
        */
       capture?: boolean;
 

--- a/types/2019-12-03/Checkout/Sessions.d.ts
+++ b/types/2019-12-03/Checkout/Sessions.d.ts
@@ -196,7 +196,7 @@ declare module 'stripe' {
          * is complete.
          * If you'd like access to the Checkout Session for the successful
          * payment, read more about it in our guide on [fulfilling your payments
-         * with webhooks](/docs/payments/checkout/fulfillment#webhooks).
+         * with webhooks](https://stripe.com/docs/payments/checkout/fulfillment#webhooks).
          */
         success_url: string;
 
@@ -362,7 +362,7 @@ declare module 'stripe' {
           /**
            * The Stripe account ID for which these funds are intended. For details,
            * see the PaymentIntents [use case for connected
-           * accounts](/docs/payments/connected-accounts).
+           * accounts](https://stripe.com/docs/payments/connected-accounts).
            */
           on_behalf_of?: string;
 

--- a/types/2019-12-03/Events.d.ts
+++ b/types/2019-12-03/Events.d.ts
@@ -55,7 +55,7 @@ declare module 'stripe' {
     namespace Event {
       interface Data {
         /**
-         * Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](#invoice_object) as the value of the object key.
+         * Object containing the API resource relevant to the event. For example, an `invoice.created` event will have a full [invoice object](https://stripe.com/docs/api#invoice_object) as the value of the object key.
          */
         object: Data.Object;
 

--- a/types/2019-12-03/Issuing/Cardholders.d.ts
+++ b/types/2019-12-03/Issuing/Cardholders.d.ts
@@ -1069,12 +1069,12 @@ declare module 'stripe' {
           namespace Verification {
             interface Document {
               /**
-               * The back of a document returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+               * The back of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
                */
               back: string | Stripe.File | null;
 
               /**
-               * The front of a document returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+               * The front of a document returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
                */
               front: string | Stripe.File | null;
             }
@@ -2173,12 +2173,12 @@ declare module 'stripe' {
           namespace Verification {
             interface Document {
               /**
-               * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+               * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
                */
               back?: string;
 
               /**
-               * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+               * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
                */
               front?: string;
             }
@@ -3253,12 +3253,12 @@ declare module 'stripe' {
           namespace Verification {
             interface Document {
               /**
-               * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+               * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
                */
               back?: string;
 
               /**
-               * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+               * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
                */
               front?: string;
             }

--- a/types/2019-12-03/Payouts.d.ts
+++ b/types/2019-12-03/Payouts.d.ts
@@ -86,7 +86,7 @@ declare module 'stripe' {
       metadata: Metadata;
 
       /**
-       * The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces](/blog/instant-payouts-for-marketplaces) for more information.)
+       * The method used to send this payout, which can be `standard` or `instant`. `instant` is only supported for payouts to debit cards. (See [Instant payouts for marketplaces](https://stripe.com/blog/instant-payouts-for-marketplaces) for more information.)
        */
       method: string;
 

--- a/types/2019-12-03/Persons.d.ts
+++ b/types/2019-12-03/Persons.d.ts
@@ -288,7 +288,7 @@ declare module 'stripe' {
       namespace Verification {
         interface AdditionalDocument {
           /**
-           * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+           * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
            */
           back: string | Stripe.File | null;
 
@@ -303,14 +303,14 @@ declare module 'stripe' {
           details_code: string | null;
 
           /**
-           * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+           * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
            */
           front: string | Stripe.File | null;
         }
 
         interface Document {
           /**
-           * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+           * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
            */
           back: string | Stripe.File | null;
 
@@ -325,7 +325,7 @@ declare module 'stripe' {
           details_code: string | null;
 
           /**
-           * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`.
+           * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`.
            */
           front: string | Stripe.File | null;
         }
@@ -556,24 +556,24 @@ declare module 'stripe' {
       namespace Verification {
         interface AdditionalDocument {
           /**
-           * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           back?: string;
 
           /**
-           * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           front?: string;
         }
 
         interface Document {
           /**
-           * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           back?: string;
 
           /**
-           * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           front?: string;
         }
@@ -791,24 +791,24 @@ declare module 'stripe' {
       namespace Verification {
         interface AdditionalDocument {
           /**
-           * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           back?: string;
 
           /**
-           * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           front?: string;
         }
 
         interface Document {
           /**
-           * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           back?: string;
 
           /**
-           * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+           * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
            */
           front?: string;
         }

--- a/types/2019-12-03/SubscriptionItems.d.ts
+++ b/types/2019-12-03/SubscriptionItems.d.ts
@@ -117,7 +117,7 @@ declare module 'stripe' {
       prorate?: boolean;
 
       /**
-       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](#retrieve_customer_invoice) endpoint.
+       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
        */
       proration_date?: number;
 
@@ -189,7 +189,7 @@ declare module 'stripe' {
       prorate?: boolean;
 
       /**
-       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](#retrieve_customer_invoice) endpoint.
+       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
        */
       proration_date?: number;
 
@@ -242,7 +242,7 @@ declare module 'stripe' {
       prorate?: boolean;
 
       /**
-       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](#retrieve_customer_invoice) endpoint.
+       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply the same proration that was previewed with the [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint.
        */
       proration_date?: number;
     }

--- a/types/2019-12-03/Subscriptions.d.ts
+++ b/types/2019-12-03/Subscriptions.d.ts
@@ -546,7 +546,7 @@ declare module 'stripe' {
       prorate?: boolean;
 
       /**
-       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations.
+       * If set, the proration will be calculated as though the subscription was updated at the given time. This can be used to apply exactly the same proration that was previewed with [upcoming invoice](https://stripe.com/docs/api#retrieve_customer_invoice) endpoint. It can also be used to implement custom proration logic, such as prorating by day instead of by second, by providing the time that you wish to use for proration calculations.
        */
       proration_date?: number;
 

--- a/types/2019-12-03/Tokens.d.ts
+++ b/types/2019-12-03/Tokens.d.ts
@@ -335,24 +335,24 @@ declare module 'stripe' {
         namespace Verification {
           interface AdditionalDocument {
             /**
-             * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }
 
           interface Document {
             /**
-             * The back of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The back of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             back?: string;
 
             /**
-             * The front of an ID returned by a [file upload](#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
+             * The front of an ID returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `identity_document`. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG or PNG format, and less than 10 MB in size.
              */
             front?: string;
           }


### PR DESCRIPTION
r? @richardm-stripe 
cc @stripe/api-libraries 

Makes many markdown links be full URL's instead of relative paths or hashes, so that cmd+click in IDE's works.