### PR TITLE
Add support for BACS Debit as a `PaymentMethod`

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -500,6 +500,8 @@ declare module 'stripe' {
       }
 
       interface Settings {
+        bacs_debit_payments?: Settings.BacsDebitPayments;
+
         branding: Settings.Branding;
 
         card_payments: Settings.CardPayments;
@@ -512,6 +514,13 @@ declare module 'stripe' {
       }
 
       namespace Settings {
+        interface BacsDebitPayments {
+          /**
+           * The Bacs Direct Debit Display Name for this account. For payments made with Bacs Direct Debit, this will appear on the mandate, and as the statement descriptor.
+           */
+          display_name?: string;
+        }
+
         interface Branding {
           /**
            * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) An icon for the account. Must be square and at least 128px x 128px.

--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -385,6 +385,8 @@ declare module 'stripe' {
 
         au_becs_debit?: PaymentMethodDetails.AuBecsDebit;
 
+        bacs_debit?: PaymentMethodDetails.BacsDebit;
+
         bancontact?: PaymentMethodDetails.Bancontact;
 
         bitcoin?: PaymentMethodDetails.Bitcoin;
@@ -540,6 +542,28 @@ declare module 'stripe' {
            * ID of the mandate used to make this payment.
            */
           mandate?: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+           */
+          fingerprint: string | null;
+
+          /**
+           * Last four digits of the bank account number.
+           */
+          last4: string | null;
+
+          /**
+           * ID of the mandate used to make this payment.
+           */
+          mandate: string | null;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code: string | null;
         }
 
         interface Bancontact {
@@ -730,9 +754,8 @@ declare module 'stripe' {
             authenticated?: boolean;
 
             /**
-             * For authenticated transactions: whether issuing bank authenticated the
-             * cardholder with a traditional challenge screen, or with device data
-             * via the 3DS2 frictionless flow.
+             * For authenticated transactions: how the customer was authenticated by
+             * the issuing bank.
              */
             authentication_flow: ThreeDSecure.AuthenticationFlow | null;
 
@@ -742,7 +765,8 @@ declare module 'stripe' {
             result: ThreeDSecure.Result;
 
             /**
-             * Additional information about why 3D Secure succeeded or failed.
+             * Additional information about why 3D Secure succeeded or failed based
+             * on the `result`.
              */
             result_reason: ThreeDSecure.ResultReason | null;
 

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -48,12 +48,12 @@ declare module 'stripe' {
          * If not provided, customers will be asked to enter their email address.
          * Use this parameter to prefill customer data if you already have an email
          * on file. To access information about the customer once a session is
-         * complete, use the `customer` field.
+         * complete, use the `customer` attribute.
          */
         customer_email: string | null;
 
         /**
-         * The line items, plans, or SKUs purchased by the customer.
+         * The line items, plans, or SKUs purchased by the customer. Prefer using `line_items`.
          */
         display_items?: Array<Session.DisplayItem>;
 
@@ -553,7 +553,7 @@ declare module 'stripe' {
         /**
          * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring [prices](https://stripe.com/docs/api/prices).
          *
-         * Alternatively, if not using recurring prices, this parameter is for one-time payments or
+         * If not using recurring prices, this parameter is for one-time payments or
          * adding invoice line items to a subscription (used in conjunction with `subscription_data.items`).
          *
          * There is a maximum of 100 line items, however it is recommended to
@@ -637,7 +637,7 @@ declare module 'stripe' {
           name?: string;
 
           /**
-           * The ID of the price object. One of `price`, `price_data` or `amount` is required.
+           * The ID of the price or plan object. One of `price`, `price_data` or `amount` is required.
            */
           price?: string;
 
@@ -1159,7 +1159,7 @@ declare module 'stripe' {
           default_tax_rates?: Array<string>;
 
           /**
-           * A list of items, each with an attached plan, that the customer is subscribing to. Use this parameter for subscriptions. To create one-time payments, use `line_items`.
+           * A list of items, each with an attached plan, that the customer is subscribing to. Prefer using `line_items`.
            */
           items?: Array<SubscriptionData.Item>;
 

--- a/types/2020-03-02/Mandates.d.ts
+++ b/types/2020-03-02/Mandates.d.ts
@@ -83,6 +83,8 @@ declare module 'stripe' {
       interface PaymentMethodDetails {
         au_becs_debit?: PaymentMethodDetails.AuBecsDebit;
 
+        bacs_debit?: PaymentMethodDetails.BacsDebit;
+
         card?: PaymentMethodDetails.Card;
 
         sepa_debit?: PaymentMethodDetails.SepaDebit;
@@ -99,6 +101,18 @@ declare module 'stripe' {
            * The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively.
            */
           url: string;
+        }
+
+        interface BacsDebit {
+          network_status: BacsDebit.NetworkStatus;
+
+          reference: string;
+
+          url: string;
+        }
+
+        namespace BacsDebit {
+          type NetworkStatus = 'accepted' | 'pending' | 'refused' | 'revoked';
         }
 
         interface Card {}

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -16,6 +16,8 @@ declare module 'stripe' {
 
       au_becs_debit?: PaymentMethod.AuBecsDebit;
 
+      bacs_debit?: PaymentMethod.BacsDebit;
+
       billing_details: PaymentMethod.BillingDetails;
 
       card?: PaymentMethod.Card;
@@ -72,6 +74,23 @@ declare module 'stripe' {
          * Last four digits of the bank account number.
          */
         last4: string | null;
+      }
+
+      interface BacsDebit {
+        /**
+         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+         */
+        fingerprint: string | null;
+
+        /**
+         * Last four digits of the bank account number.
+         */
+        last4: string | null;
+
+        /**
+         * Sort code of the bank account. (e.g., `10-20-30`)
+         */
+        sort_code: string | null;
       }
 
       interface BillingDetails {
@@ -388,6 +407,7 @@ declare module 'stripe' {
 
       type Type =
         | 'au_becs_debit'
+        | 'bacs_debit'
         | 'card'
         | 'card_present'
         | 'fpx'
@@ -400,6 +420,11 @@ declare module 'stripe' {
        * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
        */
       au_becs_debit?: PaymentMethodCreateParams.AuBecsDebit;
+
+      /**
+       * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+       */
+      bacs_debit?: PaymentMethodCreateParams.BacsDebit;
 
       /**
        * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
@@ -468,6 +493,18 @@ declare module 'stripe' {
          * Bank-State-Branch number of the bank account.
          */
         bsb_number: string;
+      }
+
+      interface BacsDebit {
+        /**
+         * Account number of the bank account that the funds will be debited from.
+         */
+        account_number?: string;
+
+        /**
+         * Sort code of the bank account. (e.g., `10-20-30`)
+         */
+        sort_code?: string;
       }
 
       interface BillingDetails {
@@ -624,6 +661,7 @@ declare module 'stripe' {
 
       type Type =
         | 'au_becs_debit'
+        | 'bacs_debit'
         | 'card'
         | 'card_present'
         | 'fpx'

--- a/types/2020-03-02/Persons.d.ts
+++ b/types/2020-03-02/Persons.d.ts
@@ -108,7 +108,7 @@ declare module 'stripe' {
       requirements?: Person.Requirements | null;
 
       /**
-       * Whether the last 4 digits of this person's SSN have been provided.
+       * Whether the last four digits of the person's Social Security number have been provided (U.S. only).
        */
       ssn_last_4_provided?: boolean;
 
@@ -515,7 +515,7 @@ declare module 'stripe' {
       relationship?: PersonCreateParams.Relationship;
 
       /**
-       * The last 4 digits of the person's social security number.
+       * The last four digits of the person's Social Security number (U.S. only).
        */
       ssn_last_4?: string;
 
@@ -750,7 +750,7 @@ declare module 'stripe' {
       relationship?: PersonUpdateParams.Relationship;
 
       /**
-       * The last 4 digits of the person's social security number.
+       * The last four digits of the person's Social Security number (U.S. only).
        */
       ssn_last_4?: string;
 

--- a/types/2020-03-02/Plans.d.ts
+++ b/types/2020-03-02/Plans.d.ts
@@ -425,7 +425,7 @@ declare module 'stripe' {
 
     class PlansResource {
       /**
-       * You can create plans using the API, or in the Stripe [Dashboard](https://dashboard.stripe.com/subscriptions/products).
+       * You can create plans using the API, or in the Stripe [Dashboard](https://dashboard.stripe.com/products).
        */
       create(
         params: PlanCreateParams,

--- a/types/2020-03-02/Tokens.d.ts
+++ b/types/2020-03-02/Tokens.d.ts
@@ -604,7 +604,7 @@ declare module 'stripe' {
         relationship?: Person.Relationship;
 
         /**
-         * The last 4 digits of the person's social security number.
+         * The last four digits of the person's Social Security number (U.S. only).
          */
         ssn_last_4?: string;
 


### PR DESCRIPTION
Add support for BACS Debit as a `PaymentMethod`
  * Add `settings[bacs_debit_payments]` on `Account`
  * Add `bacs_debit` as a `type` on `PaymentMethod` 
  * Add `payment_method_details[bacs_debit]` on `Charge`
  * Add `bacs_debit` on `Mandate`

Codegen for openapi 7a853ce

r? @cjavilla-stripe 
cc @stripe/api-libraries 