### PR TITLE
Fix `assert_capabilities` type definition

### DIFF
--- a/types/OAuth.d.ts
+++ b/types/OAuth.d.ts
@@ -320,7 +320,7 @@ declare module 'stripe' {
        * Express only
        * Check whether the suggested_capabilities were applied to the connected account.
        */
-      assert_capabilities?: string;
+      assert_capabilities?: Array<string>;
     }
 
     export class OAuthResource {


### PR DESCRIPTION
r? @paulasjes-stripe 
cc @stripe/api-libraries 

The parameter is an [(optional) array of strings](https://stripe.com/docs/connect/express-accounts#specify-capabilities-for-an-account), not a string.  Fixes #944. 