### PR TITLE
Add support for `oxxo` as a valid `type` on the List PaymentMethod API

### DIFF
--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -932,6 +932,7 @@ declare module 'stripe' {
         | 'fpx'
         | 'giropay'
         | 'ideal'
+        | 'oxxo'
         | 'p24'
         | 'sepa_debit'
         | 'sofort';


### PR DESCRIPTION
Codegen for openapi 0cb9b14

r? @ctrudeau-stripe 
cc @stripe/api-libraries 