### PR TITLE
Add support for `Coupon` when for subscriptions on Checkout

### DIFF
--- a/types/2020-03-02/BillingPortal/Sessions.d.ts
+++ b/types/2020-03-02/BillingPortal/Sessions.d.ts
@@ -60,7 +60,7 @@ declare module 'stripe' {
 
       class SessionsResource {
         /**
-         * Creates a session of the Self-service Portal.
+         * Creates a session of the self-serve Portal.
          */
         create(
           params: SessionCreateParams,

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -1050,6 +1050,11 @@ declare module 'stripe' {
           application_fee_percent?: number;
 
           /**
+           * The code of the coupon to apply to this subscription. A coupon applied to a subscription will only affect invoices created for that particular subscription.
+           */
+          coupon?: string;
+
+          /**
            * The tax rates that will apply to any subscription item that does not have
            * `tax_rates` set. Invoices created will have their `default_tax_rates` populated
            * from the subscription.


### PR DESCRIPTION
Codegen for openapi 6bc6b0c

r? @cjavilla-stripe 
cc @stripe/api-libraries 