### PR TITLE
Add support for `payment_intent_data[transfer_data][amount]` on Checkout `Session`

### DIFF
--- a/types/2019-12-03/Checkout/Sessions.d.ts
+++ b/types/2019-12-03/Checkout/Sessions.d.ts
@@ -451,6 +451,11 @@ declare module 'stripe' {
 
           interface TransferData {
             /**
+             * The amount that will be transferred automatically when a charge succeeds.
+             */
+            amount?: number;
+
+            /**
              * If specified, successful charges will be attributed to the destination
              * account for tax reporting, and the funds from charges will be transferred
              * to the destination account. The ID of the resulting transfer will be

--- a/types/2019-12-03/PaymentIntents.d.ts
+++ b/types/2019-12-03/PaymentIntents.d.ts
@@ -473,7 +473,7 @@ declare module 'stripe' {
       description?: string;
 
       /**
-       * Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`. This parameter is intended for simpler integrations that do not handle customer actions. This can only be set when `confirm=true` is supplied.
+       * Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`. This parameter is intended for simpler integrations that do not handle customer actions, like [saving cards without authentication](https://stripe.com/docs/payments/save-card-without-authentication). This parameter can only be used with [`confirm=true`](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-confirm).
        */
       error_on_requires_action?: boolean;
 
@@ -1080,7 +1080,7 @@ declare module 'stripe' {
 
     interface PaymentIntentConfirmParams {
       /**
-       * Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`. This parameter is intended for simpler integrations that do not handle customer actions.
+       * Set to `true` to fail the payment attempt if the PaymentIntent transitions into `requires_action`. This parameter is intended for simpler integrations that do not handle customer actions, like [saving cards without authentication](https://stripe.com/docs/payments/save-card-without-authentication).
        */
       error_on_requires_action?: boolean;
 


### PR DESCRIPTION
Codegen for openapi 277f09c

r? @ob-stripe 
cc @stripe/api-libraries 