### PR TITLE
Add support for `cartes_bancaires_payments` as a `Capability`

### DIFF
--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -168,6 +168,11 @@ declare module 'stripe' {
         card_payments?: Capabilities.CardPayments;
 
         /**
+         * The status of the Cartes Bancaires payments capability of the account, or whether the account can directly process Cartes Bancaires card charges in EUR currency.
+         */
+        cartes_bancaires_payments?: Capabilities.CartesBancairesPayments;
+
+        /**
          * The status of the JCB payments capability of the account, or whether the account (Japan only) can directly process JCB credit card charges in JPY currency.
          */
         jcb_payments?: Capabilities.JcbPayments;
@@ -201,6 +206,8 @@ declare module 'stripe' {
         type CardIssuing = 'active' | 'inactive' | 'pending';
 
         type CardPayments = 'active' | 'inactive' | 'pending';
+
+        type CartesBancairesPayments = 'active' | 'inactive' | 'pending';
 
         type JcbPayments = 'active' | 'inactive' | 'pending';
 
@@ -879,6 +886,11 @@ declare module 'stripe' {
         card_payments?: Capabilities.CardPayments;
 
         /**
+         * The cartes_bancaires_payments capability.
+         */
+        cartes_bancaires_payments?: Capabilities.CartesBancairesPayments;
+
+        /**
          * The jcb_payments capability.
          */
         jcb_payments?: Capabilities.JcbPayments;
@@ -927,6 +939,13 @@ declare module 'stripe' {
         }
 
         interface CardPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface CartesBancairesPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */
@@ -1311,6 +1330,7 @@ declare module 'stripe' {
         | 'bacs_debit_payments'
         | 'card_issuing'
         | 'card_payments'
+        | 'cartes_bancaires_payments'
         | 'jcb_payments'
         | 'legacy_payments'
         | 'tax_reporting_us_1099_k'
@@ -1673,6 +1693,11 @@ declare module 'stripe' {
         card_payments?: Capabilities.CardPayments;
 
         /**
+         * The cartes_bancaires_payments capability.
+         */
+        cartes_bancaires_payments?: Capabilities.CartesBancairesPayments;
+
+        /**
          * The jcb_payments capability.
          */
         jcb_payments?: Capabilities.JcbPayments;
@@ -1721,6 +1746,13 @@ declare module 'stripe' {
         }
 
         interface CardPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface CartesBancairesPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */
@@ -2105,6 +2137,7 @@ declare module 'stripe' {
         | 'bacs_debit_payments'
         | 'card_issuing'
         | 'card_payments'
+        | 'cartes_bancaires_payments'
         | 'jcb_payments'
         | 'legacy_payments'
         | 'tax_reporting_us_1099_k'

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -223,7 +223,7 @@ declare module 'stripe' {
         plans: Array<Phase.Plan>;
 
         /**
-         * Controls whether or not the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`.
+         * If the subscription schedule will prorate when transitioning to this phase. Possible values are `create_prorations` and `none`.
          */
         proration_behavior: Phase.ProrationBehavior | null;
 
@@ -522,7 +522,7 @@ declare module 'stripe' {
         plans: Array<Phase.Plan>;
 
         /**
-         * Controls whether or not a subscription schedule will create prorations when transitioning to this phase. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
+         * If a subscription schedule will create prorations when transitioning to this phase. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
          */
         proration_behavior?: Phase.ProrationBehavior;
 
@@ -895,7 +895,7 @@ declare module 'stripe' {
         plans: Array<Phase.Plan>;
 
         /**
-         * Controls whether or not a subscription schedule will create prorations when transitioning to this phase. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
+         * If a subscription schedule will create prorations when transitioning to this phase. Possible values are `create_prorations` or `none`, and the default value is `create_prorations`. See [Prorations](https://stripe.com/docs/billing/subscriptions/prorations).
          */
         proration_behavior?: Phase.ProrationBehavior;
 
@@ -1141,7 +1141,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * If the subscription schedule is `active`, indicates whether or not to generate a final invoice that contains any un-invoiced metered usage and new/pending proration invoice items. Defaults to `true`.
+       * If the subscription schedule is `active`, indicates if a final invoice will be generated that contains any un-invoiced metered usage and new/pending proration invoice items. Defaults to `true`.
        */
       invoice_now?: boolean;
 


### PR DESCRIPTION
Codegen for openapi b33818a

r? @cjavilla-stripe 
cc @stripe/api-libraries 