### PR TITLE
Proposal: Add enum values to Javascript resources

### DIFF
--- a/lib/resources/PaymentIntents.js
+++ b/lib/resources/PaymentIntents.js
@@ -22,4 +22,27 @@ module.exports = StripeResource.extend({
     method: 'POST',
     path: '/{intent}/confirm',
   }),
+
+  constants: {
+    cancellation_reason: {
+      abandoned: 'abandoned',
+      automatic: 'automatic',
+      duplicate: 'duplicate',
+      failed_invoice: 'failed_invoice',
+      fraudulent: 'fraudulent',
+      requested_by_customer: 'requested_by_customer',
+      void_invoice: 'void_invoice',
+    },
+    last_payment_error: {
+      type: {
+        api_connection_error: 'api_connection_error',
+        api_error: 'api_error',
+        authentication_error: 'authentication_error',
+        card_error: 'card_error',
+        idempotency_error: 'idempotency_error',
+        invalid_request_error: 'invalid_request_error',
+        rate_limit_error: 'rate_limit_error',
+      },
+    },
+  },
 });

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -1529,6 +1529,13 @@ declare module 'stripe' {
         id: string,
         options?: RequestOptions
       ): Promise<Stripe.PaymentIntent>;
+
+      constants: {
+        cancellation_reason: {[K in PaymentIntent.CancellationReason]: K};
+        last_payment_error: {
+          type: {[K in PaymentIntent.LastPaymentError.Type]: K};
+        };
+      };
     }
   }
 }


### PR DESCRIPTION
This is an approach to solving #541
cc @stripe/api-libraries @ob
Wanted to get feedback before proceeding to codegen.

Usage: 

When making requests, instead of
```js
stripe.paymentIntents.cancel('pi_xxx', {
  cancellation_reason: 'duplicate'
}
```
this permits
```js
stripe.paymentIntents.cancel('pi_xxx', {
  cancellation_reason: s.paymentIntents.constants.cancellation_reason.duplicate
})
```

When handling responses, instead of 
```js
if (pi.cancellation_reason === 'duplicate') {
  // do something
}
```

do

```js
if (pi.cancellation_reason === s.paymentIntents.constants.cancellation_reason.duplicate) {
  // do something
}
```

**Q: Why?**
Some users stylistically prefer to avoid "magic strings". I think this is less important in the world of Typescript, since typescript has string literal types, but not all users use typescript.

In theory this gives you the ability to autocomplete the enum values
![image](https://user-images.githubusercontent.com/52928443/78370472-b0338f00-7594-11ea-8453-40d55c5f3054.png)

I don't think we should use the constants in the documentation, but we can provide them.

**Q: How you handle differences between method-level and resource-level enums**
I propose that we *only* define enums at the resource level, and don't namespace anything per-method like we do in the typescript definitions. The enums at the resource level will include all enum entries, defined on the resource or in any of the resource's methods.

