### PR TITLE
Typescript: Add support for `discounts` on `Session.create`

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -599,6 +599,11 @@ declare module 'stripe' {
         customer_email?: string;
 
         /**
+         * The coupon or promotion code to apply to this session. Currently, only up to one may be specified.
+         */
+        discounts?: Array<SessionCreateParams.Discount>;
+
+        /**
          * Specifies which fields in the response should be expanded.
          */
         expand?: Array<string>;
@@ -658,6 +663,18 @@ declare module 'stripe' {
 
       namespace SessionCreateParams {
         type BillingAddressCollection = 'auto' | 'required';
+
+        interface Discount {
+          /**
+           * The ID of the coupon to apply to this session.
+           */
+          coupon?: string;
+
+          /**
+           * The ID of a promotion code to apply to this session.
+           */
+          promotion_code?: string;
+        }
 
         interface LineItem {
           /**


### PR DESCRIPTION
Codegen for openapi aacc1c6.
r? @remi-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `discounts` on `session.create`

