### PR TITLE
Typescript: add 'lastResponse' to return types

### DIFF
--- a/types/2020-03-02/AccountLinks.d.ts
+++ b/types/2020-03-02/AccountLinks.d.ts
@@ -85,7 +85,7 @@ declare module 'stripe' {
       create(
         params: AccountLinkCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.AccountLink>;
+      ): Promise<Stripe.Response<Stripe.AccountLink>>;
     }
   }
 }

--- a/types/2020-03-02/Accounts.d.ts
+++ b/types/2020-03-02/Accounts.d.ts
@@ -2370,8 +2370,10 @@ declare module 'stripe' {
       create(
         params?: AccountCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Account>;
-      create(options?: RequestOptions): Promise<Stripe.Account>;
+      ): Promise<Stripe.Response<Stripe.Account>>;
+      create(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Account>>;
 
       /**
        * Retrieves the details of an account.
@@ -2379,8 +2381,10 @@ declare module 'stripe' {
       retrieve(
         params?: AccountRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Account>;
-      retrieve(options?: RequestOptions): Promise<Stripe.Account>;
+      ): Promise<Stripe.Response<Stripe.Account>>;
+      retrieve(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Account>>;
 
       /**
        * Retrieves the details of an account.
@@ -2389,8 +2393,11 @@ declare module 'stripe' {
         id: string,
         params?: AccountRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Account>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Account>;
+      ): Promise<Stripe.Response<Stripe.Account>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Account>>;
 
       /**
        * Updates a connected [Express or Custom account](https://stripe.com/docs/connect/accounts) by setting the values of the parameters passed. Any parameters not provided are left unchanged. Most parameters can be changed only for Custom accounts. (These are marked Custom Only below.) Parameters marked Custom and Express are supported by both account types.
@@ -2401,7 +2408,7 @@ declare module 'stripe' {
         id: string,
         params?: AccountUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Account>;
+      ): Promise<Stripe.Response<Stripe.Account>>;
 
       /**
        * Returns a list of accounts connected to your platform via [Connect](https://stripe.com/docs/connect). If you're not a platform, the list is empty.
@@ -2423,8 +2430,11 @@ declare module 'stripe' {
         id: string,
         params?: AccountDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedAccount>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.DeletedAccount>;
+      ): Promise<Stripe.Response<Stripe.DeletedAccount>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.DeletedAccount>>;
 
       /**
        * With [Connect](https://stripe.com/docs/connect), you may flag accounts as suspicious.
@@ -2435,7 +2445,7 @@ declare module 'stripe' {
         id: string,
         params: AccountRejectParams,
         options?: RequestOptions
-      ): Promise<Stripe.Account>;
+      ): Promise<Stripe.Response<Stripe.Account>>;
 
       /**
        * Retrieves information about the specified Account Capability.
@@ -2445,12 +2455,12 @@ declare module 'stripe' {
         id: string,
         params?: CapabilityRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Capability>;
+      ): Promise<Stripe.Response<Stripe.Capability>>;
       retrieveCapability(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Capability>;
+      ): Promise<Stripe.Response<Stripe.Capability>>;
 
       /**
        * Updates an existing Account Capability.
@@ -2460,7 +2470,7 @@ declare module 'stripe' {
         id: string,
         params?: CapabilityUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Capability>;
+      ): Promise<Stripe.Response<Stripe.Capability>>;
 
       /**
        * Returns a list of capabilities associated with the account. The capabilities are returned sorted by creation date, with the most recent capability appearing first.
@@ -2482,7 +2492,7 @@ declare module 'stripe' {
         id: string,
         params: ExternalAccountCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.BankAccount | Stripe.Card>;
+      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
 
       /**
        * Retrieve a specified external account for a given account.
@@ -2492,12 +2502,12 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.BankAccount | Stripe.Card>;
+      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
       retrieveExternalAccount(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.BankAccount | Stripe.Card>;
+      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
 
       /**
        * Updates the metadata, account holder name, and account holder type of a bank account belonging to a [Custom account](https://stripe.com/docs/connect/custom-accounts), and optionally sets it as the default for its currency. Other bank account details are not editable by design.
@@ -2509,7 +2519,7 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.BankAccount | Stripe.Card>;
+      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
 
       /**
        * List external accounts for an account.
@@ -2532,12 +2542,16 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedBankAccount | Stripe.DeletedCard>;
+      ): Promise<
+        Stripe.Response<Stripe.DeletedBankAccount | Stripe.DeletedCard>
+      >;
       deleteExternalAccount(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedBankAccount | Stripe.DeletedCard>;
+      ): Promise<
+        Stripe.Response<Stripe.DeletedBankAccount | Stripe.DeletedCard>
+      >;
 
       /**
        * Creates a single-use login link for an Express account to access their Stripe dashboard.
@@ -2548,11 +2562,11 @@ declare module 'stripe' {
         id: string,
         params?: LoginLinkCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.LoginLink>;
+      ): Promise<Stripe.Response<Stripe.LoginLink>>;
       createLoginLink(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.LoginLink>;
+      ): Promise<Stripe.Response<Stripe.LoginLink>>;
 
       /**
        * Creates a new person.
@@ -2561,11 +2575,11 @@ declare module 'stripe' {
         id: string,
         params?: PersonCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Person>;
+      ): Promise<Stripe.Response<Stripe.Person>>;
       createPerson(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Person>;
+      ): Promise<Stripe.Response<Stripe.Person>>;
 
       /**
        * Retrieves an existing person.
@@ -2575,12 +2589,12 @@ declare module 'stripe' {
         id: string,
         params?: PersonRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Person>;
+      ): Promise<Stripe.Response<Stripe.Person>>;
       retrievePerson(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Person>;
+      ): Promise<Stripe.Response<Stripe.Person>>;
 
       /**
        * Updates an existing person.
@@ -2590,7 +2604,7 @@ declare module 'stripe' {
         id: string,
         params?: PersonUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Person>;
+      ): Promise<Stripe.Response<Stripe.Person>>;
 
       /**
        * Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
@@ -2613,12 +2627,12 @@ declare module 'stripe' {
         id: string,
         params?: PersonDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedPerson>;
+      ): Promise<Stripe.Response<Stripe.DeletedPerson>>;
       deletePerson(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedPerson>;
+      ): Promise<Stripe.Response<Stripe.DeletedPerson>>;
     }
   }
 }

--- a/types/2020-03-02/ApplePayDomains.d.ts
+++ b/types/2020-03-02/ApplePayDomains.d.ts
@@ -84,7 +84,7 @@ declare module 'stripe' {
       create(
         params: ApplePayDomainCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.ApplePayDomain>;
+      ): Promise<Stripe.Response<Stripe.ApplePayDomain>>;
 
       /**
        * Retrieve an apple pay domain.
@@ -93,11 +93,11 @@ declare module 'stripe' {
         id: string,
         params?: ApplePayDomainRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.ApplePayDomain>;
+      ): Promise<Stripe.Response<Stripe.ApplePayDomain>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.ApplePayDomain>;
+      ): Promise<Stripe.Response<Stripe.ApplePayDomain>>;
 
       /**
        * List apple pay domains.
@@ -115,11 +115,11 @@ declare module 'stripe' {
         id: string,
         params?: ApplePayDomainDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedApplePayDomain>;
+      ): Promise<Stripe.Response<Stripe.DeletedApplePayDomain>>;
       del(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedApplePayDomain>;
+      ): Promise<Stripe.Response<Stripe.DeletedApplePayDomain>>;
     }
   }
 }

--- a/types/2020-03-02/ApplicationFees.d.ts
+++ b/types/2020-03-02/ApplicationFees.d.ts
@@ -105,11 +105,11 @@ declare module 'stripe' {
         id: string,
         params?: ApplicationFeeRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.ApplicationFee>;
+      ): Promise<Stripe.Response<Stripe.ApplicationFee>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.ApplicationFee>;
+      ): Promise<Stripe.Response<Stripe.ApplicationFee>>;
 
       /**
        * Returns a list of application fees you've previously collected. The application fees are returned in sorted order, with the most recent fees appearing first.
@@ -135,11 +135,11 @@ declare module 'stripe' {
         id: string,
         params?: FeeRefundCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.FeeRefund>;
+      ): Promise<Stripe.Response<Stripe.FeeRefund>>;
       createRefund(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.FeeRefund>;
+      ): Promise<Stripe.Response<Stripe.FeeRefund>>;
 
       /**
        * By default, you can see the 10 most recent refunds stored directly on the application fee object, but you can also retrieve details about a specific refund stored on the application fee.
@@ -149,12 +149,12 @@ declare module 'stripe' {
         id: string,
         params?: FeeRefundRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.FeeRefund>;
+      ): Promise<Stripe.Response<Stripe.FeeRefund>>;
       retrieveRefund(
         feeId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.FeeRefund>;
+      ): Promise<Stripe.Response<Stripe.FeeRefund>>;
 
       /**
        * Updates the specified application fee refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -166,7 +166,7 @@ declare module 'stripe' {
         id: string,
         params?: FeeRefundUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.FeeRefund>;
+      ): Promise<Stripe.Response<Stripe.FeeRefund>>;
 
       /**
        * You can see a list of the refunds belonging to a specific application fee. Note that the 10 most recent refunds are always available by default on the application fee object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional refunds.

--- a/types/2020-03-02/Balance.d.ts
+++ b/types/2020-03-02/Balance.d.ts
@@ -191,8 +191,10 @@ declare module 'stripe' {
       retrieve(
         params?: BalanceRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Balance>;
-      retrieve(options?: RequestOptions): Promise<Stripe.Balance>;
+      ): Promise<Stripe.Response<Stripe.Balance>>;
+      retrieve(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Balance>>;
     }
   }
 }

--- a/types/2020-03-02/BalanceTransactions.d.ts
+++ b/types/2020-03-02/BalanceTransactions.d.ts
@@ -208,11 +208,11 @@ declare module 'stripe' {
         id: string,
         params?: BalanceTransactionRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.BalanceTransaction>;
+      ): Promise<Stripe.Response<Stripe.BalanceTransaction>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.BalanceTransaction>;
+      ): Promise<Stripe.Response<Stripe.BalanceTransaction>>;
 
       /**
        * Returns a list of transactions that have contributed to the Stripe account balance (e.g., charges, transfers, and so forth). The transactions are returned in sorted order, with the most recent transactions appearing first.

--- a/types/2020-03-02/BillingPortal/Sessions.d.ts
+++ b/types/2020-03-02/BillingPortal/Sessions.d.ts
@@ -66,7 +66,7 @@ declare module 'stripe' {
         create(
           params: SessionCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.BillingPortal.Session>;
+        ): Promise<Stripe.Response<Stripe.BillingPortal.Session>>;
       }
     }
   }

--- a/types/2020-03-02/Charges.d.ts
+++ b/types/2020-03-02/Charges.d.ts
@@ -1738,8 +1738,8 @@ declare module 'stripe' {
       create(
         params?: ChargeCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Charge>;
-      create(options?: RequestOptions): Promise<Stripe.Charge>;
+      ): Promise<Stripe.Response<Stripe.Charge>>;
+      create(options?: RequestOptions): Promise<Stripe.Response<Stripe.Charge>>;
 
       /**
        * Retrieves the details of a charge that has previously been created. Supply the unique charge ID that was returned from your previous request, and Stripe will return the corresponding charge information. The same information is returned when creating or refunding the charge.
@@ -1748,8 +1748,11 @@ declare module 'stripe' {
         id: string,
         params?: ChargeRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Charge>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Charge>;
+      ): Promise<Stripe.Response<Stripe.Charge>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Charge>>;
 
       /**
        * Updates the specified charge by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -1758,7 +1761,7 @@ declare module 'stripe' {
         id: string,
         params?: ChargeUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Charge>;
+      ): Promise<Stripe.Response<Stripe.Charge>>;
 
       /**
        * Returns a list of charges you've previously created. The charges are returned in sorted order, with the most recent charges appearing first.
@@ -1778,8 +1781,11 @@ declare module 'stripe' {
         id: string,
         params?: ChargeCaptureParams,
         options?: RequestOptions
-      ): Promise<Stripe.Charge>;
-      capture(id: string, options?: RequestOptions): Promise<Stripe.Charge>;
+      ): Promise<Stripe.Response<Stripe.Charge>>;
+      capture(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Charge>>;
     }
   }
 }

--- a/types/2020-03-02/Checkout/Sessions.d.ts
+++ b/types/2020-03-02/Checkout/Sessions.d.ts
@@ -1395,7 +1395,7 @@ declare module 'stripe' {
         create(
           params: SessionCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Checkout.Session>;
+        ): Promise<Stripe.Response<Stripe.Checkout.Session>>;
 
         /**
          * Retrieves a Session object.
@@ -1404,11 +1404,11 @@ declare module 'stripe' {
           id: string,
           params?: SessionRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Checkout.Session>;
+        ): Promise<Stripe.Response<Stripe.Checkout.Session>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Checkout.Session>;
+        ): Promise<Stripe.Response<Stripe.Checkout.Session>>;
 
         /**
          * Returns a list of Checkout Sessions.

--- a/types/2020-03-02/CountrySpecs.d.ts
+++ b/types/2020-03-02/CountrySpecs.d.ts
@@ -101,11 +101,11 @@ declare module 'stripe' {
         id: string,
         params?: CountrySpecRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.CountrySpec>;
+      ): Promise<Stripe.Response<Stripe.CountrySpec>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.CountrySpec>;
+      ): Promise<Stripe.Response<Stripe.CountrySpec>>;
 
       /**
        * Lists all Country Spec objects available in the API.

--- a/types/2020-03-02/Coupons.d.ts
+++ b/types/2020-03-02/Coupons.d.ts
@@ -236,7 +236,7 @@ declare module 'stripe' {
       create(
         params: CouponCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Coupon>;
+      ): Promise<Stripe.Response<Stripe.Coupon>>;
 
       /**
        * Retrieves the coupon with the given ID.
@@ -245,8 +245,11 @@ declare module 'stripe' {
         id: string,
         params?: CouponRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Coupon>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Coupon>;
+      ): Promise<Stripe.Response<Stripe.Coupon>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Coupon>>;
 
       /**
        * Updates the metadata of a coupon. Other coupon details (currency, duration, amount_off) are, by design, not editable.
@@ -255,7 +258,7 @@ declare module 'stripe' {
         id: string,
         params?: CouponUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Coupon>;
+      ): Promise<Stripe.Response<Stripe.Coupon>>;
 
       /**
        * Returns a list of your coupons.
@@ -273,8 +276,11 @@ declare module 'stripe' {
         id: string,
         params?: CouponDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedCoupon>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.DeletedCoupon>;
+      ): Promise<Stripe.Response<Stripe.DeletedCoupon>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.DeletedCoupon>>;
     }
   }
 }

--- a/types/2020-03-02/CreditNotes.d.ts
+++ b/types/2020-03-02/CreditNotes.d.ts
@@ -465,7 +465,7 @@ declare module 'stripe' {
       create(
         params: CreditNoteCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
 
       /**
        * Retrieves the credit note object with the given identifier.
@@ -474,11 +474,11 @@ declare module 'stripe' {
         id: string,
         params?: CreditNoteRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
 
       /**
        * Updates an existing credit note.
@@ -487,7 +487,7 @@ declare module 'stripe' {
         id: string,
         params?: CreditNoteUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
 
       /**
        * Returns a list of credit notes.
@@ -504,7 +504,7 @@ declare module 'stripe' {
       preview(
         params: CreditNotePreviewParams,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
 
       /**
        * Marks a credit note as void. Learn more about [voiding credit notes](https://stripe.com/docs/billing/invoices/credit-notes#voiding).
@@ -513,11 +513,11 @@ declare module 'stripe' {
         id: string,
         params?: CreditNoteVoidCreditNoteParams,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
       voidCreditNote(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.CreditNote>;
+      ): Promise<Stripe.Response<Stripe.CreditNote>>;
 
       /**
        * When retrieving a credit note, you'll get a lines property containing the the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/types/2020-03-02/Customers.d.ts
+++ b/types/2020-03-02/Customers.d.ts
@@ -571,8 +571,10 @@ declare module 'stripe' {
       create(
         params?: CustomerCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Customer>;
-      create(options?: RequestOptions): Promise<Stripe.Customer>;
+      ): Promise<Stripe.Response<Stripe.Customer>>;
+      create(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Customer>>;
 
       /**
        * Retrieves the details of an existing customer. You need only supply the unique customer identifier that was returned upon customer creation.
@@ -581,11 +583,11 @@ declare module 'stripe' {
         id: string,
         params?: CustomerRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Customer | Stripe.DeletedCustomer>;
+      ): Promise<Stripe.Response<Stripe.Customer | Stripe.DeletedCustomer>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Customer | Stripe.DeletedCustomer>;
+      ): Promise<Stripe.Response<Stripe.Customer | Stripe.DeletedCustomer>>;
 
       /**
        * Updates the specified customer by setting the values of the parameters passed. Any parameters not provided will be left unchanged. For example, if you pass the source parameter, that becomes the customer's active source (e.g., a card) to be used for all charges in the future. When you update a customer to a new valid card source by passing the source parameter: for each of the customer's current subscriptions, if the subscription bills automatically and is in the past_due state, then the latest open invoice for the subscription with automatic collection enabled will be retried. This retry will not count as an automatic retry, and will not affect the next regularly scheduled payment for the invoice. Changing the default_source for a customer will not trigger this behavior.
@@ -596,7 +598,7 @@ declare module 'stripe' {
         id: string,
         params?: CustomerUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Customer>;
+      ): Promise<Stripe.Response<Stripe.Customer>>;
 
       /**
        * Returns a list of your customers. The customers are returned sorted by creation date, with the most recent customers appearing first.
@@ -614,11 +616,11 @@ declare module 'stripe' {
         id: string,
         params?: CustomerDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedCustomer>;
+      ): Promise<Stripe.Response<Stripe.DeletedCustomer>>;
       del(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedCustomer>;
+      ): Promise<Stripe.Response<Stripe.DeletedCustomer>>;
 
       /**
        * Removes the currently applied discount on a customer.
@@ -627,11 +629,11 @@ declare module 'stripe' {
         id: string,
         params?: CustomerDeleteDiscountParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedDiscount>;
+      ): Promise<Stripe.Response<Stripe.DeletedDiscount>>;
       deleteDiscount(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedDiscount>;
+      ): Promise<Stripe.Response<Stripe.DeletedDiscount>>;
 
       /**
        * Creates an immutable transaction that updates the customer's [balance](https://stripe.com/docs/api/customers/object#customer_object-balance).
@@ -640,7 +642,7 @@ declare module 'stripe' {
         id: string,
         params: CustomerBalanceTransactionCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.CustomerBalanceTransaction>;
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
 
       /**
        * Retrieves a specific transaction that updated the customer's [balance](https://stripe.com/docs/api/customers/object#customer_object-balance).
@@ -650,12 +652,12 @@ declare module 'stripe' {
         id: string,
         params?: CustomerBalanceTransactionRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.CustomerBalanceTransaction>;
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
       retrieveBalanceTransaction(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.CustomerBalanceTransaction>;
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
 
       /**
        * Most customer balance transaction fields are immutable, but you may update its description and metadata.
@@ -665,7 +667,7 @@ declare module 'stripe' {
         id: string,
         params?: CustomerBalanceTransactionUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.CustomerBalanceTransaction>;
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
 
       /**
        * Returns a list of transactions that updated the customer's [balance](https://stripe.com/docs/api/customers/object#customer_object-balance).
@@ -691,7 +693,7 @@ declare module 'stripe' {
         id: string,
         params: CustomerSourceCreateParams,
         options?: RequestOptions
-      ): Promise<CustomerSource>;
+      ): Promise<Stripe.Response<CustomerSource>>;
 
       /**
        * Retrieve a specified source for a given customer.
@@ -701,12 +703,12 @@ declare module 'stripe' {
         id: string,
         params?: CustomerSourceRetrieveParams,
         options?: RequestOptions
-      ): Promise<CustomerSource>;
+      ): Promise<Stripe.Response<CustomerSource>>;
       retrieveSource(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<CustomerSource>;
+      ): Promise<Stripe.Response<CustomerSource>>;
 
       /**
        * Update a specified source for a given customer.
@@ -716,12 +718,16 @@ declare module 'stripe' {
         id: string,
         params?: CustomerSourceUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Card | Stripe.BankAccount | Stripe.Source>;
+      ): Promise<
+        Stripe.Response<Stripe.Card | Stripe.BankAccount | Stripe.Source>
+      >;
       updateSource(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Card | Stripe.BankAccount | Stripe.Source>;
+      ): Promise<
+        Stripe.Response<Stripe.Card | Stripe.BankAccount | Stripe.Source>
+      >;
 
       /**
        * List sources for a specified customer.
@@ -745,22 +751,26 @@ declare module 'stripe' {
         params?: CustomerSourceDeleteParams,
         options?: RequestOptions
       ): Promise<
-        | CustomerSource
-        | Stripe.DeletedAlipayAccount
-        | Stripe.DeletedBankAccount
-        | Stripe.DeletedBitcoinReceiver
-        | Stripe.DeletedCard
+        Stripe.Response<
+          | CustomerSource
+          | Stripe.DeletedAlipayAccount
+          | Stripe.DeletedBankAccount
+          | Stripe.DeletedBitcoinReceiver
+          | Stripe.DeletedCard
+        >
       >;
       deleteSource(
         customerId: string,
         id: string,
         options?: RequestOptions
       ): Promise<
-        | CustomerSource
-        | Stripe.DeletedAlipayAccount
-        | Stripe.DeletedBankAccount
-        | Stripe.DeletedBitcoinReceiver
-        | Stripe.DeletedCard
+        Stripe.Response<
+          | CustomerSource
+          | Stripe.DeletedAlipayAccount
+          | Stripe.DeletedBankAccount
+          | Stripe.DeletedBitcoinReceiver
+          | Stripe.DeletedCard
+        >
       >;
 
       /**
@@ -771,12 +781,12 @@ declare module 'stripe' {
         id: string,
         params?: CustomerSourceVerifyParams,
         options?: RequestOptions
-      ): Promise<Stripe.BankAccount>;
+      ): Promise<Stripe.Response<Stripe.BankAccount>>;
       verifySource(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.BankAccount>;
+      ): Promise<Stripe.Response<Stripe.BankAccount>>;
 
       /**
        * Creates a new TaxID object for a customer.
@@ -785,7 +795,7 @@ declare module 'stripe' {
         id: string,
         params: TaxIdCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.TaxId>;
+      ): Promise<Stripe.Response<Stripe.TaxId>>;
 
       /**
        * Retrieves the TaxID object with the given identifier.
@@ -795,12 +805,12 @@ declare module 'stripe' {
         id: string,
         params?: TaxIdRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.TaxId>;
+      ): Promise<Stripe.Response<Stripe.TaxId>>;
       retrieveTaxId(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.TaxId>;
+      ): Promise<Stripe.Response<Stripe.TaxId>>;
 
       /**
        * Returns a list of tax IDs for a customer.
@@ -823,12 +833,12 @@ declare module 'stripe' {
         id: string,
         params?: TaxIdDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedTaxId>;
+      ): Promise<Stripe.Response<Stripe.DeletedTaxId>>;
       deleteTaxId(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedTaxId>;
+      ): Promise<Stripe.Response<Stripe.DeletedTaxId>>;
     }
   }
 }

--- a/types/2020-03-02/Disputes.d.ts
+++ b/types/2020-03-02/Disputes.d.ts
@@ -453,8 +453,11 @@ declare module 'stripe' {
         id: string,
         params?: DisputeRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Dispute>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Dispute>;
+      ): Promise<Stripe.Response<Stripe.Dispute>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Dispute>>;
 
       /**
        * When you get a dispute, contacting your customer is always the best first step. If that doesn't work, you can submit evidence to help us resolve the dispute in your favor. You can do this in your [dashboard](https://dashboard.stripe.com/disputes), but if you prefer, you can use the API to submit evidence programmatically.
@@ -465,7 +468,7 @@ declare module 'stripe' {
         id: string,
         params?: DisputeUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Dispute>;
+      ): Promise<Stripe.Response<Stripe.Dispute>>;
 
       /**
        * Returns a list of your disputes.
@@ -485,8 +488,11 @@ declare module 'stripe' {
         id: string,
         params?: DisputeCloseParams,
         options?: RequestOptions
-      ): Promise<Stripe.Dispute>;
-      close(id: string, options?: RequestOptions): Promise<Stripe.Dispute>;
+      ): Promise<Stripe.Response<Stripe.Dispute>>;
+      close(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Dispute>>;
     }
   }
 }

--- a/types/2020-03-02/EphemeralKeys.d.ts
+++ b/types/2020-03-02/EphemeralKeys.d.ts
@@ -67,8 +67,10 @@ declare module 'stripe' {
       create(
         params?: EphemeralKeyCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.EphemeralKey>;
-      create(options?: RequestOptions): Promise<Stripe.EphemeralKey>;
+      ): Promise<Stripe.Response<Stripe.EphemeralKey>>;
+      create(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.EphemeralKey>>;
 
       /**
        * Invalidates a short-lived API key for a given resource.
@@ -77,8 +79,11 @@ declare module 'stripe' {
         id: string,
         params?: EphemeralKeyDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.EphemeralKey>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.EphemeralKey>;
+      ): Promise<Stripe.Response<Stripe.EphemeralKey>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.EphemeralKey>>;
     }
   }
 }

--- a/types/2020-03-02/Events.d.ts
+++ b/types/2020-03-02/Events.d.ts
@@ -124,8 +124,11 @@ declare module 'stripe' {
         id: string,
         params?: EventRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Event>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Event>;
+      ): Promise<Stripe.Response<Stripe.Event>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Event>>;
 
       /**
        * List events, going back up to 30 days. Each event data is rendered according to Stripe API version at its creation time, specified in [event object](https://stripe.com/docs/api/events/object) api_version attribute (not according to your current Stripe API version or Stripe-Version header).

--- a/types/2020-03-02/ExchangeRates.d.ts
+++ b/types/2020-03-02/ExchangeRates.d.ts
@@ -45,11 +45,11 @@ declare module 'stripe' {
         id: string,
         params?: ExchangeRateRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.ExchangeRate>;
+      ): Promise<Stripe.Response<Stripe.ExchangeRate>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.ExchangeRate>;
+      ): Promise<Stripe.Response<Stripe.ExchangeRate>>;
 
       /**
        * Returns a list of objects that contain the rates at which foreign currencies are converted to one another. Only shows the currencies for which Stripe supports.

--- a/types/2020-03-02/FileLinks.d.ts
+++ b/types/2020-03-02/FileLinks.d.ts
@@ -123,7 +123,7 @@ declare module 'stripe' {
       create(
         params: FileLinkCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.FileLink>;
+      ): Promise<Stripe.Response<Stripe.FileLink>>;
 
       /**
        * Retrieves the file link with the given ID.
@@ -132,8 +132,11 @@ declare module 'stripe' {
         id: string,
         params?: FileLinkRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.FileLink>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.FileLink>;
+      ): Promise<Stripe.Response<Stripe.FileLink>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.FileLink>>;
 
       /**
        * Updates an existing file link object. Expired links can no longer be updated.
@@ -142,7 +145,7 @@ declare module 'stripe' {
         id: string,
         params?: FileLinkUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.FileLink>;
+      ): Promise<Stripe.Response<Stripe.FileLink>>;
 
       /**
        * Returns a list of file links.

--- a/types/2020-03-02/Files.d.ts
+++ b/types/2020-03-02/Files.d.ts
@@ -120,8 +120,8 @@ declare module 'stripe' {
       create(
         params?: FileCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.File>;
-      create(options?: RequestOptions): Promise<Stripe.File>;
+      ): Promise<Stripe.Response<Stripe.File>>;
+      create(options?: RequestOptions): Promise<Stripe.Response<Stripe.File>>;
 
       /**
        * Retrieves the details of an existing file object. Supply the unique file ID from a file, and Stripe will return the corresponding file object. To access file contents, see the [File Upload Guide](https://stripe.com/docs/file-upload#download-file-contents).
@@ -130,8 +130,11 @@ declare module 'stripe' {
         id: string,
         params?: FileRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.File>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.File>;
+      ): Promise<Stripe.Response<Stripe.File>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.File>>;
 
       /**
        * Returns a list of the files that your account has access to. The files are returned sorted by creation date, with the most recently created files appearing first.

--- a/types/2020-03-02/InvoiceItems.d.ts
+++ b/types/2020-03-02/InvoiceItems.d.ts
@@ -444,7 +444,7 @@ declare module 'stripe' {
       create(
         params: InvoiceItemCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.InvoiceItem>;
+      ): Promise<Stripe.Response<Stripe.InvoiceItem>>;
 
       /**
        * Retrieves the invoice item with the given ID.
@@ -453,11 +453,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceItemRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.InvoiceItem>;
+      ): Promise<Stripe.Response<Stripe.InvoiceItem>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.InvoiceItem>;
+      ): Promise<Stripe.Response<Stripe.InvoiceItem>>;
 
       /**
        * Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it's attached to is closed.
@@ -466,7 +466,7 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceItemUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.InvoiceItem>;
+      ): Promise<Stripe.Response<Stripe.InvoiceItem>>;
 
       /**
        * Returns a list of your invoice items. Invoice items are returned sorted by creation date, with the most recently created invoice items appearing first.
@@ -484,11 +484,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceItemDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedInvoiceItem>;
+      ): Promise<Stripe.Response<Stripe.DeletedInvoiceItem>>;
       del(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedInvoiceItem>;
+      ): Promise<Stripe.Response<Stripe.DeletedInvoiceItem>>;
     }
   }
 }

--- a/types/2020-03-02/Invoices.d.ts
+++ b/types/2020-03-02/Invoices.d.ts
@@ -1270,7 +1270,7 @@ declare module 'stripe' {
       create(
         params: InvoiceCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * Retrieves the invoice with the given ID.
@@ -1279,8 +1279,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * Draft invoices are fully editable. Once an invoice is [finalized](https://stripe.com/docs/billing/invoices/workflow#finalized),
@@ -1294,7 +1297,7 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.
@@ -1312,8 +1315,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedInvoice>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.DeletedInvoice>;
+      ): Promise<Stripe.Response<Stripe.DeletedInvoice>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.DeletedInvoice>>;
 
       /**
        * Stripe automatically finalizes drafts before sending and attempting payment on invoices. However, if you'd like to finalize a draft invoice manually, you can do so using this method.
@@ -1322,11 +1328,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceFinalizeInvoiceParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
       finalizeInvoice(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * Marking an invoice as uncollectible is useful for keeping track of bad debts that can be written off for accounting purposes.
@@ -1335,11 +1341,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceMarkUncollectibleParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
       markUncollectible(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * Stripe automatically creates and then attempts to collect payment on invoices for customers on subscriptions according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to attempt payment on an invoice out of the normal collection schedule or for some other reason, you can do so.
@@ -1348,8 +1354,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoicePayParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
-      pay(id: string, options?: RequestOptions): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
+      pay(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discount that is applicable to the customer.
@@ -1361,8 +1370,10 @@ declare module 'stripe' {
       retrieveUpcoming(
         params?: InvoiceRetrieveUpcomingParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
-      retrieveUpcoming(options?: RequestOptions): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
+      retrieveUpcoming(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * Stripe will automatically send invoices to customers according to your [subscriptions settings](https://dashboard.stripe.com/account/billing/automatic). However, if you'd like to manually send an invoice to your customer out of the normal schedule, you can do so. When sending invoices that have already been paid, there will be no reference to the payment in the email.
@@ -1373,11 +1384,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceSendInvoiceParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
       sendInvoice(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.
@@ -1386,11 +1397,11 @@ declare module 'stripe' {
         id: string,
         params?: InvoiceVoidInvoiceParams,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
       voidInvoice(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Invoice>;
+      ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
        * When retrieving an invoice, you'll get a lines property containing the total count of line items and the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.

--- a/types/2020-03-02/IssuerFraudRecords.d.ts
+++ b/types/2020-03-02/IssuerFraudRecords.d.ts
@@ -80,11 +80,11 @@ declare module 'stripe' {
         id: string,
         params?: IssuerFraudRecordRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.IssuerFraudRecord>;
+      ): Promise<Stripe.Response<Stripe.IssuerFraudRecord>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.IssuerFraudRecord>;
+      ): Promise<Stripe.Response<Stripe.IssuerFraudRecord>>;
 
       /**
        * Returns a list of issuer fraud records.

--- a/types/2020-03-02/Issuing/Authorizations.d.ts
+++ b/types/2020-03-02/Issuing/Authorizations.d.ts
@@ -392,11 +392,11 @@ declare module 'stripe' {
           id: string,
           params?: AuthorizationRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
 
         /**
          * Updates the specified Issuing Authorization object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -405,7 +405,7 @@ declare module 'stripe' {
           id: string,
           params?: AuthorizationUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
 
         /**
          * Returns a list of Issuing Authorization objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -425,11 +425,11 @@ declare module 'stripe' {
           id: string,
           params?: AuthorizationApproveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
         approve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
 
         /**
          * Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
@@ -438,11 +438,11 @@ declare module 'stripe' {
           id: string,
           params?: AuthorizationDeclineParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
         decline(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Authorization>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Authorization>>;
       }
     }
   }

--- a/types/2020-03-02/Issuing/Cardholders.d.ts
+++ b/types/2020-03-02/Issuing/Cardholders.d.ts
@@ -3329,7 +3329,7 @@ declare module 'stripe' {
         create(
           params: CardholderCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Cardholder>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Cardholder>>;
 
         /**
          * Retrieves an Issuing Cardholder object.
@@ -3338,11 +3338,11 @@ declare module 'stripe' {
           id: string,
           params?: CardholderRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Cardholder>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Cardholder>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Cardholder>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Cardholder>>;
 
         /**
          * Updates the specified Issuing Cardholder object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -3351,7 +3351,7 @@ declare module 'stripe' {
           id: string,
           params?: CardholderUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Cardholder>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Cardholder>>;
 
         /**
          * Returns a list of Issuing Cardholder objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/types/2020-03-02/Issuing/Cards.d.ts
+++ b/types/2020-03-02/Issuing/Cards.d.ts
@@ -3156,7 +3156,7 @@ declare module 'stripe' {
         create(
           params: CardCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Card>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Card>>;
 
         /**
          * Retrieves an Issuing Card object.
@@ -3165,11 +3165,11 @@ declare module 'stripe' {
           id: string,
           params?: CardRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Card>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Card>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Card>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Card>>;
 
         /**
          * Updates the specified Issuing Card object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -3178,7 +3178,7 @@ declare module 'stripe' {
           id: string,
           params?: CardUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Card>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Card>>;
 
         /**
          * Returns a list of Issuing Card objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -3196,11 +3196,11 @@ declare module 'stripe' {
           id: string,
           params?: CardRetrieveDetailsParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.CardDetails>;
+        ): Promise<Stripe.Response<Stripe.Issuing.CardDetails>>;
         retrieveDetails(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.CardDetails>;
+        ): Promise<Stripe.Response<Stripe.Issuing.CardDetails>>;
       }
     }
   }

--- a/types/2020-03-02/Issuing/Disputes.d.ts
+++ b/types/2020-03-02/Issuing/Disputes.d.ts
@@ -77,8 +77,10 @@ declare module 'stripe' {
         create(
           params?: DisputeCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Dispute>;
-        create(options?: RequestOptions): Promise<Stripe.Issuing.Dispute>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
+        create(
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
 
         /**
          * Retrieves an Issuing Dispute object.
@@ -87,11 +89,11 @@ declare module 'stripe' {
           id: string,
           params?: DisputeRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Dispute>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Dispute>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
 
         /**
          * Updates the specified Issuing Dispute object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -100,7 +102,7 @@ declare module 'stripe' {
           id: string,
           params?: DisputeUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Dispute>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
 
         /**
          * Returns a list of Issuing Dispute objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/types/2020-03-02/Issuing/Transactions.d.ts
+++ b/types/2020-03-02/Issuing/Transactions.d.ts
@@ -332,11 +332,11 @@ declare module 'stripe' {
           id: string,
           params?: TransactionRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Transaction>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Transaction>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Transaction>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Transaction>>;
 
         /**
          * Updates the specified Issuing Transaction object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -345,7 +345,7 @@ declare module 'stripe' {
           id: string,
           params?: TransactionUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Issuing.Transaction>;
+        ): Promise<Stripe.Response<Stripe.Issuing.Transaction>>;
 
         /**
          * Returns a list of Issuing Transaction objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.

--- a/types/2020-03-02/Mandates.d.ts
+++ b/types/2020-03-02/Mandates.d.ts
@@ -172,8 +172,11 @@ declare module 'stripe' {
         id: string,
         params?: MandateRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Mandate>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Mandate>;
+      ): Promise<Stripe.Response<Stripe.Mandate>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Mandate>>;
     }
   }
 }

--- a/types/2020-03-02/OrderReturns.d.ts
+++ b/types/2020-03-02/OrderReturns.d.ts
@@ -83,11 +83,11 @@ declare module 'stripe' {
         id: string,
         params?: OrderReturnRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.OrderReturn>;
+      ): Promise<Stripe.Response<Stripe.OrderReturn>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.OrderReturn>;
+      ): Promise<Stripe.Response<Stripe.OrderReturn>>;
 
       /**
        * Returns a list of your order returns. The returns are returned sorted by creation date, with the most recently created return appearing first.

--- a/types/2020-03-02/Orders.d.ts
+++ b/types/2020-03-02/Orders.d.ts
@@ -505,7 +505,7 @@ declare module 'stripe' {
       create(
         params: OrderCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Order>;
+      ): Promise<Stripe.Response<Stripe.Order>>;
 
       /**
        * Retrieves the details of an existing order. Supply the unique order ID from either an order creation request or the order list, and Stripe will return the corresponding order information.
@@ -514,8 +514,11 @@ declare module 'stripe' {
         id: string,
         params?: OrderRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Order>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Order>;
+      ): Promise<Stripe.Response<Stripe.Order>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Order>>;
 
       /**
        * Updates the specific order by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -524,7 +527,7 @@ declare module 'stripe' {
         id: string,
         params?: OrderUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Order>;
+      ): Promise<Stripe.Response<Stripe.Order>>;
 
       /**
        * Returns a list of your orders. The orders are returned sorted by creation date, with the most recently created orders appearing first.
@@ -542,8 +545,11 @@ declare module 'stripe' {
         id: string,
         params?: OrderPayParams,
         options?: RequestOptions
-      ): Promise<Stripe.Order>;
-      pay(id: string, options?: RequestOptions): Promise<Stripe.Order>;
+      ): Promise<Stripe.Response<Stripe.Order>>;
+      pay(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Order>>;
 
       /**
        * Return all or part of an order. The order must have a status of paid or fulfilled before it can be returned. Once all items have been returned, the order will become canceled or returned depending on which status the order started in.
@@ -552,11 +558,11 @@ declare module 'stripe' {
         id: string,
         params?: OrderReturnOrderParams,
         options?: RequestOptions
-      ): Promise<Stripe.OrderReturn>;
+      ): Promise<Stripe.Response<Stripe.OrderReturn>>;
       returnOrder(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.OrderReturn>;
+      ): Promise<Stripe.Response<Stripe.OrderReturn>>;
     }
   }
 }

--- a/types/2020-03-02/PaymentIntents.d.ts
+++ b/types/2020-03-02/PaymentIntents.d.ts
@@ -2347,7 +2347,7 @@ declare module 'stripe' {
       create(
         params: PaymentIntentCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
 
       /**
        * Retrieves the details of a PaymentIntent that has previously been created.
@@ -2360,11 +2360,11 @@ declare module 'stripe' {
         id: string,
         params?: PaymentIntentRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
 
       /**
        * Updates properties on a PaymentIntent object without confirming.
@@ -2379,7 +2379,7 @@ declare module 'stripe' {
         id: string,
         params?: PaymentIntentUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
 
       /**
        * Returns a list of PaymentIntents.
@@ -2399,11 +2399,11 @@ declare module 'stripe' {
         id: string,
         params?: PaymentIntentCancelParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
       cancel(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
 
       /**
        * Capture the funds of an existing uncaptured PaymentIntent when its status is requires_capture.
@@ -2416,11 +2416,11 @@ declare module 'stripe' {
         id: string,
         params?: PaymentIntentCaptureParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
       capture(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
 
       /**
        * Confirm that your customer intends to pay with current or provided
@@ -2453,11 +2453,11 @@ declare module 'stripe' {
         id: string,
         params?: PaymentIntentConfirmParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
       confirm(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentIntent>;
+      ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
     }
   }
 }

--- a/types/2020-03-02/PaymentMethods.d.ts
+++ b/types/2020-03-02/PaymentMethods.d.ts
@@ -924,8 +924,10 @@ declare module 'stripe' {
       create(
         params?: PaymentMethodCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
-      create(options?: RequestOptions): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
+      create(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
 
       /**
        * Retrieves a PaymentMethod object.
@@ -934,11 +936,11 @@ declare module 'stripe' {
         id: string,
         params?: PaymentMethodRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
 
       /**
        * Updates a PaymentMethod object. A PaymentMethod must be attached a customer to be updated.
@@ -947,7 +949,7 @@ declare module 'stripe' {
         id: string,
         params?: PaymentMethodUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
 
       /**
        * Returns a list of PaymentMethods for a given Customer
@@ -974,7 +976,7 @@ declare module 'stripe' {
         id: string,
         params: PaymentMethodAttachParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
 
       /**
        * Detaches a PaymentMethod object from a Customer.
@@ -983,11 +985,11 @@ declare module 'stripe' {
         id: string,
         params?: PaymentMethodDetachParams,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
       detach(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PaymentMethod>;
+      ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
     }
   }
 }

--- a/types/2020-03-02/Payouts.d.ts
+++ b/types/2020-03-02/Payouts.d.ts
@@ -227,7 +227,7 @@ declare module 'stripe' {
       create(
         params: PayoutCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Payout>;
+      ): Promise<Stripe.Response<Stripe.Payout>>;
 
       /**
        * Retrieves the details of an existing payout. Supply the unique payout ID from either a payout creation request or the payout list, and Stripe will return the corresponding payout information.
@@ -236,8 +236,11 @@ declare module 'stripe' {
         id: string,
         params?: PayoutRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Payout>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Payout>;
+      ): Promise<Stripe.Response<Stripe.Payout>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Payout>>;
 
       /**
        * Updates the specified payout by setting the values of the parameters passed. Any parameters not provided will be left unchanged. This request accepts only the metadata as arguments.
@@ -246,7 +249,7 @@ declare module 'stripe' {
         id: string,
         params?: PayoutUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Payout>;
+      ): Promise<Stripe.Response<Stripe.Payout>>;
 
       /**
        * Returns a list of existing payouts sent to third-party bank accounts or that Stripe has sent you. The payouts are returned in sorted order, with the most recently created payouts appearing first.
@@ -264,8 +267,11 @@ declare module 'stripe' {
         id: string,
         params?: PayoutCancelParams,
         options?: RequestOptions
-      ): Promise<Stripe.Payout>;
-      cancel(id: string, options?: RequestOptions): Promise<Stripe.Payout>;
+      ): Promise<Stripe.Response<Stripe.Payout>>;
+      cancel(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Payout>>;
     }
   }
 }

--- a/types/2020-03-02/Plans.d.ts
+++ b/types/2020-03-02/Plans.d.ts
@@ -431,7 +431,7 @@ declare module 'stripe' {
       create(
         params: PlanCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Plan>;
+      ): Promise<Stripe.Response<Stripe.Plan>>;
 
       /**
        * Retrieves the plan with the given ID.
@@ -440,8 +440,11 @@ declare module 'stripe' {
         id: string,
         params?: PlanRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Plan>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Plan>;
+      ): Promise<Stripe.Response<Stripe.Plan>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Plan>>;
 
       /**
        * Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan's ID, amount, currency, or billing cycle.
@@ -450,7 +453,7 @@ declare module 'stripe' {
         id: string,
         params?: PlanUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Plan>;
+      ): Promise<Stripe.Response<Stripe.Plan>>;
 
       /**
        * Returns a list of your plans.
@@ -468,8 +471,11 @@ declare module 'stripe' {
         id: string,
         params?: PlanDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedPlan>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.DeletedPlan>;
+      ): Promise<Stripe.Response<Stripe.DeletedPlan>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.DeletedPlan>>;
     }
   }
 }

--- a/types/2020-03-02/Prices.d.ts
+++ b/types/2020-03-02/Prices.d.ts
@@ -536,7 +536,7 @@ declare module 'stripe' {
       create(
         params: PriceCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Price>;
+      ): Promise<Stripe.Response<Stripe.Price>>;
 
       /**
        * Retrieves the price with the given ID.
@@ -545,8 +545,11 @@ declare module 'stripe' {
         id: string,
         params?: PriceRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Price>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Price>;
+      ): Promise<Stripe.Response<Stripe.Price>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Price>>;
 
       /**
        * Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.
@@ -555,7 +558,7 @@ declare module 'stripe' {
         id: string,
         params?: PriceUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Price>;
+      ): Promise<Stripe.Response<Stripe.Price>>;
 
       /**
        * Returns a list of your prices.

--- a/types/2020-03-02/Products.d.ts
+++ b/types/2020-03-02/Products.d.ts
@@ -416,7 +416,7 @@ declare module 'stripe' {
       create(
         params: ProductCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Product>;
+      ): Promise<Stripe.Response<Stripe.Product>>;
 
       /**
        * Retrieves the details of an existing product. Supply the unique product ID from either a product creation request or the product list, and Stripe will return the corresponding product information.
@@ -425,8 +425,11 @@ declare module 'stripe' {
         id: string,
         params?: ProductRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Product>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Product>;
+      ): Promise<Stripe.Response<Stripe.Product>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Product>>;
 
       /**
        * Updates the specific product by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -435,7 +438,7 @@ declare module 'stripe' {
         id: string,
         params?: ProductUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Product>;
+      ): Promise<Stripe.Response<Stripe.Product>>;
 
       /**
        * Returns a list of your products. The products are returned sorted by creation date, with the most recently created products appearing first.
@@ -453,8 +456,11 @@ declare module 'stripe' {
         id: string,
         params?: ProductDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedProduct>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.DeletedProduct>;
+      ): Promise<Stripe.Response<Stripe.DeletedProduct>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.DeletedProduct>>;
     }
   }
 }

--- a/types/2020-03-02/PromotionCodes.d.ts
+++ b/types/2020-03-02/PromotionCodes.d.ts
@@ -218,7 +218,7 @@ declare module 'stripe' {
       create(
         params: PromotionCodeCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.PromotionCode>;
+      ): Promise<Stripe.Response<Stripe.PromotionCode>>;
 
       /**
        * Retrieves the promotion code with the given ID.
@@ -227,11 +227,11 @@ declare module 'stripe' {
         id: string,
         params?: PromotionCodeRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.PromotionCode>;
+      ): Promise<Stripe.Response<Stripe.PromotionCode>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.PromotionCode>;
+      ): Promise<Stripe.Response<Stripe.PromotionCode>>;
 
       /**
        * Updates the specified promotion code by setting the values of the parameters passed. Most fields are, by design, not editable.
@@ -240,7 +240,7 @@ declare module 'stripe' {
         id: string,
         params?: PromotionCodeUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.PromotionCode>;
+      ): Promise<Stripe.Response<Stripe.PromotionCode>>;
 
       /**
        * Returns a list of your promotion codes.

--- a/types/2020-03-02/Radar/EarlyFraudWarnings.d.ts
+++ b/types/2020-03-02/Radar/EarlyFraudWarnings.d.ts
@@ -71,11 +71,11 @@ declare module 'stripe' {
           id: string,
           params?: EarlyFraudWarningRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.EarlyFraudWarning>;
+        ): Promise<Stripe.Response<Stripe.Radar.EarlyFraudWarning>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.EarlyFraudWarning>;
+        ): Promise<Stripe.Response<Stripe.Radar.EarlyFraudWarning>>;
 
         /**
          * Returns a list of early fraud warnings.

--- a/types/2020-03-02/Radar/ValueListItems.d.ts
+++ b/types/2020-03-02/Radar/ValueListItems.d.ts
@@ -116,7 +116,7 @@ declare module 'stripe' {
         create(
           params: ValueListItemCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueListItem>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueListItem>>;
 
         /**
          * Retrieves a ValueListItem object.
@@ -125,11 +125,11 @@ declare module 'stripe' {
           id: string,
           params?: ValueListItemRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueListItem>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueListItem>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueListItem>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueListItem>>;
 
         /**
          * Returns a list of ValueListItem objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -146,11 +146,11 @@ declare module 'stripe' {
           id: string,
           params?: ValueListItemDeleteParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.DeletedValueListItem>;
+        ): Promise<Stripe.Response<Stripe.Radar.DeletedValueListItem>>;
         del(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.DeletedValueListItem>;
+        ): Promise<Stripe.Response<Stripe.Radar.DeletedValueListItem>>;
       }
     }
   }

--- a/types/2020-03-02/Radar/ValueLists.d.ts
+++ b/types/2020-03-02/Radar/ValueLists.d.ts
@@ -185,7 +185,7 @@ declare module 'stripe' {
         create(
           params: ValueListCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueList>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueList>>;
 
         /**
          * Retrieves a ValueList object.
@@ -194,11 +194,11 @@ declare module 'stripe' {
           id: string,
           params?: ValueListRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueList>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueList>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueList>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueList>>;
 
         /**
          * Updates a ValueList object by setting the values of the parameters passed. Any parameters not provided will be left unchanged. Note that item_type is immutable.
@@ -207,7 +207,7 @@ declare module 'stripe' {
           id: string,
           params?: ValueListUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.ValueList>;
+        ): Promise<Stripe.Response<Stripe.Radar.ValueList>>;
 
         /**
          * Returns a list of ValueList objects. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -225,11 +225,11 @@ declare module 'stripe' {
           id: string,
           params?: ValueListDeleteParams,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.DeletedValueList>;
+        ): Promise<Stripe.Response<Stripe.Radar.DeletedValueList>>;
         del(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Radar.DeletedValueList>;
+        ): Promise<Stripe.Response<Stripe.Radar.DeletedValueList>>;
       }
     }
   }

--- a/types/2020-03-02/Refunds.d.ts
+++ b/types/2020-03-02/Refunds.d.ts
@@ -178,8 +178,8 @@ declare module 'stripe' {
       create(
         params?: RefundCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Refund>;
-      create(options?: RequestOptions): Promise<Stripe.Refund>;
+      ): Promise<Stripe.Response<Stripe.Refund>>;
+      create(options?: RequestOptions): Promise<Stripe.Response<Stripe.Refund>>;
 
       /**
        * Retrieves the details of an existing refund.
@@ -189,12 +189,12 @@ declare module 'stripe' {
         id: string,
         params?: RefundRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Refund>;
+      ): Promise<Stripe.Response<Stripe.Refund>>;
       retrieve(
         chargeId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Refund>;
+      ): Promise<Stripe.Response<Stripe.Refund>>;
 
       /**
        * Retrieves the details of an existing refund.
@@ -203,8 +203,11 @@ declare module 'stripe' {
         id: string,
         params?: RefundRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Refund>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Refund>;
+      ): Promise<Stripe.Response<Stripe.Refund>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Refund>>;
 
       /**
        * Updates the specified refund by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -215,7 +218,7 @@ declare module 'stripe' {
         id: string,
         params?: RefundUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Refund>;
+      ): Promise<Stripe.Response<Stripe.Refund>>;
 
       /**
        * You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional refunds.

--- a/types/2020-03-02/Reporting/ReportRuns.d.ts
+++ b/types/2020-03-02/Reporting/ReportRuns.d.ts
@@ -820,7 +820,7 @@ declare module 'stripe' {
         create(
           params: ReportRunCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Reporting.ReportRun>;
+        ): Promise<Stripe.Response<Stripe.Reporting.ReportRun>>;
 
         /**
          * Retrieves the details of an existing Report Run. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
@@ -829,11 +829,11 @@ declare module 'stripe' {
           id: string,
           params?: ReportRunRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Reporting.ReportRun>;
+        ): Promise<Stripe.Response<Stripe.Reporting.ReportRun>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Reporting.ReportRun>;
+        ): Promise<Stripe.Response<Stripe.Reporting.ReportRun>>;
 
         /**
          * Returns a list of Report Runs, with the most recent appearing first. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)

--- a/types/2020-03-02/Reporting/ReportTypes.d.ts
+++ b/types/2020-03-02/Reporting/ReportTypes.d.ts
@@ -69,11 +69,11 @@ declare module 'stripe' {
           id: string,
           params?: ReportTypeRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Reporting.ReportType>;
+        ): Promise<Stripe.Response<Stripe.Reporting.ReportType>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Reporting.ReportType>;
+        ): Promise<Stripe.Response<Stripe.Reporting.ReportType>>;
 
         /**
          * Returns a full list of Report Types. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)

--- a/types/2020-03-02/Reviews.d.ts
+++ b/types/2020-03-02/Reviews.d.ts
@@ -166,8 +166,11 @@ declare module 'stripe' {
         id: string,
         params?: ReviewRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Review>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Review>;
+      ): Promise<Stripe.Response<Stripe.Review>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Review>>;
 
       /**
        * Returns a list of Review objects that have open set to true. The objects are sorted in descending order by creation date, with the most recently created object appearing first.
@@ -185,8 +188,11 @@ declare module 'stripe' {
         id: string,
         params?: ReviewApproveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Review>;
-      approve(id: string, options?: RequestOptions): Promise<Stripe.Review>;
+      ): Promise<Stripe.Response<Stripe.Review>>;
+      approve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Review>>;
     }
   }
 }

--- a/types/2020-03-02/SKUs.d.ts
+++ b/types/2020-03-02/SKUs.d.ts
@@ -389,7 +389,7 @@ declare module 'stripe' {
       create(
         params: SkuCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Sku>;
+      ): Promise<Stripe.Response<Stripe.Sku>>;
 
       /**
        * Retrieves the details of an existing SKU. Supply the unique SKU identifier from either a SKU creation request or from the product, and Stripe will return the corresponding SKU information.
@@ -398,11 +398,11 @@ declare module 'stripe' {
         id: string,
         params?: SkuRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Sku | Stripe.DeletedSku>;
+      ): Promise<Stripe.Response<Stripe.Sku | Stripe.DeletedSku>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Sku | Stripe.DeletedSku>;
+      ): Promise<Stripe.Response<Stripe.Sku | Stripe.DeletedSku>>;
 
       /**
        * Updates the specific SKU by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -413,7 +413,7 @@ declare module 'stripe' {
         id: string,
         params?: SkuUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Sku>;
+      ): Promise<Stripe.Response<Stripe.Sku>>;
 
       /**
        * Returns a list of your SKUs. The SKUs are returned sorted by creation date, with the most recently created SKUs appearing first.
@@ -431,8 +431,11 @@ declare module 'stripe' {
         id: string,
         params?: SkuDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedSku>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.DeletedSku>;
+      ): Promise<Stripe.Response<Stripe.DeletedSku>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.DeletedSku>>;
     }
   }
 }

--- a/types/2020-03-02/SetupIntents.d.ts
+++ b/types/2020-03-02/SetupIntents.d.ts
@@ -710,8 +710,10 @@ declare module 'stripe' {
       create(
         params?: SetupIntentCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
-      create(options?: RequestOptions): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
+      create(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
 
       /**
        * Retrieves the details of a SetupIntent that has previously been created.
@@ -724,11 +726,11 @@ declare module 'stripe' {
         id: string,
         params?: SetupIntentRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
 
       /**
        * Updates a SetupIntent object.
@@ -737,7 +739,7 @@ declare module 'stripe' {
         id: string,
         params?: SetupIntentUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
 
       /**
        * Returns a list of SetupIntents.
@@ -757,8 +759,11 @@ declare module 'stripe' {
         id: string,
         params?: SetupIntentCancelParams,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
-      cancel(id: string, options?: RequestOptions): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
+      cancel(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
 
       /**
        * Confirm that your customer intends to set up the current or
@@ -779,11 +784,11 @@ declare module 'stripe' {
         id: string,
         params?: SetupIntentConfirmParams,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
       confirm(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.SetupIntent>;
+      ): Promise<Stripe.Response<Stripe.SetupIntent>>;
     }
   }
 }

--- a/types/2020-03-02/Sigma/ScheduledQueryRuns.d.ts
+++ b/types/2020-03-02/Sigma/ScheduledQueryRuns.d.ts
@@ -90,11 +90,11 @@ declare module 'stripe' {
           id: string,
           params?: ScheduledQueryRunRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Sigma.ScheduledQueryRun>;
+        ): Promise<Stripe.Response<Stripe.Sigma.ScheduledQueryRun>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Sigma.ScheduledQueryRun>;
+        ): Promise<Stripe.Response<Stripe.Sigma.ScheduledQueryRun>>;
 
         /**
          * Returns a list of scheduled query runs.

--- a/types/2020-03-02/Sources.d.ts
+++ b/types/2020-03-02/Sources.d.ts
@@ -1350,8 +1350,8 @@ declare module 'stripe' {
       create(
         params?: SourceCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Source>;
-      create(options?: RequestOptions): Promise<Stripe.Source>;
+      ): Promise<Stripe.Response<Stripe.Source>>;
+      create(options?: RequestOptions): Promise<Stripe.Response<Stripe.Source>>;
 
       /**
        * Retrieves an existing source object. Supply the unique source ID from a source creation request and Stripe will return the corresponding up-to-date source object information.
@@ -1360,8 +1360,11 @@ declare module 'stripe' {
         id: string,
         params?: SourceRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Source>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Source>;
+      ): Promise<Stripe.Response<Stripe.Source>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Source>>;
 
       /**
        * Updates the specified source by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -1372,7 +1375,7 @@ declare module 'stripe' {
         id: string,
         params?: SourceUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Source>;
+      ): Promise<Stripe.Response<Stripe.Source>>;
 
       /**
        * List source transactions for a given source.
@@ -1394,7 +1397,7 @@ declare module 'stripe' {
         id: string,
         params: SourceVerifyParams,
         options?: RequestOptions
-      ): Promise<Stripe.Source>;
+      ): Promise<Stripe.Response<Stripe.Source>>;
     }
   }
 }

--- a/types/2020-03-02/SubscriptionItems.d.ts
+++ b/types/2020-03-02/SubscriptionItems.d.ts
@@ -427,7 +427,7 @@ declare module 'stripe' {
       create(
         params: SubscriptionItemCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionItem>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionItem>>;
 
       /**
        * Retrieves the subscription item with the given ID.
@@ -436,11 +436,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionItemRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionItem>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionItem>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionItem>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionItem>>;
 
       /**
        * Updates the plan or quantity of an item on a current subscription.
@@ -449,7 +449,7 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionItemUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionItem>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionItem>>;
 
       /**
        * Returns a list of your subscription items for a given subscription.
@@ -466,11 +466,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionItemDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedSubscriptionItem>;
+      ): Promise<Stripe.Response<Stripe.DeletedSubscriptionItem>>;
       del(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedSubscriptionItem>;
+      ): Promise<Stripe.Response<Stripe.DeletedSubscriptionItem>>;
 
       /**
        * Creates a usage record for a specified subscription item and date, and fills it with a quantity.
@@ -485,7 +485,7 @@ declare module 'stripe' {
         id: string,
         params: UsageRecordCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.UsageRecord>;
+      ): Promise<Stripe.Response<Stripe.UsageRecord>>;
 
       /**
        * For the specified subscription item, returns a list of summary objects. Each object in the list provides usage information that's been summarized from multiple usage records and over a subscription billing period (e.g., 15 usage records in the month of September).

--- a/types/2020-03-02/SubscriptionSchedules.d.ts
+++ b/types/2020-03-02/SubscriptionSchedules.d.ts
@@ -1171,8 +1171,10 @@ declare module 'stripe' {
       create(
         params?: SubscriptionScheduleCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
-      create(options?: RequestOptions): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
+      create(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
 
       /**
        * Retrieves the details of an existing subscription schedule. You only need to supply the unique subscription schedule identifier that was returned upon subscription schedule creation.
@@ -1181,11 +1183,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionScheduleRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
 
       /**
        * Updates an existing subscription schedule.
@@ -1194,7 +1196,7 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionScheduleUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
 
       /**
        * Retrieves the list of your subscription schedules.
@@ -1214,11 +1216,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionScheduleCancelParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
       cancel(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
 
       /**
        * Releases the subscription schedule immediately, which will stop scheduling of its phases, but leave any existing subscription in place. A schedule can only be released if its status is not_started or active. If the subscription schedule is currently associated with a subscription, releasing it will remove its subscription property and set the subscription's ID to the released_subscription property.
@@ -1227,11 +1229,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionScheduleReleaseParams,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
       release(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.SubscriptionSchedule>;
+      ): Promise<Stripe.Response<Stripe.SubscriptionSchedule>>;
     }
   }
 }

--- a/types/2020-03-02/Subscriptions.d.ts
+++ b/types/2020-03-02/Subscriptions.d.ts
@@ -1073,7 +1073,7 @@ declare module 'stripe' {
       create(
         params: SubscriptionCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Subscription>;
+      ): Promise<Stripe.Response<Stripe.Subscription>>;
 
       /**
        * Retrieves the subscription with the given ID.
@@ -1082,11 +1082,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Subscription>;
+      ): Promise<Stripe.Response<Stripe.Subscription>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Subscription>;
+      ): Promise<Stripe.Response<Stripe.Subscription>>;
 
       /**
        * Updates an existing subscription on a customer to match the specified parameters. When changing plans or quantities, we will optionally prorate the price we charge next month to make up for any price changes. To preview how the proration will be calculated, use the [upcoming invoice](https://stripe.com/docs/api#upcoming_invoice) endpoint.
@@ -1095,7 +1095,7 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Subscription>;
+      ): Promise<Stripe.Response<Stripe.Subscription>>;
 
       /**
        * By default, returns a list of subscriptions that have not been canceled. In order to list canceled subscriptions, specify status=canceled.
@@ -1117,8 +1117,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.Subscription>;
-      del(id: string, options?: RequestOptions): Promise<Stripe.Subscription>;
+      ): Promise<Stripe.Response<Stripe.Subscription>>;
+      del(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Subscription>>;
 
       /**
        * Removes the currently applied discount on a subscription.
@@ -1127,11 +1130,11 @@ declare module 'stripe' {
         id: string,
         params?: SubscriptionDeleteDiscountParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedDiscount>;
+      ): Promise<Stripe.Response<Stripe.DeletedDiscount>>;
       deleteDiscount(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedDiscount>;
+      ): Promise<Stripe.Response<Stripe.DeletedDiscount>>;
     }
   }
 }

--- a/types/2020-03-02/TaxRates.d.ts
+++ b/types/2020-03-02/TaxRates.d.ts
@@ -171,7 +171,7 @@ declare module 'stripe' {
       create(
         params: TaxRateCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.TaxRate>;
+      ): Promise<Stripe.Response<Stripe.TaxRate>>;
 
       /**
        * Retrieves a tax rate with the given ID
@@ -180,8 +180,11 @@ declare module 'stripe' {
         id: string,
         params?: TaxRateRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.TaxRate>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.TaxRate>;
+      ): Promise<Stripe.Response<Stripe.TaxRate>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.TaxRate>>;
 
       /**
        * Updates an existing tax rate.
@@ -190,7 +193,7 @@ declare module 'stripe' {
         id: string,
         params?: TaxRateUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.TaxRate>;
+      ): Promise<Stripe.Response<Stripe.TaxRate>>;
 
       /**
        * Returns a list of your tax rates. Tax rates are returned sorted by creation date, with the most recently created tax rates appearing first.

--- a/types/2020-03-02/Terminal/ConnectionTokens.d.ts
+++ b/types/2020-03-02/Terminal/ConnectionTokens.d.ts
@@ -41,10 +41,10 @@ declare module 'stripe' {
         create(
           params?: ConnectionTokenCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.ConnectionToken>;
+        ): Promise<Stripe.Response<Stripe.Terminal.ConnectionToken>>;
         create(
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.ConnectionToken>;
+        ): Promise<Stripe.Response<Stripe.Terminal.ConnectionToken>>;
       }
     }
   }

--- a/types/2020-03-02/Terminal/Locations.d.ts
+++ b/types/2020-03-02/Terminal/Locations.d.ts
@@ -191,7 +191,7 @@ declare module 'stripe' {
         create(
           params: LocationCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Location>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
 
         /**
          * Retrieves a Location object.
@@ -200,11 +200,11 @@ declare module 'stripe' {
           id: string,
           params?: LocationRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Location>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Location>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
 
         /**
          * Updates a Location object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -213,7 +213,7 @@ declare module 'stripe' {
           id: string,
           params?: LocationUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Location>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
 
         /**
          * Returns a list of Location objects.
@@ -233,11 +233,11 @@ declare module 'stripe' {
           id: string,
           params?: LocationDeleteParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.DeletedLocation>;
+        ): Promise<Stripe.Response<Stripe.Terminal.DeletedLocation>>;
         del(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.DeletedLocation>;
+        ): Promise<Stripe.Response<Stripe.Terminal.DeletedLocation>>;
       }
     }
   }

--- a/types/2020-03-02/Terminal/Readers.d.ts
+++ b/types/2020-03-02/Terminal/Readers.d.ts
@@ -176,7 +176,7 @@ declare module 'stripe' {
         create(
           params: ReaderCreateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Reader>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Reader>>;
 
         /**
          * Retrieves a Reader object.
@@ -185,11 +185,11 @@ declare module 'stripe' {
           id: string,
           params?: ReaderRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Reader>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Reader>>;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Reader>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Reader>>;
 
         /**
          * Updates a Reader object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -198,7 +198,7 @@ declare module 'stripe' {
           id: string,
           params?: ReaderUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.Reader>;
+        ): Promise<Stripe.Response<Stripe.Terminal.Reader>>;
 
         /**
          * Returns a list of Reader objects.
@@ -216,11 +216,11 @@ declare module 'stripe' {
           id: string,
           params?: ReaderDeleteParams,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.DeletedReader>;
+        ): Promise<Stripe.Response<Stripe.Terminal.DeletedReader>>;
         del(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Terminal.DeletedReader>;
+        ): Promise<Stripe.Response<Stripe.Terminal.DeletedReader>>;
       }
     }
   }

--- a/types/2020-03-02/Tokens.d.ts
+++ b/types/2020-03-02/Tokens.d.ts
@@ -771,8 +771,8 @@ declare module 'stripe' {
       create(
         params?: TokenCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Token>;
-      create(options?: RequestOptions): Promise<Stripe.Token>;
+      ): Promise<Stripe.Response<Stripe.Token>>;
+      create(options?: RequestOptions): Promise<Stripe.Response<Stripe.Token>>;
 
       /**
        * Retrieves the token with the given ID.
@@ -781,8 +781,11 @@ declare module 'stripe' {
         id: string,
         params?: TokenRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Token>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Token>;
+      ): Promise<Stripe.Response<Stripe.Token>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Token>>;
     }
   }
 }

--- a/types/2020-03-02/Topups.d.ts
+++ b/types/2020-03-02/Topups.d.ts
@@ -206,7 +206,7 @@ declare module 'stripe' {
       create(
         params: TopupCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Topup>;
+      ): Promise<Stripe.Response<Stripe.Topup>>;
 
       /**
        * Retrieves the details of a top-up that has previously been created. Supply the unique top-up ID that was returned from your previous request, and Stripe will return the corresponding top-up information.
@@ -215,8 +215,11 @@ declare module 'stripe' {
         id: string,
         params?: TopupRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Topup>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Topup>;
+      ): Promise<Stripe.Response<Stripe.Topup>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Topup>>;
 
       /**
        * Updates the metadata of a top-up. Other top-up details are not editable by design.
@@ -225,7 +228,7 @@ declare module 'stripe' {
         id: string,
         params?: TopupUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Topup>;
+      ): Promise<Stripe.Response<Stripe.Topup>>;
 
       /**
        * Returns a list of top-ups.
@@ -243,8 +246,11 @@ declare module 'stripe' {
         id: string,
         params?: TopupCancelParams,
         options?: RequestOptions
-      ): Promise<Stripe.Topup>;
-      cancel(id: string, options?: RequestOptions): Promise<Stripe.Topup>;
+      ): Promise<Stripe.Response<Stripe.Topup>>;
+      cancel(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Topup>>;
     }
   }
 }

--- a/types/2020-03-02/Transfers.d.ts
+++ b/types/2020-03-02/Transfers.d.ts
@@ -192,7 +192,7 @@ declare module 'stripe' {
       create(
         params: TransferCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Transfer>;
+      ): Promise<Stripe.Response<Stripe.Transfer>>;
 
       /**
        * Retrieves the details of an existing transfer. Supply the unique transfer ID from either a transfer creation request or the transfer list, and Stripe will return the corresponding transfer information.
@@ -201,8 +201,11 @@ declare module 'stripe' {
         id: string,
         params?: TransferRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Transfer>;
-      retrieve(id: string, options?: RequestOptions): Promise<Stripe.Transfer>;
+      ): Promise<Stripe.Response<Stripe.Transfer>>;
+      retrieve(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Transfer>>;
 
       /**
        * Updates the specified transfer by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -213,7 +216,7 @@ declare module 'stripe' {
         id: string,
         params?: TransferUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Transfer>;
+      ): Promise<Stripe.Response<Stripe.Transfer>>;
 
       /**
        * Returns a list of existing transfers sent to connected accounts. The transfers are returned in sorted order, with the most recently created transfers appearing first.
@@ -235,11 +238,11 @@ declare module 'stripe' {
         id: string,
         params?: TransferReversalCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.TransferReversal>;
+      ): Promise<Stripe.Response<Stripe.TransferReversal>>;
       createReversal(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.TransferReversal>;
+      ): Promise<Stripe.Response<Stripe.TransferReversal>>;
 
       /**
        * By default, you can see the 10 most recent reversals stored directly on the transfer object, but you can also retrieve details about a specific reversal stored on the transfer.
@@ -249,12 +252,12 @@ declare module 'stripe' {
         id: string,
         params?: TransferReversalRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.TransferReversal>;
+      ): Promise<Stripe.Response<Stripe.TransferReversal>>;
       retrieveReversal(
         idId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.TransferReversal>;
+      ): Promise<Stripe.Response<Stripe.TransferReversal>>;
 
       /**
        * Updates the specified reversal by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -266,7 +269,7 @@ declare module 'stripe' {
         id: string,
         params?: TransferReversalUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.TransferReversal>;
+      ): Promise<Stripe.Response<Stripe.TransferReversal>>;
 
       /**
        * You can see a list of the reversals belonging to a specific transfer. Note that the 10 most recent reversals are always available by default on the transfer object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional reversals.

--- a/types/2020-03-02/WebhookEndpoints.d.ts
+++ b/types/2020-03-02/WebhookEndpoints.d.ts
@@ -603,7 +603,7 @@ declare module 'stripe' {
       create(
         params: WebhookEndpointCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.WebhookEndpoint>;
+      ): Promise<Stripe.Response<Stripe.WebhookEndpoint>>;
 
       /**
        * Retrieves the webhook endpoint with the given ID.
@@ -612,11 +612,11 @@ declare module 'stripe' {
         id: string,
         params?: WebhookEndpointRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.WebhookEndpoint>;
+      ): Promise<Stripe.Response<Stripe.WebhookEndpoint>>;
       retrieve(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.WebhookEndpoint>;
+      ): Promise<Stripe.Response<Stripe.WebhookEndpoint>>;
 
       /**
        * Updates the webhook endpoint. You may edit the url, the list of enabled_events, and the status of your endpoint.
@@ -625,7 +625,7 @@ declare module 'stripe' {
         id: string,
         params?: WebhookEndpointUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.WebhookEndpoint>;
+      ): Promise<Stripe.Response<Stripe.WebhookEndpoint>>;
 
       /**
        * Returns a list of your webhook endpoints.
@@ -643,11 +643,11 @@ declare module 'stripe' {
         id: string,
         params?: WebhookEndpointDeleteParams,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedWebhookEndpoint>;
+      ): Promise<Stripe.Response<Stripe.DeletedWebhookEndpoint>>;
       del(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.DeletedWebhookEndpoint>;
+      ): Promise<Stripe.Response<Stripe.DeletedWebhookEndpoint>>;
     }
   }
 }

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -112,6 +112,17 @@ declare module 'stripe' {
       timeout?: number;
     }
 
+    export type Response<T> = T & {
+      headers: {[key: string]: string};
+      lastResponse: {
+        requestId: string;
+        statusCode: number;
+        apiVersion?: string;
+        idempotencyKey?: string;
+        stripeAccount?: string;
+      };
+    };
+
     /**
      * A container for paginated lists of objects.
      * The array of objects is on the `.data` property,
@@ -139,7 +150,7 @@ declare module 'stripe' {
     }
 
     export interface ApiListPromise<T>
-      extends Promise<ApiList<T>>,
+      extends Promise<Response<ApiList<T>>>,
         AsyncIterableIterator<T> {
       autoPagingEach(
         handler: (item: T) => boolean | void | Promise<boolean | void>

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -131,6 +131,36 @@ stripe.setHost('host', 'port', 'protocol');
       const declineCode: string = err.decline_code;
     }
   }
+
+  {
+    const custs = await stripe.customers.list();
+    const lr = custs.lastResponse;
+    const requestId: string = lr.requestId;
+    const statusCode: number = lr.statusCode;
+    const apiVersion: string | undefined = lr.apiVersion;
+    const idempotencyKey: string | undefined = lr.idempotencyKey;
+    const headers = custs.headers;
+    const header: string | undefined = custs.headers['request-id'];
+  }
+
+  {
+    const cust = await stripe.customers.retrieve('foo');
+    const lr = cust.lastResponse;
+    const requestId: string = lr.requestId;
+    const statusCode: number = lr.statusCode;
+    const apiVersion: string | undefined = lr.apiVersion;
+    const idempotencyKey: string | undefined = lr.idempotencyKey;
+    const headers = cust.headers;
+    const header: string | undefined = cust.headers['request-id'];
+  }
+  {
+    const acct = await stripe.accounts.createExternalAccount('foo', {
+      ['external_account']: 'foo',
+    });
+    if (acct.object === 'card') {
+      const rid: string = acct.lastResponse.requestId;
+    }
+  }
 })();
 
 const stripeCardError: Stripe.StripeCardError = Stripe.errors.generate({


### PR DESCRIPTION
r? @ctrudeau-stripe @jlomas-stripe 
cc @remi-stripe @stripe/api-libraries 

Fixes #983

Approach:

In codegen, all the API responses that correspond to *single* resources now return e.g. `Stripe.Response<Customer>` instead of `Customer`. What is [`Stripe.Response`](https://github.com/stripe/stripe-node/pull/990/files#diff-ba34d254505765932ab7f27eb575b5c8R115)?
```typescript
export type Response<T> = T & {
  headers: {[key: string]: string};
  lastResponse: {
    requestId: string;
    statusCode: number;
    apiVersion?: string;
    idempotencyKey?: string;
    stripeAccount?: string;
  };
};
```
As far as I can reason, intersection types are subtypes of their constituents, so this should be non-breaking and safe.

*List* responses are a little trickier. I didn't change anything in the codegen, because each method definition (e.g. `stripe.accounts.listExternalAccounts` has a type like
```
/**
 * List external accounts for an account.
 */
listExternalAccounts(
  id: string,
  params?: ExternalAccountListParams,
  options?: RequestOptions
): ApiListPromise<Stripe.BankAccount | Stripe.Card>;
listExternalAccounts(
  id: string,
  options?: RequestOptions
): ApiListPromise<Stripe.BankAccount | Stripe.Card>;

```
so instead I [redefined](https://github.com/stripe/stripe-node/pull/990/files#diff-ba34d254505765932ab7f27eb575b5c8L142) ApiListPromise to `extends Promise<Stripe.Response<ApiList<T>>>` instead of `extends Promise<ApiList<T>>`

I was also a bit concerned about the "intersection type of union types". In theory, `Response<BankAccount | Card>` should be the same as `Response<BankAccount> | Response<Card>`, and so when a user does a refinement (i.e. they do `if (res.object === 'card') {...}), inside their if statement, `res` should be a `Response<Card>`. I checked it and in practice this seems to work.
Testing strategy:

Added property accesses to the [typescriptTest.js](
https://github.com/stripe/stripe-node/blob/ab1e35e2c4a1cc8430922df90b904366895d2dca/types/test/typescriptTest.ts#L135-L155) for lists and a non-list response.