### PR TITLE
Add new fields to lastResponse: apiVersion, stripeAccount, idempotencyKey

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -124,9 +124,24 @@ StripeResource.prototype = {
         const headers = res.headers || {};
         // NOTE: Stripe responds with lowercase header names/keys.
 
-        // For convenience, make Request-Id easily accessible on
+        // For convenience, make some headers easily accessible on
         // lastResponse.
         res.requestId = headers['request-id'];
+
+        const stripeAccount = headers['stripe-account'];
+        if (stripeAccount) {
+          res.stripeAccount = stripeAccount;
+        }
+
+        const apiVersion = headers['stripe-version'];
+        if (apiVersion) {
+          res.apiVersion = apiVersion;
+        }
+
+        const idempotencyKey = headers['idempotency-key'];
+        if (idempotencyKey) {
+          res.idempotencyKey = idempotencyKey;
+        }
 
         const requestEndTime = Date.now();
         const requestDurationMs = requestEndTime - req._requestStart;


### PR DESCRIPTION
r? @jlomas-stripe  
cc @stripe/api-libraries @brandur-stripe 

If any of these three fields are set in the headers, copy them over to lastResponse as suggested in #406.
Also add tests for the new fields and refactor an existing test for lastResponse.