### PR TITLE
Add support for `amount_total`, `amount_subtotal` and `amount_details` on Checkout `Session`

### DIFF
--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -17,6 +17,16 @@ declare module 'stripe' {
         object: 'checkout.session';
 
         /**
+         * Total of all items before discounts or taxes are applied.
+         */
+        amount_subtotal: number | null;
+
+        /**
+         * Total of all items after discounts and taxes are applied.
+         */
+        amount_total: number | null;
+
+        /**
          * Describes whether Checkout should collect the customer's billing address.
          */
         billing_address_collection: Session.BillingAddressCollection | null;
@@ -32,6 +42,11 @@ declare module 'stripe' {
          * session with your internal systems.
          */
         client_reference_id: string | null;
+
+        /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        currency: string | null;
 
         /**
          * The ID of the customer for this session.
@@ -125,6 +140,11 @@ declare module 'stripe' {
          * subscription creation is successful.
          */
         success_url: string;
+
+        /**
+         * Tax and discount details for the computed total amount.
+         */
+        total_details: Session.TotalDetails | null;
       }
 
       namespace Session {
@@ -506,6 +526,66 @@ declare module 'stripe' {
         }
 
         type SubmitType = 'auto' | 'book' | 'donate' | 'pay';
+
+        interface TotalDetails {
+          /**
+           * This is the sum of all the line item discounts.
+           */
+          amount_discount: number;
+
+          /**
+           * This is the sum of all the line item tax amounts.
+           */
+          amount_tax: number;
+
+          breakdown?: TotalDetails.Breakdown;
+        }
+
+        namespace TotalDetails {
+          interface Breakdown {
+            /**
+             * The aggregated line item discounts.
+             */
+            discounts: Array<Breakdown.Discount>;
+
+            /**
+             * The aggregated line item tax amounts by rate.
+             */
+            taxes: Array<Breakdown.Tax>;
+          }
+
+          namespace Breakdown {
+            interface Discount {
+              /**
+               * The amount discounted.
+               */
+              amount: number;
+
+              /**
+               * A discount represents the actual application of a coupon to a particular
+               * customer. It contains information about when the discount began and when it
+               * will end.
+               *
+               * Related guide: [Applying Discounts to Subscriptions](https://stripe.com/docs/billing/subscriptions/discounts).
+               */
+              discount: Stripe.Discount;
+            }
+
+            interface Tax {
+              /**
+               * Amount of tax applied for this rate.
+               */
+              amount: number;
+
+              /**
+               * Tax rates can be applied to [invoices](https://stripe.com/docs/billing/invoices/tax-rates), [subscriptions](https://stripe.com/docs/billing/subscriptions/taxes) and [Checkout Sessions](https://stripe.com/docs/payments/checkout/set-up-a-subscription#tax-rates) to collect tax.
+               *
+               * Related guide: [Tax Rates](https://stripe.com/docs/billing/taxes/tax-rates).
+               */
+              rate: Stripe.TaxRate;
+            }
+          }
+        }
       }
 
       interface SessionCreateParams {
@@ -818,7 +898,7 @@ declare module 'stripe' {
           on_behalf_of?: string;
 
           /**
-           * Email address that the receipt for the resulting payment will be sent to.
+           * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
            */
           receipt_email?: string;
 

--- a/types/2020-03-02/InvoiceLineItems.d.ts
+++ b/types/2020-03-02/InvoiceLineItems.d.ts
@@ -201,7 +201,7 @@ declare module 'stripe' {
       subscription_default_tax_rates?: Array<string> | null;
 
       /**
-       * List of subscription items, each with an attached plan.
+       * A list of up to 20 subscription items, each with an attached price.
        */
       subscription_items?: Array<
         InvoiceLineItemListUpcomingParams.SubscriptionItem

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -898,7 +898,7 @@ declare module 'stripe' {
       subscription_default_tax_rates?: Array<string> | null;
 
       /**
-       * List of subscription items, each with an attached plan.
+       * A list of up to 20 subscription items, each with an attached price.
        */
       subscription_items?: Array<
         InvoiceRetrieveUpcomingParams.SubscriptionItem

--- a/types/2020-03-02/LineItems.d.ts
+++ b/types/2020-03-02/LineItems.d.ts
@@ -63,7 +63,7 @@ declare module 'stripe' {
     namespace LineItem {
       interface Discount {
         /**
-         * Discount amount for this line item.
+         * The amount discounted.
          */
         amount: number;
 
@@ -79,7 +79,7 @@ declare module 'stripe' {
 
       interface Tax {
         /**
-         * Amount of tax for this line item.
+         * Amount of tax applied for this rate.
          */
         amount: number;
 

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -140,7 +140,7 @@ declare module 'stripe' {
       payment_method_types: Array<string>;
 
       /**
-       * Email address that the receipt for the resulting payment will be sent to.
+       * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
        */
       receipt_email: string | null;
 
@@ -606,7 +606,7 @@ declare module 'stripe' {
       payment_method_types?: Array<string>;
 
       /**
-       * Email address that the receipt for the resulting payment will be sent to.
+       * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
        */
       receipt_email?: string;
 
@@ -1193,7 +1193,7 @@ declare module 'stripe' {
       payment_method_types?: Array<string>;
 
       /**
-       * Email address that the receipt for the resulting payment will be sent to.
+       * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
        */
       receipt_email?: string | null;
 
@@ -1752,7 +1752,7 @@ declare module 'stripe' {
       payment_method_options?: PaymentIntentConfirmParams.PaymentMethodOptions;
 
       /**
-       * Email address that the receipt for the resulting payment will be sent to.
+       * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
        */
       receipt_email?: string | null;
 
@@ -2317,7 +2317,7 @@ declare module 'stripe' {
       list(options?: RequestOptions): ApiListPromise<Stripe.PaymentIntent>;
 
       /**
-       * A PaymentIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action.
+       * A PaymentIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, or requires_action.
        *
        * Once canceled, no additional charges will be made by the PaymentIntent and any operations on the PaymentIntent will fail with an error. For PaymentIntents with status='requires_capture', the remaining amount_capturable will automatically be refunded.
        */

--- a/types/2020-03-02/SetupIntents.d.ts
+++ b/types/2020-03-02/SetupIntents.d.ts
@@ -748,7 +748,7 @@ declare module 'stripe' {
       list(options?: RequestOptions): ApiListPromise<Stripe.SetupIntent>;
 
       /**
-       * A SetupIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action.
+       * A SetupIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_confirmation, or requires_action.
        *
        * Once canceled, setup is abandoned and any operations on the SetupIntent will fail with an error.
        */

--- a/types/2020-03-02/SubscriptionItems.d.ts
+++ b/types/2020-03-02/SubscriptionItems.d.ts
@@ -124,7 +124,7 @@ declare module 'stripe' {
        *
        * Use `pending_if_incomplete` to update the subscription using [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates). When you use `pending_if_incomplete` you can only pass the parameters [supported by pending updates](https://stripe.com/docs/billing/pending-updates-reference#supported-attributes).
        *
-       * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's first invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not create a subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
+       * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not update the subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
        */
       payment_behavior?: SubscriptionItemCreateParams.PaymentBehavior;
 
@@ -267,7 +267,7 @@ declare module 'stripe' {
        *
        * Use `pending_if_incomplete` to update the subscription using [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates). When you use `pending_if_incomplete` you can only pass the parameters [supported by pending updates](https://stripe.com/docs/billing/pending-updates-reference#supported-attributes).
        *
-       * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's first invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not create a subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
+       * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not update the subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
        */
       payment_behavior?: SubscriptionItemUpdateParams.PaymentBehavior;
 
@@ -487,7 +487,7 @@ declare module 'stripe' {
       ): Promise<Stripe.UsageRecord>;
 
       /**
-       * For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that's been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the billing plan's month of September).
+       * For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that's been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).
        *
        * The list is sorted in reverse-chronological order (newest first). The first list item represents the most current usage period that hasn't ended yet. Since new usage records can still be added, the returned summary information for the subscription item's ID should be seen as unstable until the subscription billing period ends.
        */

--- a/types/2020-03-02/Subscriptions.d.ts
+++ b/types/2020-03-02/Subscriptions.d.ts
@@ -100,7 +100,7 @@ declare module 'stripe' {
       ended_at: number | null;
 
       /**
-       * List of subscription items, each with an attached plan.
+       * List of subscription items, each with an attached price.
        */
       items: ApiList<Stripe.SubscriptionItem>;
 
@@ -371,7 +371,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * A list of up to 20 subscription items, each with an attached plan.
+       * A list of up to 20 subscription items, each with an attached price.
        */
       items?: Array<SubscriptionCreateParams.Item>;
 
@@ -694,7 +694,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * List of subscription items, each with an attached plan.
+       * A list of up to 20 subscription items, each with an attached price.
        */
       items?: Array<SubscriptionUpdateParams.Item>;
 
@@ -718,7 +718,7 @@ declare module 'stripe' {
        *
        * Use `pending_if_incomplete` to update the subscription using [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates). When you use `pending_if_incomplete` you can only pass the parameters [supported by pending updates](https://stripe.com/docs/billing/pending-updates-reference#supported-attributes).
        *
-       * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's first invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not create a subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
+       * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not update the subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
        */
       payment_behavior?: SubscriptionUpdateParams.PaymentBehavior;
 

--- a/types/2020-03-02/TaxRates.d.ts
+++ b/types/2020-03-02/TaxRates.d.ts
@@ -15,7 +15,7 @@ declare module 'stripe' {
       object: 'tax_rate';
 
       /**
-       * Defaults to `true`. When set to `false`, this tax rate is considered archived and cannot be applied to new applications or Checkout Sessions, but will still be applied to subscriptions and invoices that already have it set.
+       * Defaults to `true`. When set to `false`, this tax rate cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
        */
       active: boolean;
 
@@ -77,7 +77,7 @@ declare module 'stripe' {
       percentage: number;
 
       /**
-       * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates continue to work where they are currently applied however they cannot be used for new applications or Checkout Sessions.
+       * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
        */
       active?: boolean;
 
@@ -111,7 +111,7 @@ declare module 'stripe' {
 
     interface TaxRateUpdateParams {
       /**
-       * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates continue to work where they are currently applied however they cannot be used for new applications or Checkout Sessions.
+       * Flag determining whether the tax rate is active or inactive (archived). Inactive tax rates cannot be used with new applications or Checkout Sessions, but will still work for subscriptions and invoices that already have it set.
        */
       active?: boolean;
 


### PR DESCRIPTION
Codegen for openapi df0ebe7

r? @cjavilla-stripe 
cc @stripe/api-libraries 