### PR TITLE
Add support for `settings[branding][secondary_color]` on `Account`

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -516,6 +516,11 @@ declare module 'stripe' {
            * A CSS hex color value representing the primary branding color for this account
            */
           primary_color: string | null;
+
+          /**
+           * A CSS hex color value representing the secondary branding color for this account
+           */
+          secondary_color: string | null;
         }
 
         interface CardPayments {
@@ -1145,6 +1150,11 @@ declare module 'stripe' {
            * A CSS hex color value representing the primary branding color for this account.
            */
           primary_color?: string;
+
+          /**
+           * A CSS hex color value representing the secondary branding color for this account.
+           */
+          secondary_color?: string;
         }
 
         interface CardPayments {
@@ -1765,6 +1775,11 @@ declare module 'stripe' {
            * A CSS hex color value representing the primary branding color for this account.
            */
           primary_color?: string;
+
+          /**
+           * A CSS hex color value representing the secondary branding color for this account.
+           */
+          secondary_color?: string;
         }
 
         interface CardPayments {

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -695,7 +695,7 @@ declare module 'stripe' {
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
-        card?: PaymentMethodOptions.Card;
+        card?: PaymentMethodOptions.Card | null;
       }
 
       namespace PaymentMethodOptions {
@@ -861,7 +861,7 @@ declare module 'stripe' {
       /**
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam;
+      metadata?: MetadataParam | null;
 
       /**
        * ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent.
@@ -939,7 +939,7 @@ declare module 'stripe' {
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
-        card?: PaymentMethodOptions.Card;
+        card?: PaymentMethodOptions.Card | null;
       }
 
       namespace PaymentMethodOptions {
@@ -1299,7 +1299,7 @@ declare module 'stripe' {
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
-        card?: PaymentMethodOptions.Card;
+        card?: PaymentMethodOptions.Card | null;
       }
 
       namespace PaymentMethodOptions {

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -646,7 +646,7 @@ declare module 'stripe' {
       /**
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam;
+      metadata?: MetadataParam | null;
 
       /**
        * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.

--- a/types/2020-03-02/SetupIntents.d.ts
+++ b/types/2020-03-02/SetupIntents.d.ts
@@ -467,7 +467,7 @@ declare module 'stripe' {
       /**
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam;
+      metadata?: MetadataParam | null;
 
       /**
        * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.


### PR DESCRIPTION
Codegen for openapi 4d2f7b4

r? @richardm-stripe 
cc @stripe/api-libraries 