### PR TITLE
TS Fixes: arrays of subobjects, emptyStringable fields

### DIFF
--- a/types/2019-12-03/CreditNoteLineItems.d.ts
+++ b/types/2019-12-03/CreditNoteLineItems.d.ts
@@ -180,7 +180,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
 
         /**
          * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`

--- a/types/2019-12-03/CreditNotes.d.ts
+++ b/types/2019-12-03/CreditNotes.d.ts
@@ -239,7 +239,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
 
         /**
          * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
@@ -391,7 +391,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
 
         /**
          * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`

--- a/types/2019-12-03/Customers.d.ts
+++ b/types/2019-12-03/Customers.d.ts
@@ -283,7 +283,7 @@ declare module 'stripe' {
         /**
          * Default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
          */
-        custom_fields?: InvoiceSettings.CustomFields | null;
+        custom_fields?: Array<InvoiceSettings.CustomField> | null;
 
         /**
          * ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices.
@@ -297,7 +297,7 @@ declare module 'stripe' {
       }
 
       namespace InvoiceSettings {
-        interface CustomFields {
+        interface CustomField {
           /**
            * The name of the custom field. This may be up to 30 characters.
            */
@@ -464,7 +464,7 @@ declare module 'stripe' {
         /**
          * Default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
          */
-        custom_fields?: InvoiceSettings.CustomFields | null;
+        custom_fields?: Array<InvoiceSettings.CustomField> | null;
 
         /**
          * ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices.
@@ -478,7 +478,7 @@ declare module 'stripe' {
       }
 
       namespace InvoiceSettings {
-        interface CustomFields {
+        interface CustomField {
           /**
            * The name of the custom field. This may be up to 30 characters.
            */

--- a/types/2019-12-03/Customers.d.ts
+++ b/types/2019-12-03/Customers.d.ts
@@ -204,7 +204,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: AddressParam | '';
+      address?: AddressParam | null;
 
       /**
        * An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
@@ -378,7 +378,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: AddressParam | '';
+      address?: AddressParam | null;
 
       /**
        * An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.

--- a/types/2019-12-03/InvoiceItems.d.ts
+++ b/types/2019-12-03/InvoiceItems.d.ts
@@ -275,7 +275,7 @@ declare module 'stripe' {
       /**
        * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice do not apply to this invoice item. Pass an empty string to remove previously-defined tax rates.
        */
-      tax_rates?: Array<string> | '';
+      tax_rates?: Array<string> | null;
 
       /**
        * The integer unit amount in **%s** of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount.

--- a/types/2019-12-03/InvoiceLineItems.d.ts
+++ b/types/2019-12-03/InvoiceLineItems.d.ts
@@ -172,8 +172,8 @@ declare module 'stripe' {
        * For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`.
        */
       subscription_billing_cycle_anchor?:
-        | number
-        | InvoiceLineItemListUpcomingParams.SubscriptionBillingCycleAnchor;
+        | InvoiceLineItemListUpcomingParams.SubscriptionBillingCycleAnchor
+        | number;
 
       /**
        * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`

--- a/types/2019-12-03/InvoiceLineItems.d.ts
+++ b/types/2019-12-03/InvoiceLineItems.d.ts
@@ -178,7 +178,7 @@ declare module 'stripe' {
       /**
        * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`
        */
-      subscription_cancel_at?: number | '';
+      subscription_cancel_at?: number | null;
 
       /**
        * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -193,7 +193,7 @@ declare module 'stripe' {
       /**
        * If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set.
        */
-      subscription_default_tax_rates?: Array<string> | '';
+      subscription_default_tax_rates?: Array<string> | null;
 
       /**
        * List of subscription items, each with an attached plan.
@@ -284,7 +284,7 @@ declare module 'stripe' {
          */
         quantity?: number;
 
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
 
         /**
          * The integer unit amount in **%s** of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -352,7 +352,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
       }
 
       namespace SubscriptionItem {

--- a/types/2019-12-03/Invoices.d.ts
+++ b/types/2019-12-03/Invoices.d.ts
@@ -850,8 +850,8 @@ declare module 'stripe' {
        * For new subscriptions, a future timestamp to anchor the subscription's [billing cycle](https://stripe.com/docs/subscriptions/billing-cycle). This is used to determine the date of the first full invoice, and, for plans with `month` or `year` intervals, the day of the month for subsequent invoices. For existing subscriptions, the value can only be set to `now` or `unchanged`.
        */
       subscription_billing_cycle_anchor?:
-        | number
-        | InvoiceRetrieveUpcomingParams.SubscriptionBillingCycleAnchor;
+        | InvoiceRetrieveUpcomingParams.SubscriptionBillingCycleAnchor
+        | number;
 
       /**
        * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`

--- a/types/2019-12-03/Invoices.d.ts
+++ b/types/2019-12-03/Invoices.d.ts
@@ -657,7 +657,7 @@ declare module 'stripe' {
       /**
        * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an empty string to remove previously-defined tax rates.
        */
-      default_tax_rates?: Array<string> | '';
+      default_tax_rates?: Array<string> | null;
 
       /**
        * An arbitrary string attached to the object. Often useful for displaying to users. Referenced as 'memo' in the Dashboard.
@@ -692,7 +692,7 @@ declare module 'stripe' {
       /**
        * The percent tax rate applied to the invoice, represented as a non-negative decimal number (with at most four decimal places) between 0 and 100. To unset a previously-set value, pass an empty string. This field can be updated only on `draft` invoices. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
        */
-      tax_percent?: number | '';
+      tax_percent?: number | null;
 
       /**
        * If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge. This will be unset if you POST an empty value.
@@ -856,7 +856,7 @@ declare module 'stripe' {
       /**
        * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`
        */
-      subscription_cancel_at?: number | '';
+      subscription_cancel_at?: number | null;
 
       /**
        * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -871,7 +871,7 @@ declare module 'stripe' {
       /**
        * If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set.
        */
-      subscription_default_tax_rates?: Array<string> | '';
+      subscription_default_tax_rates?: Array<string> | null;
 
       /**
        * List of subscription items, each with an attached plan.
@@ -962,7 +962,7 @@ declare module 'stripe' {
          */
         quantity?: number;
 
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
 
         /**
          * The integer unit amount in **%s** of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -1030,7 +1030,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
       }
 
       namespace SubscriptionItem {

--- a/types/2019-12-03/Invoices.d.ts
+++ b/types/2019-12-03/Invoices.d.ts
@@ -319,18 +319,6 @@ declare module 'stripe' {
 
       type CollectionMethod = 'charge_automatically' | 'send_invoice';
 
-      interface CustomField {
-        /**
-         * The name of the custom field.
-         */
-        name: string;
-
-        /**
-         * The value of the custom field.
-         */
-        value: string;
-      }
-
       interface CustomerShipping {
         address?: Address;
 
@@ -393,6 +381,18 @@ declare module 'stripe' {
           | 'unknown'
           | 'us_ein'
           | 'za_vat';
+      }
+
+      interface CustomField {
+        /**
+         * The name of the custom field.
+         */
+        name: string;
+
+        /**
+         * The value of the custom field.
+         */
+        value: string;
       }
 
       type Status =
@@ -520,7 +520,7 @@ declare module 'stripe' {
       /**
        * A list of up to 4 custom fields to be displayed on the invoice.
        */
-      custom_fields?: InvoiceCreateParams.CustomFields | null;
+      custom_fields?: Array<InvoiceCreateParams.CustomField> | null;
 
       /**
        * The number of days from when the invoice is created until it is due. Valid only for invoices where `collection_method=send_invoice`.
@@ -591,7 +591,7 @@ declare module 'stripe' {
     namespace InvoiceCreateParams {
       type CollectionMethod = 'charge_automatically' | 'send_invoice';
 
-      interface CustomFields {
+      interface CustomField {
         /**
          * The name of the custom field. This may be up to 30 characters.
          */
@@ -637,7 +637,7 @@ declare module 'stripe' {
       /**
        * A list of up to 4 custom fields to be displayed on the invoice. If a value for `custom_fields` is specified, the list specified will replace the existing custom field list on this invoice. Pass an empty string to remove previously-defined fields.
        */
-      custom_fields?: InvoiceUpdateParams.CustomFields | null;
+      custom_fields?: Array<InvoiceUpdateParams.CustomField> | null;
 
       /**
        * The number of days from which the invoice is created until it is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices.
@@ -703,7 +703,7 @@ declare module 'stripe' {
     namespace InvoiceUpdateParams {
       type CollectionMethod = 'charge_automatically' | 'send_invoice';
 
-      interface CustomFields {
+      interface CustomField {
         /**
          * The name of the custom field. This may be up to 30 characters.
          */

--- a/types/2019-12-03/Issuing/Authorizations.d.ts
+++ b/types/2019-12-03/Issuing/Authorizations.d.ts
@@ -288,7 +288,7 @@ declare module 'stripe' {
         /**
          * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | '';
+        metadata?: MetadataParam | null;
       }
 
       interface AuthorizationListParams extends PaginationParams {
@@ -336,7 +336,7 @@ declare module 'stripe' {
         /**
          * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | '';
+        metadata?: MetadataParam | null;
       }
 
       interface AuthorizationDeclineParams {
@@ -348,7 +348,7 @@ declare module 'stripe' {
         /**
          * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | '';
+        metadata?: MetadataParam | null;
       }
 
       class AuthorizationsResource {

--- a/types/2019-12-03/Issuing/Cards.d.ts
+++ b/types/2019-12-03/Issuing/Cards.d.ts
@@ -2174,7 +2174,7 @@ declare module 'stripe' {
         /**
          * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | '';
+        metadata?: MetadataParam | null;
 
         /**
          * Whether authorizations can be approved on this card.

--- a/types/2019-12-03/Issuing/Transactions.d.ts
+++ b/types/2019-12-03/Issuing/Transactions.d.ts
@@ -151,7 +151,7 @@ declare module 'stripe' {
         /**
          * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | '';
+        metadata?: MetadataParam | null;
       }
 
       interface TransactionListParams extends PaginationParams {

--- a/types/2019-12-03/Orders.d.ts
+++ b/types/2019-12-03/Orders.d.ts
@@ -461,11 +461,11 @@ declare module 'stripe' {
       /**
        * List of items to return.
        */
-      items?: OrderReturnOrderParams.Items | null;
+      items?: Array<OrderReturnOrderParams.Item> | null;
     }
 
     namespace OrderReturnOrderParams {
-      interface Items {
+      interface Item {
         /**
          * The amount (price) for this order item to return.
          */
@@ -489,10 +489,10 @@ declare module 'stripe' {
         /**
          * The type of this order item. Must be `sku`, `tax`, or `shipping`.
          */
-        type?: Items.Type;
+        type?: Item.Type;
       }
 
-      namespace Items {
+      namespace Item {
         type Type = 'discount' | 'shipping' | 'sku' | 'tax';
       }
     }

--- a/types/2019-12-03/PaymentIntents.d.ts
+++ b/types/2019-12-03/PaymentIntents.d.ts
@@ -788,7 +788,7 @@ declare module 'stripe' {
       /**
        * The amount of the application fee (if any) for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details.
        */
-      application_fee_amount?: number | '';
+      application_fee_amount?: number | null;
 
       /**
        * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -830,7 +830,7 @@ declare module 'stripe' {
       /**
        * Email address that the receipt for the resulting payment will be sent to.
        */
-      receipt_email?: string | '';
+      receipt_email?: string | null;
 
       /**
        * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer. Defaults to `false`.
@@ -1045,7 +1045,7 @@ declare module 'stripe' {
       /**
        * Email address that the receipt for the resulting payment will be sent to.
        */
-      receipt_email?: string | '';
+      receipt_email?: string | null;
 
       /**
        * The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.

--- a/types/2019-12-03/PaymentIntents.d.ts
+++ b/types/2019-12-03/PaymentIntents.d.ts
@@ -1141,6 +1141,7 @@ declare module 'stripe' {
           type Type = 'offline' | 'online';
         }
       }
+
       interface MandateData2 {
         /**
          * This hash contains details about the customer acceptance of the Mandate.

--- a/types/2019-12-03/PaymentMethods.d.ts
+++ b/types/2019-12-03/PaymentMethods.d.ts
@@ -524,6 +524,7 @@ declare module 'stripe' {
          */
         number: string;
       }
+
       interface Card2 {
         token: string;
       }

--- a/types/2019-12-03/Persons.d.ts
+++ b/types/2019-12-03/Persons.d.ts
@@ -528,7 +528,7 @@ declare module 'stripe' {
         /**
          * The percent owned by the person of the account's legal entity.
          */
-        percent_ownership?: number | '';
+        percent_ownership?: number | null;
 
         /**
          * Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
@@ -763,7 +763,7 @@ declare module 'stripe' {
         /**
          * The percent owned by the person of the account's legal entity.
          */
-        percent_ownership?: number | '';
+        percent_ownership?: number | null;
 
         /**
          * Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.

--- a/types/2019-12-03/Plans.d.ts
+++ b/types/2019-12-03/Plans.d.ts
@@ -243,7 +243,7 @@ declare module 'stripe' {
        */
       nickname?: string;
 
-      product?: string | PlanCreateParams.Product;
+      product?: PlanCreateParams.Product | string;
 
       /**
        * Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.

--- a/types/2019-12-03/Products.d.ts
+++ b/types/2019-12-03/Products.d.ts
@@ -275,7 +275,7 @@ declare module 'stripe' {
       /**
        * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g., `["color", "size"]`). If a value for `attributes` is specified, the list specified will replace the existing attributes list on this product. Any attributes not present after the update will be deleted from the SKUs for this product.
        */
-      attributes?: Array<string> | '';
+      attributes?: Array<string> | null;
 
       /**
        * A short one-line description of the product, meant to be displayable to the customer. May only be set if `type=good`.
@@ -300,7 +300,7 @@ declare module 'stripe' {
       /**
        * A list of up to 8 URLs of images for this product, meant to be displayable to the customer. May only be set if `type=good`.
        */
-      images?: Array<string> | '';
+      images?: Array<string> | null;
 
       /**
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.

--- a/types/2019-12-03/SetupIntents.d.ts
+++ b/types/2019-12-03/SetupIntents.d.ts
@@ -557,6 +557,7 @@ declare module 'stripe' {
           type Type = 'offline' | 'online';
         }
       }
+
       interface MandateData2 {
         /**
          * This hash contains details about the customer acceptance of the Mandate.

--- a/types/2019-12-03/Sources.d.ts
+++ b/types/2019-12-03/Sources.d.ts
@@ -806,7 +806,7 @@ declare module 'stripe' {
         /**
          * The amount specified by the mandate. (Leave null for a mandate covering all amounts)
          */
-        amount?: number | '';
+        amount?: number | null;
 
         /**
          * The currency specified by the mandate. (Must match `currency` of the source)
@@ -1098,7 +1098,7 @@ declare module 'stripe' {
         /**
          * The amount specified by the mandate. (Leave null for a mandate covering all amounts)
          */
-        amount?: number | '';
+        amount?: number | null;
 
         /**
          * The currency specified by the mandate. (Must match `currency` of the source)

--- a/types/2019-12-03/SubscriptionItems.d.ts
+++ b/types/2019-12-03/SubscriptionItems.d.ts
@@ -138,7 +138,7 @@ declare module 'stripe' {
       /**
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
        */
-      tax_rates?: Array<string> | '';
+      tax_rates?: Array<string> | null;
     }
 
     namespace SubscriptionItemCreateParams {
@@ -224,7 +224,7 @@ declare module 'stripe' {
       /**
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
        */
-      tax_rates?: Array<string> | '';
+      tax_rates?: Array<string> | null;
     }
 
     namespace SubscriptionItemUpdateParams {

--- a/types/2019-12-03/SubscriptionSchedules.d.ts
+++ b/types/2019-12-03/SubscriptionSchedules.d.ts
@@ -406,7 +406,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        default_tax_rates?: Array<string> | '';
+        default_tax_rates?: Array<string> | null;
 
         /**
          * The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
@@ -485,7 +485,7 @@ declare module 'stripe' {
           /**
            * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
            */
-          tax_rates?: Array<string> | '';
+          tax_rates?: Array<string> | null;
         }
 
         namespace Plan {
@@ -615,7 +615,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        default_tax_rates?: Array<string> | '';
+        default_tax_rates?: Array<string> | null;
 
         /**
          * The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
@@ -699,7 +699,7 @@ declare module 'stripe' {
           /**
            * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
            */
-          tax_rates?: Array<string> | '';
+          tax_rates?: Array<string> | null;
         }
 
         namespace Plan {

--- a/types/2019-12-03/Subscriptions.d.ts
+++ b/types/2019-12-03/Subscriptions.d.ts
@@ -332,7 +332,7 @@ declare module 'stripe' {
       /**
        * The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription.
        */
-      default_tax_rates?: Array<string> | '';
+      default_tax_rates?: Array<string> | null;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -381,7 +381,7 @@ declare module 'stripe' {
       /**
        * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
        */
-      tax_percent?: number | '';
+      tax_percent?: number | null;
 
       /**
        * If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges. This will be unset if you POST an empty value.
@@ -443,7 +443,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
       }
 
       namespace Item {
@@ -512,7 +512,7 @@ declare module 'stripe' {
       /**
        * A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
        */
-      cancel_at?: number | '';
+      cancel_at?: number | null;
 
       /**
        * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -547,7 +547,7 @@ declare module 'stripe' {
       /**
        * The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. Pass an empty string to remove previously-defined tax rates.
        */
-      default_tax_rates?: Array<string> | '';
+      default_tax_rates?: Array<string> | null;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -603,7 +603,7 @@ declare module 'stripe' {
       /**
        * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
        */
-      tax_percent?: number | '';
+      tax_percent?: number | null;
 
       /**
        * If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges. This will be unset if you POST an empty value.
@@ -677,7 +677,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | '';
+        tax_rates?: Array<string> | null;
       }
 
       namespace Item {

--- a/types/2019-12-03/Tokens.d.ts
+++ b/types/2019-12-03/Tokens.d.ts
@@ -307,7 +307,7 @@ declare module 'stripe' {
           /**
            * The percent owned by the person of the account's legal entity.
            */
-          percent_ownership?: number | '';
+          percent_ownership?: number | null;
 
           /**
            * Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.

--- a/types/2019-12-03/Tokens.d.ts
+++ b/types/2019-12-03/Tokens.d.ts
@@ -55,7 +55,7 @@ declare module 'stripe' {
        */
       bank_account?: string | TokenCreateParams.BankAccount;
 
-      card?: string | TokenCreateParams.Card;
+      card?: TokenCreateParams.Card | string;
 
       /**
        * The customer (owned by the application's account) for which to create a token. This can be used only with an [OAuth access token](https://stripe.com/docs/connect/standard-accounts) or [Stripe-Account header](https://stripe.com/docs/connect/authentication). For more details, see [Cloning Saved Payment Methods](https://stripe.com/docs/connect/cloning-saved-payment-methods).


### PR DESCRIPTION
r? @ob-stripe 
cc @jlomas-stripe @stripe/api-libraries 
1. More consistently encode "emptyStringable" types (described in the openapi spec as `anyOf(X, enum([''])`) as `X | null` instead of `X | ''`.
2. Fixes issue #766
3. A little bit of churn re: ordering of things because of codegen changes.