### PR TITLE
Refactor remaining 'var' to 'let/const' usages

### DIFF
--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -48,7 +48,7 @@ const Webhook = {
         opts.secret
       );
 
-    var generatedHeader = [
+    const generatedHeader = [
       't=' + opts.timestamp,
       opts.scheme + '=' + opts.signature,
     ].join(',');

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -64,8 +64,9 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
 
 function makeRequest(self, requestArgs, spec, overrideData) {
   return new Promise((resolve, reject) => {
+    let opts;
     try {
-      var opts = getRequestOpts(self, requestArgs, spec, overrideData);
+      opts = getRequestOpts(self, requestArgs, spec, overrideData);
     } catch (err) {
       reject(err);
       return;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -67,7 +67,7 @@ const utils = (module.exports = {
   /**
    * Outputs a new function with interpolated object property values.
    * Use like so:
-   *   var fn = makeURLInterpolator('some/url/{param1}/{param2}');
+   *   const fn = makeURLInterpolator('some/url/{param1}/{param2}');
    *   fn({ param1: 123, param2: 456 }); // => 'some/url/123/456'
    */
   makeURLInterpolator: (() => {

--- a/test/resources/BalanceTransactions.spec.js
+++ b/test/resources/BalanceTransactions.spec.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var stripe = require('../../testUtils').getSpyableStripe();
-var expect = require('chai').expect;
+const stripe = require('../../testUtils').getSpyableStripe();
+const expect = require('chai').expect;
 
 describe('BalanceTransactions Resource', function() {
   describe('retrieve', function() {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -510,8 +510,8 @@ describe('utils', () => {
     it('handles being unable to require `child_process`', () => {
       utils._exec = null;
 
-      var actualErr = null;
-      var actualRes = null;
+      let actualErr = null;
+      let actualRes = null;
       function myCb(err, res) {
         actualErr = err;
         actualRes = res;


### PR DESCRIPTION
Cleans up the remaining `var` usages and converts them to `let/const` usages. 

Let me know if you can find any other `var`s and I will update the pull request. Thanks!