### PR TITLE
chore: replace recommended extension sublime babel with babel javascript

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,7 @@
   "recommendations": [
     // JS Language plugins (~required)
     "dbaeumer.vscode-eslint",
-    "joshpeng.sublime-babel-vscode",
+    "mgmcdermott.vscode-language-babel",
     "esbenp.prettier-vscode",
 
     // Highly recommended


### PR DESCRIPTION
Sublime Babel which is no longer available on the vscode marketplace and we get below message when trying to open project in vscode.
Babel Javascript is well maintained alternative.
[differences](https://github.com/michaelgmcd/vscode-language-babel/issues/1)


![image](https://user-images.githubusercontent.com/26551780/96310952-03979700-1026-11eb-80d4-d14a70824bef.png)
