### PR TITLE
Add support for `ThreeDSecure` on Issuing `Authorization`

### DIFF
--- a/types/2020-03-02/Issuing/Authorizations.d.ts
+++ b/types/2020-03-02/Issuing/Authorizations.d.ts
@@ -266,9 +266,9 @@ declare module 'stripe' {
           address_zip_check: VerificationData.AddressZipCheck;
 
           /**
-           * Whether 3DS authentication was performed.
+           * [DEPRECATED] Whether 3DS authentication was performed.
            */
-          authentication: VerificationData.Authentication;
+          authentication?: VerificationData.Authentication;
 
           /**
            * Whether the cardholder provided a CVC and if it matched Stripe's record.
@@ -279,6 +279,11 @@ declare module 'stripe' {
            * Whether the cardholder provided an expiry date and if it matched Stripe's record.
            */
           expiry_check: VerificationData.ExpiryCheck;
+
+          /**
+           * 3D Secure details on this authorization.
+           */
+          three_d_secure: VerificationData.ThreeDSecure | null;
         }
 
         namespace VerificationData {
@@ -291,6 +296,17 @@ declare module 'stripe' {
           type CvcCheck = 'match' | 'mismatch' | 'not_provided';
 
           type ExpiryCheck = 'match' | 'mismatch' | 'not_provided';
+
+          interface ThreeDSecure {
+            /**
+             * The outcome of the 3D Secure authentication request.
+             */
+            result: ThreeDSecure.Result;
+          }
+
+          namespace ThreeDSecure {
+            type Result = 'attempt_acknowledged' | 'authenticated' | 'failed';
+          }
         }
       }
 

--- a/types/2020-03-02/Issuing/Disputes.d.ts
+++ b/types/2020-03-02/Issuing/Disputes.d.ts
@@ -277,12 +277,12 @@ declare module 'stripe' {
 
       interface DisputeListParams extends PaginationParams {
         /**
-         * Only return issuing disputes that were created during the given date interval.
+         * Select issuing disputes that were created during the given date interval.
          */
         created?: RangeQueryParam | number;
 
         /**
-         * Only return issuing disputes for the given transaction.
+         * Select the issuing dispute for the given transaction.
          */
         disputed_transaction?: string;
 

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -257,7 +257,7 @@ declare module 'stripe' {
          * throughout its lifetime as it interfaces with Stripe.js to perform
          * authentication flows and ultimately creates at most one successful charge.
          *
-         * Related guide: [Payment Intents API](https://stripe.com/docs/payments/payment-intents/creating-payment-intents).
+         * Related guide: [Payment Intents API](https://stripe.com/docs/payments/payment-intents).
          */
         payment_intent?: Stripe.PaymentIntent;
 
@@ -287,6 +287,8 @@ declare module 'stripe' {
          *
          * By using SetupIntents, you ensure that your customers experience the minimum set of required friction,
          * even as regulations change over time.
+         *
+         * Related guide: [Setup Intents API](https://stripe.com/docs/payments/setup-intents).
          */
         setup_intent?: Stripe.SetupIntent;
 

--- a/types/2020-03-02/Plans.d.ts
+++ b/types/2020-03-02/Plans.d.ts
@@ -37,7 +37,7 @@ declare module 'stripe' {
       /**
        * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
        */
-      billing_scheme: Plan.BillingScheme | null;
+      billing_scheme: Plan.BillingScheme;
 
       /**
        * Time at which the object was created. Measured in seconds since the Unix epoch.

--- a/types/2020-03-02/Products.d.ts
+++ b/types/2020-03-02/Products.d.ts
@@ -47,7 +47,7 @@ declare module 'stripe' {
       description: string | null;
 
       /**
-       * A list of up to 8 URLs of images for this product, meant to be displayable to the customer. Only applicable to products of `type=good`.
+       * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
        */
       images: Array<string>;
 

--- a/types/2020-03-02/SetupIntents.d.ts
+++ b/types/2020-03-02/SetupIntents.d.ts
@@ -159,7 +159,7 @@ declare module 'stripe' {
          * throughout its lifetime as it interfaces with Stripe.js to perform
          * authentication flows and ultimately creates at most one successful charge.
          *
-         * Related guide: [Payment Intents API](https://stripe.com/docs/payments/payment-intents/creating-payment-intents).
+         * Related guide: [Payment Intents API](https://stripe.com/docs/payments/payment-intents).
          */
         payment_intent?: Stripe.PaymentIntent;
 
@@ -189,6 +189,8 @@ declare module 'stripe' {
          *
          * By using SetupIntents, you ensure that your customers experience the minimum set of required friction,
          * even as regulations change over time.
+         *
+         * Related guide: [Setup Intents API](https://stripe.com/docs/payments/setup-intents).
          */
         setup_intent?: Stripe.SetupIntent;
 


### PR DESCRIPTION
Codegen for openapi f8c0941

Docs: https://stripe.com/docs/api/issuing/authorizations/object#issuing_authorization_object-verification_data-three_d_secure

r? @ob-stripe 
cc @stripe/api-libraries 