### PR TITLE
Rename `sort_code` to `sender_sort_code` on `SourceTransaction` for BACS debit

### DIFF
--- a/types/2019-12-03/SourceTransactions.d.ts
+++ b/types/2019-12-03/SourceTransactions.d.ts
@@ -144,7 +144,7 @@ declare module 'stripe' {
         /**
          * Sender sort code associated with the transfer.
          */
-        sort_code?: string;
+        sender_sort_code?: string;
       }
 
       interface PaperCheck {

--- a/types/2019-12-03/SubscriptionSchedules.d.ts
+++ b/types/2019-12-03/SubscriptionSchedules.d.ts
@@ -781,7 +781,7 @@ declare module 'stripe' {
 
     class SubscriptionSchedulesResource {
       /**
-       * Creates a new subscription schedule object.
+       * Creates a new subscription schedule object. Each customer can have up to 25 active or scheduled subscriptions.
        */
       create(
         params?: SubscriptionScheduleCreateParams,

--- a/types/2019-12-03/Subscriptions.d.ts
+++ b/types/2019-12-03/Subscriptions.d.ts
@@ -340,7 +340,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * A list of up to 25 subscription items, each with an attached plan.
+       * A list of up to 20 subscription items, each with an attached plan.
        */
       items?: Array<SubscriptionCreateParams.Item>;
 
@@ -789,7 +789,7 @@ declare module 'stripe' {
 
     class SubscriptionsResource {
       /**
-       * Creates a new subscription on an existing customer.
+       * Creates a new subscription on an existing customer. Each customer can have up to 25 active or scheduled subscriptions.
        */
       create(
         params: SubscriptionCreateParams,


### PR DESCRIPTION
Codegen for openapi f9f9b8b

r? @ob-stripe 
cc @stripe/api-libraries 
