### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -730,17 +730,43 @@ declare module 'stripe' {
             authenticated?: boolean;
 
             /**
+             * Indicates the outcome of 3D Secure authentication.
+             */
+            result: ThreeDSecure.Result;
+
+            /**
+             * Additional information about why 3D Secure succeeded or failed.
+             */
+            result_reason: ThreeDSecure.ResultReason | null;
+
+            /**
              * Whether or not 3D Secure succeeded.
              */
             succeeded?: boolean;
 
             /**
-             * The version of 3D Secure that was used for this payment.
+             * The version of 3D Secure that was used.
              */
             version: ThreeDSecure.Version;
           }
 
           namespace ThreeDSecure {
+            type Result =
+              | 'attempt_acknowledged'
+              | 'authenticated'
+              | 'failed'
+              | 'not_supported'
+              | 'processing_error';
+
+            type ResultReason =
+              | 'abandoned'
+              | 'bypassed'
+              | 'canceled'
+              | 'card_not_enrolled'
+              | 'network_not_supported'
+              | 'protocol_error'
+              | 'rejected';
+
             type Version = '1.0.2' | '2.1.0' | '2.2.0';
           }
 

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -667,7 +667,7 @@ declare module 'stripe' {
             /**
              * The ID of the product that this price will belong to.
              */
-            product: string;
+            product?: string;
 
             /**
              * The recurring components of a price such as `interval` and `usage_type`.

--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -341,7 +341,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
+         * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, or `sa_vat`
          */
         type: TaxIdDatum.Type;
 
@@ -353,12 +353,14 @@ declare module 'stripe' {
 
       namespace TaxIdDatum {
         type Type =
+          | 'ae_trn'
           | 'au_abn'
           | 'br_cnpj'
           | 'br_cpf'
           | 'ca_bn'
           | 'ca_qst'
           | 'ch_vat'
+          | 'cl_tin'
           | 'es_cif'
           | 'eu_vat'
           | 'hk_br'
@@ -372,6 +374,7 @@ declare module 'stripe' {
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
+          | 'sa_vat'
           | 'sg_gst'
           | 'sg_uen'
           | 'th_vat'

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -347,7 +347,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -359,12 +359,14 @@ declare module 'stripe' {
 
       namespace CustomerTaxId {
         type Type =
+          | 'ae_trn'
           | 'au_abn'
           | 'br_cnpj'
           | 'br_cpf'
           | 'ca_bn'
           | 'ca_qst'
           | 'ch_vat'
+          | 'cl_tin'
           | 'es_cif'
           | 'eu_vat'
           | 'hk_br'
@@ -378,6 +380,7 @@ declare module 'stripe' {
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
+          | 'sa_vat'
           | 'sg_gst'
           | 'sg_uen'
           | 'th_vat'

--- a/types/2020-03-02/LineItems.d.ts
+++ b/types/2020-03-02/LineItems.d.ts
@@ -52,7 +52,7 @@ declare module 'stripe' {
       /**
        * The taxes applied to the line item.
        */
-      taxes: Array<LineItem.Tax> | null;
+      taxes?: Array<LineItem.Tax>;
     }
 
     namespace LineItem {

--- a/types/2020-03-02/SourceMandateNotifications.d.ts
+++ b/types/2020-03-02/SourceMandateNotifications.d.ts
@@ -14,6 +14,8 @@ declare module 'stripe' {
        */
       object: 'source_mandate_notification';
 
+      acss_debit?: SourceMandateNotification.AcssDebit;
+
       /**
        * A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the amount associated with the mandate notification. The amount is expressed in the currency of the underlying source. Required if the notification type is `debit_initiated`.
        */
@@ -60,6 +62,13 @@ declare module 'stripe' {
     }
 
     namespace SourceMandateNotification {
+      interface AcssDebit {
+        /**
+         * The statement descriptor associate with the debit.
+         */
+        statement_descriptor?: string;
+      }
+
       interface BacsDebit {
         /**
          * Last 4 digits of the account number associated with the debit.

--- a/types/2020-03-02/TaxIds.d.ts
+++ b/types/2020-03-02/TaxIds.d.ts
@@ -37,7 +37,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -51,12 +51,14 @@ declare module 'stripe' {
 
     namespace TaxId {
       type Type =
+        | 'ae_trn'
         | 'au_abn'
         | 'br_cnpj'
         | 'br_cpf'
         | 'ca_bn'
         | 'ca_qst'
         | 'ch_vat'
+        | 'cl_tin'
         | 'es_cif'
         | 'eu_vat'
         | 'hk_br'
@@ -70,6 +72,7 @@ declare module 'stripe' {
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
+        | 'sa_vat'
         | 'sg_gst'
         | 'sg_uen'
         | 'th_vat'
@@ -122,7 +125,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, or `sg_gst`
+       * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, or `sa_vat`
        */
       type: TaxIdCreateParams.Type;
 
@@ -139,12 +142,14 @@ declare module 'stripe' {
 
     namespace TaxIdCreateParams {
       type Type =
+        | 'ae_trn'
         | 'au_abn'
         | 'br_cnpj'
         | 'br_cpf'
         | 'ca_bn'
         | 'ca_qst'
         | 'ch_vat'
+        | 'cl_tin'
         | 'es_cif'
         | 'eu_vat'
         | 'hk_br'
@@ -158,6 +163,7 @@ declare module 'stripe' {
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
+        | 'sa_vat'
         | 'sg_gst'
         | 'sg_uen'
         | 'th_vat'


### PR DESCRIPTION
Multiple API changes:
  * Add support for `ae_trn`, `cl_tin` and `sa_vat` as `type` on `TaxId`
  * Add `result` and `result_reason` inside `payment_method_details[card][three_d_secure]` on `Charge`

Codegen for openapi cd33b40

r? @cjavilla-stripe 
cc @stripe/api-libraries 