### PR TITLE
Do not mutate user-supplied opts

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -149,7 +149,7 @@ const utils = (module.exports = {
       if (typeof arg === 'string') {
         opts.auth = args.pop();
       } else if (utils.isOptionsHash(arg)) {
-        const params = args.pop();
+        const params = {...args.pop()};
 
         const extraKeys = Object.keys(params).filter(
           (key) => !OPTIONS_KEYS.includes(key)

--- a/test/makeRequest.spec.js
+++ b/test/makeRequest.spec.js
@@ -1,0 +1,29 @@
+'use strict';
+
+require('../testUtils');
+
+const makeRequest = require('../lib/makeRequest');
+const expect = require('chai').expect;
+
+describe('makeRequest', () => {
+  describe('args', () => {
+    it('does not mutate user-supplied deprecated opts', () => {
+      const args = [
+        {
+          stripe_account: 'bad',
+        },
+      ];
+      const mockSelf = {
+        createResourcePathWithSymbols: () => {},
+        createFullPath: () => {},
+        _request: () => {},
+      };
+      makeRequest(mockSelf, args, {}, {});
+      expect(args).to.deep.equal([
+        {
+          stripe_account: 'bad',
+        },
+      ]);
+    });
+  });
+});


### PR DESCRIPTION
### Summary

When a user supplies opts to a function, the user's opts are mutated. This becomes a problem when a user supplies an opt that is deprecated; e.g. `stripe_account` instead of `stripeAccount`. In this scenario:

- Before calling the function:
```javascript
opts = {
  ...
  stripe_account: ...,  // user supplies a deprecated opt
  ...
}
```
- After calling the function, the object is mutated:
```javascript
opts = {
  ...
  stripe_account: ...,
  stripeAccount: ...,  // the function unexpectedly inserts the non-deprecated version of the opt
  ...
}
```
Because of this mutation, the user is warned that they have supplied both of these args, when in fact they have only supplied one.

This change makes a shallow copy of the user's opts so that this does not happen.

### Motivation
fixes https://github.com/stripe/stripe-node/issues/1029

### Test plan
- Unit tests

