### PR TITLE
fix StripeConfig.apiVersion type

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -21,7 +21,7 @@ declare module 'stripe' {
        *
        * @docs https://stripe.com/docs/api/versioning
        */
-      apiVersion: LatestApiVersion;
+      apiVersion?: null | string;
 
       /**
        * Optionally indicate that you are using TypeScript.


### PR DESCRIPTION
The type for `StripeConfig.apiVersion` seems incorrect.  It is not required, and `null` can be passed (which it even states in the comment), but as it stands right now, the only way to avoid a typescript error is to always set the property and set it to _exactly_ the string `"2020-03-02"`.

This PR makes the type match what the client constructor actually accepts -- `apiVersion` is optional, and accepts a string or null. A stricter type could be created by making a union of all possible api versions, like: `'2020-03-02' | '2019-12-03'` etc, but there are so many historical api versions it seems to make more sense just to make the type `string`.