### PR TITLE
Add support for `br_cpf` and `br_cnpj` as `type` on `TaxId`

### DIFF
--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -341,7 +341,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
+         * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
          */
         type: TaxIdDatum.Type;
 
@@ -354,6 +354,8 @@ declare module 'stripe' {
       namespace TaxIdDatum {
         type Type =
           | 'au_abn'
+          | 'br_cnpj'
+          | 'br_cpf'
           | 'ca_bn'
           | 'ca_qst'
           | 'ch_vat'

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -347,7 +347,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -360,6 +360,8 @@ declare module 'stripe' {
       namespace CustomerTaxId {
         type Type =
           | 'au_abn'
+          | 'br_cnpj'
+          | 'br_cpf'
           | 'ca_bn'
           | 'ca_qst'
           | 'ch_vat'

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -254,6 +254,11 @@ declare module 'stripe' {
           plan: string | Stripe.Plan | Stripe.DeletedPlan;
 
           /**
+           * ID of the price to which the customer should be subscribed.
+           */
+          price?: string | Stripe.Price | Stripe.DeletedPrice;
+
+          /**
            * Quantity of the plan to which the customer should be subscribed.
            */
           quantity?: number;

--- a/types/2020-03-02/TaxIds.d.ts
+++ b/types/2020-03-02/TaxIds.d.ts
@@ -37,7 +37,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `au_abn`, `ca_bn`, `ca_qst`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -52,6 +52,8 @@ declare module 'stripe' {
     namespace TaxId {
       type Type =
         | 'au_abn'
+        | 'br_cnpj'
+        | 'br_cpf'
         | 'ca_bn'
         | 'ca_qst'
         | 'ch_vat'
@@ -120,7 +122,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `eu_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
+       * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
        */
       type: TaxIdCreateParams.Type;
 
@@ -138,6 +140,8 @@ declare module 'stripe' {
     namespace TaxIdCreateParams {
       type Type =
         | 'au_abn'
+        | 'br_cnpj'
+        | 'br_cpf'
         | 'ca_bn'
         | 'ca_qst'
         | 'ch_vat'


### PR DESCRIPTION
Codegen for openapi 76b55df

r? @ob-stripe 
cc @stripe/api-libraries 