### PR TITLE
Add support for `purchase_details` on Issuing `Transaction`

### DIFF
--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -549,9 +549,11 @@ declare module 'stripe' {
         expand?: Array<string>;
 
         /**
-         * A list of items the customer is purchasing. Use this parameter for
-         * one-time payments or adding invoice line items to a subscription (used
-         * in conjunction with `subscription_data`).
+         * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring [prices](https://stripe.com/docs/api/prices).
+         *
+         * Alternatively, if not using recurring prices, this parameter is for one-time payments or
+         * adding invoice line items to a subscription (used in conjunction with `subscription_data.items`).
+         *
          * There is a maximum of 100 line items, however it is recommended to
          * consolidate line items if there are more than a few dozen.
          */
@@ -568,7 +570,7 @@ declare module 'stripe' {
         metadata?: MetadataParam;
 
         /**
-         * The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`.
+         * The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`. Required when using prices or `setup` mode. Pass `subscription` if Checkout session includes at least one recurring item.
          */
         mode?: SessionCreateParams.Mode;
 
@@ -606,37 +608,39 @@ declare module 'stripe' {
 
         interface LineItem {
           /**
-           * The amount to be collected per unit of the line item.
+           * The amount to be collected per unit of the line item. If specified, must also pass `currency` and `name`.
            */
           amount?: number;
 
           /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). Required if `amount` is passed.
            */
           currency?: string;
 
           /**
            * The description for the line item, to be displayed on the Checkout page.
+           *
+           * If using `price` or `price_data`, will default to the name of the associated product.
            */
           description?: string;
 
           /**
-           * A list of images representing this line item. Each image can be up to 5 MB in size.
+           * A list of image URLs representing this line item. Each image can be up to 5 MB in size. If passing `price` or `price_data`, specify images on the associated product instead.
            */
           images?: Array<string>;
 
           /**
-           * The name for the line item.
+           * The name for the item to be displayed on the Checkout page. Required if `amount` is passed.
            */
           name?: string;
 
           /**
-           * The ID of the price object.
+           * The ID of the price object. One of `price`, `price_data` or `amount` is required.
            */
           price?: string;
 
           /**
-           * Data used to generate a new price object inline.
+           * Data used to generate a new price object inline. One of `price`, `price_data` or `amount` is required.
            */
           price_data?: LineItem.PriceData;
 

--- a/types/2020-03-02/Issuing/Transactions.d.ts
+++ b/types/2020-03-02/Issuing/Transactions.d.ts
@@ -73,6 +73,11 @@ declare module 'stripe' {
         metadata: Metadata;
 
         /**
+         * Additional purchase information that is optionally provided by the merchant.
+         */
+        purchase_details: Transaction.PurchaseDetails | null;
+
+        /**
          * The nature of the transaction.
          */
         type: Transaction.Type;
@@ -114,6 +119,152 @@ declare module 'stripe' {
            * State where the seller is located
            */
           state: string | null;
+        }
+
+        interface PurchaseDetails {
+          /**
+           * Information about the flight that was purchased with this transaction.
+           */
+          flight: PurchaseDetails.Flight | null;
+
+          /**
+           * Information about fuel that was purchased with this transaction.
+           */
+          fuel: PurchaseDetails.Fuel | null;
+
+          /**
+           * Information about lodging that was purchased with this transaction.
+           */
+          lodging: PurchaseDetails.Lodging | null;
+
+          /**
+           * The line items in the purchase.
+           */
+          receipt: Array<PurchaseDetails.Receipt> | null;
+
+          /**
+           * A merchant-specific order number.
+           */
+          reference: string | null;
+        }
+
+        namespace PurchaseDetails {
+          interface Flight {
+            /**
+             * The time that the flight departed.
+             */
+            departure_at: number | null;
+
+            /**
+             * The name of the passenger.
+             */
+            passenger_name: string | null;
+
+            /**
+             * Whether the ticket is refundable.
+             */
+            refundable: boolean | null;
+
+            /**
+             * The legs of the trip.
+             */
+            segments: Array<Flight.Segment> | null;
+
+            /**
+             * The travel agency that issued the ticket.
+             */
+            travel_agency: string | null;
+          }
+
+          namespace Flight {
+            interface Segment {
+              /**
+               * The flight's destination airport code.
+               */
+              arrival_airport_code: string | null;
+
+              /**
+               * The airline carrier code.
+               */
+              carrier: string | null;
+
+              /**
+               * The airport code that the flight departed from.
+               */
+              departure_airport_code: string | null;
+
+              /**
+               * The flight number.
+               */
+              flight_number: string | null;
+
+              /**
+               * The flight's service class.
+               */
+              service_class: string | null;
+
+              /**
+               * Whether a stopover is allowed on this flight.
+               */
+              stopover_allowed: boolean | null;
+            }
+          }
+
+          interface Fuel {
+            /**
+             * The type of fuel that was purchased. One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
+             */
+            type: string;
+
+            /**
+             * The units for `volume`. One of `us_gallon` or `liter`.
+             */
+            unit: string;
+
+            /**
+             * The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
+             */
+            unit_cost_decimal: string;
+
+            /**
+             * The volume of the fuel that was pumped, represented as a decimal string with at most 12 decimal places.
+             */
+            volume_decimal: string | null;
+          }
+
+          interface Lodging {
+            /**
+             * The time of checking into the lodging.
+             */
+            check_in_at: number | null;
+
+            /**
+             * The number of nights stayed at the lodging.
+             */
+            nights: number | null;
+          }
+
+          interface Receipt {
+            /**
+             * The description of the item. The maximum length of this field is 26 characters.
+             */
+            description: string | null;
+
+            /**
+             * The quantity of the item.
+             */
+            quantity: number | null;
+
+            /**
+             * The total for this line item in cents.
+             */
+            total: number | null;
+
+            /**
+             * The unit cost of the item in cents.
+             */
+            unit_cost: number | null;
+          }
         }
 
         type Type = 'capture' | 'refund';


### PR DESCRIPTION
Codegen for openapi 6579724

r? @richardm-stripe 
cc @stripe/api-libraries 