### PR TITLE
Update type definitions for customers.create

### DIFF
--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -207,6 +207,11 @@ declare module 'stripe' {
 
     interface CustomerCreateParams {
       /**
+       * Unique identifier for the object.
+       */
+      id?: string;
+      
+      /**
        * The customer's address.
        */
       address?: AddressParam | null;


### PR DESCRIPTION
What's done - Updated type definitions for CustomerCreateParams to take optional id. 

Issue - Actual customers.create works well with id and create new customer with the specified id, but it was not there is type declarations.