### PR TITLE
Multiple API changes for Issuing and other docstrings

### DIFF
--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -17,7 +17,7 @@ declare module 'stripe' {
       alternate_statement_descriptors?: Charge.AlternateStatementDescriptors;
 
       /**
-       * Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+       * Amount intended to be collected by this payment. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
        */
       amount: number;
 
@@ -710,12 +710,12 @@ declare module 'stripe' {
             /**
              * Whether or not authentication was performed. 3D Secure will succeed without authentication when the card is not enrolled.
              */
-            authenticated: boolean;
+            authenticated?: boolean;
 
             /**
              * Whether or not 3D Secure succeeded.
              */
-            succeeded: boolean;
+            succeeded?: boolean;
 
             /**
              * The version of 3D Secure that was used for this payment.
@@ -1196,7 +1196,7 @@ declare module 'stripe' {
 
     interface ChargeCreateParams {
       /**
-       * Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+       * Amount intended to be collected by this payment. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
        */
       amount?: number;
 

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -518,12 +518,10 @@ declare module 'stripe' {
         client_reference_id?: string;
 
         /**
-         * ID of an existing customer, if one exists. Only supported for Checkout
-         * Sessions in `payment` or `subscription` mode, but not Checkout Sessions
-         * in `setup` mode. The email stored on the customer will be used to prefill
-         * the email field on the Checkout page. If the customer changes their email
-         * on the Checkout page, the Customer object will be updated with the new
-         * email.
+         * ID of an existing customer, if one exists. The email stored on the
+         * customer will be used to prefill the email field on the Checkout page.
+         * If the customer changes their email on the Checkout page, the Customer
+         * object will be updated with the new email.
          * If blank for Checkout Sessions in `payment` or `subscription` mode,
          * Checkout will create a new customer object based on information
          * provided during the session.
@@ -610,7 +608,7 @@ declare module 'stripe' {
           currency?: string;
 
           /**
-           * The description for the line item.
+           * The description for the line item, to be displayed on the Checkout page.
            */
           description?: string;
 
@@ -694,7 +692,7 @@ declare module 'stripe' {
           /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
            *
-           * If present, the payment method used with this PaymentIntent can be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the transaction completes.
+           * Providing this parameter will attach the payment method to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
            *
            * For more, learn to [save card details during payment](https://stripe.com/docs/payments/save-during-payment).
            *

--- a/types/2020-03-02/IssuerFraudRecords.d.ts
+++ b/types/2020-03-02/IssuerFraudRecords.d.ts
@@ -35,7 +35,7 @@ declare module 'stripe' {
       fraud_type: string;
 
       /**
-       * If true, the associated charge is subject to [liability shift](https://stripe.com/docs/sources/three-d-secure#disputed-payments).
+       * If true, the associated charge is subject to [liability shift](https://stripe.com/docs/payments/3d-secure#disputed-payments).
        */
       has_liability_shift: boolean;
 

--- a/types/2020-03-02/Issuing/Authorizations.d.ts
+++ b/types/2020-03-02/Issuing/Authorizations.d.ts
@@ -16,6 +16,11 @@ declare module 'stripe' {
         object: 'issuing.authorization';
 
         /**
+         * The total amount in the card's currency that was authorized or rejected.
+         */
+        amount: number;
+
+        /**
          * Whether the authorization has been approved.
          */
         approved: boolean;
@@ -28,12 +33,12 @@ declare module 'stripe' {
         /**
          * The amount that has been authorized. This will be `0` when the object is created, and increase after it has been approved.
          */
-        authorized_amount: number;
+        authorized_amount?: number;
 
         /**
          * The currency that was presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
          */
-        authorized_currency: string;
+        authorized_currency?: string;
 
         /**
          * List of balance transactions associated with this authorization.
@@ -56,24 +61,39 @@ declare module 'stripe' {
         created: number;
 
         /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        currency: string;
+
+        /**
          * The amount the authorization is expected to be in `held_currency`. When Stripe holds funds from you, this is the amount reserved for the authorization. This will be `0` when the object is created, and increase after it has been approved. For multi-currency transactions, `held_amount` can be used to determine the expected exchange rate.
          */
-        held_amount: number;
+        held_amount?: number;
 
         /**
          * The currency of the [held amount](https://stripe.com/docs/api#issuing_authorization_object-held_amount). This will always be the card currency.
          */
-        held_currency: string;
+        held_currency?: string;
 
         /**
          * If set `true`, you may provide [held_amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-held_amount) to control how much to hold for the authorization.
          */
-        is_held_amount_controllable: boolean;
+        is_held_amount_controllable?: boolean;
 
         /**
          * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
          */
         livemode: boolean;
+
+        /**
+         * The total amount that was authorized or rejected in the local merchant_currency.
+         */
+        merchant_amount: number;
+
+        /**
+         * The currency that was presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        merchant_currency: string;
 
         merchant_data: Authorization.MerchantData;
 
@@ -85,15 +105,20 @@ declare module 'stripe' {
         /**
          * The amount the user is requesting to be authorized. This field will only be non-zero during an `issuing.authorization.request` webhook.
          */
-        pending_authorized_amount: number;
+        pending_authorized_amount?: number;
 
         /**
          * The additional amount Stripe will hold if the authorization is approved. This field will only be non-zero during an `issuing.authorization.request` webhook.
          */
-        pending_held_amount: number;
+        pending_held_amount?: number;
 
         /**
-         * History of every time the authorization was approved/denied (whether approved/denied by you directly, or by Stripe based on your authorization_controls). If the merchant changes the authorization by performing an [incremental authorization or partial capture](https://stripe.com/docs/issuing/authorizations/special_scenarios#incremental-authorizations), you can look at request_history to see the previous states of the authorization.
+         * The pending authorization request. This field will only be non-null during an `issuing.authorization.request` webhook.
+         */
+        pending_request: Authorization.PendingRequest | null;
+
+        /**
+         * History of every time the authorization was approved/denied (whether approved/denied by you directly, or by Stripe based on your authorization_controls). If the merchant changes the authorization by performing an [incremental authorization or partial capture](https://stripe.com/docs/issuing/purchases/authorizations), you can look at request_history to see the previous states of the authorization.
          */
         request_history: Array<Authorization.RequestHistory>;
 
@@ -170,7 +195,39 @@ declare module 'stripe' {
           url: string | null;
         }
 
+        interface PendingRequest {
+          /**
+           * The additional amount Stripe will hold if the authorization is approved, in the [currency](https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency), which is always the card's currency.
+           */
+          amount: number;
+
+          /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency: string;
+
+          /**
+           * If set `true`, you may provide [amount](https://stripe.com/docs/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization.
+           */
+          is_amount_controllable: boolean;
+
+          /**
+           * The amount the merchant is requesting to be authorized in the `merchant_currency`.
+           */
+          merchant_amount: number;
+
+          /**
+           * The local currency the merchant is requesting to authorize.
+           */
+          merchant_currency: string;
+        }
+
         interface RequestHistory {
+          /**
+           * The amount of the authorization is your card's currency. Stripe held this amount from your account to fund the authorization, if the request was approved
+           */
+          amount: number;
+
           /**
            * Whether this request was approved.
            */
@@ -179,12 +236,12 @@ declare module 'stripe' {
           /**
            * The amount that was authorized at the time of this request
            */
-          authorized_amount: number;
+          authorized_amount?: number;
 
           /**
            * The currency that was presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
            */
-          authorized_currency: string;
+          authorized_currency?: string;
 
           /**
            * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -192,14 +249,29 @@ declare module 'stripe' {
           created: number;
 
           /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency: string;
+
+          /**
            * The amount Stripe held from your account to fund the authorization, if the request was approved
            */
-          held_amount: number;
+          held_amount?: number;
 
           /**
            * The currency of the [held amount](https://stripe.com/docs/api#issuing_authorization_object-held_amount)
            */
-          held_currency: string;
+          held_currency?: string;
+
+          /**
+           * The amount that was authorized at the time of this request
+           */
+          merchant_amount: number;
+
+          /**
+           * The currency that was collected by the merchant and presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          merchant_currency: string;
 
           /**
            * The reason for the approval or decline.
@@ -373,6 +445,11 @@ declare module 'stripe' {
       }
 
       interface AuthorizationApproveParams {
+        /**
+         * If the authorization's `pending_request.is_amount_controllable` property is `true`, you may provide this value to control how much to hold for the authorization. Must be positive (use [`decline`](https://stripe.com/docs/api/issuing/authorizations/decline) to decline an authorization request).
+         */
+        amount?: number;
+
         /**
          * Specifies which fields in the response should be expanded.
          */

--- a/types/2020-03-02/Issuing/Cardholders.d.ts
+++ b/types/2020-03-02/Issuing/Cardholders.d.ts
@@ -16,7 +16,7 @@ declare module 'stripe' {
         object: 'issuing.cardholder';
 
         /**
-         * Spending rules that give you some control over how this cardholder's cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/authorizations) documentation for more details.
+         * Spending rules that give you some control over how this cardholder's cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
          */
         authorization_controls: Cardholder.AuthorizationControls | null;
 
@@ -1130,7 +1130,7 @@ declare module 'stripe' {
         type: CardholderCreateParams.Type;
 
         /**
-         * Spending rules that give you control over how your cardholders can make charges. Refer to our [authorizations](https://stripe.com/docs/issuing/authorizations) documentation for more details.
+         * Spending rules that give you control over how your cardholders can make charges. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
          */
         authorization_controls?: CardholderCreateParams.AuthorizationControls;
 
@@ -2221,7 +2221,7 @@ declare module 'stripe' {
 
       interface CardholderUpdateParams {
         /**
-         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/authorizations) documentation for more details.
+         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
          */
         authorization_controls?: CardholderUpdateParams.AuthorizationControls;
 

--- a/types/2020-03-02/Issuing/Cards.d.ts
+++ b/types/2020-03-02/Issuing/Cards.d.ts
@@ -73,6 +73,11 @@ declare module 'stripe' {
         pin: Card.Pin | null;
 
         /**
+         * The latest card that replaces this card, if any.
+         */
+        replaced_by: string | Stripe.Issuing.Card | null;
+
+        /**
          * The card this card replaces, if any.
          */
         replacement_for: string | Stripe.Issuing.Card | null;
@@ -1131,7 +1136,7 @@ declare module 'stripe' {
         type: CardCreateParams.Type;
 
         /**
-         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/authorizations) documentation for more details.
+         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
          */
         authorization_controls?: CardCreateParams.AuthorizationControls;
 
@@ -2176,7 +2181,7 @@ declare module 'stripe' {
 
       interface CardUpdateParams {
         /**
-         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/authorizations) documentation for more details.
+         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
          */
         authorization_controls?: CardUpdateParams.AuthorizationControls;
 
@@ -3227,7 +3232,7 @@ declare module 'stripe' {
         list(options?: RequestOptions): ApiListPromise<Stripe.Issuing.Card>;
 
         /**
-         * For virtual cards only. Retrieves an Issuing card_details object that contains [the sensitive details](https://stripe.com/docs/issuing/cards/management#virtual-card-info) of a virtual card.
+         * For virtual cards only. Retrieves an Issuing card_details object that contains [the sensitive details](https://stripe.com/docs/issuing/cards/virtual#virtual-card-info) of a virtual card.
          */
         retrieveDetails(
           id: string,

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -83,7 +83,9 @@ declare module 'stripe' {
       /**
        * ID of the Customer this PaymentIntent belongs to, if one exists.
        *
-       * If present, payment methods used with this PaymentIntent can only be attached to this Customer, and payment methods attached to other Customers cannot be used with this PaymentIntent.
+       * Payment methods attached to other Customers cannot be used with this PaymentIntent.
+       *
+       * If present in combination with [setup_future_usage](https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage), this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent has been confirmed and any required actions from the user are complete.
        */
       customer: string | Stripe.Customer | Stripe.DeletedCustomer | null;
 
@@ -150,7 +152,7 @@ declare module 'stripe' {
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
-       * If present, the payment method used with this PaymentIntent can be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the transaction completes.
+       * Providing this parameter will attach the payment method to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
        *
        * For more, learn to [save card details during payment](https://stripe.com/docs/payments/save-during-payment).
        *
@@ -271,8 +273,8 @@ declare module 'stripe' {
         payment_method?: Stripe.PaymentMethod;
 
         /**
-         * A SetupIntent guides you through the process of setting up a customer's payment credentials for future payments.
-         * For example, you could use a SetupIntent to set up your customer's card without immediately collecting a payment.
+         * A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.
+         * For example, you could use a SetupIntent to set up and save your customer's card without immediately collecting a payment.
          * Later, you can use [PaymentIntents](https://stripe.com/docs/api#payment_intents) to drive the payment flow.
          *
          * Create a SetupIntent as soon as you're ready to collect your customer's payment credentials.
@@ -284,6 +286,10 @@ declare module 'stripe' {
          * For example, cardholders in [certain regions](https://stripe.com/guides/strong-customer-authentication) may need to be run through
          * [Strong Customer Authentication](https://stripe.com/docs/strong-customer-authentication) at the time of payment method collection
          * in order to streamline later [off-session payments](https://stripe.com/docs/payments/setup-intents).
+         * If the SetupIntent is used with a [Customer](https://stripe.com/docs/api#setup_intents/object#setup_intent_object-customer), upon success,
+         * it will automatically attach the resulting payment method to that Customer.
+         * We recommend using SetupIntents or [setup_future_usage](https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage) on
+         * PaymentIntents to save payment methods in order to prevent saving invalid or unoptimized payment methods.
          *
          * By using SetupIntents, you ensure that your customers experience the minimum set of required friction,
          * even as regulations change over time.
@@ -503,7 +509,9 @@ declare module 'stripe' {
       /**
        * ID of the Customer this PaymentIntent belongs to, if one exists.
        *
-       * If present, payment methods used with this PaymentIntent can only be attached to this Customer, and payment methods attached to other Customers cannot be used with this PaymentIntent.
+       * Payment methods attached to other Customers cannot be used with this PaymentIntent.
+       *
+       * If present in combination with [setup_future_usage](https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage), this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent has been confirmed and any required actions from the user are complete.
        */
       customer?: string;
 
@@ -575,18 +583,18 @@ declare module 'stripe' {
       return_url?: string;
 
       /**
-       * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer. Defaults to `false`.
+       * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer immediately.
        *
-       * If the payment method is already saved to a customer, this does nothing. If this type of payment method cannot be saved to a customer, the request will error.
+       * If the payment method is already saved to a customer, this parameter does nothing. If this type of payment method cannot be saved to a customer, the request will error.
        *
-       * _Note that saving a payment method using this parameter does not guarantee that the payment method can be charged._ To ensure that only payment methods which can be charged are saved to a customer, you can [manually save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method in response to the [`payment_intent.succeeded` webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
+       * Saving a payment method using this parameter is _not recommended_ because it will save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure that only payment methods which are likely to be chargeable are saved to a customer, use the (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage] property, which saves the payment method after the PaymentIntent has been confirmed and all required actions by the customer are complete.
        */
       save_payment_method?: boolean;
 
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
-       * If present, the payment method used with this PaymentIntent can be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the transaction completes.
+       * Providing this parameter will attach the payment method to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
        *
        * For more, learn to [save card details during payment](https://stripe.com/docs/payments/save-during-payment).
        *
@@ -838,7 +846,9 @@ declare module 'stripe' {
       /**
        * ID of the Customer this PaymentIntent belongs to, if one exists.
        *
-       * If present, payment methods used with this PaymentIntent can only be attached to this Customer, and payment methods attached to other Customers cannot be used with this PaymentIntent.
+       * Payment methods attached to other Customers cannot be used with this PaymentIntent.
+       *
+       * If present in combination with [setup_future_usage](https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage), this PaymentIntent's payment method will be attached to the Customer after the PaymentIntent has been confirmed and any required actions from the user are complete.
        */
       customer?: string;
 
@@ -878,20 +888,20 @@ declare module 'stripe' {
       receipt_email?: string | null;
 
       /**
-       * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer. Defaults to `false`.
+       * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer immediately.
        *
-       * If the payment method is already saved to a customer, this does nothing. If this type of payment method cannot be saved to a customer, the request will error.
+       * If the payment method is already saved to a customer, this parameter does nothing. If this type of payment method cannot be saved to a customer, the request will error.
        *
-       * _Note that saving a payment method using this parameter does not guarantee that the payment method can be charged._ To ensure that only payment methods which can be charged are saved to a customer, you can [manually save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method in response to the [`payment_intent.succeeded` webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
+       * Saving a payment method using this parameter is _not recommended_ because it will save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure that only payment methods which are likely to be chargeable are saved to a customer, use the (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage] property, which saves the payment method after the PaymentIntent has been confirmed and all required actions by the customer are complete.
        */
       save_payment_method?: boolean;
 
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
-       * If present, the payment method used with this PaymentIntent can be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the transaction completes.
+       * Providing this parameter will attach the payment method to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
        *
-       * Use `on_session` if you intend to only reuse the payment method when your customer is present in your checkout flow. Use `off_session` if your customer may or may not be in your checkout flow.
+       * For more, learn to [save card details during payment](https://stripe.com/docs/payments/save-during-payment).
        *
        * Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules. For example, if your customer is impacted by [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will ensure that they are authenticated while processing this PaymentIntent. You will then be able to collect [off-session payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards) for this customer.
        *
@@ -1169,20 +1179,20 @@ declare module 'stripe' {
       return_url?: string;
 
       /**
-       * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer. Defaults to `false`.
+       * If the PaymentIntent has a `payment_method` and a `customer` or if you're attaching a payment method to the PaymentIntent in this request, you can pass `save_payment_method=true` to save the payment method to the customer immediately.
        *
-       * If the payment method is already saved to a customer, this does nothing. If this type of payment method cannot be saved to a customer, the request will error.
+       * If the payment method is already saved to a customer, this parameter does nothing. If this type of payment method cannot be saved to a customer, the request will error.
        *
-       * _Note that saving a payment method using this parameter does not guarantee that the payment method can be charged._ To ensure that only payment methods which can be charged are saved to a customer, you can [manually save](https://stripe.com/docs/api/customers/create#create_customer-source) the payment method in response to the [`payment_intent.succeeded` webhook](https://stripe.com/docs/api/events/types#event_types-payment_intent.succeeded).
+       * Saving a payment method using this parameter is _not recommended_ because it will save the payment method even if it cannot be charged (e.g. the user made a typo). To ensure that only payment methods which are likely to be chargeable are saved to a customer, use the (setup_future_usage)[#payment_intents/object#payment_intent_object-setup_future_usage] property, which saves the payment method after the PaymentIntent has been confirmed and all required actions by the customer are complete.
        */
       save_payment_method?: boolean;
 
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
        *
-       * If present, the payment method used with this PaymentIntent can be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer, even after the transaction completes.
+       * Providing this parameter will attach the payment method to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
        *
-       * Use `on_session` if you intend to only reuse the payment method when your customer is present in your checkout flow. Use `off_session` if your customer may or may not be in your checkout flow.
+       * For more, learn to [save card details during payment](https://stripe.com/docs/payments/save-during-payment).
        *
        * Stripe uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules. For example, if your customer is impacted by [SCA](https://stripe.com/docs/strong-customer-authentication), using `off_session` will ensure that they are authenticated while processing this PaymentIntent. You will then be able to collect [off-session payments](https://stripe.com/docs/payments/cards/charging-saved-cards#off-session-payments-with-saved-cards) for this customer.
        *

--- a/types/2020-03-02/SetupIntents.d.ts
+++ b/types/2020-03-02/SetupIntents.d.ts
@@ -39,7 +39,7 @@ declare module 'stripe' {
       /**
        * ID of the Customer this SetupIntent belongs to, if one exists.
        *
-       * If present, payment methods used with this SetupIntent can only be attached to this Customer, and payment methods attached to other Customers cannot be used with this SetupIntent.
+       * If present, the SetupIntent's payment method will be attached to the Customer on successful setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
        */
       customer: string | Stripe.Customer | Stripe.DeletedCustomer | null;
 
@@ -173,8 +173,8 @@ declare module 'stripe' {
         payment_method?: Stripe.PaymentMethod;
 
         /**
-         * A SetupIntent guides you through the process of setting up a customer's payment credentials for future payments.
-         * For example, you could use a SetupIntent to set up your customer's card without immediately collecting a payment.
+         * A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.
+         * For example, you could use a SetupIntent to set up and save your customer's card without immediately collecting a payment.
          * Later, you can use [PaymentIntents](https://stripe.com/docs/api#payment_intents) to drive the payment flow.
          *
          * Create a SetupIntent as soon as you're ready to collect your customer's payment credentials.
@@ -186,6 +186,10 @@ declare module 'stripe' {
          * For example, cardholders in [certain regions](https://stripe.com/guides/strong-customer-authentication) may need to be run through
          * [Strong Customer Authentication](https://stripe.com/docs/strong-customer-authentication) at the time of payment method collection
          * in order to streamline later [off-session payments](https://stripe.com/docs/payments/setup-intents).
+         * If the SetupIntent is used with a [Customer](https://stripe.com/docs/api#setup_intents/object#setup_intent_object-customer), upon success,
+         * it will automatically attach the resulting payment method to that Customer.
+         * We recommend using SetupIntents or [setup_future_usage](https://stripe.com/docs/api#payment_intents/object#payment_intent_object-setup_future_usage) on
+         * PaymentIntents to save payment methods in order to prevent saving invalid or unoptimized payment methods.
          *
          * By using SetupIntents, you ensure that your customers experience the minimum set of required friction,
          * even as regulations change over time.
@@ -278,7 +282,7 @@ declare module 'stripe' {
       /**
        * ID of the Customer this SetupIntent belongs to, if one exists.
        *
-       * If present, payment methods used with this SetupIntent can only be attached to this Customer, and payment methods attached to other Customers cannot be used with this SetupIntent.
+       * If present, the SetupIntent's payment method will be attached to the Customer on successful setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
        */
       customer?: string;
 
@@ -417,7 +421,7 @@ declare module 'stripe' {
 
       interface SingleUse {
         /**
-         * Amount intended to be collected by this PaymentIntent. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+         * Amount the customer is granting permission to collect later. A positive integer representing how much to charge in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
          */
         amount: number;
 
@@ -446,7 +450,7 @@ declare module 'stripe' {
       /**
        * ID of the Customer this SetupIntent belongs to, if one exists.
        *
-       * If present, payment methods used with this SetupIntent can only be attached to this Customer, and payment methods attached to other Customers cannot be used with this SetupIntent.
+       * If present, the SetupIntent's payment method will be attached to the Customer on successful setup. Payment methods attached to other Customers cannot be used with this SetupIntent.
        */
       customer?: string;
 


### PR DESCRIPTION
Multiple API changes for Issuing:
  * Add `amount`, `currency`, `merchant_amount` and `merchant_currency` on `Authorization`
  * Add `amount`, `currency`, `merchant_amount` and `merchant_currency` inside `request_history` on `Authorization`
  * Add `pending_request` on `Authorization`
  * Add `amount` when approving an `Authorization`
  * Add `replaced_by` on `Card`.

Codegen for openapi 033c40a

r? @ob-stripe 
cc @stripe/api-libraries 