### PR TITLE
Add support for `shipping[speed]` on Issuing `Card`

### DIFF
--- a/types/2019-12-03/InvoiceLineItems.d.ts
+++ b/types/2019-12-03/InvoiceLineItems.d.ts
@@ -176,7 +176,7 @@ declare module 'stripe' {
         | InvoiceLineItemListUpcomingParams.SubscriptionBillingCycleAnchor;
 
       /**
-       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period if `prorate=true`
+       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`
        */
       subscription_cancel_at?: number | '';
 

--- a/types/2019-12-03/Invoices.d.ts
+++ b/types/2019-12-03/Invoices.d.ts
@@ -845,7 +845,7 @@ declare module 'stripe' {
         | InvoiceRetrieveUpcomingParams.SubscriptionBillingCycleAnchor;
 
       /**
-       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period if `prorate=true`
+       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`
        */
       subscription_cancel_at?: number | '';
 

--- a/types/2019-12-03/Issuing/Cards.d.ts
+++ b/types/2019-12-03/Issuing/Cards.d.ts
@@ -1066,6 +1066,11 @@ declare module 'stripe' {
           name: string;
 
           /**
+           * Shipment speed.
+           */
+          speed: Shipping.Speed;
+
+          /**
            * The delivery status of the card.
            */
           status: Shipping.Status | null;
@@ -1088,6 +1093,8 @@ declare module 'stripe' {
 
         namespace Shipping {
           type Carrier = 'fedex' | 'usps';
+
+          type Speed = 'express' | 'overnight' | 'standard';
 
           type Status =
             | 'canceled'
@@ -2093,6 +2100,11 @@ declare module 'stripe' {
           name: string;
 
           /**
+           * Shipment speed.
+           */
+          speed?: Shipping.Speed;
+
+          /**
            * Packaging options.
            */
           type?: Shipping.Type;
@@ -2130,6 +2142,8 @@ declare module 'stripe' {
              */
             state?: string;
           }
+
+          type Speed = 'express' | 'overnight' | 'standard';
 
           type Type = 'bulk' | 'individual';
         }

--- a/types/2019-12-03/Subscriptions.d.ts
+++ b/types/2019-12-03/Subscriptions.d.ts
@@ -295,7 +295,7 @@ declare module 'stripe' {
       billing_thresholds?: SubscriptionCreateParams.BillingThresholds | null;
 
       /**
-       * A timestamp at which the subscription should cancel. If set to a date before the current period ends this will cause a proration if `prorate=true`.
+       * A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
        */
       cancel_at?: number;
 
@@ -367,7 +367,7 @@ declare module 'stripe' {
       pending_invoice_item_interval?: SubscriptionCreateParams.PendingInvoiceItemInterval | null;
 
       /**
-       * Boolean (defaults to `true`) telling us whether to [credit for unused time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. If `false`, the anchor period will be free (similar to a trial) and no proration adjustments will be created. This field has been deprecated and will be removed in a future API version. Use `proration_behavior=create_prorations` as a replacement for `prorate=true` and `proration_behavior=none` for `prorate=false`.
+       * This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`.
        */
       prorate?: boolean;
 
@@ -510,7 +510,7 @@ declare module 'stripe' {
       billing_thresholds?: SubscriptionUpdateParams.BillingThresholds | null;
 
       /**
-       * A timestamp at which the subscription should cancel. If set to a date before the current period ends this will cause a proration if `prorate=true`.
+       * A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
        */
       cancel_at?: number | '';
 
@@ -582,7 +582,7 @@ declare module 'stripe' {
       pending_invoice_item_interval?: SubscriptionUpdateParams.PendingInvoiceItemInterval | null;
 
       /**
-       * Boolean (defaults to `true`) telling us whether to [credit for unused time](https://stripe.com/docs/subscriptions/billing-cycle#prorations) when the billing cycle changes (e.g. when switching plans, resetting `billing_cycle_anchor=now`, or starting a trial), or if an item's `quantity` changes. If `false`, the anchor period will be free (similar to a trial) and no proration adjustments will be created. This field has been deprecated and will be removed in a future API version. Use `proration_behavior=create_prorations` as a replacement for `prorate=true` and `proration_behavior=none` for `prorate=false`.
+       * This field has been renamed to `proration_behavior`. `prorate=true` can be replaced with `proration_behavior=create_prorations` and `prorate=false` can be replaced with `proration_behavior=none`.
        */
       prorate?: boolean;
 


### PR DESCRIPTION
Codegen for openapi 32bf030

r? @ob-stripe 
cc @stripe/api-libraries 