### PR TITLE
Allow bank account id to be provided to tokens.create

### DIFF
--- a/types/2019-12-03/Tokens.d.ts
+++ b/types/2019-12-03/Tokens.d.ts
@@ -53,7 +53,7 @@ declare module 'stripe' {
       /**
        * The bank account this token will represent.
        */
-      bank_account?: TokenCreateParams.BankAccount;
+      bank_account?: string | TokenCreateParams.BankAccount;
 
       card?: string | TokenCreateParams.Card;
 


### PR DESCRIPTION
tokens.create allows for [cloning payment methods][1] from one account to another through stripe connect. When cloning a source, you do not provide the full payment method information but just the string id for the source in the appropriate key (card for credit cards and bank_account for bank accounts).

This was done correctly for credit cards but was not done for bank accounts. We are getting around this currently by using `as any` to ignore the typescript errors and allow passing a string as the bank_account.

[1]: https://stripe.com/docs/connect/cloning-saved-payment-methods