### PR TITLE
Use strict equality check for 'protocol' field for consistency

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -408,7 +408,7 @@ StripeResource.prototype = {
           : this._stripe.getApiField('timeout');
 
       const isInsecureConnection =
-        this._stripe.getApiField('protocol') == 'http';
+        this._stripe.getApiField('protocol') === 'http';
       let agent = this._stripe.getApiField('agent');
       if (agent == null) {
         agent = isInsecureConnection ? defaultHttpAgent : defaultHttpsAgent;


### PR DESCRIPTION
Minor change, but the code below uses triple `=`, so might be worth cleaning this up