### PR TITLE
Add support for `amount_details` on Issuing `Authorization` and `Transaction`

### DIFF
--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -109,7 +109,7 @@ declare module 'stripe' {
       /**
        * The customer's payment sources, if any.
        */
-      sources: ApiList<CustomerSource>;
+      sources: ApiList<CustomerSource> | null;
 
       /**
        * The customer's current subscriptions, if any.

--- a/types/2020-03-02/Issuing/Authorizations.d.ts
+++ b/types/2020-03-02/Issuing/Authorizations.d.ts
@@ -22,6 +22,11 @@ declare module 'stripe' {
         amount: number;
 
         /**
+         * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+         */
+        amount_details: Authorization.AmountDetails | null;
+
+        /**
          * Whether the authorization has been approved.
          */
         approved: boolean;
@@ -107,6 +112,13 @@ declare module 'stripe' {
       }
 
       namespace Authorization {
+        interface AmountDetails {
+          /**
+           * The fee charged by the ATM for the cash withdrawal.
+           */
+          atm_fee: number | null;
+        }
+
         type AuthorizationMethod =
           | 'chip'
           | 'contactless'
@@ -158,6 +170,11 @@ declare module 'stripe' {
           amount: number;
 
           /**
+           * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+           */
+          amount_details: PendingRequest.AmountDetails | null;
+
+          /**
            * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
            */
           currency: string;
@@ -178,11 +195,25 @@ declare module 'stripe' {
           merchant_currency: string;
         }
 
+        namespace PendingRequest {
+          interface AmountDetails {
+            /**
+             * The fee charged by the ATM for the cash withdrawal.
+             */
+            atm_fee: number | null;
+          }
+        }
+
         interface RequestHistory {
           /**
            * The authorization amount in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
            */
           amount: number;
+
+          /**
+           * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+           */
+          amount_details: RequestHistory.AmountDetails | null;
 
           /**
            * Whether this request was approved.
@@ -216,6 +247,13 @@ declare module 'stripe' {
         }
 
         namespace RequestHistory {
+          interface AmountDetails {
+            /**
+             * The fee charged by the ATM for the cash withdrawal.
+             */
+            atm_fee: number | null;
+          }
+
           type Reason =
             | 'account_disabled'
             | 'card_active'

--- a/types/2020-03-02/Issuing/Transactions.d.ts
+++ b/types/2020-03-02/Issuing/Transactions.d.ts
@@ -22,6 +22,11 @@ declare module 'stripe' {
         amount: number;
 
         /**
+         * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+         */
+        amount_details: Transaction.AmountDetails | null;
+
+        /**
          * The `Authorization` object that led to this transaction.
          */
         authorization: string | Stripe.Issuing.Authorization | null;
@@ -85,6 +90,13 @@ declare module 'stripe' {
       }
 
       namespace Transaction {
+        interface AmountDetails {
+          /**
+           * The fee charged by the ATM for the cash withdrawal.
+           */
+          atm_fee: number | null;
+        }
+
         interface MerchantData {
           /**
            * A categorization of the seller's type of business. See our [merchant categories guide](https://stripe.com/docs/issuing/merchant-categories) for a list of possible values.


### PR DESCRIPTION
Codegen for openapi 3d3c794

r? @richardm-stripe 
cc @stripe/api-libraries 