### PR TITLE
Make typescript param optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,6 @@ and instantiate it as `new Stripe()` with the latest API version.
 import Stripe from 'stripe';
 const stripe = new Stripe('sk_test_...', {
   apiVersion: '2019-12-03',
-  typescript: true,
 });
 
 const createCustomer = async () => {
@@ -174,7 +173,7 @@ const stripe = Stripe('sk_test_...', {
 | `timeout`           | 120000 (Node default timeout) | [Maximum time each request can take in ms.](#configuring-timeout)                     |
 | `host`              | `'api.stripe.com'`            | Host that requests are made to.                                                       |
 | `port`              | 443                           | Port that requests are made to.                                                       |
-| `telemetry`         | `true`                        | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                  |
+| `telemetry`         | `true`                        | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                 |
 
 Note: Both `maxNetworkRetries` and `timeout` can be overridden on a per-request basis.
 

--- a/examples/webhook-signing/typescript-node-express/express-ts.ts
+++ b/examples/webhook-signing/typescript-node-express/express-ts.ts
@@ -7,7 +7,6 @@ env.config();
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
   apiVersion: '2019-12-03',
-  typescript: true,
 });
 
 const webhookSecret: string = process.env.STRIPE_WEBHOOK_SECRET;

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -24,10 +24,10 @@ declare module 'stripe' {
       apiVersion: LatestApiVersion;
 
       /**
-       * Indicate that you are using TypeScript.
+       * Optionally indicate that you are using TypeScript.
        * This currently has no runtime effect other than adding "TypeScript" to your user-agent.
        */
-      typescript: true;
+      typescript?: true;
 
       /**
        * Enables automatic network retries with exponential backoff, up to the specified number of retries (default 0).

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -10,7 +10,6 @@ import Stripe from 'stripe';
 
 let stripe = new Stripe('sk_test_123', {
   apiVersion: '2019-12-03',
-  typescript: true,
 });
 
 // @ts-ignore lazily ignore apiVersion requirement.


### PR DESCRIPTION
r? @richardm-stripe || @ob-stripe 
cc @stripe/api-libraries 

We had added this so that our user-agent would specify whether a request came from TS vs vanilla JS. We use language/runtime information for product planning purposes, but in this case don't anticipate the information being useful enough to justify the annoyance/confusion of an extra param for the user.