### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -153,7 +153,7 @@ declare module 'stripe' {
       /**
        * ID of the PaymentIntent associated with this charge, if one exists.
        */
-      payment_intent: string | null;
+      payment_intent: string | Stripe.PaymentIntent | null;
 
       /**
        * ID of the payment method used in this charge.
@@ -178,7 +178,7 @@ declare module 'stripe' {
       /**
        * This is the URL to view the receipt for this charge. The receipt is kept up-to-date to the latest state of the charge, including any refunds. If the charge is for an Invoice, the receipt will be stylized as an Invoice receipt.
        */
-      receipt_url: string;
+      receipt_url: string | null;
 
       /**
        * Whether the charge has been fully refunded. If the charge is only partially refunded, this attribute will still be false.

--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -341,7 +341,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, or `my_sst`
+         * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
          */
         type: TaxIdDatum.Type;
 
@@ -370,6 +370,7 @@ declare module 'stripe' {
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
+          | 'sg_gst'
           | 'sg_uen'
           | 'th_vat'
           | 'tw_vat'

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -301,7 +301,7 @@ declare module 'stripe' {
       transfer_data?: Invoice.TransferData | null;
 
       /**
-       * The time at which webhooks for this invoice were successfully delivered (if the invoice had no webhooks to deliver, this will match `created`). Invoice payment is delayed until webhooks are delivered, or until all webhook delivery attempts have been exhausted.
+       * Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created.
        */
       webhooks_delivered_at: number | null;
     }
@@ -347,7 +347,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -376,6 +376,7 @@ declare module 'stripe' {
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
+          | 'sg_gst'
           | 'sg_uen'
           | 'th_vat'
           | 'tw_vat'
@@ -471,7 +472,7 @@ declare module 'stripe' {
 
       interface TransferData {
         /**
-         * The account (if any) where funds from the payment will be transferred to upon payment success.
+         * The account where funds from the payment will be transferred to upon payment success.
          */
         destination: string | Stripe.Account;
       }
@@ -584,7 +585,7 @@ declare module 'stripe' {
       tax_percent?: number;
 
       /**
-       * If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge. This will be unset if you POST an empty value.
+       * If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge.
        */
       transfer_data?: InvoiceCreateParams.TransferData;
     }

--- a/types/2020-03-02/Issuing/Authorizations.d.ts
+++ b/types/2020-03-02/Issuing/Authorizations.d.ts
@@ -16,7 +16,7 @@ declare module 'stripe' {
         object: 'issuing.authorization';
 
         /**
-         * The total amount in the card's currency that was authorized or rejected.
+         * The total amount that was authorized or rejected. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
          */
         amount: number;
 
@@ -86,7 +86,7 @@ declare module 'stripe' {
         livemode: boolean;
 
         /**
-         * The total amount that was authorized or rejected in the local merchant_currency.
+         * The total amount that was authorized or rejected. This amount is in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
          */
         merchant_amount: number;
 
@@ -197,7 +197,7 @@ declare module 'stripe' {
 
         interface PendingRequest {
           /**
-           * The additional amount Stripe will hold if the authorization is approved, in the [currency](https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency), which is always the card's currency.
+           * The additional amount Stripe will hold if the authorization is approved, in the card's [currency](https://stripe.com/docs/api#issuing_authorization_object-pending-request-currency) and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
            */
           amount: number;
 
@@ -212,7 +212,7 @@ declare module 'stripe' {
           is_amount_controllable: boolean;
 
           /**
-           * The amount the merchant is requesting to be authorized in the `merchant_currency`.
+           * The amount the merchant is requesting to be authorized in the `merchant_currency`. The amount is in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
            */
           merchant_amount: number;
 
@@ -224,7 +224,7 @@ declare module 'stripe' {
 
         interface RequestHistory {
           /**
-           * The amount of the authorization in your card's currency. Stripe held this amount from your account to fund the authorization, if the request was approved.
+           * The authorization amount in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
            */
           amount: number;
 
@@ -264,7 +264,7 @@ declare module 'stripe' {
           held_currency?: string;
 
           /**
-           * The amount that was authorized at the time of this request.
+           * The amount that was authorized at the time of this request. This amount is in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
            */
           merchant_amount: number;
 
@@ -516,7 +516,7 @@ declare module 'stripe' {
         ): ApiListPromise<Stripe.Issuing.Authorization>;
 
         /**
-         * Approves a pending Issuing Authorization object.
+         * Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
          */
         approve(
           id: string,
@@ -529,7 +529,7 @@ declare module 'stripe' {
         ): Promise<Stripe.Issuing.Authorization>;
 
         /**
-         * Declines a pending Issuing Authorization object.
+         * Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
          */
         decline(
           id: string,

--- a/types/2020-03-02/Issuing/Cardholders.d.ts
+++ b/types/2020-03-02/Issuing/Cardholders.d.ts
@@ -1096,7 +1096,7 @@ declare module 'stripe' {
           disabled_reason: Requirements.DisabledReason | null;
 
           /**
-           * If not empty, this field contains the list of fields that need to be collected in order to verify and re-enabled the cardholder.
+           * Array of fields that need to be collected in order to verify and re-enable the cardholder.
            */
           past_due: Array<Requirements.PastDue> | null;
         }
@@ -1105,6 +1105,7 @@ declare module 'stripe' {
           type DisabledReason = 'listed' | 'rejected.listed' | 'under_review';
 
           type PastDue =
+            | 'business_entity.tax_id'
             | 'individual.dob.day'
             | 'individual.dob.month'
             | 'individual.dob.year'

--- a/types/2020-03-02/Issuing/Cards.d.ts
+++ b/types/2020-03-02/Issuing/Cards.d.ts
@@ -23,6 +23,11 @@ declare module 'stripe' {
         brand: string;
 
         /**
+         * The reason why the card was canceled.
+         */
+        cancellation_reason: Card.CancellationReason | null;
+
+        /**
          * An Issuing `Cardholder` object represents an individual or business entity who is [issued](https://stripe.com/docs/issuing) cards.
          *
          * Related guide: [How to create a Cardholder](https://stripe.com/docs/issuing/cards#create-cardholder)
@@ -1043,6 +1048,8 @@ declare module 'stripe' {
           }
         }
 
+        type CancellationReason = 'lost' | 'stolen';
+
         interface Pin {
           /**
            * Wether the PIN will be accepted or not.
@@ -1054,7 +1061,15 @@ declare module 'stripe' {
           type Status = 'active' | 'blocked';
         }
 
-        type ReplacementReason = 'damage' | 'expiration' | 'loss' | 'theft';
+        type ReplacementReason =
+          | 'damage'
+          | 'damaged'
+          | 'expiration'
+          | 'expired'
+          | 'loss'
+          | 'lost'
+          | 'stolen'
+          | 'theft';
 
         interface Shipping {
           address: Address;
@@ -3038,7 +3053,15 @@ declare module 'stripe' {
           }
         }
 
-        type ReplacementReason = 'damage' | 'expiration' | 'loss' | 'theft';
+        type ReplacementReason =
+          | 'damage'
+          | 'damaged'
+          | 'expiration'
+          | 'expired'
+          | 'loss'
+          | 'lost'
+          | 'stolen'
+          | 'theft';
 
         interface Shipping {
           /**
@@ -4047,6 +4070,11 @@ declare module 'stripe' {
         authorization_controls?: CardUpdateParams.AuthorizationControls;
 
         /**
+         * Reason why the `status` of this card is `canceled`.
+         */
+        cancellation_reason?: CardUpdateParams.CancellationReason;
+
+        /**
          * Specifies which fields in the response should be expanded.
          */
         expand?: Array<string>;
@@ -4062,7 +4090,7 @@ declare module 'stripe' {
         spending_controls?: CardUpdateParams.SpendingControls;
 
         /**
-         * Whether authorizations can be approved on this card.
+         * Dictates whether authorizations can be approved on this card. If this card is being canceled because it was lost or stolen, this information should be provided as `cancellation_reason`.
          */
         status?: CardUpdateParams.Status;
       }
@@ -4988,6 +5016,8 @@ declare module 'stripe' {
               | 'yearly';
           }
         }
+
+        type CancellationReason = 'lost' | 'stolen';
 
         interface SpendingControls {
           /**

--- a/types/2020-03-02/Issuing/Transactions.d.ts
+++ b/types/2020-03-02/Issuing/Transactions.d.ts
@@ -16,7 +16,7 @@ declare module 'stripe' {
         object: 'issuing.transaction';
 
         /**
-         * The amount of this transaction in your currency. This is the amount that your balance will be updated by.
+         * The transaction amount, which will be reflected in your balance. This amount is in your currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
          */
         amount: number;
 
@@ -61,7 +61,7 @@ declare module 'stripe' {
         livemode: boolean;
 
         /**
-         * The amount that the merchant will receive, denominated in `merchant_currency`. It will be different from `amount` if the merchant is taking payment in a different currency.
+         * The amount that the merchant will receive, denominated in `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). It will be different from `amount` if the merchant is taking payment in a different currency.
          */
         merchant_amount: number;
 

--- a/types/2020-03-02/Mandates.d.ts
+++ b/types/2020-03-02/Mandates.d.ts
@@ -33,12 +33,12 @@ declare module 'stripe' {
       single_use?: Mandate.SingleUse;
 
       /**
-       * The status of the Mandate, one of `pending`, `inactive`, or `active`. The Mandate can be used to initiate a payment only if status=active.
+       * The status of the mandate, which indicates whether it can be used to initiate a payment.
        */
       status: Mandate.Status;
 
       /**
-       * The type of the mandate, one of `single_use` or `multi_use`
+       * The type of the mandate.
        */
       type: Mandate.Type;
     }

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -815,6 +815,12 @@ declare module 'stripe' {
       /**
        * Attaches a PaymentMethod object to a Customer.
        *
+       * To attach a new PaymentMethod to a customer for future payments, we recommend you use a [SetupIntent](https://stripe.com/docs/api/setup_intents)
+       * or a PaymentIntent with [setup_future_usage](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-setup_future_usage).
+       * These approaches will perform any necessary steps to ensure that the PaymentMethod can be used in a future payment. Using the
+       * /v1/payment_methods/:id/attach endpoint does not ensure that future payments can be made with the attached PaymentMethod.
+       * See [Optimizing cards for future payments](https://stripe.com/docs/payments/payment-intents#future-usage) for more information about setting up future payments.
+       *
        * To use this PaymentMethod as the default for invoice or subscription payments,
        * set [invoice_settings.default_payment_method](https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method),
        * on the Customer to the PaymentMethod's ID.

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -334,7 +334,7 @@ declare module 'stripe' {
       phases?: Array<SubscriptionScheduleCreateParams.Phase>;
 
       /**
-       * When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on. When you backdate, the `billing_cycle_anchor` of the subscription is equivalent to the `start_date`.
+       * When the subscription schedule starts. We recommend using `now` so that it starts the subscription immediately. You can also use a Unix timestamp to backdate the subscription so that it starts on a past date, or set a future date for the subscription to start on.
        */
       start_date?: number | 'now';
     }
@@ -414,7 +414,7 @@ declare module 'stripe' {
         default_payment_method?: string;
 
         /**
-         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase. When updating, pass an empty string to remove previously-defined tax rates.
+         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
          */
         default_tax_rates?: Array<string> | null;
 
@@ -638,7 +638,7 @@ declare module 'stripe' {
         default_payment_method?: string;
 
         /**
-         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase. When updating, pass an empty string to remove previously-defined tax rates.
+         * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
          */
         default_tax_rates?: Array<string> | null;
 

--- a/types/2020-03-02/Subscriptions.d.ts
+++ b/types/2020-03-02/Subscriptions.d.ts
@@ -283,7 +283,7 @@ declare module 'stripe' {
 
       interface TransferData {
         /**
-         * The account (if any) where funds from the payment will be transferred to upon payment success.
+         * The account where funds from the payment will be transferred to upon payment success.
          */
         destination: string | Stripe.Account;
       }
@@ -407,7 +407,7 @@ declare module 'stripe' {
       tax_percent?: number | null;
 
       /**
-       * If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges. This will be unset if you POST an empty value.
+       * If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges.
        */
       transfer_data?: SubscriptionCreateParams.TransferData;
 

--- a/types/2020-03-02/TaxIds.d.ts
+++ b/types/2020-03-02/TaxIds.d.ts
@@ -37,7 +37,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ca_qst`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ca_qst`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -68,6 +68,7 @@ declare module 'stripe' {
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
+        | 'sg_gst'
         | 'sg_uen'
         | 'th_vat'
         | 'tw_vat'
@@ -119,7 +120,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, or `my_sst`
+       * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
        */
       type: TaxIdCreateParams.Type;
 
@@ -153,6 +154,7 @@ declare module 'stripe' {
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
+        | 'sg_gst'
         | 'sg_uen'
         | 'th_vat'
         | 'tw_vat'


### PR DESCRIPTION
Multiple API changes:
  * Make `payment_intent` expandable on `Charge`
  * Add support for `sg_gst` as a value for `type` on `TaxId` and related APIs
  * Add `cancellation_reason` and new enum values for `replacement_reason` on Issuing `Card`

Codegen for openapi 83431de

r? @ob-stripe 
cc @stripe/api-libraries 