### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -762,6 +762,11 @@ declare module 'stripe' {
         product_description?: string;
 
         /**
+         * A publicly available mailing address for sending support issues to.
+         */
+        support_address?: BusinessProfile.SupportAddress;
+
+        /**
          * A publicly available email address for sending support issues to.
          */
         support_email?: string;
@@ -780,6 +785,40 @@ declare module 'stripe' {
          * The business's publicly available website.
          */
         url?: string;
+      }
+
+      namespace BusinessProfile {
+        interface SupportAddress {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+        }
       }
 
       type BusinessType =
@@ -1392,6 +1431,11 @@ declare module 'stripe' {
         product_description?: string;
 
         /**
+         * A publicly available mailing address for sending support issues to.
+         */
+        support_address?: BusinessProfile.SupportAddress;
+
+        /**
          * A publicly available email address for sending support issues to.
          */
         support_email?: string;
@@ -1410,6 +1454,40 @@ declare module 'stripe' {
          * The business's publicly available website.
          */
         url?: string;
+      }
+
+      namespace BusinessProfile {
+        interface SupportAddress {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+        }
       }
 
       type BusinessType =

--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -725,7 +725,11 @@ declare module 'stripe' {
             /**
              * The version of 3D Secure that was used for this payment.
              */
-            version: string;
+            version: ThreeDSecure.Version;
+          }
+
+          namespace ThreeDSecure {
+            type Version = '1.0.2' | '2.1.0' | '2.2.0';
           }
 
           interface Wallet {

--- a/types/2020-03-02/InvoiceLineItems.d.ts
+++ b/types/2020-03-02/InvoiceLineItems.d.ts
@@ -440,11 +440,6 @@ declare module 'stripe' {
         namespace PriceData {
           interface Recurring {
             /**
-             * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-             */
-            aggregate_usage?: Recurring.AggregateUsage;
-
-            /**
              * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
              */
             interval: Recurring.Interval;
@@ -453,28 +448,10 @@ declare module 'stripe' {
              * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
              */
             interval_count?: number;
-
-            /**
-             * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-             */
-            trial_period_days?: number;
-
-            /**
-             * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-             */
-            usage_type?: Recurring.UsageType;
           }
 
           namespace Recurring {
-            type AggregateUsage =
-              | 'last_during_period'
-              | 'last_ever'
-              | 'max'
-              | 'sum';
-
             type Interval = 'day' | 'month' | 'week' | 'year';
-
-            type UsageType = 'licensed' | 'metered';
           }
         }
       }

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -1117,11 +1117,6 @@ declare module 'stripe' {
         namespace PriceData {
           interface Recurring {
             /**
-             * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-             */
-            aggregate_usage?: Recurring.AggregateUsage;
-
-            /**
              * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
              */
             interval: Recurring.Interval;
@@ -1130,28 +1125,10 @@ declare module 'stripe' {
              * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
              */
             interval_count?: number;
-
-            /**
-             * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-             */
-            trial_period_days?: number;
-
-            /**
-             * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-             */
-            usage_type?: Recurring.UsageType;
           }
 
           namespace Recurring {
-            type AggregateUsage =
-              | 'last_during_period'
-              | 'last_ever'
-              | 'max'
-              | 'sum';
-
             type Interval = 'day' | 'month' | 'week' | 'year';
-
-            type UsageType = 'licensed' | 'metered';
           }
         }
       }

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -629,6 +629,11 @@ declare module 'stripe' {
 
     interface PaymentMethodUpdateParams {
       /**
+       * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+       */
+      au_becs_debit?: PaymentMethodUpdateParams.AuBecsDebit;
+
+      /**
        * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
        */
       billing_details?: PaymentMethodUpdateParams.BillingDetails;
@@ -655,6 +660,8 @@ declare module 'stripe' {
     }
 
     namespace PaymentMethodUpdateParams {
+      interface AuBecsDebit {}
+
       interface BillingDetails {
         /**
          * Billing address.

--- a/types/2020-03-02/SubscriptionItems.d.ts
+++ b/types/2020-03-02/SubscriptionItems.d.ts
@@ -214,11 +214,6 @@ declare module 'stripe' {
       namespace PriceData {
         interface Recurring {
           /**
-           * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-           */
-          aggregate_usage?: Recurring.AggregateUsage;
-
-          /**
            * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
            */
           interval: Recurring.Interval;
@@ -227,28 +222,10 @@ declare module 'stripe' {
            * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
            */
           interval_count?: number;
-
-          /**
-           * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-           */
-          trial_period_days?: number;
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-           */
-          usage_type?: Recurring.UsageType;
         }
 
         namespace Recurring {
-          type AggregateUsage =
-            | 'last_during_period'
-            | 'last_ever'
-            | 'max'
-            | 'sum';
-
           type Interval = 'day' | 'month' | 'week' | 'year';
-
-          type UsageType = 'licensed' | 'metered';
         }
       }
 
@@ -380,11 +357,6 @@ declare module 'stripe' {
       namespace PriceData {
         interface Recurring {
           /**
-           * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-           */
-          aggregate_usage?: Recurring.AggregateUsage;
-
-          /**
            * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
            */
           interval: Recurring.Interval;
@@ -393,28 +365,10 @@ declare module 'stripe' {
            * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
            */
           interval_count?: number;
-
-          /**
-           * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-           */
-          trial_period_days?: number;
-
-          /**
-           * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-           */
-          usage_type?: Recurring.UsageType;
         }
 
         namespace Recurring {
-          type AggregateUsage =
-            | 'last_during_period'
-            | 'last_ever'
-            | 'max'
-            | 'sum';
-
           type Interval = 'day' | 'month' | 'week' | 'year';
-
-          type UsageType = 'licensed' | 'metered';
         }
       }
 

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -592,11 +592,6 @@ declare module 'stripe' {
           namespace PriceData {
             interface Recurring {
               /**
-               * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-               */
-              aggregate_usage?: Recurring.AggregateUsage;
-
-              /**
                * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
                */
               interval: Recurring.Interval;
@@ -605,28 +600,10 @@ declare module 'stripe' {
                * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
                */
               interval_count?: number;
-
-              /**
-               * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-               */
-              trial_period_days?: number;
-
-              /**
-               * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-               */
-              usage_type?: Recurring.UsageType;
             }
 
             namespace Recurring {
-              type AggregateUsage =
-                | 'last_during_period'
-                | 'last_ever'
-                | 'max'
-                | 'sum';
-
               type Interval = 'day' | 'month' | 'week' | 'year';
-
-              type UsageType = 'licensed' | 'metered';
             }
           }
         }
@@ -945,11 +922,6 @@ declare module 'stripe' {
           namespace PriceData {
             interface Recurring {
               /**
-               * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-               */
-              aggregate_usage?: Recurring.AggregateUsage;
-
-              /**
                * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
                */
               interval: Recurring.Interval;
@@ -958,28 +930,10 @@ declare module 'stripe' {
                * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
                */
               interval_count?: number;
-
-              /**
-               * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-               */
-              trial_period_days?: number;
-
-              /**
-               * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-               */
-              usage_type?: Recurring.UsageType;
             }
 
             namespace Recurring {
-              type AggregateUsage =
-                | 'last_during_period'
-                | 'last_ever'
-                | 'max'
-                | 'sum';
-
               type Interval = 'day' | 'month' | 'week' | 'year';
-
-              type UsageType = 'licensed' | 'metered';
             }
           }
         }

--- a/types/2020-03-02/Subscriptions.d.ts
+++ b/types/2020-03-02/Subscriptions.d.ts
@@ -563,11 +563,6 @@ declare module 'stripe' {
         namespace PriceData {
           interface Recurring {
             /**
-             * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-             */
-            aggregate_usage?: Recurring.AggregateUsage;
-
-            /**
              * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
              */
             interval: Recurring.Interval;
@@ -576,28 +571,10 @@ declare module 'stripe' {
              * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
              */
             interval_count?: number;
-
-            /**
-             * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-             */
-            trial_period_days?: number;
-
-            /**
-             * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-             */
-            usage_type?: Recurring.UsageType;
           }
 
           namespace Recurring {
-            type AggregateUsage =
-              | 'last_during_period'
-              | 'last_ever'
-              | 'max'
-              | 'sum';
-
             type Interval = 'day' | 'month' | 'week' | 'year';
-
-            type UsageType = 'licensed' | 'metered';
           }
         }
       }
@@ -928,11 +905,6 @@ declare module 'stripe' {
         namespace PriceData {
           interface Recurring {
             /**
-             * Specifies a usage aggregation strategy for prices of `usage_type=metered`. Allowed values are `sum` for summing up all usage during a period, `last_during_period` for using the last usage record reported within a period, `last_ever` for using the last usage record ever (across period bounds) or `max` which uses the usage record with the maximum reported usage during a period. Defaults to `sum`.
-             */
-            aggregate_usage?: Recurring.AggregateUsage;
-
-            /**
              * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
              */
             interval: Recurring.Interval;
@@ -941,28 +913,10 @@ declare module 'stripe' {
              * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
              */
             interval_count?: number;
-
-            /**
-             * Default number of trial days when subscribing a customer to this price using [`trial_from_plan=true`](https://stripe.com/docs/api#create_subscription-trial_from_plan).
-             */
-            trial_period_days?: number;
-
-            /**
-             * Configures how the quantity per period should be determined. Can be either `metered` or `licensed`. `licensed` automatically bills the `quantity` set when adding it to a subscription. `metered` aggregates the total usage based on usage records. Defaults to `licensed`.
-             */
-            usage_type?: Recurring.UsageType;
           }
 
           namespace Recurring {
-            type AggregateUsage =
-              | 'last_during_period'
-              | 'last_ever'
-              | 'max'
-              | 'sum';
-
             type Interval = 'day' | 'month' | 'week' | 'year';
-
-            type UsageType = 'licensed' | 'metered';
           }
         }
       }


### PR DESCRIPTION
Multiple API changes
  * Remove parameters in `price_data[recurring]` across APIs as they were never supported
  * Move `payment_method_details[card][three_d_secure]` to a list of enum values on `Charge`
  * Add support for for `business_profile[support_adress]` on `Account` create and update

Codegen for openapi fd0d8ec

Flagging this is technically a breaking change but since the feature is new-ish, not yet live and those parameters never worked we will release as a minor.

r? @ob-stripe 
cc @stripe/api-libraries 