### PR TITLE
Document the 'protocol' configuration option

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,6 +163,7 @@ const stripe = Stripe('sk_test_...', {
   timeout: 1000,
   host: 'api.example.com',
   port: 123,
+  protocol: 'http',
   telemetry: true,
 });
 ```
@@ -175,6 +176,7 @@ const stripe = Stripe('sk_test_...', {
 | `timeout`           | 80000              | [Maximum time each request can take in ms.](#configuring-timeout)                     |
 | `host`              | `'api.stripe.com'` | Host that requests are made to.                                                       |
 | `port`              | 443                | Port that requests are made to.                                                       |
+| `protocol`          | `'https'`          | Port that requests use.                                                               |
 | `telemetry`         | `true`             | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                 |
 
 Note: Both `maxNetworkRetries` and `timeout` can be overridden on a per-request basis.


### PR DESCRIPTION
There is an undocumented `protocol` option that can be used. I was trying to figure a way to use http instead of https (in the older version of the client I was using in my project) for testing and couldn't find it. But I can see it is now there and just not documented in the Readme.