### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -409,7 +409,7 @@ declare module 'stripe' {
         /**
          * The fields that need to be collected again because validation or verification failed for some reason.
          */
-        errors?: Array<Requirements.Error> | null;
+        errors: Array<Requirements.Error> | null;
 
         /**
          * The fields that need to be collected assuming all volume thresholds are reached. As they become required, these fields appear in `currently_due` as well, and the `current_deadline` is set.

--- a/types/2020-03-02/Capabilities.d.ts
+++ b/types/2020-03-02/Capabilities.d.ts
@@ -57,7 +57,7 @@ declare module 'stripe' {
         /**
          * The fields that need to be collected again because validation or verification failed for some reason.
          */
-        errors?: Array<Requirements.Error>;
+        errors: Array<Requirements.Error>;
 
         /**
          * The fields that need to be collected assuming all volume thresholds are reached. As they become required, these fields appear in `currently_due` as well, and the `current_deadline` is set.

--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -491,9 +491,19 @@ declare module 'stripe' {
           fingerprint: string | null;
 
           /**
+           * Institution number of the bank account
+           */
+          institution_number: string | null;
+
+          /**
            * Last four digits of the bank account number.
            */
           last4: string | null;
+
+          /**
+           * Transit number of the bank account.
+           */
+          transit_number: string | null;
         }
 
         interface Alipay {}

--- a/types/2020-03-02/Issuing/Cards.d.ts
+++ b/types/2020-03-02/Issuing/Cards.d.ts
@@ -43,6 +43,11 @@ declare module 'stripe' {
         currency: string;
 
         /**
+         * The card's CVC. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint.
+         */
+        cvc?: string;
+
+        /**
          * The expiration month of the card.
          */
         exp_month: number;
@@ -66,6 +71,11 @@ declare module 'stripe' {
          * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
          */
         metadata: Metadata;
+
+        /**
+         * The full unredacted card number. For security reasons, this is only available for virtual cards, and will be omitted unless you explicitly request it with [the `expand` parameter](https://stripe.com/docs/api/expanding_objects). Additionally, it's only available via the ["Retrieve a card" endpoint](https://stripe.com/docs/api/issuing/cards/retrieve), not via "List all cards" or any other endpoint.
+         */
+        number?: string;
 
         /**
          * The latest card that replaces this card, if any.

--- a/types/2020-03-02/Persons.d.ts
+++ b/types/2020-03-02/Persons.d.ts
@@ -248,7 +248,7 @@ declare module 'stripe' {
         /**
          * The fields that need to be collected again because validation or verification failed for some reason.
          */
-        errors?: Array<Requirements.Error>;
+        errors: Array<Requirements.Error>;
 
         /**
          * Fields that need to be collected assuming all volume thresholds are reached. As fields are needed, they are moved to `currently_due` and the account's `current_deadline` is set.

--- a/types/2020-03-02/Plans.d.ts
+++ b/types/2020-03-02/Plans.d.ts
@@ -15,7 +15,7 @@ declare module 'stripe' {
       object: 'plan';
 
       /**
-       * Whether the plan is currently available for new subscriptions.
+       * Whether the price can be used for new purchases.
        */
       active: boolean;
 
@@ -35,7 +35,7 @@ declare module 'stripe' {
       amount_decimal: string | null;
 
       /**
-       * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `amount`) will be charged per unit in `quantity` (for plans with `usage_type=licensed`), or per unit of total usage (for plans with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
+       * Describes how to compute the price per period. Either `per_unit` or `tiered`. `per_unit` indicates that the fixed amount (specified in `unit_amount` or `unit_amount_decimal`) will be charged per unit in `quantity` (for prices with `usage_type=licensed`), or per unit of total usage (for prices with `usage_type=metered`). `tiered` indicates that the unit pricing will be computed using a tiering strategy as defined using the `tiers` and `tiers_mode` attributes.
        */
       billing_scheme: Plan.BillingScheme;
 


### PR DESCRIPTION
Multiple API changes:
  * Add `institution_number` and `transit_number` in `payment_method_details[acss]` on `Charge`
  * Add `cvc` and `number` as properties that can be included when retrieving an issuing `Card`.

Codegen for openapi 14a5272

r? @richardm-stripe 
cc @stripe/api-libraries 