### PR TITLE
Multiple API changes

### DIFF
--- a/types/2019-12-03/Cards.d.ts
+++ b/types/2019-12-03/Cards.d.ts
@@ -154,7 +154,7 @@ declare module 'stripe' {
       recipient?: string | Stripe.Recipient | null;
 
       /**
-       * If the card number is tokenized, this is the method that was used. Can be `apple_pay` or `google_pay`.
+       * If the card number is tokenized, this is the method that was used. Can be `amex_express_checkout`, `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null.
        */
       tokenization_method: string | null;
     }

--- a/types/2019-12-03/Charges.d.ts
+++ b/types/2019-12-03/Charges.d.ts
@@ -931,7 +931,7 @@ declare module 'stripe' {
           account_holder_type: Fpx.AccountHolderType | null;
 
           /**
-           * The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `cimb`, `bank_islam`, `bank_rakyat`, `bank_muamalat`, `bsn`, `deutsche_bank`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `maybank2e`, `ocbc`, `public_bank`, `pb_enterprise`, `rhb`, `standard_chartered`, `uob`, or `uob_regional`.
+           * The customer's bank. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, `pb_enterprise`, or `uob_regional`.
            */
           bank: Fpx.Bank;
 
@@ -1454,12 +1454,12 @@ declare module 'stripe' {
       amount?: number;
 
       /**
-       * An application fee to add on to this charge. Can only be used with Stripe Connect.
+       * An application fee to add on to this charge.
        */
       application_fee?: number;
 
       /**
-       * An application fee amount to add on to this charge, which must be less than or equal to the original amount. Can only be used with Stripe Connect.
+       * An application fee amount to add on to this charge, which must be less than or equal to the original amount.
        */
       application_fee_amount?: number;
 

--- a/types/2019-12-03/Checkout/Sessions.d.ts
+++ b/types/2019-12-03/Checkout/Sessions.d.ts
@@ -404,6 +404,13 @@ declare module 'stripe' {
           statement_descriptor?: string;
 
           /**
+           * Provides information about the charge that customers see on their statements. Concatenated with the
+           * prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete
+           * statement descriptor. Maximum 22 characters for the concatenated descriptor.
+           */
+          statement_descriptor_suffix?: string;
+
+          /**
            * The parameters used to automatically create a Transfer when the payment succeeds.
            * For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
            */

--- a/types/2019-12-03/CreditNoteLineItems.d.ts
+++ b/types/2019-12-03/CreditNoteLineItems.d.ts
@@ -55,7 +55,7 @@ declare module 'stripe' {
       tax_rates: Array<Stripe.TaxRate>;
 
       /**
-       * The type of the credit note line item, one of `custom_line_item` or `invoice_line_item`. When the type is `invoice_line_item` there is an additional `invoice_line_item` property on the resource the value of which is the id of the credited line item on the invoice.
+       * The type of the credit note line item, one of `invoice_line_item` or `custom_line_item`. When the type is `invoice_line_item` there is an additional `invoice_line_item` property on the resource the value of which is the id of the credited line item on the invoice.
        */
       type: CreditNoteLineItem.Type;
 
@@ -183,7 +183,7 @@ declare module 'stripe' {
         tax_rates?: Array<string> | '';
 
         /**
-         * Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`
+         * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
          */
         type: Line.Type;
 

--- a/types/2019-12-03/CreditNotes.d.ts
+++ b/types/2019-12-03/CreditNotes.d.ts
@@ -118,7 +118,7 @@ declare module 'stripe' {
       total: number;
 
       /**
-       * Type of this credit note, one of `post_payment` or `pre_payment`. A `pre_payment` credit note means it was issued when the invoice was open. A `post_payment` credit note means it was issued when the invoice was paid.
+       * Type of this credit note, one of `pre_payment` or `post_payment`. A `pre_payment` credit note means it was issued when the invoice was open. A `post_payment` credit note means it was issued when the invoice was paid.
        */
       type: CreditNote.Type;
 
@@ -242,7 +242,7 @@ declare module 'stripe' {
         tax_rates?: Array<string> | '';
 
         /**
-         * Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`
+         * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
          */
         type: Line.Type;
 
@@ -394,7 +394,7 @@ declare module 'stripe' {
         tax_rates?: Array<string> | '';
 
         /**
-         * Type of the credit note line item, one of `custom_line_item` or `invoice_line_item`
+         * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
          */
         type: Line.Type;
 

--- a/types/2019-12-03/CustomerBalanceTransactions.d.ts
+++ b/types/2019-12-03/CustomerBalanceTransactions.d.ts
@@ -65,7 +65,7 @@ declare module 'stripe' {
       metadata: Metadata | null;
 
       /**
-       * Transaction type: `adjustment`, `applied_to_invoice`, `credit_note`, `initial`, `invoice_too_large`, `invoice_too_small`, `unapplied_from_invoice`, or `unspent_receiver_credit`. See the [Customer Balance page](https://stripe.com/docs/billing/customer/balance#types) to learn more about transaction types.
+       * Transaction type: `adjustment`, `applied_to_invoice`, `credit_note`, `initial`, `invoice_too_large`, `invoice_too_small`, `unspent_receiver_credit`, or `unapplied_from_invoice`. See the [Customer Balance page](https://stripe.com/docs/billing/customer/balance#types) to learn more about transaction types.
        */
       type: CustomerBalanceTransaction.Type;
     }

--- a/types/2019-12-03/Customers.d.ts
+++ b/types/2019-12-03/Customers.d.ts
@@ -331,7 +331,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`
+         * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`
          */
         type: TaxIdDatum.Type;
 
@@ -345,18 +345,24 @@ declare module 'stripe' {
         type Type =
           | 'au_abn'
           | 'ca_bn'
+          | 'ca_qst'
           | 'ch_vat'
           | 'es_cif'
           | 'eu_vat'
           | 'hk_br'
           | 'in_gst'
+          | 'jp_cn'
+          | 'kr_brn'
+          | 'li_uid'
           | 'mx_rfc'
+          | 'my_itn'
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
           | 'sg_uen'
           | 'th_vat'
           | 'tw_vat'
+          | 'us_ein'
           | 'za_vat';
       }
     }

--- a/types/2019-12-03/Invoices.d.ts
+++ b/types/2019-12-03/Invoices.d.ts
@@ -359,7 +359,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `unknown`, or `za_vat`
+         * The type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -373,12 +373,17 @@ declare module 'stripe' {
         type Type =
           | 'au_abn'
           | 'ca_bn'
+          | 'ca_qst'
           | 'ch_vat'
           | 'es_cif'
           | 'eu_vat'
           | 'hk_br'
           | 'in_gst'
+          | 'jp_cn'
+          | 'kr_brn'
+          | 'li_uid'
           | 'mx_rfc'
+          | 'my_itn'
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
@@ -386,6 +391,7 @@ declare module 'stripe' {
           | 'th_vat'
           | 'tw_vat'
           | 'unknown'
+          | 'us_ein'
           | 'za_vat';
       }
 

--- a/types/2019-12-03/Issuing/Authorizations.d.ts
+++ b/types/2019-12-03/Issuing/Authorizations.d.ts
@@ -225,12 +225,12 @@ declare module 'stripe' {
 
           interface ViolatedAuthorizationControl {
             /**
-             * Entity which the authorization control acts on. One of `account`, `card`, or `cardholder`.
+             * Entity which the authorization control acts on. One of `card`, `cardholder`, or `account`.
              */
             entity: ViolatedAuthorizationControl.Entity;
 
             /**
-             * Name of the authorization control. One of `allowed_categories`, `blocked_categories`, `max_amount`, `max_approvals`, or `spending_limits`.
+             * Name of the authorization control. One of `allowed_categories`, `blocked_categories`, `spending_limits`, `max_approvals`, or `max_amount`.
              */
             name: ViolatedAuthorizationControl.Name;
           }
@@ -261,7 +261,7 @@ declare module 'stripe' {
           address_zip_check: string;
 
           /**
-           * One of `exempt`, `failure`, `none`, or `success`.
+           * One of `success`, `failure`, `exempt`, or `none`.
            */
           authentication: string;
 

--- a/types/2019-12-03/Issuing/Disputes.d.ts
+++ b/types/2019-12-03/Issuing/Disputes.d.ts
@@ -48,12 +48,12 @@ declare module 'stripe' {
         metadata: Metadata;
 
         /**
-         * Reason for this dispute. One of `other` or `fraudulent`.
+         * Reason for this dispute. One of `fraudulent` or `other`.
          */
         reason: string;
 
         /**
-         * Current status of dispute. One of `lost`, `under_review`, `unsubmitted`, or `won`.
+         * Current status of dispute. One of `unsubmitted`, `under_review`, `won`, or `lost`.
          */
         status: Dispute.Status;
       }
@@ -107,7 +107,7 @@ declare module 'stripe' {
         disputed_transaction: string;
 
         /**
-         * The reason for the dispute. One of `other` or `fraudulent`.
+         * The reason for the dispute.
          */
         reason: DisputeCreateParams.Reason;
 

--- a/types/2019-12-03/Mandates.d.ts
+++ b/types/2019-12-03/Mandates.d.ts
@@ -33,12 +33,12 @@ declare module 'stripe' {
       single_use?: Mandate.SingleUse;
 
       /**
-       * The status of the Mandate, one of `active`, `inactive`, or `pending`. The Mandate can be used to initiate a payment only if status=active.
+       * The status of the Mandate, one of `pending`, `inactive`, or `active`. The Mandate can be used to initiate a payment only if status=active.
        */
       status: Mandate.Status;
 
       /**
-       * The type of the mandate, one of `multi_use` or `single_use`
+       * The type of the mandate, one of `single_use` or `multi_use`
        */
       type: Mandate.Type;
     }

--- a/types/2019-12-03/PaymentMethods.d.ts
+++ b/types/2019-12-03/PaymentMethods.d.ts
@@ -273,7 +273,7 @@ declare module 'stripe' {
         account_holder_type: Fpx.AccountHolderType | null;
 
         /**
-         * The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `cimb`, `bank_islam`, `bank_rakyat`, `bank_muamalat`, `bsn`, `deutsche_bank`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `maybank2e`, `ocbc`, `public_bank`, `pb_enterprise`, `rhb`, `standard_chartered`, `uob`, or `uob_regional`.
+         * The customer's bank, if provided. Can be one of `affin_bank`, `alliance_bank`, `ambank`, `bank_islam`, `bank_muamalat`, `bank_rakyat`, `bsn`, `cimb`, `hong_leong_bank`, `hsbc`, `kfh`, `maybank2u`, `ocbc`, `public_bank`, `rhb`, `standard_chartered`, `uob`, `deutsche_bank`, `maybank2e`, `pb_enterprise`, or `uob_regional`.
          */
         bank: Fpx.Bank;
       }

--- a/types/2019-12-03/TaxIds.d.ts
+++ b/types/2019-12-03/TaxIds.d.ts
@@ -37,7 +37,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `za_vat`, or `unknown`
+       * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -53,12 +53,17 @@ declare module 'stripe' {
       type Type =
         | 'au_abn'
         | 'ca_bn'
+        | 'ca_qst'
         | 'ch_vat'
         | 'es_cif'
         | 'eu_vat'
         | 'hk_br'
         | 'in_gst'
+        | 'jp_cn'
+        | 'kr_brn'
+        | 'li_uid'
         | 'mx_rfc'
+        | 'my_itn'
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
@@ -66,11 +71,12 @@ declare module 'stripe' {
         | 'th_vat'
         | 'tw_vat'
         | 'unknown'
+        | 'us_ein'
         | 'za_vat';
 
       interface Verification {
         /**
-         * Verification status, one of `pending`, `unavailable`, `unverified`, or `verified`.
+         * Verification status, one of `pending`, `verified`, `unverified`, or `unavailable`.
          */
         status: Verification.Status;
 
@@ -112,7 +118,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `mx_rfc`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, or `za_vat`
+       * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, or `ca_qst`
        */
       type: TaxIdCreateParams.Type;
 
@@ -131,18 +137,24 @@ declare module 'stripe' {
       type Type =
         | 'au_abn'
         | 'ca_bn'
+        | 'ca_qst'
         | 'ch_vat'
         | 'es_cif'
         | 'eu_vat'
         | 'hk_br'
         | 'in_gst'
+        | 'jp_cn'
+        | 'kr_brn'
+        | 'li_uid'
         | 'mx_rfc'
+        | 'my_itn'
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
         | 'sg_uen'
         | 'th_vat'
         | 'tw_vat'
+        | 'us_ein'
         | 'za_vat';
     }
 

--- a/types/2019-12-03/Tokens.d.ts
+++ b/types/2019-12-03/Tokens.d.ts
@@ -58,7 +58,7 @@ declare module 'stripe' {
       card?: string | TokenCreateParams.Card;
 
       /**
-       * The customer (owned by the application's account) for which to create a token. For use only with [Stripe Connect](https://stripe.com/docs/connect). Also, this can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
+       * The customer (owned by the application's account) for which to create a token. This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).
        */
       customer?: string;
 


### PR DESCRIPTION
Multiple API changes
* Add support for new `type` values for `TaxId`.
* Add support for `payment_intent_data[statement_descriptor_suffix]` on Checkout `Session`.

Codegen for openapi 7562c6b

r? @ob-stripe 
cc @stripe/api-libraries 