### PR TITLE
Add support for `contribution` in `reporting_category` on `ReportRun`

### DIFF
--- a/types/2020-08-27/Reporting/ReportRuns.d.ts
+++ b/types/2020-08-27/Reporting/ReportRuns.d.ts
@@ -172,6 +172,7 @@ declare module 'stripe' {
             | 'charge_failure'
             | 'connect_collection_transfer'
             | 'connect_reserved_funds'
+            | 'contribution'
             | 'dispute'
             | 'dispute_reversal'
             | 'fee'


### PR DESCRIPTION
Codegen for openapi d9177af

r? @ctrudeau-stripe 
cc @stripe/api-libraries 