### PR TITLE
Add support for `jp_rn` and `ru_kpp` as a `type` on `TaxId`

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -93,7 +93,7 @@ declare module 'stripe' {
         metadata: Metadata | null;
 
         /**
-         * The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`.
+         * The mode of the Checkout Session.
          */
         mode: Session.Mode;
 
@@ -628,7 +628,7 @@ declare module 'stripe' {
         metadata?: MetadataParam;
 
         /**
-         * The mode of the Checkout Session, one of `payment`, `setup`, or `subscription`. Required when using prices or `setup` mode. Pass `subscription` if Checkout session includes at least one recurring item.
+         * The mode of the Checkout Session. Required when using prices or `setup` mode. Pass `subscription` if Checkout session includes at least one recurring item.
          */
         mode?: SessionCreateParams.Mode;
 

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -347,7 +347,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+         * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
          */
         type: TaxIdDatum.Type;
 
@@ -373,6 +373,7 @@ declare module 'stripe' {
           | 'id_npwp'
           | 'in_gst'
           | 'jp_cn'
+          | 'jp_rn'
           | 'kr_brn'
           | 'li_uid'
           | 'mx_rfc'
@@ -382,6 +383,7 @@ declare module 'stripe' {
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
+          | 'ru_kpp'
           | 'sa_vat'
           | 'sg_gst'
           | 'sg_uen'

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -355,7 +355,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -381,6 +381,7 @@ declare module 'stripe' {
           | 'id_npwp'
           | 'in_gst'
           | 'jp_cn'
+          | 'jp_rn'
           | 'kr_brn'
           | 'li_uid'
           | 'mx_rfc'
@@ -390,6 +391,7 @@ declare module 'stripe' {
           | 'no_vat'
           | 'nz_gst'
           | 'ru_inn'
+          | 'ru_kpp'
           | 'sa_vat'
           | 'sg_gst'
           | 'sg_uen'

--- a/types/2020-08-27/TaxIds.d.ts
+++ b/types/2020-08-27/TaxIds.d.ts
@@ -38,7 +38,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -69,6 +69,7 @@ declare module 'stripe' {
         | 'id_npwp'
         | 'in_gst'
         | 'jp_cn'
+        | 'jp_rn'
         | 'kr_brn'
         | 'li_uid'
         | 'mx_rfc'
@@ -78,6 +79,7 @@ declare module 'stripe' {
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
+        | 'ru_kpp'
         | 'sa_vat'
         | 'sg_gst'
         | 'sg_uen'
@@ -131,7 +133,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
        */
       type: TaxIdCreateParams.Type;
 
@@ -162,6 +164,7 @@ declare module 'stripe' {
         | 'id_npwp'
         | 'in_gst'
         | 'jp_cn'
+        | 'jp_rn'
         | 'kr_brn'
         | 'li_uid'
         | 'mx_rfc'
@@ -171,6 +174,7 @@ declare module 'stripe' {
         | 'no_vat'
         | 'nz_gst'
         | 'ru_inn'
+        | 'ru_kpp'
         | 'sa_vat'
         | 'sg_gst'
         | 'sg_uen'


### PR DESCRIPTION
Codegen for openapi 555ca3b

r? @ctrudeau-stripe 
cc @stripe/api-libraries 