### PR TITLE
Change timeout default to constant 80000 instead Node default

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,15 +165,15 @@ const stripe = Stripe('sk_test_...', {
 });
 ```
 
-| Option              | Default                       | Description                                                                           |
-| ------------------- | ----------------------------- | ------------------------------------------------------------------------------------- |
-| `apiVersion`        | `null`                        | Stripe API version to be used. If not set the account's default version will be used. |
-| `maxNetworkRetries` | 0                             | The amount of times a request should be [retried](#network-retries).                  |
-| `httpAgent`         | `null`                        | [Proxy](#configuring-a-proxy) agent to be used by the library.                        |
-| `timeout`           | 120000 (Node default timeout) | [Maximum time each request can take in ms.](#configuring-timeout)                     |
-| `host`              | `'api.stripe.com'`            | Host that requests are made to.                                                       |
-| `port`              | 443                           | Port that requests are made to.                                                       |
-| `telemetry`         | `true`                        | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                 |
+| Option              | Default            | Description                                                                           |
+| ------------------- | ------------------ | ------------------------------------------------------------------------------------- |
+| `apiVersion`        | `null`             | Stripe API version to be used. If not set the account's default version will be used. |
+| `maxNetworkRetries` | 0                  | The amount of times a request should be [retried](#network-retries).                  |
+| `httpAgent`         | `null`             | [Proxy](#configuring-a-proxy) agent to be used by the library.                        |
+| `timeout`           | 80000              | [Maximum time each request can take in ms.](#configuring-timeout)                     |
+| `host`              | `'api.stripe.com'` | Host that requests are made to.                                                       |
+| `port`              | 443                | Port that requests are made to.                                                       |
+| `telemetry`         | `true`             | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                 |
 
 Note: Both `maxNetworkRetries` and `timeout` can be overridden on a per-request basis.
 

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -7,8 +7,7 @@ const DEFAULT_PORT = '443';
 const DEFAULT_BASE_PATH = '/v1/';
 const DEFAULT_API_VERSION = null;
 
-// Use node's default timeout:
-const DEFAULT_TIMEOUT = require('http').createServer().timeout;
+const DEFAULT_TIMEOUT = 80000;
 
 Stripe.PACKAGE_VERSION = require('../package.json').version;
 

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -7,8 +7,6 @@ const utils = require('../lib/utils');
 const Stripe = require('../lib/stripe');
 const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), 'latest');
 
-const http = require('http');
-
 const expect = require('chai').expect;
 
 const CUSTOMER_DETAILS = {
@@ -208,10 +206,9 @@ describe('Stripe Module', function() {
   });
 
   describe('setTimeout', () => {
-    it('Should define a default equal to the node default', () => {
-      expect(stripe.getApiField('timeout')).to.equal(
-        http.createServer().timeout
-      );
+    const defaultTimeout = 80000;
+    it('Should define a default of 80000', () => {
+      expect(stripe.getApiField('timeout')).to.equal(defaultTimeout);
     });
     it('Should allow me to set a custom timeout', () => {
       stripe.setTimeout(900);
@@ -219,9 +216,7 @@ describe('Stripe Module', function() {
     });
     it('Should allow me to set null, to reset to the default', () => {
       stripe.setTimeout(null);
-      expect(stripe.getApiField('timeout')).to.equal(
-        http.createServer().timeout
-      );
+      expect(stripe.getApiField('timeout')).to.equal(defaultTimeout);
     });
   });
 

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -44,7 +44,7 @@ declare module 'stripe' {
 
       /**
        * Request timeout in milliseconds.
-       * The default is Node's default of 120 seconds.
+       * The default is 80000
        */
       timeout?: number;
 


### PR DESCRIPTION
Closes #806 

Set `timeout` default to a constant 80 seconds instead of using the default value of the version of Node.js the user is running.

Updated tests, docs, comment in types def file.

**Note**: Not sure how you define breaking changes here, but this would be a departure from the previous default behavior of 120 seconds. This issue is currently out in the wild though (for anyone _\*brave\*_ enough to be using v13 in production) so I would suggest a release as soon as feasible. 

Switching this back to a constant 120 seconds and a minor version bump would prevent anyone from encountering the issue in the current major.