### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -425,7 +425,7 @@ declare module 'stripe' {
         disabled_reason: string | null;
 
         /**
-         * The fields that need to be collected again because validation or verification failed for some reason.
+         * The fields that are `currently_due` and need to be collected again because validation or verification failed for some reason.
          */
         errors: Array<Requirements.Error> | null;
 

--- a/types/2020-03-02/Capabilities.d.ts
+++ b/types/2020-03-02/Capabilities.d.ts
@@ -55,7 +55,7 @@ declare module 'stripe' {
         disabled_reason: string | null;
 
         /**
-         * The fields that need to be collected again because validation or verification failed for some reason.
+         * The fields that are `currently_due` and need to be collected again because validation or verification failed for some reason.
          */
         errors: Array<Requirements.Error>;
 

--- a/types/2020-03-02/Cards.d.ts
+++ b/types/2020-03-02/Cards.d.ts
@@ -154,7 +154,7 @@ declare module 'stripe' {
       recipient?: string | Stripe.Recipient | null;
 
       /**
-       * If the card number is tokenized, this is the method that was used. Can be `amex_express_checkout`, `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null.
+       * If the card number is tokenized, this is the method that was used. Can be `android_pay` (includes Google Pay), `apple_pay`, `masterpass`, `visa_checkout`, or null.
        */
       tokenization_method: string | null;
     }

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -205,6 +205,7 @@ declare module 'stripe' {
           | 'el'
           | 'en'
           | 'es'
+          | 'es-419'
           | 'et'
           | 'fi'
           | 'fr'
@@ -670,7 +671,7 @@ declare module 'stripe' {
           quantity: number;
 
           /**
-           * The tax rates which apply to this line item. This is only allowed in subscription mode.
+           * The [tax rates](https://stripe.com/docs/api/tax_rates) which apply to this line item. This is only allowed in subscription mode.
            */
           tax_rates?: Array<string>;
         }
@@ -758,6 +759,7 @@ declare module 'stripe' {
           | 'el'
           | 'en'
           | 'es'
+          | 'es-419'
           | 'et'
           | 'fi'
           | 'fr'

--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -113,7 +113,7 @@ declare module 'stripe' {
       /**
        * The customer's current subscriptions, if any.
        */
-      subscriptions?: ApiList<Stripe.Subscription>;
+      subscriptions: ApiList<Stripe.Subscription> | null;
 
       /**
        * Describes the customer's tax exemption status. One of `none`, `exempt`, or `reverse`. When set to `reverse`, invoice and receipt PDFs include the text **"Reverse charge"**.

--- a/types/2020-03-02/Issuing/Transactions.d.ts
+++ b/types/2020-03-02/Issuing/Transactions.d.ts
@@ -217,7 +217,7 @@ declare module 'stripe' {
             type: string;
 
             /**
-             * The units for `volume`. One of `us_gallon` or `liter`.
+             * The units for `volume_decimal`. One of `us_gallon` or `liter`.
              */
             unit: string;
 

--- a/types/2020-03-02/Persons.d.ts
+++ b/types/2020-03-02/Persons.d.ts
@@ -246,7 +246,7 @@ declare module 'stripe' {
         currently_due: Array<string>;
 
         /**
-         * The fields that need to be collected again because validation or verification failed for some reason.
+         * The fields that are `currently_due` and need to be collected again because validation or verification failed for some reason.
          */
         errors: Array<Requirements.Error>;
 

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -97,6 +97,11 @@ declare module 'stripe' {
 
       interface DefaultSettings {
         /**
+         * Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+         */
+        billing_cycle_anchor: DefaultSettings.BillingCycleAnchor;
+
+        /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period
          */
         billing_thresholds: DefaultSettings.BillingThresholds | null;
@@ -123,6 +128,8 @@ declare module 'stripe' {
       }
 
       namespace DefaultSettings {
+        type BillingCycleAnchor = 'automatic' | 'phase_start';
+
         interface BillingThresholds {
           /**
            * Monetary threshold that triggers the subscription to create an invoice
@@ -169,6 +176,11 @@ declare module 'stripe' {
          * A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account during this phase of the schedule.
          */
         application_fee_percent: number | null;
+
+        /**
+         * Possible values are `phase_start` or `automatic`. If `phase_start` then billing cycle anchor of the subscription is set to the start of the phase when entering the phase. If `automatic` then the billing cycle anchor is automatically modified as needed when entering the phase. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+         */
+        billing_cycle_anchor: Phase.BillingCycleAnchor | null;
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period
@@ -248,6 +260,8 @@ declare module 'stripe' {
            */
           quantity: number | null;
         }
+
+        type BillingCycleAnchor = 'automatic' | 'phase_start';
 
         interface BillingThresholds {
           /**
@@ -377,6 +391,11 @@ declare module 'stripe' {
     namespace SubscriptionScheduleCreateParams {
       interface DefaultSettings {
         /**
+         * Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed. Cannot be set to `phase_start` if this phase specifies a trial. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+         */
+        billing_cycle_anchor?: DefaultSettings.BillingCycleAnchor;
+
+        /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
          */
         billing_thresholds?: DefaultSettings.BillingThresholds | null;
@@ -403,6 +422,8 @@ declare module 'stripe' {
       }
 
       namespace DefaultSettings {
+        type BillingCycleAnchor = 'automatic' | 'phase_start';
+
         interface BillingThresholds {
           /**
            * Monetary threshold that triggers the subscription to advance to a new billing period
@@ -449,6 +470,11 @@ declare module 'stripe' {
          * A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made by a platform account on a connected account in order to set an application fee percentage. For more information, see the application fees [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).
          */
         application_fee_percent?: number;
+
+        /**
+         * Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed. Cannot be set to `phase_start` if this phase specifies a trial. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+         */
+        billing_cycle_anchor?: Phase.BillingCycleAnchor;
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
@@ -562,6 +588,8 @@ declare module 'stripe' {
             unit_amount_decimal?: string;
           }
         }
+
+        type BillingCycleAnchor = 'automatic' | 'phase_start';
 
         interface BillingThresholds {
           /**
@@ -736,6 +764,11 @@ declare module 'stripe' {
     namespace SubscriptionScheduleUpdateParams {
       interface DefaultSettings {
         /**
+         * Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed. Cannot be set to `phase_start` if this phase specifies a trial. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+         */
+        billing_cycle_anchor?: DefaultSettings.BillingCycleAnchor;
+
+        /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
          */
         billing_thresholds?: DefaultSettings.BillingThresholds | null;
@@ -762,6 +795,8 @@ declare module 'stripe' {
       }
 
       namespace DefaultSettings {
+        type BillingCycleAnchor = 'automatic' | 'phase_start';
+
         interface BillingThresholds {
           /**
            * Monetary threshold that triggers the subscription to advance to a new billing period
@@ -808,6 +843,11 @@ declare module 'stripe' {
          * A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the application owner's Stripe account. The request must be made by a platform account on a connected account in order to set an application fee percentage. For more information, see the application fees [documentation](https://stripe.com/docs/connect/subscriptions#collecting-fees-on-subscriptions).
          */
         application_fee_percent?: number;
+
+        /**
+         * Can be set to `phase_start` to set the anchor to the start of the phase or `automatic` to automatically change it if needed. Cannot be set to `phase_start` if this phase specifies a trial. For more information, see the billing cycle [documentation](https://stripe.com/docs/billing/subscriptions/billing-cycle).
+         */
+        billing_cycle_anchor?: Phase.BillingCycleAnchor;
 
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
@@ -926,6 +966,8 @@ declare module 'stripe' {
             unit_amount_decimal?: string;
           }
         }
+
+        type BillingCycleAnchor = 'automatic' | 'phase_start';
 
         interface BillingThresholds {
           /**

--- a/types/2020-03-02/TaxRates.d.ts
+++ b/types/2020-03-02/TaxRates.d.ts
@@ -15,7 +15,7 @@ declare module 'stripe' {
       object: 'tax_rate';
 
       /**
-       * Defaults to `true`. When set to `false`, this tax rate cannot be applied to objects in the API, but will still be applied to subscriptions and invoices that already have it set.
+       * Defaults to `true`. When set to `false`, this tax rate is considered archived and cannot be applied to new applications or Checkout Sessions, but will still be applied to subscriptions and invoices that already have it set.
        */
       active: boolean;
 
@@ -77,7 +77,7 @@ declare module 'stripe' {
       percentage: number;
 
       /**
-       * Flag determining whether the tax rate is active or inactive. Inactive tax rates continue to work where they are currently applied however they cannot be used for new applications.
+       * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates continue to work where they are currently applied however they cannot be used for new applications or Checkout Sessions.
        */
       active?: boolean;
 
@@ -111,7 +111,7 @@ declare module 'stripe' {
 
     interface TaxRateUpdateParams {
       /**
-       * Flag determining whether the tax rate is active or inactive. Inactive tax rates continue to work where they are currently applied however they cannot be used for new applications.
+       * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates continue to work where they are currently applied however they cannot be used for new applications or Checkout Sessions.
        */
       active?: boolean;
 
@@ -143,12 +143,12 @@ declare module 'stripe' {
 
     interface TaxRateListParams extends PaginationParams {
       /**
-       * Optional flag to filter by tax rates that are either active or not active (archived)
+       * Optional flag to filter by tax rates that are either active or inactive (archived).
        */
       active?: boolean;
 
       /**
-       * Optional range for filtering created date
+       * Optional range for filtering created date.
        */
       created?: RangeQueryParam | number;
 
@@ -158,7 +158,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * Optional flag to filter by tax rates that are inclusive (or those that are not inclusive)
+       * Optional flag to filter by tax rates that are inclusive (or those that are not inclusive).
        */
       inclusive?: boolean;
     }


### PR DESCRIPTION
Multiple API changes:
  * Adds `es-419` as a `locale` to Checkout `Session`
  * Adds `billing_cycle_anchor` to `default_settings` and `phases` for `SubscriptionSchedule`

Codegen for openapi 19ea774

r? @remi-stripe 
cc @stripe/api-libraries 