### PR TITLE
Add support for Bancontact, EPS, Giropay and P24 on Checkout `Session`

### DIFF
--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -901,7 +901,15 @@ declare module 'stripe' {
           }
         }
 
-        type PaymentMethodType = 'bacs_debit' | 'card' | 'fpx' | 'ideal';
+        type PaymentMethodType =
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'card'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'ideal'
+          | 'p24';
 
         interface SetupIntentData {
           /**


### PR DESCRIPTION
Codegen for openapi 8a11585

r? @cjavilla-stripe 
cc @stripe/api-libraries 