### PR TITLE
README: Suggest @ts-ignore for betas

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,8 @@ and use a comment like `// @ts-ignore stripe-version-2019-10-17` to silence type
 and anywhere the types differ between your API version and the latest.
 When you upgrade, you should remove these comments.
 
+We also recommend using `// @ts-ignore` if you have access to a beta feature and need to send parameters beyond the type definitions.
+
 #### Using `expand` with TypeScript
 
 [Expandable][expanding_objects] fields are typed as `string | Foo`,


### PR DESCRIPTION
Mention `ts-ignore` as appropriate for betas in the section of the README.md where we suggest using `@ts-ignore` for old api versions.

see #892