### PR TITLE
Add support for `id_npwp` and `my_frp` as `type` on `TaxId`

### DIFF
--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -820,11 +820,16 @@ declare module 'stripe' {
           receipt_email?: string;
 
           /**
-           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           * Indicates that you intend to make future payments with the payment
+           * method collected by this Checkout Session.
            *
-           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           * When setting this to `off_session`, Checkout will show a notice to the
+           * customer that their payment details will be saved and used for future
+           * payments.
            *
-           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           * When processing card payments, Checkout also uses `setup_future_usage`
+           * to dynamically optimize your payment flow and comply with regional
+           * legislation and network rules, such as SCA.
            */
           setup_future_usage?: PaymentIntentData.SetupFutureUsage;
 

--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -341,7 +341,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, or `sa_vat`
+         * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, or `my_frp`
          */
         type: TaxIdDatum.Type;
 
@@ -364,11 +364,13 @@ declare module 'stripe' {
           | 'es_cif'
           | 'eu_vat'
           | 'hk_br'
+          | 'id_npwp'
           | 'in_gst'
           | 'jp_cn'
           | 'kr_brn'
           | 'li_uid'
           | 'mx_rfc'
+          | 'my_frp'
           | 'my_itn'
           | 'my_sst'
           | 'no_vat'

--- a/types/2020-03-02/InvoiceLineItems.d.ts
+++ b/types/2020-03-02/InvoiceLineItems.d.ts
@@ -181,7 +181,7 @@ declare module 'stripe' {
         | number;
 
       /**
-       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`
+       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.
        */
       subscription_cancel_at?: number | null;
 
@@ -208,7 +208,7 @@ declare module 'stripe' {
       >;
 
       /**
-       * If previewing an update to a subscription, this decides whether the preview will show the result of applying prorations or not. If set, one of `subscription_items` or `subscription`, and one of `subscription_items` or `subscription_trial_end` are required. This field has been deprecated and will be removed in a future API version. Use `subscription_proration_behavior=create_prorations` as a replacement for `subscription_prorate=true` and `subscription_proration_behavior=none` for `subscription_prorate=false`.
+       * This field has been renamed to `subscription_proration_behavior`. `subscription_prorate=true` can be replaced with `subscription_proration_behavior=create_prorations` and `subscription_prorate=false` can be replaced with `subscription_proration_behavior=none`.
        */
       subscription_prorate?: boolean;
 

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -347,7 +347,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -370,11 +370,13 @@ declare module 'stripe' {
           | 'es_cif'
           | 'eu_vat'
           | 'hk_br'
+          | 'id_npwp'
           | 'in_gst'
           | 'jp_cn'
           | 'kr_brn'
           | 'li_uid'
           | 'mx_rfc'
+          | 'my_frp'
           | 'my_itn'
           | 'my_sst'
           | 'no_vat'
@@ -876,7 +878,7 @@ declare module 'stripe' {
         | number;
 
       /**
-       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.`
+       * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.
        */
       subscription_cancel_at?: number | null;
 

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -730,7 +730,7 @@ declare module 'stripe' {
 
     interface PaymentMethodUpdateParams {
       /**
-       * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+       * This is a legacy parameter that will be removed in the future. It is a hash that does not accept any keys.
        */
       au_becs_debit?: PaymentMethodUpdateParams.AuBecsDebit;
 
@@ -755,7 +755,7 @@ declare module 'stripe' {
       metadata?: MetadataParam | null;
 
       /**
-       * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+       * This is a legacy parameter that will be removed in the future. It is a hash that does not accept any keys.
        */
       sepa_debit?: PaymentMethodUpdateParams.SepaDebit;
     }

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -354,7 +354,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * Migrate an existing subscription to be managed by a subscription schedule. If this parameter is set, a subscription schedule will be created using the subscription's plan(s), set to auto-renew using the subscription's interval. When using this parameter, other parameters (such as phase values) cannot be set. To create a subscription schedule with other modifications, we recommend making two separate API calls.
+       * Migrate an existing subscription to be managed by a subscription schedule. If this parameter is set, a subscription schedule will be created using the subscription's item(s), set to auto-renew using the subscription's interval. When using this parameter, other parameters (such as phase values) cannot be set. To create a subscription schedule with other modifications, we recommend making two separate API calls.
        */
       from_subscription?: string;
 
@@ -486,12 +486,12 @@ declare module 'stripe' {
         invoice_settings?: Phase.InvoiceSettings;
 
         /**
-         * Integer representing the multiplier applied to the plan interval. For example, `iterations=2` applied to a plan with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`. If set, `end_date` must not be set.
+         * Integer representing the multiplier applied to the price interval. For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`. If set, `end_date` must not be set.
          */
         iterations?: number;
 
         /**
-         * List of configuration items, each with an attached plan, to apply during this phase of the subscription schedule.
+         * List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
          */
         plans: Array<Phase.Plan>;
 
@@ -501,7 +501,7 @@ declare module 'stripe' {
         proration_behavior?: Phase.ProrationBehavior;
 
         /**
-         * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period during thise phase of the schedule. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
+         * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period during thise phase of the schedule. For example, a price which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
          */
         tax_percent?: number;
 
@@ -591,7 +591,7 @@ declare module 'stripe' {
           billing_thresholds?: Plan.BillingThresholds | null;
 
           /**
-           * The plan ID to subscribe to.
+           * The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
            */
           plan?: string;
 
@@ -606,7 +606,7 @@ declare module 'stripe' {
           price_data?: Plan.PriceData;
 
           /**
-           * Quantity for the given plan. Can be set only if the plan's `usage_type` is `licensed` and not `metered`.
+           * Quantity for the given price. Can be set only if the price's `usage_type` is `licensed` and not `metered`.
            */
           quantity?: number;
 
@@ -845,12 +845,12 @@ declare module 'stripe' {
         invoice_settings?: Phase.InvoiceSettings;
 
         /**
-         * Integer representing the multiplier applied to the plan interval. For example, `iterations=2` applied to a plan with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`. If set, `end_date` must not be set.
+         * Integer representing the multiplier applied to the price interval. For example, `iterations=2` applied to a price with `interval=month` and `interval_count=3` results in a phase of duration `2 * 3 months = 6 months`. If set, `end_date` must not be set.
          */
         iterations?: number;
 
         /**
-         * List of configuration items, each with an attached plan, to apply during this phase of the subscription schedule.
+         * List of configuration items, each with an attached price, to apply during this phase of the subscription schedule.
          */
         plans: Array<Phase.Plan>;
 
@@ -865,7 +865,7 @@ declare module 'stripe' {
         start_date?: number | 'now';
 
         /**
-         * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period during thise phase of the schedule. For example, a plan which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
+         * A non-negative decimal (with at most four decimal places) between 0 and 100. This represents the percentage of the subscription invoice subtotal that will be calculated and added as tax to the final amount in each billing period during thise phase of the schedule. For example, a price which charges $10/month with a `tax_percent` of `20.0` will charge $12 per invoice. To unset a previously-set value, pass an empty string. This field has been deprecated and will be removed in a future API version, for further information view the [migration docs](https://stripe.com/docs/billing/migration/taxes) for `tax_rates`.
          */
         tax_percent?: number;
 
@@ -955,7 +955,7 @@ declare module 'stripe' {
           billing_thresholds?: Plan.BillingThresholds | null;
 
           /**
-           * The plan ID to subscribe to.
+           * The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
            */
           plan?: string;
 
@@ -970,7 +970,7 @@ declare module 'stripe' {
           price_data?: Plan.PriceData;
 
           /**
-           * Quantity for the given plan. Can be set only if the plan's `usage_type` is `licensed` and not `metered`.
+           * Quantity for the given price. Can be set only if the price's `usage_type` is `licensed` and not `metered`.
            */
           quantity?: number;
 

--- a/types/2020-03-02/TaxIds.d.ts
+++ b/types/2020-03-02/TaxIds.d.ts
@@ -37,7 +37,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -62,11 +62,13 @@ declare module 'stripe' {
         | 'es_cif'
         | 'eu_vat'
         | 'hk_br'
+        | 'id_npwp'
         | 'in_gst'
         | 'jp_cn'
         | 'kr_brn'
         | 'li_uid'
         | 'mx_rfc'
+        | 'my_frp'
         | 'my_itn'
         | 'my_sst'
         | 'no_vat'
@@ -125,7 +127,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, or `sa_vat`
+       * Type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, or `my_frp`
        */
       type: TaxIdCreateParams.Type;
 
@@ -153,11 +155,13 @@ declare module 'stripe' {
         | 'es_cif'
         | 'eu_vat'
         | 'hk_br'
+        | 'id_npwp'
         | 'in_gst'
         | 'jp_cn'
         | 'kr_brn'
         | 'li_uid'
         | 'mx_rfc'
+        | 'my_frp'
         | 'my_itn'
         | 'my_sst'
         | 'no_vat'


### PR DESCRIPTION
Codegen for openapi 2394b37

r? @cjavilla-stripe 
cc @stripe/api-libraries 