### PR TITLE
Typedef for Stripe.StripeResource

### DIFF
--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -105,6 +105,8 @@ declare module 'stripe' {
 
     setAppInfo(info: Stripe.AppInfo): void;
 
+    StripeResource: Stripe.StripeResource;
+
     /**
      * Top Level Resources
      */

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -40,6 +40,7 @@ declare module 'stripe' {
         ): ApiListPromise<T>;
         del<T>(id: string, options?: RequestOptions): Promise<T>;
       };
+      static MAX_BUFFERED_REQUEST_METRICS: number;
     }
     export type LatestApiVersion = '2020-08-27';
     export type HttpAgent = Agent;

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -5,6 +5,42 @@ import {Agent} from 'http';
 
 declare module 'stripe' {
   namespace Stripe {
+    export class StripeResource {
+      static extend<
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        T extends {[prop: string]: any} & {
+          includeBasic?: Array<
+            'create' | 'retrieve' | 'update' | 'list' | 'del'
+          >;
+        }
+      >(spec: T): StripeResource & T;
+      static method(spec: {
+        method: string;
+        path: string;
+        methodType?: 'list';
+      }): (...args: any[]) => object; //eslint-disable-line @typescript-eslint/no-explicit-any
+      static BASIC_METHODS: {
+        create<T>(
+          params: CouponCreateParams,
+          options?: RequestOptions
+        ): Promise<T>;
+        retrieve<T>(
+          id: string,
+          params?: CouponRetrieveParams,
+          options?: RequestOptions
+        ): Promise<T>;
+        update<T>(
+          id: string,
+          params?: CouponUpdateParams,
+          options?: RequestOptions
+        ): Promise<T>;
+        list<T>(
+          params?: CouponListParams,
+          options?: RequestOptions
+        ): ApiListPromise<T>;
+        del<T>(id: string, options?: RequestOptions): Promise<T>;
+      };
+    }
     export type LatestApiVersion = '2020-08-27';
     export type HttpAgent = Agent;
 

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -176,3 +176,6 @@ Stripe.StripeResource.extend({
     path: 'foo',
   }),
 });
+
+const maxBufferedRequestMetrics: number =
+  Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS;

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -168,3 +168,11 @@ const stripeCardError: Stripe.StripeCardError = Stripe.errors.generate({
   code: 'card_declined',
   charge: 'ch_123',
 });
+
+Stripe.StripeResource.extend({
+  includeBasic: ['retrieve'],
+  foo: Stripe.StripeResource.method({
+    method: 'create',
+    path: 'foo',
+  }),
+});


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-node/issues/994
r? @jlomas-stripe 
cc @stripe/api-libraries 

We considered adding this for https://github.com/stripe/stripe-node/pull/920 but then opted not to, but per #994 this is not convenient for users. We could just expose `any` but why not try and get the types right?

The types in this PR are an approximation that reflect mostly the "public interface" of Stripe.StripeResource, and still use `any` a great deal, but it's a starting place.