### PR TITLE
Detect api keys that begin with quotation marks

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -107,6 +107,7 @@ function Stripe(key, config = {}) {
   }
 
   this._prepResources();
+  this._validateApiKey(key);
   this._setApiKey(key);
 
   this.errors = require('./Error');
@@ -221,6 +222,14 @@ Stripe.prototype = {
   _setApiKey(key) {
     if (key) {
       this._setApiField('auth', `Bearer ${key}`);
+    }
+  },
+
+  _validateApiKey(key) {
+    if (key && (key[0] === "'" || key[0] === '"')) {
+      throw new Error(
+        `Invalid API key: ${key}. API keys should not begin with quotation marks.`
+      );
     }
   },
 

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -100,6 +100,18 @@ describe('Stripe Module', function() {
       }).not.to.throw();
     });
 
+    it('Should forbid api keys that begin with a single quote', () => {
+      expect(() => {
+        Stripe(`'${testUtils.getUserStripeKey()}'`);
+      }).to.throw(/API keys should not begin with quotation marks/);
+    });
+
+    it('Should forbid api keys that begin with a double quote', () => {
+      expect(() => {
+        Stripe(`"${testUtils.getUserStripeKey()}"`);
+      }).to.throw(/API keys should not begin with quotation marks/);
+    });
+
     it('should perform a no-op if null, undefined or empty values are passed', () => {
       const cases = [null, undefined, '', {}];
 


### PR DESCRIPTION
r? @ob-stripe 
cc @stripe/api-libraries 
Initializing the client now throws an exception when the provided api key begins with `'` or `"`. This should prevent confusion like https://github.com/stripe/stripe-node/issues/950 -- quotation marks can make the normal server-side error message super confusing.