### PR TITLE
Add types dir to npmignore whitelist and stop warning when instantiating stripe with no args

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -10,3 +10,4 @@
 !/VERSION
 !/package.json
 !/lib/**/*
+!/types/**/*

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -98,13 +98,13 @@ function Stripe(key, config = {}) {
   }
 
   this._prepResources();
-  this.setApiKey(key);
+  this._setApiKey(key);
 
   this.errors = require('./Error');
   this.webhooks = require('./Webhooks');
 
   this._prevRequestMetrics = [];
-  this.setTelemetryEnabled(props.telemetry !== false);
+  this._enableTelemetry = props.telemetry !== false;
 }
 
 Stripe.errors = require('./Error');
@@ -200,6 +200,13 @@ Stripe.prototype = {
     emitWarning(
       '`setApiKey` is deprecated. Use the `apiKey` request option instead.'
     );
+    this._setApiKey(key);
+  },
+
+  /**
+   * @private
+   */
+  _setApiKey(key) {
     if (key) {
       this._setApiField('auth', `Bearer ${key}`);
     }


### PR DESCRIPTION
r? @jlomas-stripe 
cc @stripe/api-libraries 
Fixes https://github.com/stripe/stripe-node/issues/756

Tested in a repl:
```
> require('./lib/stripe')('hi'); 1
1
> require('./lib/stripe')('hi').customers.list(); 1
1
> (node:46965) UnhandledPromiseRejectionWarning: Error: Invalid API Key provided: hi
```

Note that it did not log warnings.