### PR TITLE
Document but discourage `protocol` config option

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ const stripe = Stripe('sk_test_...', {
 | `timeout`           | 80000              | [Maximum time each request can take in ms.](#configuring-timeout)                     |
 | `host`              | `'api.stripe.com'` | Host that requests are made to.                                                       |
 | `port`              | 443                | Port that requests are made to.                                                       |
+| `protocol`          | `'https'`          | `'https'` or `'http'`. `http` is never appropriate for sending requests to Stripe servers, and we strongly discourage `http`, even in local testing scenarios, as this can result in your credentials being transmitted over an insecure channel.
 | `telemetry`         | `true`             | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                 |
 
 Note: Both `maxNetworkRetries` and `timeout` can be overridden on a per-request basis.

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -65,6 +65,16 @@ function Stripe(key, config = {}) {
   this.once = this._emitter.once.bind(this._emitter);
   this.off = this._emitter.removeListener.bind(this._emitter);
 
+  if (
+    props.protocol &&
+    props.protocol !== 'https' &&
+    (!props.host || /\.stripe\.com$/.test(props.host))
+  ) {
+    throw new Error(
+      'The `https` protocol must be used when sending requests to `*.stripe.com`'
+    );
+  }
+
   this._api = {
     auth: null,
     host: props.host || DEFAULT_HOST,

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -58,6 +58,47 @@ describe('Stripe Module', function() {
         });
       }).to.not.throw();
     });
+    it('should forbid sending http to *.stripe.com', () => {
+      expect(() => {
+        Stripe(testUtils.getUserStripeKey(), {
+          host: 'foo.stripe.com',
+          protocol: 'http',
+        });
+      }).to.throw(/The `https` protocol must be used/);
+
+      expect(() => {
+        Stripe(testUtils.getUserStripeKey(), {
+          protocol: 'http',
+        });
+      }).to.throw(/The `https` protocol must be used/);
+
+      expect(() => {
+        Stripe(testUtils.getUserStripeKey(), {
+          protocol: 'http',
+          host: 'api.stripe.com',
+        });
+      }).to.throw(/The `https` protocol must be used/);
+
+      expect(() => {
+        Stripe(testUtils.getUserStripeKey(), {
+          protocol: 'https',
+          host: 'api.stripe.com',
+        });
+      }).not.to.throw();
+
+      expect(() => {
+        Stripe(testUtils.getUserStripeKey(), {
+          host: 'api.stripe.com',
+        });
+      }).not.to.throw();
+
+      expect(() => {
+        Stripe(testUtils.getUserStripeKey(), {
+          protocol: 'http',
+          host: 'localhost',
+        });
+      }).not.to.throw();
+    });
 
     it('should perform a no-op if null, undefined or empty values are passed', () => {
       const cases = [null, undefined, '', {}];


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 
Throws an exception when the stripe client is initialized if the `http` protocol is specified without configuring a non-stripe.com host.
Also documents the `protocol` configuration option.
Fixes https://github.com/stripe/stripe-node/pull/938