### PR TITLE
Add support for `description`, `iin` and `issuer` in `payment_method_details[card_present]` and `payment_method_details[interac_present]` on `Charge`

### DIFF
--- a/types/2020-08-27/Cards.d.ts
+++ b/types/2020-08-27/Cards.d.ts
@@ -98,7 +98,7 @@ declare module 'stripe' {
       deleted?: void;
 
       /**
-       * Card description. (Only for internal use only and not typically available in standard API requests.)
+       * Card description. (For internal use only and not typically available in standard API requests.)
        */
       description?: string;
 
@@ -128,12 +128,12 @@ declare module 'stripe' {
       funding: string;
 
       /**
-       * Issuer identification number of the card. (Only for internal use only and not typically available in standard API requests.)
+       * Issuer identification number of the card. (For internal use only and not typically available in standard API requests.)
        */
       iin?: string;
 
       /**
-       * Issuer bank name of the card. (Only for internal use only and not typically available in standard API requests.)
+       * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
        */
       issuer?: string;
 

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -647,7 +647,7 @@ declare module 'stripe' {
           country: string | null;
 
           /**
-           * Card description. (Only for internal use only and not typically available in standard API requests.)
+           * Card description. (For internal use only and not typically available in standard API requests.)
            */
           description?: string | null;
 
@@ -672,7 +672,7 @@ declare module 'stripe' {
           funding: string | null;
 
           /**
-           * Issuer identification number of the card. (Only for internal use only and not typically available in standard API requests.)
+           * Issuer identification number of the card. (For internal use only and not typically available in standard API requests.)
            */
           iin?: string | null;
 
@@ -684,7 +684,7 @@ declare module 'stripe' {
           installments: Card.Installments | null;
 
           /**
-           * Issuer bank name of the card. (Only for internal use only and not typically available in standard API requests.)
+           * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
            */
           issuer?: string | null;
 
@@ -909,6 +909,11 @@ declare module 'stripe' {
           country: string | null;
 
           /**
+           * Card description. (For internal use only and not typically available in standard API requests.)
+           */
+          description?: string | null;
+
+          /**
            * Authorization response cryptogram.
            */
           emv_auth_data: string | null;
@@ -937,6 +942,16 @@ declare module 'stripe' {
            * ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod.
            */
           generated_card: string | null;
+
+          /**
+           * Issuer identification number of the card. (For internal use only and not typically available in standard API requests.)
+           */
+          iin?: string | null;
+
+          /**
+           * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+           */
+          issuer?: string | null;
 
           /**
            * The last four digits of the card.
@@ -1175,6 +1190,11 @@ declare module 'stripe' {
           country: string | null;
 
           /**
+           * Card description. (For internal use only and not typically available in standard API requests.)
+           */
+          description?: string | null;
+
+          /**
            * Authorization response cryptogram.
            */
           emv_auth_data: string | null;
@@ -1203,6 +1223,16 @@ declare module 'stripe' {
            * ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod.
            */
           generated_card: string | null;
+
+          /**
+           * Issuer identification number of the card. (For internal use only and not typically available in standard API requests.)
+           */
+          iin?: string | null;
+
+          /**
+           * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+           */
+          issuer?: string | null;
 
           /**
            * The last four digits of the card.

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -151,7 +151,7 @@ declare module 'stripe' {
         country: string | null;
 
         /**
-         * Card description. (Only for internal use only and not typically available in standard API requests.)
+         * Card description. (For internal use only and not typically available in standard API requests.)
          */
         description?: string | null;
 
@@ -176,12 +176,12 @@ declare module 'stripe' {
         funding: string;
 
         /**
-         * Issuer identification number of the card. (Only for internal use only and not typically available in standard API requests.)
+         * Issuer identification number of the card. (For internal use only and not typically available in standard API requests.)
          */
         iin?: string | null;
 
         /**
-         * Issuer bank name of the card. (Only for internal use only and not typically available in standard API requests.)
+         * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
          */
         issuer?: string | null;
 


### PR DESCRIPTION
Codegen for openapi e8e2ba1

r? @paulasjes-stripe 
cc @stripe/api-libraries 