### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -511,6 +511,8 @@ declare module 'stripe' {
         payments: Settings.Payments;
 
         payouts?: Settings.Payouts;
+
+        sepa_debit_payments?: Settings.SepaDebitPayments;
       }
 
       namespace Settings {
@@ -631,6 +633,13 @@ declare module 'stripe' {
              */
             weekly_anchor?: string;
           }
+        }
+
+        interface SepaDebitPayments {
+          /**
+           * SEPA creditor identifier that identifies the company making the payment.
+           */
+          creditor_id?: string;
         }
       }
 

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -198,21 +198,34 @@ declare module 'stripe' {
 
         type Locale =
           | 'auto'
+          | 'bg'
+          | 'cs'
           | 'da'
           | 'de'
+          | 'el'
           | 'en'
           | 'es'
+          | 'et'
           | 'fi'
           | 'fr'
+          | 'hu'
           | 'it'
           | 'ja'
+          | 'lt'
+          | 'lv'
           | 'ms'
+          | 'mt'
           | 'nb'
           | 'nl'
           | 'pl'
           | 'pt'
           | 'pt-BR'
+          | 'ro'
+          | 'ru'
+          | 'sk'
+          | 'sl'
           | 'sv'
+          | 'tr'
           | 'zh';
 
         type Mode = 'payment' | 'setup' | 'subscription';
@@ -500,7 +513,14 @@ declare module 'stripe' {
         cancel_url: string;
 
         /**
-         * A list of the types of payment methods (e.g., card) this Checkout session can accept.
+         * A list of the types of payment methods (e.g., `card`) this Checkout session can accept.
+         *
+         * Read more about the supported payment methods and their requirements in our [payment
+         * method details guide](https://stripe.com/docs/payments/checkout/payment-methods).
+         *
+         * If multiple payment methods are passed, Checkout will dynamically reorder them to
+         * prioritize the most relevant payment methods based on the customer's location and
+         * other characteristics.
          */
         payment_method_types: Array<SessionCreateParams.PaymentMethodType>;
 
@@ -552,9 +572,7 @@ declare module 'stripe' {
 
         /**
          * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring [prices](https://stripe.com/docs/api/prices).
-         *
-         * If not using recurring prices, this parameter is for one-time payments or
-         * adding invoice line items to a subscription (used in conjunction with `subscription_data.items`).
+         * One-time prices in `subscription` mode will be on the initial invoice only.
          *
          * There is a maximum of 100 line items, however it is recommended to
          * consolidate line items if there are more than a few dozen.
@@ -680,7 +698,7 @@ declare module 'stripe' {
             recurring?: PriceData.Recurring;
 
             /**
-             * A positive integer in %s (or 0 for a free price) representing how much to charge.
+             * A positive integer in %s representing how much to charge.
              */
             unit_amount?: number;
 
@@ -733,21 +751,34 @@ declare module 'stripe' {
 
         type Locale =
           | 'auto'
+          | 'bg'
+          | 'cs'
           | 'da'
           | 'de'
+          | 'el'
           | 'en'
           | 'es'
+          | 'et'
           | 'fi'
           | 'fr'
+          | 'hu'
           | 'it'
           | 'ja'
+          | 'lt'
+          | 'lv'
           | 'ms'
+          | 'mt'
           | 'nb'
           | 'nl'
           | 'pl'
           | 'pt'
           | 'pt-BR'
+          | 'ro'
+          | 'ru'
+          | 'sk'
+          | 'sl'
           | 'sv'
+          | 'tr'
           | 'zh';
 
         type Mode = 'payment' | 'setup' | 'subscription';

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -298,7 +298,7 @@ declare module 'stripe' {
       /**
        * The account (if any) the payment will be attributed to for tax reporting, and where funds from the payment will be transferred to for the invoice.
        */
-      transfer_data?: Invoice.TransferData | null;
+      transfer_data: Invoice.TransferData | null;
 
       /**
        * Invoices are automatically paid or sent 1 hour after webhooks are delivered, or until all webhook delivery attempts have [been exhausted](https://stripe.com/docs/billing/webhooks#understand). This field tracks the time when webhooks for this invoice were successfully delivered. If the invoice had no webhooks to deliver, this will be set while the invoice is being created.

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -346,10 +346,23 @@ declare module 'stripe' {
       }
 
       interface PaymentMethodOptions {
+        bancontact?: PaymentMethodOptions.Bancontact;
+
         card?: PaymentMethodOptions.Card;
       }
 
       namespace PaymentMethodOptions {
+        interface Bancontact {
+          /**
+           * Preferred language of the Bancontact authorization page that the customer is redirected to.
+           */
+          preferred_language: Bancontact.PreferredLanguage;
+        }
+
+        namespace Bancontact {
+          type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
         interface Card {
           /**
            * Installment details for this payment (Mexico only).
@@ -693,12 +706,28 @@ declare module 'stripe' {
 
       interface PaymentMethodOptions {
         /**
+         * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
+         */
+        bancontact?: PaymentMethodOptions.Bancontact | null;
+
+        /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
         card?: PaymentMethodOptions.Card | null;
       }
 
       namespace PaymentMethodOptions {
+        interface Bancontact {
+          /**
+           * Preferred language of the Bancontact authorization page that the customer is redirected to.
+           */
+          preferred_language?: Bancontact.PreferredLanguage;
+        }
+
+        namespace Bancontact {
+          type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
         interface Card {
           /**
            * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
@@ -937,12 +966,28 @@ declare module 'stripe' {
     namespace PaymentIntentUpdateParams {
       interface PaymentMethodOptions {
         /**
+         * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
+         */
+        bancontact?: PaymentMethodOptions.Bancontact | null;
+
+        /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
         card?: PaymentMethodOptions.Card | null;
       }
 
       namespace PaymentMethodOptions {
+        interface Bancontact {
+          /**
+           * Preferred language of the Bancontact authorization page that the customer is redirected to.
+           */
+          preferred_language?: Bancontact.PreferredLanguage;
+        }
+
+        namespace Bancontact {
+          type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
         interface Card {
           /**
            * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
@@ -1297,12 +1342,28 @@ declare module 'stripe' {
 
       interface PaymentMethodOptions {
         /**
+         * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
+         */
+        bancontact?: PaymentMethodOptions.Bancontact | null;
+
+        /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
         card?: PaymentMethodOptions.Card | null;
       }
 
       namespace PaymentMethodOptions {
+        interface Bancontact {
+          /**
+           * Preferred language of the Bancontact authorization page that the customer is redirected to.
+           */
+          preferred_language?: Bancontact.PreferredLanguage;
+        }
+
+        namespace Bancontact {
+          type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
         interface Card {
           /**
            * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -18,6 +18,8 @@ declare module 'stripe' {
 
       bacs_debit?: PaymentMethod.BacsDebit;
 
+      bancontact?: PaymentMethod.Bancontact;
+
       billing_details: PaymentMethod.BillingDetails;
 
       card?: PaymentMethod.Card;
@@ -34,7 +36,11 @@ declare module 'stripe' {
        */
       customer: string | Stripe.Customer | null;
 
+      eps?: PaymentMethod.Eps;
+
       fpx?: PaymentMethod.Fpx;
+
+      giropay?: PaymentMethod.Giropay;
 
       ideal?: PaymentMethod.Ideal;
 
@@ -49,6 +55,8 @@ declare module 'stripe' {
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
        */
       metadata: Metadata;
+
+      p24?: PaymentMethod.P24;
 
       sepa_debit?: PaymentMethod.SepaDebit;
 
@@ -92,6 +100,8 @@ declare module 'stripe' {
          */
         sort_code: string | null;
       }
+
+      interface Bancontact {}
 
       interface BillingDetails {
         /**
@@ -296,6 +306,8 @@ declare module 'stripe' {
 
       interface CardPresent {}
 
+      interface Eps {}
+
       interface Fpx {
         /**
          * Account holder type, if provided. Can be one of `individual` or `company`.
@@ -333,6 +345,8 @@ declare module 'stripe' {
           | 'standard_chartered'
           | 'uob';
       }
+
+      interface Giropay {}
 
       interface Ideal {
         /**
@@ -378,6 +392,8 @@ declare module 'stripe' {
 
       interface InteracPresent {}
 
+      interface P24 {}
+
       interface SepaDebit {
         /**
          * Bank code of bank associated with the bank account.
@@ -408,10 +424,14 @@ declare module 'stripe' {
       type Type =
         | 'au_becs_debit'
         | 'bacs_debit'
+        | 'bancontact'
         | 'card'
         | 'card_present'
+        | 'eps'
         | 'fpx'
+        | 'giropay'
         | 'ideal'
+        | 'p24'
         | 'sepa_debit';
     }
 
@@ -425,6 +445,11 @@ declare module 'stripe' {
        * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
        */
       bacs_debit?: PaymentMethodCreateParams.BacsDebit;
+
+      /**
+       * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+       */
+      bancontact?: PaymentMethodCreateParams.Bancontact;
 
       /**
        * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
@@ -442,6 +467,11 @@ declare module 'stripe' {
       customer?: string;
 
       /**
+       * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+       */
+      eps?: PaymentMethodCreateParams.Eps;
+
+      /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
@@ -450,6 +480,11 @@ declare module 'stripe' {
        * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
        */
       fpx?: PaymentMethodCreateParams.Fpx;
+
+      /**
+       * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+       */
+      giropay?: PaymentMethodCreateParams.Giropay;
 
       /**
        * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
@@ -465,6 +500,11 @@ declare module 'stripe' {
        * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
       metadata?: MetadataParam;
+
+      /**
+       * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+       */
+      p24?: PaymentMethodCreateParams.P24;
 
       /**
        * The PaymentMethod to share.
@@ -506,6 +546,8 @@ declare module 'stripe' {
          */
         sort_code?: string;
       }
+
+      interface Bancontact {}
 
       interface BillingDetails {
         /**
@@ -589,6 +631,8 @@ declare module 'stripe' {
         token: string;
       }
 
+      interface Eps {}
+
       interface Fpx {
         /**
          * Account holder type for FPX transaction
@@ -627,6 +671,8 @@ declare module 'stripe' {
           | 'uob';
       }
 
+      interface Giropay {}
+
       interface Ideal {
         /**
          * The customer's bank.
@@ -652,6 +698,8 @@ declare module 'stripe' {
 
       interface InteracPresent {}
 
+      interface P24 {}
+
       interface SepaDebit {
         /**
          * IBAN of the bank account.
@@ -662,10 +710,14 @@ declare module 'stripe' {
       type Type =
         | 'au_becs_debit'
         | 'bacs_debit'
+        | 'bancontact'
         | 'card'
         | 'card_present'
+        | 'eps'
         | 'fpx'
+        | 'giropay'
         | 'ideal'
+        | 'p24'
         | 'sepa_debit';
     }
 
@@ -802,10 +854,14 @@ declare module 'stripe' {
     namespace PaymentMethodListParams {
       type Type =
         | 'au_becs_debit'
+        | 'bancontact'
         | 'card'
         | 'card_present'
+        | 'eps'
         | 'fpx'
+        | 'giropay'
         | 'ideal'
+        | 'p24'
         | 'sepa_debit';
     }
 

--- a/types/2020-03-02/Sources.d.ts
+++ b/types/2020-03-02/Sources.d.ts
@@ -611,6 +611,11 @@ declare module 'stripe' {
           description: string | null;
 
           /**
+           * The ID of the associated object for this line item. Expandable if not null (e.g., expandable to a SKU).
+           */
+          parent: string | null;
+
+          /**
            * The quantity of this order item. When type is `sku`, this is the number of instances of the SKU to be ordered.
            */
           quantity?: number;

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -119,7 +119,7 @@ declare module 'stripe' {
         /**
          * The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
          */
-        transfer_data?: DefaultSettings.TransferData | null;
+        transfer_data: DefaultSettings.TransferData | null;
       }
 
       namespace DefaultSettings {
@@ -228,7 +228,7 @@ declare module 'stripe' {
         /**
          * The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
          */
-        transfer_data?: Phase.TransferData | null;
+        transfer_data: Phase.TransferData | null;
 
         /**
          * When the trial ends within the phase.

--- a/types/2020-03-02/Subscriptions.d.ts
+++ b/types/2020-03-02/Subscriptions.d.ts
@@ -185,7 +185,7 @@ declare module 'stripe' {
       /**
        * The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
        */
-      transfer_data?: Subscription.TransferData | null;
+      transfer_data: Subscription.TransferData | null;
 
       /**
        * If the subscription has a trial, the end of that trial.


### PR DESCRIPTION
Multiple API changes
  * Add support for bg, cs, el, et, hu, lt, lv, mt, ro, ru, sk, sl and tr as new locale on Checkout `Session`
  * Add `settings[sepa_debit_payments][creditor_id]` on `Account`
  * Add support for Bancontact, EPS, Giropay and P24 on `PaymentMethod`, `PaymentIntent` and `SetupIntent`
  * Add support for `order_item[parent]` on `Source` for Klarna

Codegen for openapi 1158945

r? @cjavilla-stripe 
cc @stripe/api-libraries 