### PR TITLE
Support passing `tax_rates` when creating invoice items through `Subscription` or `SubscriptionSchedule`

### DIFF
--- a/types/2020-08-27/Cards.d.ts
+++ b/types/2020-08-27/Cards.d.ts
@@ -118,7 +118,7 @@ declare module 'stripe' {
       exp_year: number;
 
       /**
-       * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number,for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+       * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
        */
       fingerprint?: string | null;
 

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -662,7 +662,7 @@ declare module 'stripe' {
           exp_year: number;
 
           /**
-           * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number,for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+           * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
            */
           fingerprint?: string | null;
 
@@ -929,7 +929,7 @@ declare module 'stripe' {
           exp_year: number;
 
           /**
-           * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number,for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+           * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
            */
           fingerprint: string | null;
 
@@ -1210,7 +1210,7 @@ declare module 'stripe' {
           exp_year: number;
 
           /**
-           * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number,for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+           * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
            */
           fingerprint: string | null;
 

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -166,7 +166,7 @@ declare module 'stripe' {
         exp_year: number;
 
         /**
-         * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number,for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
+         * Uniquely identifies this particular card number. You can use this attribute to check whether two customers who've signed up with you are using the same card number, for example. For payment methods that tokenize card information (Apple Pay, Google Pay), the tokenized number might be provided instead of the underlying card number.
          */
         fingerprint?: string | null;
 

--- a/types/2020-08-27/SubscriptionSchedules.d.ts
+++ b/types/2020-08-27/SubscriptionSchedules.d.ts
@@ -255,6 +255,11 @@ declare module 'stripe' {
            * The quantity of the invoice item.
            */
           quantity: number | null;
+
+          /**
+           * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
+           */
+          tax_rates?: Array<Stripe.TaxRate> | null;
         }
 
         type BillingCycleAnchor = 'automatic' | 'phase_start';
@@ -554,6 +559,11 @@ declare module 'stripe' {
            * Quantity for this item. Defaults to 1.
            */
           quantity?: number;
+
+          /**
+           * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
+           */
+          tax_rates?: Array<string> | null;
         }
 
         namespace AddInvoiceItem {
@@ -922,6 +932,11 @@ declare module 'stripe' {
            * Quantity for this item. Defaults to 1.
            */
           quantity?: number;
+
+          /**
+           * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
+           */
+          tax_rates?: Array<string> | null;
         }
 
         namespace AddInvoiceItem {

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -434,6 +434,11 @@ declare module 'stripe' {
          * Quantity for this item. Defaults to 1.
          */
         quantity?: number;
+
+        /**
+         * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
+         */
+        tax_rates?: Array<string> | null;
       }
 
       namespace AddInvoiceItem {
@@ -759,6 +764,11 @@ declare module 'stripe' {
          * Quantity for this item. Defaults to 1.
          */
         quantity?: number;
+
+        /**
+         * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
+         */
+        tax_rates?: Array<string> | null;
       }
 
       namespace AddInvoiceItem {


### PR DESCRIPTION
Codegen for openapi ea5fa98

r? @ctrudeau-stripe 
cc @stripe/api-libraries 