### PR TITLE
More idiomatic types

### DIFF
--- a/types/2020-08-27/FileLinks.d.ts
+++ b/types/2020-08-27/FileLinks.d.ts
@@ -89,7 +89,7 @@ declare module 'stripe' {
       /**
        * A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately.
        */
-      expires_at?: 'now' | number | '';
+      expires_at?: 'now' | number | null;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.

--- a/types/2020-08-27/Payouts.d.ts
+++ b/types/2020-08-27/Payouts.d.ts
@@ -56,8 +56,8 @@ declare module 'stripe' {
       destination:
         | string
         | Stripe.BankAccount
-        | Stripe.Card
         | Stripe.DeletedBankAccount
+        | Stripe.Card
         | Stripe.DeletedCard
         | null;
 


### PR DESCRIPTION
Changes `FileLinkUpdateParams.expires_at^ to be "nullable" rather than "emptyStringable".

stripe-node converts nulls to empty strings before sending over the wire (urlencoded has no concept of 'null'), and using null is a more idiomatic way of "unsetting" a property so our convention for these type bindings is to provide null instead of empty string, but up till now our codegen infrastructure wasn't property handling this case before since it got confused by the presence of "now".

r? @ctrudeau-stripe 
cc @stripe/api-libraries
