### PR TITLE
Multiple API changes reflect in Typescript definitions

### DIFF
--- a/types/2019-12-03/Balance.d.ts
+++ b/types/2019-12-03/Balance.d.ts
@@ -56,6 +56,11 @@ declare module 'stripe' {
            * Amount for card.
            */
           card?: number;
+
+          /**
+           * Amount for FPX.
+           */
+          fpx?: number;
         }
       }
 
@@ -84,6 +89,11 @@ declare module 'stripe' {
            * Amount for card.
            */
           card?: number;
+
+          /**
+           * Amount for FPX.
+           */
+          fpx?: number;
         }
       }
 
@@ -112,6 +122,11 @@ declare module 'stripe' {
            * Amount for card.
            */
           card?: number;
+
+          /**
+           * Amount for FPX.
+           */
+          fpx?: number;
         }
       }
     }

--- a/types/2019-12-03/Checkout/Sessions.d.ts
+++ b/types/2019-12-03/Checkout/Sessions.d.ts
@@ -460,7 +460,7 @@ declare module 'stripe' {
           }
         }
 
-        type PaymentMethodType = 'card' | 'ideal';
+        type PaymentMethodType = 'card' | 'fpx' | 'ideal';
 
         interface SetupIntentData {
           /**

--- a/types/2019-12-03/Issuing/Authorizations.d.ts
+++ b/types/2019-12-03/Issuing/Authorizations.d.ts
@@ -251,24 +251,34 @@ declare module 'stripe' {
 
         interface VerificationData {
           /**
-           * Whether the cardholder provided an address first line and if it matched the cardholder's `billing.address.line1`. One of `match`, `mismatch`, or `not_provided`.
+           * Whether the cardholder provided an address first line and if it matched the cardholder's `billing.address.line1`.
            */
-          address_line1_check: string;
+          address_line1_check: VerificationData.AddressLine1Check;
 
           /**
-           * Whether the cardholder provided a zip (or postal code) and if it matched the cardholder's `billing.address.postal_code`. One of `match`, `mismatch`, or `not_provided`.
+           * Whether the cardholder provided a zip (or postal code) and if it matched the cardholder's `billing.address.postal_code`.
            */
-          address_zip_check: string;
+          address_zip_check: VerificationData.AddressZipCheck;
 
           /**
-           * One of `success`, `failure`, `exempt`, or `none`.
+           * Whether 3DS authentication was performed.
            */
-          authentication: string;
+          authentication: VerificationData.Authentication;
 
           /**
-           * Whether the cardholder provided a CVC and if it matched Stripe's record. One of `match`, `mismatch`, or `not_provided`.
+           * Whether the cardholder provided a CVC and if it matched Stripe's record.
            */
-          cvc_check: string;
+          cvc_check: VerificationData.CvcCheck;
+        }
+
+        namespace VerificationData {
+          type AddressLine1Check = 'match' | 'mismatch' | 'not_provided';
+
+          type AddressZipCheck = 'match' | 'mismatch' | 'not_provided';
+
+          type Authentication = 'failure' | 'none' | 'success';
+
+          type CvcCheck = 'match' | 'mismatch' | 'not_provided';
         }
       }
 

--- a/types/2019-12-03/PaymentIntents.d.ts
+++ b/types/2019-12-03/PaymentIntents.d.ts
@@ -823,6 +823,11 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * Payment-method-specific configuration for this PaymentIntent.
+       */
+      payment_method_options?: PaymentIntentUpdateParams.PaymentMethodOptions;
+
+      /**
        * The list of payment method types (e.g. card) that this PaymentIntent is allowed to use.
        */
       payment_method_types?: Array<string>;
