### PR TITLE
Add Stripe.Emptyable type definition

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -199,7 +199,7 @@ declare module 'stripe' {
     /**
      * The Stripe API uses url-encoding for requests, and stripe-node encodes a
      * `null` param as an empty string, because there is no concept of `null`
-     * in url-encoding.
+     * in url-encoding. Both `null` and `''` behave identically.
      */
     export type Emptyable<T> = null | '' | T;
 

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -196,6 +196,13 @@ declare module 'stripe' {
       autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
     }
 
+    /**
+     * The Stripe API uses url-encoding for requests, and stripe-node encodes a
+     * `null` param as an empty string, because there is no concept of `null`
+     * in url-encoding.
+     */
+    export type Emptyable<T> = null | '' | T;
+
     export interface RequestEvent {
       api_version: string;
       account?: string;


### PR DESCRIPTION
r? @suz-stripe 
cc @stripe/api-libraries 

Defines `Stripe.Emptyable<T> = null | '' | T` type. Many params in the Stripe API has a "pass empty string to unset" idiom, and stripe-node converts nulls to empty strings over the wire. Presently, the type bindings encode all of these as `T | null`, but this [is a bit confusing](https://github.com/stripe/stripe-node/issues/1051) because some of the docstrings recommend empty strings.

I think adding an "Emptyable" wrapper like this will make the meaning of these type definitions a little bit more clear, and it also gives us a single place where we can document this behavior.

In VSCode, the present mouseover looks like
![image](https://user-images.githubusercontent.com/52928443/97198909-c51c7d80-1785-11eb-9e7b-4e42f55028a1.png)
and the new one will be this:
![image](https://user-images.githubusercontent.com/52928443/97199323-43791f80-1786-11eb-9520-f03222052298.png)

It seems like VSCode omits mention of `| null` altogether, so the new mouseover is the only one that actually communicates the emptyable nature of the field .
