### PR TITLE
Update Typescript types

### DIFF
--- a/types/2020-08-27/CreditNoteLineItems.d.ts
+++ b/types/2020-08-27/CreditNoteLineItems.d.ts
@@ -33,7 +33,7 @@ declare module 'stripe' {
       /**
        * The amount of discount calculated per discount for this line item
        */
-      discount_amounts?: Array<CreditNoteLineItem.DiscountAmount>;
+      discount_amounts: Array<CreditNoteLineItem.DiscountAmount>;
 
       /**
        * ID of the invoice line item being credited

--- a/types/2020-08-27/CreditNotes.d.ts
+++ b/types/2020-08-27/CreditNotes.d.ts
@@ -51,7 +51,7 @@ declare module 'stripe' {
       /**
        * The aggregate amounts calculated per discount for all line items.
        */
-      discount_amounts?: Array<CreditNote.DiscountAmount>;
+      discount_amounts: Array<CreditNote.DiscountAmount>;
 
       /**
        * ID of the invoice.

--- a/types/2020-08-27/Discounts.d.ts
+++ b/types/2020-08-27/Discounts.d.ts
@@ -8,7 +8,7 @@ declare module 'stripe' {
       /**
        * The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array.
        */
-      id?: string;
+      id: string;
 
       /**
        * String representing the object's type. Objects of the same type share the same value.
@@ -42,12 +42,12 @@ declare module 'stripe' {
       /**
        * The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice.
        */
-      invoice?: string | null;
+      invoice: string | null;
 
       /**
        * The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item.
        */
-      invoice_item?: string | null;
+      invoice_item: string | null;
 
       /**
        * The promotion code applied to create this discount.
@@ -72,7 +72,7 @@ declare module 'stripe' {
       /**
        * The ID of the discount object. Discounts cannot be fetched by ID. Use `expand[]=discounts` in API calls to expand discount IDs in an array.
        */
-      id?: string;
+      id: string;
 
       /**
        * String representing the object's type. Objects of the same type share the same value.
@@ -104,12 +104,12 @@ declare module 'stripe' {
       /**
        * The invoice that the discount's coupon was applied to, if it was applied directly to a particular invoice.
        */
-      invoice?: string | null;
+      invoice: string | null;
 
       /**
        * The invoice item `id` (or invoice line item `id` for invoice line items of type='subscription') that the discount's coupon was applied to, if it was applied directly to a particular invoice item or invoice line item.
        */
-      invoice_item?: string | null;
+      invoice_item: string | null;
 
       /**
        * The promotion code applied to create this discount.

--- a/types/2020-08-27/InvoiceItems.d.ts
+++ b/types/2020-08-27/InvoiceItems.d.ts
@@ -50,7 +50,7 @@ declare module 'stripe' {
       /**
        * The discounts which apply to the invoice item. Item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
        */
-      discounts?: Array<string | Stripe.Discount> | null;
+      discounts: Array<string | Stripe.Discount> | null;
 
       /**
        * The ID of the invoice this invoice item belongs to.

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -33,7 +33,7 @@ declare module 'stripe' {
       /**
        * The amount of discount calculated per discount for this line item.
        */
-      discount_amounts?: Array<InvoiceLineItem.DiscountAmount> | null;
+      discount_amounts: Array<InvoiceLineItem.DiscountAmount> | null;
 
       /**
        * If true, discounts will apply to this line item. Always false for prorations.
@@ -43,7 +43,7 @@ declare module 'stripe' {
       /**
        * The discounts applied to the invoice line item. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
        */
-      discounts?: Array<string | Stripe.Discount> | null;
+      discounts: Array<string | Stripe.Discount> | null;
 
       /**
        * The ID of the [invoice item](https://stripe.com/docs/api/invoiceitems) associated with this line item if any.
@@ -171,6 +171,9 @@ declare module 'stripe' {
        */
       customer?: string;
 
+      /**
+       * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the discount from the customer or subscription. Pass an empty string to avoid inheriting any discounts.
+       */
       discounts?: Array<InvoiceLineItemListUpcomingParams.Discount> | null;
 
       /**

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -153,14 +153,14 @@ declare module 'stripe' {
       description: string | null;
 
       /**
-       * Describes the current discount applied to this invoice, if there is one.
+       * Describes the current discount applied to this invoice, if there is one. Not populated if there are multiple discounts.
        */
       discount: Stripe.Discount | null;
 
       /**
        * The discounts applied to the invoice. Line item discounts are applied before invoice discounts. Use `expand[]=discounts` to expand each discount.
        */
-      discounts?: Array<
+      discounts: Array<
         string | Stripe.Discount | Stripe.DeletedDiscount
       > | null;
 
@@ -296,7 +296,7 @@ declare module 'stripe' {
       /**
        * The aggregate amounts calculated per discount across all line items.
        */
-      total_discount_amounts?: Array<Invoice.TotalDiscountAmount> | null;
+      total_discount_amounts: Array<Invoice.TotalDiscountAmount> | null;
 
       /**
        * The aggregate amounts calculated per tax rate for all line items.
@@ -894,6 +894,9 @@ declare module 'stripe' {
        */
       customer?: string;
 
+      /**
+       * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the discount from the customer or subscription. Pass an empty string to avoid inheriting any discounts.
+       */
       discounts?: Array<InvoiceRetrieveUpcomingParams.Discount> | null;
 
       /**
@@ -1336,7 +1339,7 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
-       * At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discount that is applicable to the customer.
+       * At any time, you can preview the upcoming invoice for a customer. This will show you all the charges that are pending, including subscription renewal charges, invoice item charges, etc. It will also show you any discounts that are applicable to the invoice.
        *
        * Note that when you are viewing an upcoming invoice, you are simply viewing a preview – the invoice has not yet been created. As such, the upcoming invoice will not show up in invoice listing calls, and you cannot use the API to pay or edit the invoice. If you want to change the amount that your customer will be billed, you can add, remove, or update pending invoice items, or update the customer's discount.
        *


### PR DESCRIPTION
r? @ctrudeau-stripe 

Updates the type bindings for several discount-related fields to indicate that these fields will now always be present.