@@ -886,6 +891,75 @@ declare module 'stripe' {
     }
 
     namespace PaymentIntentUpdateParams {
+      interface PaymentMethodOptions {
+        /**
+         * Configuration for any card payments attempted on this PaymentIntent.
+         */
+        card?: PaymentMethodOptions.Card;
+      }
+
+      namespace PaymentMethodOptions {
+        interface Card {
+          /**
+           * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
+           *
+           * For more information, see the [installments integration guide](https://stripe.com/docs/payments/installments).
+           */
+          installments?: Card.Installments;
+
+          /**
+           * When specified, this parameter indicates that a transaction will be marked
+           * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
+           * parameter can only be provided during confirmation.
+           */
+          moto?: boolean;
+
+          /**
+           * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
+           */
+          request_three_d_secure?: Card.RequestThreeDSecure;
+        }
+
+        namespace Card {
+          interface Installments {
+            /**
+             * Setting to true enables installments for this PaymentIntent.
+             * This will cause the response to contain a list of available installment plans.
+             * Setting to false will prevent any selected plan from applying to a charge.
+             */
+            enabled?: boolean;
+
+            /**
+             * The selected installment plan to use for this payment attempt.
+             * This parameter can only be provided during confirmation.
+             */
+            plan?: Installments.Plan | null;
+          }
+
+          namespace Installments {
+            interface Plan {
+              /**
+               * For `fixed_count` installment plans, this is the number of installment payments your customer will make to their credit card.
+               */
+              count: number;
+
+              /**
+               * For `fixed_count` installment plans, this is the interval between installment payments your customer will make to their credit card.
+               * One of `month`.
+               */
+              interval: 'month';
+
+              /**
+               * Type of installment plan, one of `fixed_count`.
+               */
+              type: 'fixed_count';
+            }
+          }
+
+          type RequestThreeDSecure = 'any' | 'automatic';
+        }
+      }
+
       type SetupFutureUsage = 'off_session' | 'on_session';
 
       interface Shipping {

--- a/types/2019-12-03/PaymentMethods.d.ts
+++ b/types/2019-12-03/PaymentMethods.d.ts
@@ -56,10 +56,19 @@ declare module 'stripe' {
 
     namespace PaymentMethod {
       interface AuBecsDebit {
+        /**
+         * Six-digit number identifying bank and branch associated with this bank account.
+         */
         bsb_number: string | null;
 
+        /**
+         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+         */
         fingerprint: string | null;
 
+        /**
+         * Last four digits of the bank account number.
+         */
         last4: string | null;
       }
 
@@ -385,7 +394,7 @@ declare module 'stripe' {
 
     interface PaymentMethodCreateParams {
       /**
-       * If this is a `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+       * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
        */
       au_becs_debit?: PaymentMethodCreateParams.AuBecsDebit;
 
@@ -730,7 +739,7 @@ declare module 'stripe' {
     }
 
     namespace PaymentMethodListParams {
-      type Type = 'card' | 'card_present' | 'ideal' | 'sepa_debit';
+      type Type = 'card' | 'card_present' | 'fpx' | 'ideal' | 'sepa_debit';
     }
 
     interface PaymentMethodAttachParams {

--- a/types/2019-12-03/Payouts.d.ts
+++ b/types/2019-12-03/Payouts.d.ts
@@ -91,7 +91,7 @@ declare module 'stripe' {
       method: string;
 
       /**
-       * The source balance this payout came from. One of `card` or `bank_account`.
+       * The source balance this payout came from. One of `card`, `fpx`, or `bank_account`.
        */
       source_type: string;
 
@@ -152,7 +152,7 @@ declare module 'stripe' {
       method?: PayoutCreateParams.Method;
 
       /**
-       * The balance type of your Stripe balance to draw this payout from. Balances for different payment sources are kept separately. You can find the amounts with the balances API. One of `bank_account` or `card`.
+       * The balance type of your Stripe balance to draw this payout from. Balances for different payment sources are kept separately. You can find the amounts with the balances API. One of `bank_account`, `card`, or `fpx`.
        */
       source_type?: PayoutCreateParams.SourceType;
 
@@ -165,7 +165,7 @@ declare module 'stripe' {
     namespace PayoutCreateParams {
       type Method = 'instant' | 'standard';
 
-      type SourceType = 'bank_account' | 'card';
+      type SourceType = 'bank_account' | 'card' | 'fpx';
     }
 
     interface PayoutRetrieveParams {

--- a/types/2019-12-03/Plans.d.ts
+++ b/types/2019-12-03/Plans.d.ts
@@ -20,7 +20,7 @@ declare module 'stripe' {
       active: boolean;
 
       /**
-       * Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for picking the last usage record reported within a period, `last_ever` for picking the last usage record ever (across period bounds) or `max` which picks the usage record with the maximum reported usage during a period. Defaults to `sum`.
+       * Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
        */
       aggregate_usage: Plan.AggregateUsage | null;
 
@@ -52,12 +52,12 @@ declare module 'stripe' {
       deleted?: void;
 
       /**
-       * One of `day`, `week`, `month` or `year`. The frequency with which a subscription should be billed.
+       * The frequency at which a subscription is billed. One of `day`, `week`, `month` or `year`.
        */
       interval: Plan.Interval;
 
       /**
-       * The number of intervals (specified in the `interval` property) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.
+       * The number of intervals (specified in the `interval` attribute) between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months.
        */
       interval_count: number;
 
@@ -87,12 +87,12 @@ declare module 'stripe' {
       tiers: Array<Plan.Tier> | null;
 
       /**
-       * Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price, in `graduated` tiering pricing can successively change as the quantity grows.
+       * Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.
        */
       tiers_mode: Plan.TiersMode | null;
 
       /**
-       * Apply a transformation to the reported usage or set quantity before computing the billed price. Cannot be combined with `tiers`.
+       * Apply a transformation to the reported usage or set quantity before computing the amount billed. Cannot be combined with `tiers`.
        */
       transform_usage: Plan.TransformUsage | null;
 
@@ -102,7 +102,7 @@ declare module 'stripe' {
       trial_period_days: number | null;
 
       /**
-       * Configures how the quantity per period should be determined, can be either `metered` or `licensed`. `licensed` will automatically bill the `quantity` set when adding it to a subscription, `metered` will aggregate the total usage based on usage records. Defaults to `licensed`.
+       * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
        */
       usage_type: Plan.UsageType;
     }
@@ -199,7 +199,7 @@ declare module 'stripe' {
       active?: boolean;
 
       /**
-       * Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for picking the last usage record reported within a period, `last_ever` for picking the last usage record ever (across period bounds) or `max` which picks the usage record with the maximum reported usage during a period. Defaults to `sum`.
+       * Specifies a usage aggregation strategy for plans of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
        */
       aggregate_usage?: PlanCreateParams.AggregateUsage;
 
@@ -266,7 +266,7 @@ declare module 'stripe' {
       trial_period_days?: number;
 
       /**
-       * Configures how the quantity per period should be determined, can be either `metered` or `licensed`. `licensed` will automatically bill the `quantity` set for a plan when adding it to a subscription, `metered` will aggregate the total usage based on usage records. Defaults to `licensed`.
+       * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
        */
       usage_type?: PlanCreateParams.UsageType;
     }

--- a/types/2019-12-03/SetupIntents.d.ts
+++ b/types/2019-12-03/SetupIntents.d.ts
@@ -431,9 +431,43 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * Payment-method-specific configuration for this SetupIntent.
+       */
+      payment_method_options?: SetupIntentUpdateParams.PaymentMethodOptions;
+
+      /**
        * The list of payment method types (e.g. card) that this SetupIntent is allowed to set up. If this is not provided, defaults to ["card"].
        */
       payment_method_types?: Array<string>;
+    }
+
+    namespace SetupIntentUpdateParams {
+      interface PaymentMethodOptions {
+        /**
+         * Configuration for any card setup attempted on this SetupIntent.
+         */
+        card?: PaymentMethodOptions.Card;
+      }
+
+      namespace PaymentMethodOptions {
+        interface Card {
+          /**
+           * When specified, this parameter signals that a card has been collected
+           * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
+           * parameter can only be provided during confirmation.
+           */
+          moto?: boolean;
+
+          /**
+           * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
+           */
+          request_three_d_secure?: Card.RequestThreeDSecure;
+        }
+
+        namespace Card {
+          type RequestThreeDSecure = 'any' | 'automatic';
+        }
+      }
     }
 
     interface SetupIntentListParams extends PaginationParams {

--- a/types/2019-12-03/Transfers.d.ts
+++ b/types/2019-12-03/Transfers.d.ts
@@ -80,7 +80,7 @@ declare module 'stripe' {
       source_transaction: string | Stripe.Charge | null;
 
       /**
-       * The source balance this transfer came from. One of `card` or `bank_account`.
+       * The source balance this transfer came from. One of `card`, `fpx`, or `bank_account`.
        */
       source_type: string | null;
 
@@ -127,7 +127,7 @@ declare module 'stripe' {
       source_transaction?: string;
 
       /**
-       * The source balance to use for this transfer. One of `bank_account` or `card`. For most users, this will default to `card`.
+       * The source balance to use for this transfer. One of `bank_account`, `card`, or `fpx`. For most users, this will default to `card`.
        */
       source_type?: TransferCreateParams.SourceType;
 
@@ -138,7 +138,7 @@ declare module 'stripe' {
     }
 
     namespace TransferCreateParams {
-      type SourceType = 'bank_account' | 'card';
+      type SourceType = 'bank_account' | 'card' | 'fpx';
     }
 
     interface TransferRetrieveParams {


### PR DESCRIPTION
Multiple API changes reflected in Typescript definitions
* Add `fpx` as a valid `source_type` on `Balance`, `Payout` and `Transfer`
* Add `fpx` support on Checkout `Session`
* Fields inside `verification_data` on Issuing `Authorization` are now enums
* Support updating `payment_method_options` on `PaymentIntent` and `SetupIntent`

Codegen for openapi 9f798bd

r? @ob-stripe 
cc @stripe/api-libraries 