### PR TITLE
Multiple API changes

### DIFF
--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -657,8 +657,8 @@ declare module 'stripe' {
         expand?: Array<string>;
 
         /**
-         * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring [prices](https://stripe.com/docs/api/prices).
-         * One-time prices in `subscription` mode will be on the initial invoice only.
+         * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring [Prices](https://stripe.com/docs/api/prices).
+         * One-time Prices in `subscription` mode will be on the initial invoice only.
          *
          * There is a maximum of 100 line items, however it is recommended to
          * consolidate line items if there are more than a few dozen.
@@ -741,12 +741,12 @@ declare module 'stripe' {
           name?: string;
 
           /**
-           * The ID of the price or plan object. One of `price`, `price_data` or `amount` is required.
+           * The ID of the [Price](https://stripe.com/docs/api/prices) or [Plan](https://stripe.com/docs/api/plans) object. One of `price`, `price_data` or `amount` is required.
            */
           price?: string;
 
           /**
-           * Data used to generate a new price object inline. One of `price`, `price_data` or `amount` is required.
+           * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline. One of `price`, `price_data` or `amount` is required.
            */
           price_data?: LineItem.PriceData;
 

--- a/types/2020-03-02/CreditNoteLineItems.d.ts
+++ b/types/2020-03-02/CreditNoteLineItems.d.ts
@@ -31,6 +31,11 @@ declare module 'stripe' {
       discount_amount: number;
 
       /**
+       * The amount of discount calculated per discount for this line item
+       */
+      discount_amounts?: Array<CreditNoteLineItem.DiscountAmount>;
+
+      /**
        * ID of the invoice line item being credited
        */
       invoice_line_item?: string;
@@ -72,6 +77,18 @@ declare module 'stripe' {
     }
 
     namespace CreditNoteLineItem {
+      interface DiscountAmount {
+        /**
+         * The amount, in %s, of the discount.
+         */
+        amount: number;
+
+        /**
+         * The discount that was applied to get this discount amount.
+         */
+        discount: string | Stripe.Discount | Stripe.DeletedDiscount;
+      }
+
       interface TaxAmount {
         /**
          * The amount, in %s, of the tax.

--- a/types/2020-03-02/CreditNotes.d.ts
+++ b/types/2020-03-02/CreditNotes.d.ts
@@ -49,6 +49,11 @@ declare module 'stripe' {
       discount_amount: number;
 
       /**
+       * The aggregate amounts calculated per discount for all line items.
+       */
+      discount_amounts?: Array<CreditNote.DiscountAmount>;
+
+      /**
        * ID of the invoice.
        */
       invoice: string | Stripe.Invoice;
@@ -130,6 +135,18 @@ declare module 'stripe' {
     }
 
     namespace CreditNote {
+      interface DiscountAmount {
+        /**
+         * The amount, in %s, of the discount.
+         */
+        amount: number;
+
+        /**
+         * The discount that was applied to get this discount amount.
+         */
+        discount: string | Stripe.Discount | Stripe.DeletedDiscount;
+      }
+
       type Reason =
         | 'duplicate'
         | 'fraudulent'

--- a/types/2020-03-02/Discounts.d.ts
+++ b/types/2020-03-02/Discounts.d.ts
@@ -6,6 +6,11 @@ declare module 'stripe' {
      */
     interface Discount {
       /**
+       * The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array.
+       */
+      id?: string;
+
+      /**
        * String representing the object's type. Objects of the same type share the same value.
        */
       object: 'discount';
@@ -30,6 +35,16 @@ declare module 'stripe' {
       end: number | null;
 
       /**
+       * The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice.
+       */
+      invoice?: string | null;
+
+      /**
+       * The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item.
+       */
+      invoice_item?: string | null;
+
+      /**
        * Date that the coupon was applied.
        */
       start: number;
@@ -44,6 +59,11 @@ declare module 'stripe' {
      * The DeletedDiscount object.
      */
     interface DeletedDiscount {
+      /**
+       * The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array.
+       */
+      id?: string;
+
       /**
        * String representing the object's type. Objects of the same type share the same value.
        */
@@ -65,6 +85,16 @@ declare module 'stripe' {
        * Always true for a deleted object
        */
       deleted: true;
+
+      /**
+       * The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice.
+       */
+      invoice?: string | null;
+
+      /**
+       * The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item.
+       */
+      invoice_item?: string | null;
 
       /**
        * Date that the coupon was applied.

--- a/types/2020-03-02/InvoiceItems.d.ts
+++ b/types/2020-03-02/InvoiceItems.d.ts
@@ -48,6 +48,11 @@ declare module 'stripe' {
       discountable: boolean;
 
       /**
+       * The discounts which apply to the invoice item. Item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
+       */
+      discounts?: Array<string | Stripe.Discount> | null;
+
+      /**
        * The ID of the invoice this invoice item belongs to.
        */
       invoice: string | Stripe.Invoice | null;
@@ -176,6 +181,11 @@ declare module 'stripe' {
       discountable?: boolean;
 
       /**
+       * The coupons to redeem into discounts for the invoice item or invoice line item.
+       */
+      discounts?: Array<InvoiceItemCreateParams.Discount> | null;
+
+      /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
@@ -201,7 +211,7 @@ declare module 'stripe' {
       price?: string;
 
       /**
-       * Data used to generate a new price object inline.
+       * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
        */
       price_data?: InvoiceItemCreateParams.PriceData;
 
@@ -232,6 +242,18 @@ declare module 'stripe' {
     }
 
     namespace InvoiceItemCreateParams {
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+      }
+
       interface Period {
         /**
          * The end of the period, which must be greater than or equal to the start.
@@ -291,6 +313,11 @@ declare module 'stripe' {
       discountable?: boolean;
 
       /**
+       * The coupons & existing discounts which apply to the invoice item or invoice line item. Item discounts are applied before invoice discounts. Pass an empty string to remove previously-defined discounts.
+       */
+      discounts?: Array<InvoiceItemUpdateParams.Discount> | null;
+
+      /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
@@ -311,7 +338,7 @@ declare module 'stripe' {
       price?: string;
 
       /**
-       * Data used to generate a new price object inline.
+       * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
        */
       price_data?: InvoiceItemUpdateParams.PriceData;
 
@@ -337,6 +364,18 @@ declare module 'stripe' {
     }
 
     namespace InvoiceItemUpdateParams {
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+      }
+
       interface Period {
         /**
          * The end of the period, which must be greater than or equal to the start.

--- a/types/2020-03-02/InvoiceLineItems.d.ts
+++ b/types/2020-03-02/InvoiceLineItems.d.ts
@@ -31,9 +31,19 @@ declare module 'stripe' {
       description: string | null;
 
       /**
+       * The amount of discount calculated per discount for this line item.
+       */
+      discount_amounts?: Array<InvoiceLineItem.DiscountAmount> | null;
+
+      /**
        * If true, discounts will apply to this line item. Always false for prorations.
        */
       discountable: boolean;
+
+      /**
+       * The discounts applied to the invoice line item. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
+       */
+      discounts?: Array<string | Stripe.Discount> | null;
 
       /**
        * The ID of the [invoice item](https://stripe.com/docs/api/invoiceitems) associated with this line item if any.
@@ -104,6 +114,18 @@ declare module 'stripe' {
     }
 
     namespace InvoiceLineItem {
+      interface DiscountAmount {
+        /**
+         * The amount, in %s, of the discount.
+         */
+        amount: number;
+
+        /**
+         * The discount that was applied to get this discount amount.
+         */
+        discount: string | Stripe.Discount | Stripe.DeletedDiscount;
+      }
+
       interface Period {
         /**
          * End of the line item's billing period
@@ -153,6 +175,8 @@ declare module 'stripe' {
        * The identifier of the customer whose upcoming invoice you'd like to retrieve.
        */
       customer?: string;
+
+      discounts?: Array<InvoiceLineItemListUpcomingParams.Discount> | null;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -249,6 +273,18 @@ declare module 'stripe' {
     }
 
     namespace InvoiceLineItemListUpcomingParams {
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+      }
+
       interface InvoiceItem {
         /**
          * The integer amount in **%s** of previewed invoice item.
@@ -271,6 +307,11 @@ declare module 'stripe' {
         discountable?: boolean;
 
         /**
+         * The coupons to redeem into discounts for the invoice item in the preview.
+         */
+        discounts?: Array<InvoiceItem.Discount> | null;
+
+        /**
          * The ID of the invoice item to update in preview. If not specified, a new invoice item will be added to the preview of the upcoming invoice.
          */
         invoiceitem?: string;
@@ -291,7 +332,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: InvoiceItem.PriceData;
 
@@ -314,6 +355,18 @@ declare module 'stripe' {
       }
 
       namespace InvoiceItem {
+        interface Discount {
+          /**
+           * ID of the coupon to create a new discount for.
+           */
+          coupon?: string;
+
+          /**
+           * ID of an existing discount on the object (or one of its ancestors) to reuse.
+           */
+          discount?: string;
+        }
+
         interface Period {
           /**
            * The end of the period, which must be greater than or equal to the start.
@@ -388,7 +441,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: SubscriptionItem.PriceData;
 

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -158,6 +158,13 @@ declare module 'stripe' {
       discount: Stripe.Discount | null;
 
       /**
+       * The discounts applied to the invoice. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
+       */
+      discounts?: Array<
+        string | Stripe.Discount | Stripe.DeletedDiscount
+      > | null;
+
+      /**
        * The date on which payment for this invoice is due. This value will be `null` for invoices where `collection_method=charge_automatically`.
        */
       due_date: number | null;
@@ -290,6 +297,11 @@ declare module 'stripe' {
        * Total after discounts and taxes.
        */
       total: number;
+
+      /**
+       * The aggregate amounts calculated per discount across all line items.
+       */
+      total_discount_amounts?: Array<Invoice.TotalDiscountAmount> | null;
 
       /**
        * The aggregate amounts calculated per tax rate for all line items.
@@ -461,6 +473,18 @@ declare module 'stripe' {
         }
       }
 
+      interface TotalDiscountAmount {
+        /**
+         * The amount, in %s, of the discount.
+         */
+        amount: number;
+
+        /**
+         * The discount that was applied to get this discount amount.
+         */
+        discount: string | Stripe.Discount | Stripe.DeletedDiscount;
+      }
+
       interface TotalTaxAmount {
         /**
          * The amount, in %s, of the tax.
@@ -563,6 +587,11 @@ declare module 'stripe' {
       description?: string;
 
       /**
+       * The coupons to redeem into discounts for the invoice. If not specified, inherits the discount from the invoice's customer. Pass an empty string to avoid inheriting any discounts.
+       */
+      discounts?: Array<InvoiceCreateParams.Discount> | null;
+
+      /**
        * The date on which payment for this invoice is due. Valid only for invoices where `collection_method=send_invoice`.
        */
       due_date?: number;
@@ -616,6 +645,18 @@ declare module 'stripe' {
          * The value of the custom field. This may be up to 30 characters.
          */
         value: string;
+      }
+
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
       }
 
       interface TransferData {
@@ -685,6 +726,11 @@ declare module 'stripe' {
       description?: string;
 
       /**
+       * The discounts that will apply to the invoice. Pass an empty string to remove previously-defined discounts.
+       */
+      discounts?: Array<InvoiceUpdateParams.Discount> | null;
+
+      /**
        * The date on which payment for this invoice is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices.
        */
       due_date?: number;
@@ -733,6 +779,18 @@ declare module 'stripe' {
          * The value of the custom field. This may be up to 30 characters.
          */
         value: string;
+      }
+
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
       }
 
       interface TransferData {
@@ -851,6 +909,8 @@ declare module 'stripe' {
        */
       customer?: string;
 
+      discounts?: Array<InvoiceRetrieveUpcomingParams.Discount> | null;
+
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -946,6 +1006,18 @@ declare module 'stripe' {
     }
 
     namespace InvoiceRetrieveUpcomingParams {
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+      }
+
       interface InvoiceItem {
         /**
          * The integer amount in **%s** of previewed invoice item.
@@ -968,6 +1040,11 @@ declare module 'stripe' {
         discountable?: boolean;
 
         /**
+         * The coupons to redeem into discounts for the invoice item in the preview.
+         */
+        discounts?: Array<InvoiceItem.Discount> | null;
+
+        /**
          * The ID of the invoice item to update in preview. If not specified, a new invoice item will be added to the preview of the upcoming invoice.
          */
         invoiceitem?: string;
@@ -988,7 +1065,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: InvoiceItem.PriceData;
 
@@ -1011,6 +1088,18 @@ declare module 'stripe' {
       }
 
       namespace InvoiceItem {
+        interface Discount {
+          /**
+           * ID of the coupon to create a new discount for.
+           */
+          coupon?: string;
+
+          /**
+           * ID of an existing discount on the object (or one of its ancestors) to reuse.
+           */
+          discount?: string;
+        }
+
         interface Period {
           /**
            * The end of the period, which must be greater than or equal to the start.
@@ -1085,7 +1174,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: SubscriptionItem.PriceData;
 

--- a/types/2020-03-02/Issuing/Cardholders.d.ts
+++ b/types/2020-03-02/Issuing/Cardholders.d.ts
@@ -61,7 +61,7 @@ declare module 'stripe' {
         requirements: Cardholder.Requirements;
 
         /**
-         * Spending rules that give you some control over how this cardholder's cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
+         * Rules that control spending across this cardholder's cards. Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
          */
         spending_controls: Cardholder.SpendingControls | null;
 
@@ -177,22 +177,22 @@ declare module 'stripe' {
 
         interface SpendingControls {
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this cardholder's cards.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
            */
           allowed_categories: Array<SpendingControls.AllowedCategory> | null;
 
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to always decline on this cardholder's cards.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
            */
           blocked_categories: Array<SpendingControls.BlockedCategory> | null;
 
           /**
-           * Limit the spending with rules based on time intervals and categories.
+           * Limit spending with amount-based rules that apply across this cardholder's cards.
            */
           spending_limits: Array<SpendingControls.SpendingLimit> | null;
 
           /**
-           * Currency for the amounts within spending_limits.
+           * Currency of the amounts within `spending_limits`.
            */
           spending_limits_currency: string | null;
         }
@@ -780,17 +780,17 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per time interval.
+             * Maximum amount allowed to spend per interval.
              */
             amount: number;
 
             /**
-             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges.
+             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
              */
             categories: Array<SpendingLimit.Category> | null;
 
             /**
-             * The time interval or event with which to apply this spending limit towards.
+             * Interval (or event) to which the amount applies.
              */
             interval: SpendingLimit.Interval;
           }
@@ -1148,7 +1148,7 @@ declare module 'stripe' {
         phone_number?: string;
 
         /**
-         * Spending rules that give you control over how your cardholders can make charges. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
+         * Rules that control spending across this cardholder's cards. Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
          */
         spending_controls?: CardholderCreateParams.SpendingControls;
 
@@ -1271,22 +1271,22 @@ declare module 'stripe' {
 
         interface SpendingControls {
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
            */
           allowed_categories?: Array<SpendingControls.AllowedCategory>;
 
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to always decline on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
            */
           blocked_categories?: Array<SpendingControls.BlockedCategory>;
 
           /**
-           * Limit the spending with rules based on time intervals and categories.
+           * Limit spending with amount-based rules that apply across this cardholder's cards.
            */
           spending_limits?: Array<SpendingControls.SpendingLimit>;
 
           /**
-           * Currency for your spending limits. Defaults to your merchant country's currency.
+           * Currency of amounts within `spending_limits`. Defaults to your merchant country's currency.
            */
           spending_limits_currency?: string;
         }
@@ -1874,17 +1874,17 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per time interval.
+             * Maximum amount allowed to spend per interval.
              */
             amount: number;
 
             /**
-             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges.
+             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
              */
             categories?: Array<SpendingLimit.Category>;
 
             /**
-             * The time interval with which to apply this spending limit towards.
+             * Interval (or event) to which the amount applies.
              */
             interval: SpendingLimit.Interval;
           }
@@ -2239,7 +2239,7 @@ declare module 'stripe' {
         phone_number?: string;
 
         /**
-         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
+         * Rules that control spending across this cardholder's cards. Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
          */
         spending_controls?: CardholderUpdateParams.SpendingControls;
 
@@ -2362,22 +2362,22 @@ declare module 'stripe' {
 
         interface SpendingControls {
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
            */
           allowed_categories?: Array<SpendingControls.AllowedCategory>;
 
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to always decline on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
            */
           blocked_categories?: Array<SpendingControls.BlockedCategory>;
 
           /**
-           * Limit the spending with rules based on time intervals and categories.
+           * Limit spending with amount-based rules that apply across this cardholder's cards.
            */
           spending_limits?: Array<SpendingControls.SpendingLimit>;
 
           /**
-           * Currency for your spending limits. Defaults to your merchant country's currency.
+           * Currency of amounts within `spending_limits`. Defaults to your merchant country's currency.
            */
           spending_limits_currency?: string;
         }
@@ -2965,17 +2965,17 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per time interval.
+             * Maximum amount allowed to spend per interval.
              */
             amount: number;
 
             /**
-             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges.
+             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
              */
             categories?: Array<SpendingLimit.Category>;
 
             /**
-             * The time interval with which to apply this spending limit towards.
+             * Interval (or event) to which the amount applies.
              */
             interval: SpendingLimit.Interval;
           }

--- a/types/2020-03-02/Issuing/Cards.d.ts
+++ b/types/2020-03-02/Issuing/Cards.d.ts
@@ -178,22 +178,22 @@ declare module 'stripe' {
 
         interface SpendingControls {
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
            */
           allowed_categories: Array<SpendingControls.AllowedCategory> | null;
 
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to always decline on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
            */
           blocked_categories: Array<SpendingControls.BlockedCategory> | null;
 
           /**
-           * Limit the spending with rules based on time intervals and categories.
+           * Limit spending with amount-based rules.
            */
           spending_limits: Array<SpendingControls.SpendingLimit> | null;
 
           /**
-           * Currency for the amounts within spending_limits. Locked to the currency of the card.
+           * Currency of the amounts within `spending_limits`. Always the same as the currency of the card.
            */
           spending_limits_currency: string | null;
         }
@@ -781,17 +781,17 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per time interval.
+             * Maximum amount allowed to spend per interval.
              */
             amount: number;
 
             /**
-             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges.
+             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
              */
             categories: Array<SpendingLimit.Category> | null;
 
             /**
-             * The time interval or event with which to apply this spending limit towards.
+             * Interval (or event) to which the amount applies.
              */
             interval: SpendingLimit.Interval;
           }
@@ -1144,7 +1144,7 @@ declare module 'stripe' {
         shipping?: CardCreateParams.Shipping;
 
         /**
-         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
+         * Rules that control spending for this card. Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
          */
         spending_controls?: CardCreateParams.SpendingControls;
 
@@ -1219,17 +1219,17 @@ declare module 'stripe' {
 
         interface SpendingControls {
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
            */
           allowed_categories?: Array<SpendingControls.AllowedCategory>;
 
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to always decline on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
            */
           blocked_categories?: Array<SpendingControls.BlockedCategory>;
 
           /**
-           * Limit the spending with rules based on time intervals and categories.
+           * Limit spending with amount-based rules.
            */
           spending_limits?: Array<SpendingControls.SpendingLimit>;
         }
@@ -1817,17 +1817,17 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per time interval.
+             * Maximum amount allowed to spend per interval.
              */
             amount: number;
 
             /**
-             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges.
+             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
              */
             categories?: Array<SpendingLimit.Category>;
 
             /**
-             * The time interval with which to apply this spending limit towards.
+             * Interval (or event) to which the amount applies.
              */
             interval: SpendingLimit.Interval;
           }
@@ -2162,7 +2162,7 @@ declare module 'stripe' {
         metadata?: MetadataParam | null;
 
         /**
-         * Spending rules that give you some control over how your cards can be used. Refer to our [authorizations](https://stripe.com/docs/issuing/purchases/authorizations) documentation for more details.
+         * Rules that control spending for this card. Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.
          */
         spending_controls?: CardUpdateParams.SpendingControls;
 
@@ -2177,17 +2177,17 @@ declare module 'stripe' {
 
         interface SpendingControls {
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations permitted on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
            */
           allowed_categories?: Array<SpendingControls.AllowedCategory>;
 
           /**
-           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to always decline on this card.
+           * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
            */
           blocked_categories?: Array<SpendingControls.BlockedCategory>;
 
           /**
-           * Limit the spending with rules based on time intervals and categories.
+           * Limit spending with amount-based rules.
            */
           spending_limits?: Array<SpendingControls.SpendingLimit>;
         }
@@ -2775,17 +2775,17 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per time interval.
+             * Maximum amount allowed to spend per interval.
              */
             amount: number;
 
             /**
-             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) on which to apply the spending limit. Leave this blank to limit all charges.
+             * Array of strings containing [categories](https://stripe.com/docs/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
              */
             categories?: Array<SpendingLimit.Category>;
 
             /**
-             * The time interval with which to apply this spending limit towards.
+             * Interval (or event) to which the amount applies.
              */
             interval: SpendingLimit.Interval;
           }

--- a/types/2020-03-02/Prices.d.ts
+++ b/types/2020-03-02/Prices.d.ts
@@ -215,7 +215,7 @@ declare module 'stripe' {
       currency: string;
 
       /**
-       * Whether the price is currently active. Defaults to `true`.
+       * Whether the price can be used for new purchases. Defaults to `true`.
        */
       active?: boolean;
 
@@ -421,7 +421,7 @@ declare module 'stripe' {
 
     interface PriceUpdateParams {
       /**
-       * Whether the price is currently active. Defaults to `true`.
+       * Whether the price can be used for new purchases. Defaults to `true`.
        */
       active?: boolean;
 

--- a/types/2020-03-02/SubscriptionItems.d.ts
+++ b/types/2020-03-02/SubscriptionItems.d.ts
@@ -140,7 +140,7 @@ declare module 'stripe' {
       price?: string;
 
       /**
-       * Data used to generate a new price object inline.
+       * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
        */
       price_data?: SubscriptionItemCreateParams.PriceData;
 
@@ -283,7 +283,7 @@ declare module 'stripe' {
       price?: string;
 
       /**
-       * Data used to generate a new price object inline.
+       * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
        */
       price_data?: SubscriptionItemUpdateParams.PriceData;
 

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -556,7 +556,7 @@ declare module 'stripe' {
           price?: string;
 
           /**
-           * Data used to generate a new price object inline.
+           * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
            */
           price_data?: AddInvoiceItem.PriceData;
 
@@ -630,7 +630,7 @@ declare module 'stripe' {
           price?: string;
 
           /**
-           * Data used to generate a new price object inline.
+           * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
            */
           price_data?: Plan.PriceData;
 
@@ -934,7 +934,7 @@ declare module 'stripe' {
           price?: string;
 
           /**
-           * Data used to generate a new price object inline.
+           * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
            */
           price_data?: AddInvoiceItem.PriceData;
 
@@ -1008,7 +1008,7 @@ declare module 'stripe' {
           price?: string;
 
           /**
-           * Data used to generate a new price object inline.
+           * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
            */
           price_data?: Plan.PriceData;
 

--- a/types/2020-03-02/Subscriptions.d.ts
+++ b/types/2020-03-02/Subscriptions.d.ts
@@ -446,7 +446,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: AddInvoiceItem.PriceData;
 
@@ -516,7 +516,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: Item.PriceData;
 
@@ -776,7 +776,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: AddInvoiceItem.PriceData;
 
@@ -863,7 +863,7 @@ declare module 'stripe' {
         price?: string;
 
         /**
-         * Data used to generate a new price object inline.
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
          */
         price_data?: Item.PriceData;
 

--- a/types/2020-03-02/TaxIds.d.ts
+++ b/types/2020-03-02/TaxIds.d.ts
@@ -28,7 +28,7 @@ declare module 'stripe' {
       /**
        * ID of the customer.
        */
-      customer: string | Stripe.Customer;
+      customer: string | Stripe.Customer | null;
 
       deleted?: void;
 
@@ -47,7 +47,10 @@ declare module 'stripe' {
        */
       value: string;
 
-      verification: TaxId.Verification;
+      /**
+       * Tax ID verification information.
+       */
+      verification: TaxId.Verification | null;
     }
 
     namespace TaxId {


### PR DESCRIPTION
Multiple API changes:
  * Add support for `id`, `invoice` and `invoice_item` on `Discount` and `DeletedDiscount`
  * Add support for `discount_amounts` on `CreditNote`, `CreditNoteLineItem`, `InvoiceLineItem`
  * Add support for `discounts` on `InvoiceItem`, `InvoiceLineItem` and `Invoice`
  * Add support for `total_discount_amounts` on `Invoice`
  * Make `customer` and `verification` on `TaxId` optional as the resource will be re-used for `Account` in the future.

Codegen for openapi 18be41c

r? @richardm-stripe (to compare with go and dotnet carefully)
cc @stripe/api-libraries 