### PR TITLE
Change from string to enum value for `billing_address_collection` on Checkout `Session`

### DIFF
--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -17,10 +17,9 @@ declare module 'stripe' {
         object: 'checkout.session';
 
         /**
-         * The value (`auto` or `required`) for whether Checkout collected the
-         * customer's billing address.
+         * Describes whether Checkout should collect the customer's billing address.
          */
-        billing_address_collection: string | null;
+        billing_address_collection: Session.BillingAddressCollection | null;
 
         /**
          * The URL the customer will be directed to if they decide to cancel payment and return to your website.
@@ -129,6 +128,8 @@ declare module 'stripe' {
       }
 
       namespace Session {
+        type BillingAddressCollection = 'auto' | 'required';
+
         interface DisplayItem {
           /**
            * Amount for the display item.

--- a/types/2020-03-02/LineItems.d.ts
+++ b/types/2020-03-02/LineItems.d.ts
@@ -84,7 +84,7 @@ declare module 'stripe' {
         amount: number;
 
         /**
-         * Tax rates can be applied to invoices and subscriptions to collect tax.
+         * Tax rates can be applied to [invoices](https://stripe.com/docs/billing/invoices/tax-rates), [subscriptions](https://stripe.com/docs/billing/subscriptions/taxes) and [Checkout Sessions](https://stripe.com/docs/payments/checkout/set-up-a-subscription#tax-rates) to collect tax.
          *
          * Related guide: [Tax Rates](https://stripe.com/docs/billing/taxes/tax-rates).
          */

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -42,7 +42,7 @@ declare module 'stripe' {
       default_settings: SubscriptionSchedule.DefaultSettings;
 
       /**
-       * Behavior of the subscription schedule and underlying subscription when it ends.
+       * Behavior of the subscription schedule and underlying subscription when it ends. Possible values are `release` and `cancel`.
        */
       end_behavior: SubscriptionSchedule.EndBehavior;
 
@@ -223,7 +223,7 @@ declare module 'stripe' {
         plans: Array<Phase.Plan>;
 
         /**
-         * Controls whether or not the subscription schedule will prorate when transitioning to this phase. Values are `create_prorations` and `none`.
+         * Controls whether or not the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`.
          */
         proration_behavior: Phase.ProrationBehavior | null;
 
@@ -522,7 +522,7 @@ declare module 'stripe' {
         plans: Array<Phase.Plan>;
 
         /**
-         * Controls whether or not a subscription schedule will create prorations when transitioning to this phase. Valid values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
+         * Controls whether or not a subscription schedule will create prorations when transitioning to this phase. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
          */
         proration_behavior?: Phase.ProrationBehavior;
 
@@ -756,7 +756,7 @@ declare module 'stripe' {
       prorate?: boolean;
 
       /**
-       * If the update changes the current phase, indicates if the changes should be prorated. Valid values are `create_prorations` or `none`, and the default value is `create_prorations`.
+       * If the update changes the current phase, indicates if the changes should be prorated. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`.
        */
       proration_behavior?: SubscriptionScheduleUpdateParams.ProrationBehavior;
     }
@@ -895,7 +895,7 @@ declare module 'stripe' {
         plans: Array<Phase.Plan>;
 
         /**
-         * Controls whether or not a subscription schedule will create prorations when transitioning to this phase. Valid values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
+         * Controls whether or not a subscription schedule will create prorations when transitioning to this phase. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
          */
         proration_behavior?: Phase.ProrationBehavior;
 


### PR DESCRIPTION
  * Change from string to enum value for `billing_address_collection` on Checkout `Session`

r? @remi-stripe 
cc @stripe/api-libraries 