### PR TITLE
Expose StripeResource on instance

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -104,6 +104,9 @@ function Stripe(key, config = {}) {
 
   this._prevRequestMetrics = [];
   this._enableTelemetry = props.telemetry !== false;
+
+  // Expose StripeResource on the instance too
+  this.StripeResource = Stripe.StripeResource;
 }
 
 Stripe.errors = require('./Error');


### PR DESCRIPTION
r? @stripe/api-libraries
cc @stripe/api-libraries @remi-stripe @paulasjes-stripe 

This just surfaces the `StripeResource` on the instance as well, so you can continue to do `const stripe = require('stripe')(apiKeyHere);` but still be able to add resources while working with beta things.