### PR TITLE
Add support for listing line items on a `CreditNote`

### DIFF
--- a/lib/resources/CreditNotes.js
+++ b/lib/resources/CreditNotes.js
@@ -17,4 +17,16 @@ module.exports = StripeResource.extend({
     method: 'POST',
     path: '/{id}/void',
   }),
+
+  listLineItems: stripeMethod({
+    method: 'GET',
+    path: '/{creditNote}/lines',
+    methodType: 'list',
+  }),
+
+  listPreviewLineItems: stripeMethod({
+    method: 'GET',
+    path: '/preview/lines',
+    methodType: 'list',
+  }),
 });

--- a/test/resources/CreditNotes.spec.js
+++ b/test/resources/CreditNotes.spec.js
@@ -48,6 +48,32 @@ describe('CreditNotes Resource', () => {
     });
   });
 
+  describe('listLineItems', () => {
+    it('Sends the correct request', () => {
+      stripe.creditNotes.listLineItems('cn_123');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/credit_notes/cn_123/lines',
+        headers: {},
+        data: {},
+        settings: {},
+      });
+    });
+  });
+
+  describe('listPreviewLineItems', () => {
+    it('Sends the correct request', () => {
+      stripe.creditNotes.listPreviewLineItems();
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/credit_notes/preview/lines',
+        headers: {},
+        data: {},
+        settings: {},
+      });
+    });
+  });
+
   describe('update', () => {
     it('Sends the correct request', () => {
       stripe.creditNotes.update('cn_123', {application_fee: 200});

--- a/types/2019-12-03/Accounts.d.ts
+++ b/types/2019-12-03/Accounts.d.ts
@@ -1794,7 +1794,7 @@ declare module 'stripe' {
        *
        * Accounts created using test-mode keys can be deleted at any time. Accounts created using live-mode keys can only be deleted once all balances are zero.
        *
-       * If you want to delete your own account, use the [data tab in your account settings](https://dashboard.stripe.com/account/data) instead.
+       * If you want to delete your own account, use the [account information tab in your account settings](https://dashboard.stripe.com/account) instead.
        */
       del(
         id: string,

--- a/types/2019-12-03/CreditNoteLineItems.d.ts
+++ b/types/2019-12-03/CreditNoteLineItems.d.ts
@@ -1,0 +1,212 @@
+declare module 'stripe' {
+  namespace Stripe {
+    /**
+     * The CreditNoteLineItem object.
+     */
+    interface CreditNoteLineItem {
+      /**
+       * Unique identifier for the object.
+       */
+      id: string;
+
+      /**
+       * String representing the object's type. Objects of the same type share the same value.
+       */
+      object: 'credit_note_line_item';
+
+      /**
+       * The integer amount in **%s** representing the gross amount being credited for this line item, excluding (exclusive) tax and discounts.
+       */
+      amount: number;
+
+      /**
+       * Description of the item being credited.
+       */
+      description: string | null;
+
+      /**
+       * The integer amount in **%s** representing the discount being credited for this line item.
+       */
+      discount_amount: number;
+
+      /**
+       * ID of the invoice line item being credited
+       */
+      invoice_line_item?: string;
+
+      /**
+       * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+       */
+      livemode: boolean;
+
+      /**
+       * The number of units of product being credited.
+       */
+      quantity: number | null;
+
+      /**
+       * The amount of tax calculated per tax rate for this line item
+       */
+      tax_amounts: Array<CreditNoteLineItem.TaxAmount>;
+
+      /**
+       * The tax rates which apply to the line item.
+       */
+      tax_rates: Array<Stripe.TaxRate>;
+
+      /**
+       * The type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. When the type is `invoice_line_item` there is an additional `invoice_line_item` property on the resource the value of which is the id of the credited line item on the invoice.
+       */
+      type: CreditNoteLineItem.Type;
+
+      /**
+       * The cost of each unit of product being credited.
+       */
+      unit_amount: number | null;
+
+      /**
+       * Same as `unit_amount`, but contains a decimal value with at most 12 decimal places.
+       */
+      unit_amount_decimal: string | null;
+    }
+
+    namespace CreditNoteLineItem {
+      interface TaxAmount {
+        /**
+         * The amount, in %s, of the tax.
+         */
+        amount: number;
+
+        /**
+         * Whether this tax amount is inclusive or exclusive.
+         */
+        inclusive: boolean;
+
+        /**
+         * The tax rate that was applied to get this tax amount.
+         */
+        tax_rate: string | Stripe.TaxRate;
+      }
+
+      type Type = 'custom_line_item' | 'invoice_line_item';
+    }
+
+    interface CreditNoteLineItemListParams extends PaginationParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    interface CreditNoteLineItemListPreviewParams extends PaginationParams {
+      /**
+       * ID of the invoice.
+       */
+      invoice: string;
+
+      /**
+       * The integer amount in **%s** representing the total amount of the credit note.
+       */
+      amount?: number;
+
+      /**
+       * The integer amount in **%s** representing the amount to credit the customer's balance, which will be automatically applied to their next invoice.
+       */
+      credit_amount?: number;
+
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+
+      /**
+       * Line items that make up the credit note.
+       */
+      lines?: Array<CreditNoteLineItemListPreviewParams.Line>;
+
+      /**
+       * The credit note's memo appears on the credit note PDF.
+       */
+      memo?: string;
+
+      /**
+       * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+       */
+      metadata?: MetadataParam;
+
+      /**
+       * The integer amount in **%s** representing the amount that is credited outside of Stripe.
+       */
+      out_of_band_amount?: number;
+
+      /**
+       * Reason for issuing this credit note, one of `duplicate`, `fraudulent`, `order_change`, or `product_unsatisfactory`
+       */
+      reason?: CreditNoteLineItemListPreviewParams.Reason;
+
+      /**
+       * ID of an existing refund to link this credit note to.
+       */
+      refund?: string;
+
+      /**
+       * The integer amount in **%s** representing the amount to refund. If set, a refund will be created for the charge associated with the invoice.
+       */
+      refund_amount?: number;
+    }
+
+    namespace CreditNoteLineItemListPreviewParams {
+      interface Line {
+        /**
+         * The line item amount to credit. Only valid when `type` is `invoice_line_item` and the referenced invoice line item does not have a quantity, only an amount.
+         */
+        amount?: number;
+
+        /**
+         * The description of the credit note line item. Only valid when the `type` is `custom_line_item`.
+         */
+        description?: string;
+
+        /**
+         * The invoice line item to credit. Only valid when the `type` is `invoice_line_item`.
+         */
+        invoice_line_item?: string;
+
+        /**
+         * The line item quantity to credit.
+         */
+        quantity?: number;
+
+        /**
+         * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
+         */
+        tax_rates?: Array<string> | '';
+
+        /**
+         * Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`
+         */
+        type: Line.Type;
+
+        /**
+         * The integer unit amount in **%s** of the credit note line item. This `unit_amount` will be multiplied by the quantity to get the full amount to credit for this line item. Only valid when `type` is `custom_line_item`.
+         */
+        unit_amount?: number;
+
+        /**
+         * Same as `unit_amount`, but accepts a decimal value with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.
+         */
+        unit_amount_decimal?: string;
+      }
+
+      namespace Line {
+        type Type = 'custom_line_item' | 'invoice_line_item';
+      }
+
+      type Reason =
+        | 'duplicate'
+        | 'fraudulent'
+        | 'order_change'
+        | 'product_unsatisfactory';
+    }
+  }
+}

--- a/types/2019-12-03/index.d.ts
+++ b/types/2019-12-03/index.d.ts
@@ -79,6 +79,7 @@
 ///<reference path='./Persons.d.ts' />
 ///<reference path='./FeeRefunds.d.ts' />
 ///<reference path='./BitcoinTransactions.d.ts' />
+///<reference path='./CreditNoteLineItems.d.ts' />
 ///<reference path='./CustomerBalanceTransactions.d.ts' />
 ///<reference path='./CustomerSources.d.ts' />
 ///<reference path='./TaxIds.d.ts' />


### PR DESCRIPTION
Codegen for openapi d663cdb
r? @ob-stripe 
cc @stripe/api-libraries 