### PR TITLE
Make `original_payout` and `reversed_by` not optional anymore

### DIFF
--- a/types/2020-08-27/Payouts.d.ts
+++ b/types/2020-08-27/Payouts.d.ts
@@ -94,12 +94,12 @@ declare module 'stripe' {
       /**
        * If the payout reverses another, this is the ID of the original payout.
        */
-      original_payout?: string | Stripe.Payout | null;
+      original_payout: string | Stripe.Payout | null;
 
       /**
        * If the payout was reversed, this is the ID of the payout that reverses this payout.
        */
-      reversed_by?: string | Stripe.Payout | null;
+      reversed_by: string | Stripe.Payout | null;
 
       /**
        * The source balance this payout came from. One of `card`, `fpx`, or `bank_account`.


### PR DESCRIPTION
Codegen for openapi 604eb2c

r? @richardm-stripe 
cc @stripe/api-libraries 