### PR TITLE
Improve args check to support optional params for makeRequest

### DIFF
--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -33,7 +33,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   const options = utils.getOptionsFromArgs(args);
 
   // Validate that there are no more args.
-  if (args.length) {
+  if (args.filter((x) => x != null).length) {
     throw new Error(
       `Stripe: Unknown arguments (${args}). Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options. (on API request to ${requestMethod} \`${path}\`)`
     );

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -77,6 +77,28 @@ describe('StripeResource', () => {
         });
       });
 
+      it('works correctly with undefined optional arguments', (done) => {
+        const scope = nock(`https://${stripe.getConstant('DEFAULT_HOST')}`)
+          .get('/v1/accounts/acct_123')
+          .reply(200, '{}');
+
+        realStripe.accounts.retrieve('acct_123', undefined, (err, response) => {
+          done(err);
+          scope.done();
+        });
+      });
+
+      it('works correctly with null optional arguments', (done) => {
+        const scope = nock(`https://${stripe.getConstant('DEFAULT_HOST')}`)
+          .get('/v1/accounts/acct_123')
+          .reply(200, '{}');
+
+        realStripe.accounts.retrieve('acct_123', null, (err, response) => {
+          done(err);
+          scope.done();
+        });
+      });
+
       it('encodes data for DELETE requests as query params', (done) => {
         const data = {
           foo: 'bar',


### PR DESCRIPTION
I ran out of time trying to write an automated test for this. I'm not familiar with this nock tooling and was able to get past the root error and my basic test passing locally. Also, didn't see a compact helper so just used this filter.

This is to address #825 

```
(async () => {
  const id = 'acct_1GBs7XDllkSPMYqA';
  const account = await stripe.accounts.retrieve(id)
  console.log(account)
  const account2 = await stripe.accounts.retrieve(id, undefined)
  console.log(account2)
})();
```


r? @rattrayalex-stripe 
cc @stripe/api-libraries 

