### PR TITLE
Multiple API changes

### DIFF
--- a/lib/resources/Accounts.js
+++ b/lib/resources/Accounts.js
@@ -9,11 +9,6 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: '',
 
-  reject: stripeMethod({
-    method: 'POST',
-    path: 'accounts/{account}/reject',
-  }),
-
   create: stripeMethod({
     method: 'POST',
     path: 'accounts',
@@ -28,6 +23,11 @@ module.exports = StripeResource.extend({
     method: 'GET',
     path: 'accounts',
     methodType: 'list',
+  }),
+
+  reject: stripeMethod({
+    method: 'POST',
+    path: 'accounts/{account}/reject',
   }),
 
   retrieve(id) {

--- a/lib/resources/Customers.js
+++ b/lib/resources/Customers.js
@@ -41,6 +41,11 @@ module.exports = StripeResource.extend({
     path: '/{customer}/sources',
   }),
 
+  deleteSource: stripeMethod({
+    method: 'DELETE',
+    path: '/{customer}/sources/{id}',
+  }),
+
   listSources: stripeMethod({
     method: 'GET',
     path: '/{customer}/sources',
@@ -54,11 +59,6 @@ module.exports = StripeResource.extend({
 
   updateSource: stripeMethod({
     method: 'POST',
-    path: '/{customer}/sources/{id}',
-  }),
-
-  deleteSource: stripeMethod({
-    method: 'DELETE',
     path: '/{customer}/sources/{id}',
   }),
 

--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -25,14 +25,14 @@ module.exports = StripeResource.extend({
     path: '/{invoice}/pay',
   }),
 
-  sendInvoice: stripeMethod({
-    method: 'POST',
-    path: '/{invoice}/send',
-  }),
-
   retrieveUpcoming: stripeMethod({
     method: 'GET',
     path: '/upcoming',
+  }),
+
+  sendInvoice: stripeMethod({
+    method: 'POST',
+    path: '/{invoice}/send',
   }),
 
   voidInvoice: stripeMethod({

--- a/lib/resources/Subscriptions.js
+++ b/lib/resources/Subscriptions.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'subscriptions',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update', 'del'],
+  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
 
   deleteDiscount: stripeMethod({
     method: 'DELETE',

--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -831,7 +831,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Options for customizing how the account functions within Stripe.
@@ -1218,7 +1218,7 @@ declare module 'stripe' {
         /**
          * The category identifying the legal structure of the company or legal entity. See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details.
          */
-        structure?: Company.Structure | null;
+        structure?: Stripe.Emptyable<Company.Structure>;
 
         /**
          * The business ID number of the company, as appropriate for the company's country. (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in the UK.)
@@ -1332,7 +1332,7 @@ declare module 'stripe' {
         /**
          * The individual's date of birth.
          */
-        dob?: Individual.Dob | null;
+        dob?: Stripe.Emptyable<Individual.Dob>;
 
         /**
          * The individual's email address.
@@ -1387,7 +1387,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * The individual's phone number.
@@ -1739,7 +1739,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Options for customizing how the account functions within Stripe.
@@ -2121,7 +2121,7 @@ declare module 'stripe' {
         /**
          * The category identifying the legal structure of the company or legal entity. See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details.
          */
-        structure?: Company.Structure | null;
+        structure?: Stripe.Emptyable<Company.Structure>;
 
         /**
          * The business ID number of the company, as appropriate for the company's country. (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in the UK.)
@@ -2235,7 +2235,7 @@ declare module 'stripe' {
         /**
          * The individual's date of birth.
          */
-        dob?: Individual.Dob | null;
+        dob?: Stripe.Emptyable<Individual.Dob>;
 
         /**
          * The individual's email address.
@@ -2290,7 +2290,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * The individual's phone number.

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1544,7 +1544,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The Stripe account ID for which these funds are intended. Automatically set if you use the `destination` parameter. For details, see [Creating Separate Charges and Transfers](https://stripe.com/docs/connect/charges-transfers#on-behalf-of).
@@ -1671,7 +1671,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * This is the email address that the receipt for this charge will be sent to. If this field is updated, then a new email receipt will be sent to the updated address.
@@ -1694,7 +1694,7 @@ declare module 'stripe' {
         /**
          * Either `safe` or `fraudulent`.
          */
-        user_report: FraudDetails.UserReport | null;
+        user_report: Stripe.Emptyable<FraudDetails.UserReport>;
       }
 
       namespace FraudDetails {

--- a/types/2020-08-27/Coupons.d.ts
+++ b/types/2020-08-27/Coupons.d.ts
@@ -160,7 +160,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set.
@@ -205,7 +205,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Name of the coupon displayed to customers on, for instance invoices, or receipts. By default the `id` is shown if `name` is not set.

--- a/types/2020-08-27/CreditNoteLineItems.d.ts
+++ b/types/2020-08-27/CreditNoteLineItems.d.ts
@@ -198,7 +198,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`

--- a/types/2020-08-27/CreditNotes.d.ts
+++ b/types/2020-08-27/CreditNotes.d.ts
@@ -257,7 +257,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`
@@ -409,7 +409,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the credit note line item. Only valid when the `type` is `custom_line_item`.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * Type of the credit note line item, one of `invoice_line_item` or `custom_line_item`

--- a/types/2020-08-27/CustomerBalanceTransactions.d.ts
+++ b/types/2020-08-27/CustomerBalanceTransactions.d.ts
@@ -108,7 +108,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface CustomerBalanceTransactionRetrieveParams {
@@ -132,7 +132,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface CustomerBalanceTransactionListParams extends PaginationParams {

--- a/types/2020-08-27/CustomerSources.d.ts
+++ b/types/2020-08-27/CustomerSources.d.ts
@@ -84,7 +84,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Cardholder name.

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -210,7 +210,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: AddressParam | null;
+      address?: Stripe.Emptyable<AddressParam>;
 
       /**
        * An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
@@ -247,7 +247,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The customer's full name or business name.
@@ -279,14 +279,14 @@ declare module 'stripe' {
       /**
        * The customer's shipping information. Appears on invoices emailed to this customer.
        */
-      shipping?: CustomerCreateParams.Shipping | null;
+      shipping?: Stripe.Emptyable<CustomerCreateParams.Shipping>;
 
       source?: string;
 
       /**
        * The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
        */
-      tax_exempt?: CustomerCreateParams.TaxExempt | null;
+      tax_exempt?: Stripe.Emptyable<CustomerCreateParams.TaxExempt>;
 
       /**
        * The customer's tax IDs.
@@ -299,7 +299,7 @@ declare module 'stripe' {
         /**
          * Default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
          */
-        custom_fields?: Array<InvoiceSettings.CustomField> | null;
+        custom_fields?: Stripe.Emptyable<Array<InvoiceSettings.CustomField>>;
 
         /**
          * ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices.
@@ -405,7 +405,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: AddressParam | null;
+      address?: Stripe.Emptyable<AddressParam>;
 
       /**
        * An integer amount in %s that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
@@ -451,7 +451,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The customer's full name or business name.
@@ -481,14 +481,14 @@ declare module 'stripe' {
       /**
        * The customer's shipping information. Appears on invoices emailed to this customer.
        */
-      shipping?: CustomerUpdateParams.Shipping | null;
+      shipping?: Stripe.Emptyable<CustomerUpdateParams.Shipping>;
 
       source?: string;
 
       /**
        * The customer's tax exemption. One of `none`, `exempt`, or `reverse`.
        */
-      tax_exempt?: CustomerUpdateParams.TaxExempt | null;
+      tax_exempt?: Stripe.Emptyable<CustomerUpdateParams.TaxExempt>;
 
       /**
        * Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
@@ -501,7 +501,7 @@ declare module 'stripe' {
         /**
          * Default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
          */
-        custom_fields?: Array<InvoiceSettings.CustomField> | null;
+        custom_fields?: Stripe.Emptyable<Array<InvoiceSettings.CustomField>>;
 
         /**
          * ID of a payment method that's attached to the customer, to be used as the customer's default payment method for subscriptions and invoices.

--- a/types/2020-08-27/Disputes.d.ts
+++ b/types/2020-08-27/Disputes.d.ts
@@ -272,7 +272,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Whether to immediately submit evidence to the bank. If `false`, evidence is staged on the dispute. Staged evidence is visible in the API and Dashboard, and can be submitted to the bank by making another request with this attribute set to `true` (the default).

--- a/types/2020-08-27/ExternalAccounts.d.ts
+++ b/types/2020-08-27/ExternalAccounts.d.ts
@@ -39,7 +39,9 @@ declare module 'stripe' {
       /**
        * The type of entity that holds the account. This can be either `individual` or `company`.
        */
-      account_holder_type?: ExternalAccountUpdateParams.AccountHolderType | null;
+      account_holder_type?: Stripe.Emptyable<
+        ExternalAccountUpdateParams.AccountHolderType
+      >;
 
       /**
        * City/District/Suburb/Town/Village.
@@ -94,7 +96,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Cardholder name.

--- a/types/2020-08-27/FeeRefunds.d.ts
+++ b/types/2020-08-27/FeeRefunds.d.ts
@@ -79,7 +79,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface FeeRefundListParams extends PaginationParams {

--- a/types/2020-08-27/FileLinks.d.ts
+++ b/types/2020-08-27/FileLinks.d.ts
@@ -70,7 +70,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface FileLinkRetrieveParams {
@@ -89,12 +89,12 @@ declare module 'stripe' {
       /**
        * A future timestamp after which the link will no longer be usable, or `now` to expire the link immediately.
        */
-      expires_at?: 'now' | number | null;
+      expires_at?: Stripe.Emptyable<'now' | number>;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface FileLinkListParams extends PaginationParams {

--- a/types/2020-08-27/InvoiceItems.d.ts
+++ b/types/2020-08-27/InvoiceItems.d.ts
@@ -178,7 +178,7 @@ declare module 'stripe' {
       /**
        * The coupons to redeem into discounts for the invoice item or invoice line item.
        */
-      discounts?: Array<InvoiceItemCreateParams.Discount> | null;
+      discounts?: Stripe.Emptyable<Array<InvoiceItemCreateParams.Discount>>;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -193,7 +193,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The period associated with this invoice item.
@@ -310,7 +310,7 @@ declare module 'stripe' {
       /**
        * The coupons & existing discounts which apply to the invoice item or invoice line item. Item discounts are applied before invoice discounts. Pass an empty string to remove previously-defined discounts.
        */
-      discounts?: Array<InvoiceItemUpdateParams.Discount> | null;
+      discounts?: Stripe.Emptyable<Array<InvoiceItemUpdateParams.Discount>>;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -320,7 +320,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The period associated with this invoice item.
@@ -345,7 +345,7 @@ declare module 'stripe' {
       /**
        * The tax rates which apply to the invoice item. When set, the `default_tax_rates` on the invoice do not apply to this invoice item. Pass an empty string to remove previously-defined tax rates.
        */
-      tax_rates?: Array<string> | null;
+      tax_rates?: Stripe.Emptyable<Array<string>>;
 
       /**
        * The integer unit amount in %s of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount.

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -174,7 +174,9 @@ declare module 'stripe' {
       /**
        * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the discount from the customer or subscription. Pass an empty string to avoid inheriting any discounts.
        */
-      discounts?: Array<InvoiceLineItemListUpcomingParams.Discount> | null;
+      discounts?: Stripe.Emptyable<
+        Array<InvoiceLineItemListUpcomingParams.Discount>
+      >;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -206,7 +208,7 @@ declare module 'stripe' {
       /**
        * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.
        */
-      subscription_cancel_at?: number | null;
+      subscription_cancel_at?: Stripe.Emptyable<number>;
 
       /**
        * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -221,7 +223,7 @@ declare module 'stripe' {
       /**
        * If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set.
        */
-      subscription_default_tax_rates?: Array<string> | null;
+      subscription_default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
       /**
        * A list of up to 20 subscription items, each with an attached price.
@@ -297,7 +299,7 @@ declare module 'stripe' {
         /**
          * The coupons to redeem into discounts for the invoice item in the preview.
          */
-        discounts?: Array<InvoiceItem.Discount> | null;
+        discounts?: Stripe.Emptyable<Array<InvoiceItem.Discount>>;
 
         /**
          * The ID of the invoice item to update in preview. If not specified, a new invoice item will be added to the preview of the upcoming invoice.
@@ -307,7 +309,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * The period associated with this invoice item.
@@ -329,7 +331,7 @@ declare module 'stripe' {
          */
         quantity?: number;
 
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The integer unit amount in %s of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -396,7 +398,9 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: SubscriptionItem.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<
+          SubscriptionItem.BillingThresholds
+        >;
 
         /**
          * Delete all usage for a given subscription item. Allowed only when `deleted` is set to `true` and the current plan's `usage_type` is `metered`.
@@ -416,7 +420,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * Plan ID for this item, as a string.
@@ -441,7 +445,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
       }
 
       namespace SubscriptionItem {

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -556,7 +556,7 @@ declare module 'stripe' {
       /**
        * A list of up to 4 custom fields to be displayed on the invoice.
        */
-      custom_fields?: Array<InvoiceCreateParams.CustomField> | null;
+      custom_fields?: Stripe.Emptyable<Array<InvoiceCreateParams.CustomField>>;
 
       /**
        * The number of days from when the invoice is created until it is due. Valid only for invoices where `collection_method=send_invoice`.
@@ -586,7 +586,7 @@ declare module 'stripe' {
       /**
        * The coupons to redeem into discounts for the invoice. If not specified, inherits the discount from the invoice's customer. Pass an empty string to avoid inheriting any discounts.
        */
-      discounts?: Array<InvoiceCreateParams.Discount> | null;
+      discounts?: Stripe.Emptyable<Array<InvoiceCreateParams.Discount>>;
 
       /**
        * The date on which payment for this invoice is due. Valid only for invoices where `collection_method=send_invoice`.
@@ -606,7 +606,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`.
@@ -690,7 +690,7 @@ declare module 'stripe' {
       /**
        * A list of up to 4 custom fields to be displayed on the invoice. If a value for `custom_fields` is specified, the list specified will replace the existing custom field list on this invoice. Pass an empty string to remove previously-defined fields.
        */
-      custom_fields?: Array<InvoiceUpdateParams.CustomField> | null;
+      custom_fields?: Stripe.Emptyable<Array<InvoiceUpdateParams.CustomField>>;
 
       /**
        * The number of days from which the invoice is created until it is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices.
@@ -710,7 +710,7 @@ declare module 'stripe' {
       /**
        * The tax rates that will apply to any line item that does not have `tax_rates` set. Pass an empty string to remove previously-defined tax rates.
        */
-      default_tax_rates?: Array<string> | null;
+      default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
       /**
        * An arbitrary string attached to the object. Often useful for displaying to users. Referenced as 'memo' in the Dashboard.
@@ -720,7 +720,7 @@ declare module 'stripe' {
       /**
        * The discounts that will apply to the invoice. Pass an empty string to remove previously-defined discounts.
        */
-      discounts?: Array<InvoiceUpdateParams.Discount> | null;
+      discounts?: Stripe.Emptyable<Array<InvoiceUpdateParams.Discount>>;
 
       /**
        * The date on which payment for this invoice is due. Only valid for invoices where `collection_method=send_invoice`. This field can only be updated on `draft` invoices.
@@ -740,7 +740,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`.
@@ -750,7 +750,7 @@ declare module 'stripe' {
       /**
        * If specified, the funds from the invoice will be transferred to the destination and the ID of the resulting transfer will be found on the invoice's charge. This will be unset if you POST an empty value.
        */
-      transfer_data?: InvoiceUpdateParams.TransferData | null;
+      transfer_data?: Stripe.Emptyable<InvoiceUpdateParams.TransferData>;
     }
 
     namespace InvoiceUpdateParams {
@@ -899,7 +899,9 @@ declare module 'stripe' {
       /**
        * The coupons to redeem into discounts for the invoice preview. If not specified, inherits the discount from the customer or subscription. Pass an empty string to avoid inheriting any discounts.
        */
-      discounts?: Array<InvoiceRetrieveUpcomingParams.Discount> | null;
+      discounts?: Stripe.Emptyable<
+        Array<InvoiceRetrieveUpcomingParams.Discount>
+      >;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -931,7 +933,7 @@ declare module 'stripe' {
       /**
        * Timestamp indicating when the subscription should be scheduled to cancel. Will prorate if within the current period and prorations have been enabled using `proration_behavior`.
        */
-      subscription_cancel_at?: number | null;
+      subscription_cancel_at?: Stripe.Emptyable<number>;
 
       /**
        * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -946,7 +948,7 @@ declare module 'stripe' {
       /**
        * If provided, the invoice returned will preview updating or creating a subscription with these default tax rates. The default tax rates will apply to any line item that does not have `tax_rates` set.
        */
-      subscription_default_tax_rates?: Array<string> | null;
+      subscription_default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
       /**
        * A list of up to 20 subscription items, each with an attached price.
@@ -1022,7 +1024,7 @@ declare module 'stripe' {
         /**
          * The coupons to redeem into discounts for the invoice item in the preview.
          */
-        discounts?: Array<InvoiceItem.Discount> | null;
+        discounts?: Stripe.Emptyable<Array<InvoiceItem.Discount>>;
 
         /**
          * The ID of the invoice item to update in preview. If not specified, a new invoice item will be added to the preview of the upcoming invoice.
@@ -1032,7 +1034,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * The period associated with this invoice item.
@@ -1054,7 +1056,7 @@ declare module 'stripe' {
          */
         quantity?: number;
 
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The integer unit amount in %s of the charge to be applied to the upcoming invoice. This unit_amount will be multiplied by the quantity to get the full amount. If you want to apply a credit to the customer's account, pass a negative unit_amount.
@@ -1121,7 +1123,9 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: SubscriptionItem.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<
+          SubscriptionItem.BillingThresholds
+        >;
 
         /**
          * Delete all usage for a given subscription item. Allowed only when `deleted` is set to `true` and the current plan's `usage_type` is `metered`.
@@ -1141,7 +1145,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * Plan ID for this item, as a string.
@@ -1166,7 +1170,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
       }
 
       namespace SubscriptionItem {

--- a/types/2020-08-27/Issuing/Authorizations.d.ts
+++ b/types/2020-08-27/Issuing/Authorizations.d.ts
@@ -321,7 +321,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       interface AuthorizationListParams extends PaginationParams {
@@ -369,7 +369,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       interface AuthorizationDeclineParams {
@@ -381,7 +381,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       class AuthorizationsResource {

--- a/types/2020-08-27/Issuing/Cards.d.ts
+++ b/types/2020-08-27/Issuing/Cards.d.ts
@@ -2159,7 +2159,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * Rules that control spending for this card. Refer to our [documentation](https://stripe.com/docs/issuing/controls/spending-controls) for more details.

--- a/types/2020-08-27/Issuing/Disputes.d.ts
+++ b/types/2020-08-27/Issuing/Disputes.d.ts
@@ -344,32 +344,34 @@ declare module 'stripe' {
           /**
            * Evidence provided when `reason` is 'canceled'.
            */
-          canceled?: Evidence.Canceled | null;
+          canceled?: Stripe.Emptyable<Evidence.Canceled>;
 
           /**
            * Evidence provided when `reason` is 'duplicate'.
            */
-          duplicate?: Evidence.Duplicate | null;
+          duplicate?: Stripe.Emptyable<Evidence.Duplicate>;
 
           /**
            * Evidence provided when `reason` is 'fraudulent'.
            */
-          fraudulent?: Evidence.Fraudulent | null;
+          fraudulent?: Stripe.Emptyable<Evidence.Fraudulent>;
 
           /**
            * Evidence provided when `reason` is 'merchandise_not_as_described'.
            */
-          merchandise_not_as_described?: Evidence.MerchandiseNotAsDescribed | null;
+          merchandise_not_as_described?: Stripe.Emptyable<
+            Evidence.MerchandiseNotAsDescribed
+          >;
 
           /**
            * Evidence provided when `reason` is 'not_received'.
            */
-          not_received?: Evidence.NotReceived | null;
+          not_received?: Stripe.Emptyable<Evidence.NotReceived>;
 
           /**
            * Evidence provided when `reason` is 'other'.
            */
-          other?: Evidence.Other | null;
+          other?: Stripe.Emptyable<Evidence.Other>;
 
           /**
            * The reason for filing the dispute. The evidence should be submitted in the field of the same name.
@@ -379,7 +381,9 @@ declare module 'stripe' {
           /**
            * Evidence provided when `reason` is 'service_not_as_described'.
            */
-          service_not_as_described?: Evidence.ServiceNotAsDescribed | null;
+          service_not_as_described?: Stripe.Emptyable<
+            Evidence.ServiceNotAsDescribed
+          >;
         }
 
         namespace Evidence {
@@ -387,17 +391,17 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Date when order was canceled.
              */
-            canceled_at?: number | null;
+            canceled_at?: Stripe.Emptyable<number>;
 
             /**
              * Whether the cardholder was provided with a cancellation policy.
              */
-            cancellation_policy_provided?: boolean | null;
+            cancellation_policy_provided?: Stripe.Emptyable<boolean>;
 
             /**
              * Reason for canceling the order.
@@ -407,7 +411,7 @@ declare module 'stripe' {
             /**
              * Date when the cardholder expected to receive the product.
              */
-            expected_at?: number | null;
+            expected_at?: Stripe.Emptyable<number>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -422,17 +426,17 @@ declare module 'stripe' {
             /**
              * Whether the product was a merchandise or service.
              */
-            product_type?: Canceled.ProductType | null;
+            product_type?: Stripe.Emptyable<Canceled.ProductType>;
 
             /**
              * Result of cardholder's attempt to return the product.
              */
-            return_status?: Canceled.ReturnStatus | null;
+            return_status?: Stripe.Emptyable<Canceled.ReturnStatus>;
 
             /**
              * Date when the product was returned or attempted to be returned.
              */
-            returned_at?: number | null;
+            returned_at?: Stripe.Emptyable<number>;
           }
 
           namespace Canceled {
@@ -445,22 +449,22 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the card statement showing that the product had already been paid for.
              */
-            card_statement?: string | null;
+            card_statement?: Stripe.Emptyable<string>;
 
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the receipt showing that the product had been paid for in cash.
              */
-            cash_receipt?: string | null;
+            cash_receipt?: Stripe.Emptyable<string>;
 
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Image of the front and back of the check that was used to pay for the product.
              */
-            check_image?: string | null;
+            check_image?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -477,7 +481,7 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -489,7 +493,7 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -499,7 +503,7 @@ declare module 'stripe' {
             /**
              * Date when the product was received.
              */
-            received_at?: number | null;
+            received_at?: Stripe.Emptyable<number>;
 
             /**
              * Description of the cardholder's attempt to return the product.
@@ -509,12 +513,14 @@ declare module 'stripe' {
             /**
              * Result of cardholder's attempt to return the product.
              */
-            return_status?: MerchandiseNotAsDescribed.ReturnStatus | null;
+            return_status?: Stripe.Emptyable<
+              MerchandiseNotAsDescribed.ReturnStatus
+            >;
 
             /**
              * Date when the product was returned or attempted to be returned.
              */
-            returned_at?: number | null;
+            returned_at?: Stripe.Emptyable<number>;
           }
 
           namespace MerchandiseNotAsDescribed {
@@ -525,12 +531,12 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Date when the cardholder expected to receive the product.
              */
-            expected_at?: number | null;
+            expected_at?: Stripe.Emptyable<number>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -545,7 +551,7 @@ declare module 'stripe' {
             /**
              * Whether the product was a merchandise or service.
              */
-            product_type?: NotReceived.ProductType | null;
+            product_type?: Stripe.Emptyable<NotReceived.ProductType>;
           }
 
           namespace NotReceived {
@@ -556,7 +562,7 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -571,7 +577,7 @@ declare module 'stripe' {
             /**
              * Whether the product was a merchandise or service.
              */
-            product_type?: Other.ProductType | null;
+            product_type?: Stripe.Emptyable<Other.ProductType>;
           }
 
           namespace Other {
@@ -591,12 +597,12 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Date when order was canceled.
              */
-            canceled_at?: number | null;
+            canceled_at?: Stripe.Emptyable<number>;
 
             /**
              * Reason for canceling the order.
@@ -611,7 +617,7 @@ declare module 'stripe' {
             /**
              * Date when the product was received.
              */
-            received_at?: number | null;
+            received_at?: Stripe.Emptyable<number>;
           }
         }
       }
@@ -637,7 +643,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       namespace DisputeUpdateParams {
@@ -645,32 +651,34 @@ declare module 'stripe' {
           /**
            * Evidence provided when `reason` is 'canceled'.
            */
-          canceled?: Evidence.Canceled | null;
+          canceled?: Stripe.Emptyable<Evidence.Canceled>;
 
           /**
            * Evidence provided when `reason` is 'duplicate'.
            */
-          duplicate?: Evidence.Duplicate | null;
+          duplicate?: Stripe.Emptyable<Evidence.Duplicate>;
 
           /**
            * Evidence provided when `reason` is 'fraudulent'.
            */
-          fraudulent?: Evidence.Fraudulent | null;
+          fraudulent?: Stripe.Emptyable<Evidence.Fraudulent>;
 
           /**
            * Evidence provided when `reason` is 'merchandise_not_as_described'.
            */
-          merchandise_not_as_described?: Evidence.MerchandiseNotAsDescribed | null;
+          merchandise_not_as_described?: Stripe.Emptyable<
+            Evidence.MerchandiseNotAsDescribed
+          >;
 
           /**
            * Evidence provided when `reason` is 'not_received'.
            */
-          not_received?: Evidence.NotReceived | null;
+          not_received?: Stripe.Emptyable<Evidence.NotReceived>;
 
           /**
            * Evidence provided when `reason` is 'other'.
            */
-          other?: Evidence.Other | null;
+          other?: Stripe.Emptyable<Evidence.Other>;
 
           /**
            * The reason for filing the dispute. The evidence should be submitted in the field of the same name.
@@ -680,7 +688,9 @@ declare module 'stripe' {
           /**
            * Evidence provided when `reason` is 'service_not_as_described'.
            */
-          service_not_as_described?: Evidence.ServiceNotAsDescribed | null;
+          service_not_as_described?: Stripe.Emptyable<
+            Evidence.ServiceNotAsDescribed
+          >;
         }
 
         namespace Evidence {
@@ -688,17 +698,17 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Date when order was canceled.
              */
-            canceled_at?: number | null;
+            canceled_at?: Stripe.Emptyable<number>;
 
             /**
              * Whether the cardholder was provided with a cancellation policy.
              */
-            cancellation_policy_provided?: boolean | null;
+            cancellation_policy_provided?: Stripe.Emptyable<boolean>;
 
             /**
              * Reason for canceling the order.
@@ -708,7 +718,7 @@ declare module 'stripe' {
             /**
              * Date when the cardholder expected to receive the product.
              */
-            expected_at?: number | null;
+            expected_at?: Stripe.Emptyable<number>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -723,17 +733,17 @@ declare module 'stripe' {
             /**
              * Whether the product was a merchandise or service.
              */
-            product_type?: Canceled.ProductType | null;
+            product_type?: Stripe.Emptyable<Canceled.ProductType>;
 
             /**
              * Result of cardholder's attempt to return the product.
              */
-            return_status?: Canceled.ReturnStatus | null;
+            return_status?: Stripe.Emptyable<Canceled.ReturnStatus>;
 
             /**
              * Date when the product was returned or attempted to be returned.
              */
-            returned_at?: number | null;
+            returned_at?: Stripe.Emptyable<number>;
           }
 
           namespace Canceled {
@@ -746,22 +756,22 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the card statement showing that the product had already been paid for.
              */
-            card_statement?: string | null;
+            card_statement?: Stripe.Emptyable<string>;
 
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the receipt showing that the product had been paid for in cash.
              */
-            cash_receipt?: string | null;
+            cash_receipt?: Stripe.Emptyable<string>;
 
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Image of the front and back of the check that was used to pay for the product.
              */
-            check_image?: string | null;
+            check_image?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -778,7 +788,7 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -790,7 +800,7 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -800,7 +810,7 @@ declare module 'stripe' {
             /**
              * Date when the product was received.
              */
-            received_at?: number | null;
+            received_at?: Stripe.Emptyable<number>;
 
             /**
              * Description of the cardholder's attempt to return the product.
@@ -810,12 +820,14 @@ declare module 'stripe' {
             /**
              * Result of cardholder's attempt to return the product.
              */
-            return_status?: MerchandiseNotAsDescribed.ReturnStatus | null;
+            return_status?: Stripe.Emptyable<
+              MerchandiseNotAsDescribed.ReturnStatus
+            >;
 
             /**
              * Date when the product was returned or attempted to be returned.
              */
-            returned_at?: number | null;
+            returned_at?: Stripe.Emptyable<number>;
           }
 
           namespace MerchandiseNotAsDescribed {
@@ -826,12 +838,12 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Date when the cardholder expected to receive the product.
              */
-            expected_at?: number | null;
+            expected_at?: Stripe.Emptyable<number>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -846,7 +858,7 @@ declare module 'stripe' {
             /**
              * Whether the product was a merchandise or service.
              */
-            product_type?: NotReceived.ProductType | null;
+            product_type?: Stripe.Emptyable<NotReceived.ProductType>;
           }
 
           namespace NotReceived {
@@ -857,7 +869,7 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Explanation of why the cardholder is disputing this transaction.
@@ -872,7 +884,7 @@ declare module 'stripe' {
             /**
              * Whether the product was a merchandise or service.
              */
-            product_type?: Other.ProductType | null;
+            product_type?: Stripe.Emptyable<Other.ProductType>;
           }
 
           namespace Other {
@@ -892,12 +904,12 @@ declare module 'stripe' {
             /**
              * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
              */
-            additional_documentation?: string | null;
+            additional_documentation?: Stripe.Emptyable<string>;
 
             /**
              * Date when order was canceled.
              */
-            canceled_at?: number | null;
+            canceled_at?: Stripe.Emptyable<number>;
 
             /**
              * Reason for canceling the order.
@@ -912,7 +924,7 @@ declare module 'stripe' {
             /**
              * Date when the product was received.
              */
-            received_at?: number | null;
+            received_at?: Stripe.Emptyable<number>;
           }
         }
       }
@@ -952,7 +964,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       class DisputesResource {

--- a/types/2020-08-27/Issuing/Transactions.d.ts
+++ b/types/2020-08-27/Issuing/Transactions.d.ts
@@ -304,7 +304,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       interface TransactionListParams extends PaginationParams {

--- a/types/2020-08-27/Orders.d.ts
+++ b/types/2020-08-27/Orders.d.ts
@@ -326,7 +326,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary.
@@ -462,7 +462,7 @@ declare module 'stripe' {
       /**
        * List of items to return.
        */
-      items?: Array<OrderReturnOrderParams.Item> | null;
+      items?: Stripe.Emptyable<Array<OrderReturnOrderParams.Item>>;
     }
 
     namespace OrderReturnOrderParams {

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -904,7 +904,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: BillingDetails.Address | null;
+          address?: Stripe.Emptyable<BillingDetails.Address>;
 
           /**
            * Email address.
@@ -1098,27 +1098,27 @@ declare module 'stripe' {
         /**
          * If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
          */
-        alipay?: PaymentMethodOptions.Alipay | null;
+        alipay?: Stripe.Emptyable<PaymentMethodOptions.Alipay>;
 
         /**
          * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
          */
-        bancontact?: PaymentMethodOptions.Bancontact | null;
+        bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
 
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
-        card?: PaymentMethodOptions.Card | null;
+        card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
 
         /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
-        oxxo?: PaymentMethodOptions.Oxxo | null;
+        oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
 
         /**
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
-        sofort?: PaymentMethodOptions.Sofort | null;
+        sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
       }
 
       namespace PaymentMethodOptions {
@@ -1136,6 +1136,11 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
+           */
+          cvc_token?: string;
+
           /**
            * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
            *
@@ -1174,7 +1179,7 @@ declare module 'stripe' {
              * The selected installment plan to use for this payment attempt.
              * This parameter can only be provided during confirmation.
              */
-            plan?: Installments.Plan | null;
+            plan?: Stripe.Emptyable<Installments.Plan>;
           }
 
           namespace Installments {
@@ -1310,7 +1315,7 @@ declare module 'stripe' {
       /**
        * The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. The amount of the application fee collected will be capped at the total payment amount. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
        */
-      application_fee_amount?: number | null;
+      application_fee_amount?: Stripe.Emptyable<number>;
 
       /**
        * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -1339,7 +1344,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * ID of the payment method (a PaymentMethod, Card, or [compatible Source](https://stripe.com/docs/payments/payment-methods#compatibility) object) to attach to this PaymentIntent.
@@ -1366,7 +1371,7 @@ declare module 'stripe' {
       /**
        * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
        */
-      receipt_email?: string | null;
+      receipt_email?: Stripe.Emptyable<string>;
 
       /**
        * Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -1377,12 +1382,14 @@ declare module 'stripe' {
        *
        * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
        */
-      setup_future_usage?: PaymentIntentUpdateParams.SetupFutureUsage | null;
+      setup_future_usage?: Stripe.Emptyable<
+        PaymentIntentUpdateParams.SetupFutureUsage
+      >;
 
       /**
        * Shipping information for this PaymentIntent.
        */
-      shipping?: PaymentIntentUpdateParams.Shipping | null;
+      shipping?: Stripe.Emptyable<PaymentIntentUpdateParams.Shipping>;
 
       /**
        * For non-card charges, you can use this value as the complete description that appears on your customers' statements. Must contain at least one letter, maximum 22 characters.
@@ -1521,7 +1528,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: BillingDetails.Address | null;
+          address?: Stripe.Emptyable<BillingDetails.Address>;
 
           /**
            * Email address.
@@ -1715,27 +1722,27 @@ declare module 'stripe' {
         /**
          * If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
          */
-        alipay?: PaymentMethodOptions.Alipay | null;
+        alipay?: Stripe.Emptyable<PaymentMethodOptions.Alipay>;
 
         /**
          * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
          */
-        bancontact?: PaymentMethodOptions.Bancontact | null;
+        bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
 
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
-        card?: PaymentMethodOptions.Card | null;
+        card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
 
         /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
-        oxxo?: PaymentMethodOptions.Oxxo | null;
+        oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
 
         /**
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
-        sofort?: PaymentMethodOptions.Sofort | null;
+        sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
       }
 
       namespace PaymentMethodOptions {
@@ -1753,6 +1760,11 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
+           */
+          cvc_token?: string;
+
           /**
            * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
            *
@@ -1791,7 +1803,7 @@ declare module 'stripe' {
              * The selected installment plan to use for this payment attempt.
              * This parameter can only be provided during confirmation.
              */
-            plan?: Installments.Plan | null;
+            plan?: Stripe.Emptyable<Installments.Plan>;
           }
 
           namespace Installments {
@@ -2019,7 +2031,7 @@ declare module 'stripe' {
       /**
        * Email address that the receipt for the resulting payment will be sent to. If `receipt_email` is specified for a payment in live mode, a receipt will be sent regardless of your [email settings](https://dashboard.stripe.com/account/emails).
        */
-      receipt_email?: string | null;
+      receipt_email?: Stripe.Emptyable<string>;
 
       /**
        * The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.
@@ -2037,12 +2049,14 @@ declare module 'stripe' {
        *
        * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
        */
-      setup_future_usage?: PaymentIntentConfirmParams.SetupFutureUsage | null;
+      setup_future_usage?: Stripe.Emptyable<
+        PaymentIntentConfirmParams.SetupFutureUsage
+      >;
 
       /**
        * Shipping information for this PaymentIntent.
        */
-      shipping?: PaymentIntentConfirmParams.Shipping | null;
+      shipping?: Stripe.Emptyable<PaymentIntentConfirmParams.Shipping>;
 
       /**
        * Set to `true` only when using manual confirmation and the iOS or Android SDKs to handle additional authentication steps.
@@ -2252,7 +2266,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: BillingDetails.Address | null;
+          address?: Stripe.Emptyable<BillingDetails.Address>;
 
           /**
            * Email address.
@@ -2446,27 +2460,27 @@ declare module 'stripe' {
         /**
          * If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
          */
-        alipay?: PaymentMethodOptions.Alipay | null;
+        alipay?: Stripe.Emptyable<PaymentMethodOptions.Alipay>;
 
         /**
          * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
          */
-        bancontact?: PaymentMethodOptions.Bancontact | null;
+        bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
 
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
          */
-        card?: PaymentMethodOptions.Card | null;
+        card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
 
         /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
-        oxxo?: PaymentMethodOptions.Oxxo | null;
+        oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
 
         /**
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
-        sofort?: PaymentMethodOptions.Sofort | null;
+        sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
       }
 
       namespace PaymentMethodOptions {
@@ -2484,6 +2498,11 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
+           */
+          cvc_token?: string;
+
           /**
            * Installment configuration for payments attempted on this PaymentIntent (Mexico Only).
            *
@@ -2522,7 +2541,7 @@ declare module 'stripe' {
              * The selected installment plan to use for this payment attempt.
              * This parameter can only be provided during confirmation.
              */
-            plan?: Installments.Plan | null;
+            plan?: Stripe.Emptyable<Installments.Plan>;
           }
 
           namespace Installments {

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -660,7 +660,7 @@ declare module 'stripe' {
         /**
          * Billing address.
          */
-        address?: BillingDetails.Address | null;
+        address?: Stripe.Emptyable<BillingDetails.Address>;
 
         /**
          * Email address.
@@ -908,7 +908,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * This is a legacy parameter that will be removed in the future. It is a hash that does not accept any keys.
@@ -923,7 +923,7 @@ declare module 'stripe' {
         /**
          * Billing address.
          */
-        address?: BillingDetails.Address | null;
+        address?: Stripe.Emptyable<BillingDetails.Address>;
 
         /**
          * Email address.

--- a/types/2020-08-27/Payouts.d.ts
+++ b/types/2020-08-27/Payouts.d.ts
@@ -195,7 +195,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface PayoutListParams extends PaginationParams {

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -449,7 +449,7 @@ declare module 'stripe' {
       /**
        * The person's date of birth.
        */
-      dob?: PersonCreateParams.Dob | null;
+      dob?: Stripe.Emptyable<PersonCreateParams.Dob>;
 
       /**
        * The person's email address.
@@ -509,7 +509,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person.
@@ -611,7 +611,7 @@ declare module 'stripe' {
         /**
          * The percent owned by the person of the account's legal entity.
          */
-        percent_ownership?: number | null;
+        percent_ownership?: Stripe.Emptyable<number>;
 
         /**
          * Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
@@ -689,7 +689,7 @@ declare module 'stripe' {
       /**
        * The person's date of birth.
        */
-      dob?: PersonUpdateParams.Dob | null;
+      dob?: Stripe.Emptyable<PersonUpdateParams.Dob>;
 
       /**
        * The person's email address.
@@ -749,7 +749,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * A [person token](https://stripe.com/docs/connect/account-tokens), used to securely provide details to the person.
@@ -851,7 +851,7 @@ declare module 'stripe' {
         /**
          * The percent owned by the person of the account's legal entity.
          */
-        percent_ownership?: number | null;
+        percent_ownership?: Stripe.Emptyable<number>;
 
         /**
          * Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.

--- a/types/2020-08-27/Plans.d.ts
+++ b/types/2020-08-27/Plans.d.ts
@@ -237,7 +237,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * A brief description of the plan, hidden from customers.
@@ -382,7 +382,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * A brief description of the plan, hidden from customers.

--- a/types/2020-08-27/Prices.d.ts
+++ b/types/2020-08-27/Prices.d.ts
@@ -438,7 +438,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * A brief description of the price, hidden from customers.
@@ -448,7 +448,7 @@ declare module 'stripe' {
       /**
        * The recurring components of a price such as `interval` and `usage_type`.
        */
-      recurring?: PriceUpdateParams.Recurring | null;
+      recurring?: Stripe.Emptyable<PriceUpdateParams.Recurring>;
 
       /**
        * If set to true, will atomically remove the lookup key from the existing price, and assign it to this price.

--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -276,7 +276,7 @@ declare module 'stripe' {
       /**
        * A list of up to 5 alphanumeric attributes that each SKU can provide values for (e.g., `["color", "size"]`). If a value for `attributes` is specified, the list specified will replace the existing attributes list on this product. Any attributes not present after the update will be deleted from the SKUs for this product.
        */
-      attributes?: Array<string> | null;
+      attributes?: Stripe.Emptyable<Array<string>>;
 
       /**
        * A short one-line description of the product, meant to be displayable to the customer. May only be set if `type=good`.
@@ -301,12 +301,12 @@ declare module 'stripe' {
       /**
        * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
        */
-      images?: Array<string> | null;
+      images?: Stripe.Emptyable<Array<string>>;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
@@ -316,7 +316,9 @@ declare module 'stripe' {
       /**
        * The dimensions of this product for shipping purposes. A SKU associated with this product can override this value by having its own `package_dimensions`. May only be set if `type=good`.
        */
-      package_dimensions?: ProductUpdateParams.PackageDimensions | null;
+      package_dimensions?: Stripe.Emptyable<
+        ProductUpdateParams.PackageDimensions
+      >;
 
       /**
        * Whether this product is shipped (i.e., physical goods). Defaults to `true`. May only be set if `type=good`.

--- a/types/2020-08-27/PromotionCodes.d.ts
+++ b/types/2020-08-27/PromotionCodes.d.ts
@@ -176,7 +176,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface PromotionCodeListParams extends PaginationParams {

--- a/types/2020-08-27/Refunds.d.ts
+++ b/types/2020-08-27/Refunds.d.ts
@@ -104,7 +104,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       payment_intent?: string;
 
@@ -142,7 +142,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface RefundListParams extends PaginationParams {

--- a/types/2020-08-27/SKUs.d.ts
+++ b/types/2020-08-27/SKUs.d.ts
@@ -205,12 +205,12 @@ declare module 'stripe' {
         /**
          * Inventory type. Possible values are `finite`, `bucket` (not quantified), and `infinite`.
          */
-        type?: Inventory.Type;
+        type: Inventory.Type;
 
         /**
          * An indicator of the inventory available. Possible values are `in_stock`, `limited`, and `out_of_stock`. Will be present if and only if `type` is `bucket`.
          */
-        value?: Inventory.Value | null;
+        value?: Stripe.Emptyable<Inventory.Value>;
       }
 
       namespace Inventory {
@@ -283,12 +283,12 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The dimensions of this SKU for shipping purposes.
        */
-      package_dimensions?: SkuUpdateParams.PackageDimensions | null;
+      package_dimensions?: Stripe.Emptyable<SkuUpdateParams.PackageDimensions>;
 
       /**
        * The cost of the item as a positive integer in the smallest currency unit (that is, 100 cents to charge $1.00, or 100 to charge ¥100, Japanese Yen being a zero-decimal currency).
@@ -316,7 +316,7 @@ declare module 'stripe' {
         /**
          * An indicator of the inventory available. Possible values are `in_stock`, `limited`, and `out_of_stock`. Will be present if and only if `type` is `bucket`.
          */
-        value?: Inventory.Value | null;
+        value?: Stripe.Emptyable<Inventory.Value>;
       }
 
       namespace Inventory {

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -473,7 +473,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.

--- a/types/2020-08-27/Sources.d.ts
+++ b/types/2020-08-27/Sources.d.ts
@@ -814,7 +814,7 @@ declare module 'stripe' {
         /**
          * The amount specified by the mandate. (Leave null for a mandate covering all amounts)
          */
-        amount?: number | null;
+        amount?: Stripe.Emptyable<number>;
 
         /**
          * The currency specified by the mandate. (Must match `currency` of the source)
@@ -1083,7 +1083,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Information about the owner of the payment instrument that may be used or required by particular source types.
@@ -1106,7 +1106,7 @@ declare module 'stripe' {
         /**
          * The amount specified by the mandate. (Leave null for a mandate covering all amounts)
          */
-        amount?: number | null;
+        amount?: Stripe.Emptyable<number>;
 
         /**
          * The currency specified by the mandate. (Must match `currency` of the source)

--- a/types/2020-08-27/SubscriptionItems.d.ts
+++ b/types/2020-08-27/SubscriptionItems.d.ts
@@ -108,7 +108,9 @@ declare module 'stripe' {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
        */
-      billing_thresholds?: SubscriptionItemCreateParams.BillingThresholds | null;
+      billing_thresholds?: Stripe.Emptyable<
+        SubscriptionItemCreateParams.BillingThresholds
+      >;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -166,7 +168,7 @@ declare module 'stripe' {
       /**
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
        */
-      tax_rates?: Array<string> | null;
+      tax_rates?: Stripe.Emptyable<Array<string>>;
     }
 
     namespace SubscriptionItemCreateParams {
@@ -241,7 +243,9 @@ declare module 'stripe' {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
        */
-      billing_thresholds?: SubscriptionItemUpdateParams.BillingThresholds | null;
+      billing_thresholds?: Stripe.Emptyable<
+        SubscriptionItemUpdateParams.BillingThresholds
+      >;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -251,7 +255,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Indicates if a customer is on or off-session while an invoice payment is attempted.
@@ -304,7 +308,7 @@ declare module 'stripe' {
       /**
        * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
        */
-      tax_rates?: Array<string> | null;
+      tax_rates?: Stripe.Emptyable<Array<string>>;
     }
 
     namespace SubscriptionItemUpdateParams {

--- a/types/2020-08-27/SubscriptionSchedules.d.ts
+++ b/types/2020-08-27/SubscriptionSchedules.d.ts
@@ -376,7 +376,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase.
@@ -399,7 +399,9 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: DefaultSettings.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<
+          DefaultSettings.BillingThresholds
+        >;
 
         /**
          * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically` on creation.
@@ -419,7 +421,7 @@ declare module 'stripe' {
         /**
          * The data with which to automatically create a Transfer for each of the associated subscription's invoices.
          */
-        transfer_data?: DefaultSettings.TransferData | null;
+        transfer_data?: Stripe.Emptyable<DefaultSettings.TransferData>;
       }
 
       namespace DefaultSettings {
@@ -480,7 +482,7 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: Phase.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<Phase.BillingThresholds>;
 
         /**
          * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically` on creation.
@@ -500,7 +502,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
          */
-        default_tax_rates?: Array<string> | null;
+        default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
@@ -563,7 +565,7 @@ declare module 'stripe' {
           /**
            * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
            */
-          tax_rates?: Array<string> | null;
+          tax_rates?: Stripe.Emptyable<Array<string>>;
         }
 
         namespace AddInvoiceItem {
@@ -617,7 +619,7 @@ declare module 'stripe' {
           /**
            * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
            */
-          billing_thresholds?: Item.BillingThresholds | null;
+          billing_thresholds?: Stripe.Emptyable<Item.BillingThresholds>;
 
           /**
            * The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
@@ -642,7 +644,7 @@ declare module 'stripe' {
           /**
            * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
            */
-          tax_rates?: Array<string> | null;
+          tax_rates?: Stripe.Emptyable<Array<string>>;
         }
 
         namespace Item {
@@ -744,7 +746,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * List representing phases of the subscription schedule. Each phase can be customized to have different durations, plans, and coupons. If there are multiple phases, the `end_date` of one phase will always equal the `start_date` of the next phase. Note that past phases can be omitted.
@@ -767,7 +769,9 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: DefaultSettings.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<
+          DefaultSettings.BillingThresholds
+        >;
 
         /**
          * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically` on creation.
@@ -787,7 +791,7 @@ declare module 'stripe' {
         /**
          * The data with which to automatically create a Transfer for each of the associated subscription's invoices.
          */
-        transfer_data?: DefaultSettings.TransferData | null;
+        transfer_data?: Stripe.Emptyable<DefaultSettings.TransferData>;
       }
 
       namespace DefaultSettings {
@@ -848,7 +852,7 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: Phase.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<Phase.BillingThresholds>;
 
         /**
          * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay the underlying subscription at the end of each billing cycle using the default source attached to the customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically` on creation.
@@ -868,7 +872,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will set the Subscription's [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates), which means they will be the Invoice's [`default_tax_rates`](https://stripe.com/docs/api/invoices/create#create_invoice-default_tax_rates) for any Invoices issued by the Subscription during this Phase.
          */
-        default_tax_rates?: Array<string> | null;
+        default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The date at which this phase of the subscription schedule ends. If set, `iterations` must not be set.
@@ -936,7 +940,7 @@ declare module 'stripe' {
           /**
            * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
            */
-          tax_rates?: Array<string> | null;
+          tax_rates?: Stripe.Emptyable<Array<string>>;
         }
 
         namespace AddInvoiceItem {
@@ -990,7 +994,7 @@ declare module 'stripe' {
           /**
            * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
            */
-          billing_thresholds?: Item.BillingThresholds | null;
+          billing_thresholds?: Stripe.Emptyable<Item.BillingThresholds>;
 
           /**
            * The plan ID to subscribe to. You may specify the same ID in `plan` and `price`.
@@ -1015,7 +1019,7 @@ declare module 'stripe' {
           /**
            * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
            */
-          tax_rates?: Array<string> | null;
+          tax_rates?: Stripe.Emptyable<Array<string>>;
         }
 
         namespace Item {

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -41,7 +41,7 @@ declare module 'stripe' {
       cancel_at_period_end: boolean;
 
       /**
-       * If the subscription has been canceled, the date of that cancellation. If the subscription was canceled with `cancel_at_period_end`, `canceled_at` will still reflect the date of the initial cancellation request, not the end of the subscription period when the subscription is automatically moved to a canceled state.
+       * If the subscription has been canceled, the date of that cancellation. If the subscription was canceled with `cancel_at_period_end`, `canceled_at` will reflect the time of the most recent update request, not the end of the subscription period when the subscription is automatically moved to a canceled state.
        */
       canceled_at: number | null;
 
@@ -309,7 +309,9 @@ declare module 'stripe' {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
        */
-      billing_thresholds?: SubscriptionCreateParams.BillingThresholds | null;
+      billing_thresholds?: Stripe.Emptyable<
+        SubscriptionCreateParams.BillingThresholds
+      >;
 
       /**
        * A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
@@ -349,7 +351,7 @@ declare module 'stripe' {
       /**
        * The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription.
        */
-      default_tax_rates?: Array<string> | null;
+      default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -364,7 +366,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Indicates if a customer is on or off-session while an invoice payment is attempted.
@@ -383,7 +385,9 @@ declare module 'stripe' {
       /**
        * Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval.
        */
-      pending_invoice_item_interval?: SubscriptionCreateParams.PendingInvoiceItemInterval | null;
+      pending_invoice_item_interval?: Stripe.Emptyable<
+        SubscriptionCreateParams.PendingInvoiceItemInterval
+      >;
 
       /**
        * The API ID of a promotion code to apply to this subscription. A promotion code applied to a subscription will only affect invoices created for that particular subscription.
@@ -438,7 +442,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
       }
 
       namespace AddInvoiceItem {
@@ -483,7 +487,7 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: Item.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<Item.BillingThresholds>;
 
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
@@ -513,7 +517,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
       }
 
       namespace Item {
@@ -632,12 +636,14 @@ declare module 'stripe' {
       /**
        * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. Pass an empty string to remove previously-defined thresholds.
        */
-      billing_thresholds?: SubscriptionUpdateParams.BillingThresholds | null;
+      billing_thresholds?: Stripe.Emptyable<
+        SubscriptionUpdateParams.BillingThresholds
+      >;
 
       /**
        * A timestamp at which the subscription should cancel. If set to a date before the current period ends, this will cause a proration if prorations have been enabled using `proration_behavior`. If set during a future period, this will always cause a proration for that period.
        */
-      cancel_at?: number | null;
+      cancel_at?: Stripe.Emptyable<number>;
 
       /**
        * Boolean indicating whether this subscription should cancel at the end of the current period.
@@ -672,7 +678,7 @@ declare module 'stripe' {
       /**
        * The tax rates that will apply to any subscription item that does not have `tax_rates` set. Invoices created will have their `default_tax_rates` populated from the subscription. Pass an empty string to remove previously-defined tax rates.
        */
-      default_tax_rates?: Array<string> | null;
+      default_tax_rates?: Stripe.Emptyable<Array<string>>;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -687,7 +693,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Indicates if a customer is on or off-session while an invoice payment is attempted.
@@ -697,7 +703,9 @@ declare module 'stripe' {
       /**
        * If specified, payment collection for this subscription will be paused.
        */
-      pause_collection?: SubscriptionUpdateParams.PauseCollection | null;
+      pause_collection?: Stripe.Emptyable<
+        SubscriptionUpdateParams.PauseCollection
+      >;
 
       /**
        * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
@@ -711,7 +719,9 @@ declare module 'stripe' {
       /**
        * Specifies an interval for how often to bill for any pending invoice items. It is analogous to calling [Create an invoice](https://stripe.com/docs/api#create_invoice) for the given subscription at the specified interval.
        */
-      pending_invoice_item_interval?: SubscriptionUpdateParams.PendingInvoiceItemInterval | null;
+      pending_invoice_item_interval?: Stripe.Emptyable<
+        SubscriptionUpdateParams.PendingInvoiceItemInterval
+      >;
 
       /**
        * The promotion code to apply to this subscription. A promotion code applied to a subscription will only affect invoices created for that particular subscription.
@@ -735,7 +745,7 @@ declare module 'stripe' {
       /**
        * If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges. This will be unset if you POST an empty value.
        */
-      transfer_data?: SubscriptionUpdateParams.TransferData | null;
+      transfer_data?: Stripe.Emptyable<SubscriptionUpdateParams.TransferData>;
 
       /**
        * Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`.
@@ -768,7 +778,7 @@ declare module 'stripe' {
         /**
          * The tax rates which apply to the item. When set, the `default_tax_rates` do not apply to this item.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
       }
 
       namespace AddInvoiceItem {
@@ -815,7 +825,7 @@ declare module 'stripe' {
         /**
          * Define thresholds at which an invoice will be sent, and the subscription advanced to a new billing period. When updating, pass an empty string to remove previously-defined thresholds.
          */
-        billing_thresholds?: Item.BillingThresholds | null;
+        billing_thresholds?: Stripe.Emptyable<Item.BillingThresholds>;
 
         /**
          * Delete all usage for a given subscription item. Allowed only when `deleted` is set to `true` and the current plan's `usage_type` is `metered`.
@@ -835,7 +845,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * Plan ID for this item, as a string.
@@ -860,7 +870,7 @@ declare module 'stripe' {
         /**
          * A list of [Tax Rate](https://stripe.com/docs/api/tax_rates) ids. These Tax Rates will override the [`default_tax_rates`](https://stripe.com/docs/api/subscriptions/create#create_subscription-default_tax_rates) on the Subscription. When updating, pass an empty string to remove previously-defined tax rates.
          */
-        tax_rates?: Array<string> | null;
+        tax_rates?: Stripe.Emptyable<Array<string>>;
       }
 
       namespace Item {

--- a/types/2020-08-27/TaxRates.d.ts
+++ b/types/2020-08-27/TaxRates.d.ts
@@ -139,7 +139,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface TaxRateListParams extends PaginationParams {

--- a/types/2020-08-27/Terminal/Locations.d.ts
+++ b/types/2020-08-27/Terminal/Locations.d.ts
@@ -75,7 +75,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       namespace LocationCreateParams {
@@ -138,7 +138,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       namespace LocationUpdateParams {

--- a/types/2020-08-27/Terminal/Readers.d.ts
+++ b/types/2020-08-27/Terminal/Readers.d.ts
@@ -112,7 +112,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       interface ReaderRetrieveParams {
@@ -136,7 +136,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
       }
 
       interface ReaderListParams extends PaginationParams {

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -80,6 +80,11 @@ declare module 'stripe' {
       customer?: string;
 
       /**
+       * The updated CVC value this token will represent.
+       */
+      cvc_update?: TokenCreateParams.CvcUpdate;
+
+      /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
@@ -179,7 +184,7 @@ declare module 'stripe' {
           /**
            * The category identifying the legal structure of the company or legal entity. See [Business structure](https://stripe.com/docs/connect/identity-verification#business-structure) for more details.
            */
-          structure?: Company.Structure | null;
+          structure?: Stripe.Emptyable<Company.Structure>;
 
           /**
            * The business ID number of the company, as appropriate for the company's country. (Examples are an Employer ID Number in the U.S., a Business Number in Canada, or a Company Number in the UK.)
@@ -293,7 +298,7 @@ declare module 'stripe' {
           /**
            * The individual's date of birth.
            */
-          dob?: Individual.Dob | null;
+          dob?: Stripe.Emptyable<Individual.Dob>;
 
           /**
            * The individual's email address.
@@ -348,7 +353,7 @@ declare module 'stripe' {
           /**
            * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
            */
-          metadata?: MetadataParam | null;
+          metadata?: Stripe.Emptyable<MetadataParam>;
 
           /**
            * The individual's phone number.
@@ -525,6 +530,13 @@ declare module 'stripe' {
         number: string;
       }
 
+      interface CvcUpdate {
+        /**
+         * The CVC value, in string form.
+         */
+        cvc: string;
+      }
+
       interface Person {
         /**
          * The person's address.
@@ -544,7 +556,7 @@ declare module 'stripe' {
         /**
          * The person's date of birth.
          */
-        dob?: Person.Dob | null;
+        dob?: Stripe.Emptyable<Person.Dob>;
 
         /**
          * The person's email address.
@@ -599,7 +611,7 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
-        metadata?: MetadataParam | null;
+        metadata?: Stripe.Emptyable<MetadataParam>;
 
         /**
          * The person's phone number.
@@ -696,7 +708,7 @@ declare module 'stripe' {
           /**
            * The percent owned by the person of the account's legal entity.
            */
-          percent_ownership?: number | null;
+          percent_ownership?: Stripe.Emptyable<number>;
 
           /**
            * Whether the person is authorized as the primary representative of the account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.

--- a/types/2020-08-27/Topups.d.ts
+++ b/types/2020-08-27/Topups.d.ts
@@ -124,7 +124,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The ID of a source to transfer funds from. For most users, this should be left unspecified which will use the bank account that was set up in the dashboard for the specified currency. In test mode, this can be a test bank token (see [Testing Top-ups](https://stripe.com/docs/connect/testing#testing-top-ups)).
@@ -163,7 +163,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface TopupListParams extends PaginationParams {

--- a/types/2020-08-27/TransferReversals.d.ts
+++ b/types/2020-08-27/TransferReversals.d.ts
@@ -75,7 +75,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * Boolean indicating whether the application fee should be refunded when reversing this transfer. If a full transfer reversal is given, the full application fee will be refunded. Otherwise, the application fee will be refunded with an amount proportional to the amount of the transfer reversed.
@@ -99,7 +99,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface TransferReversalListParams extends PaginationParams {

--- a/types/2020-08-27/Transfers.d.ts
+++ b/types/2020-08-27/Transfers.d.ts
@@ -163,7 +163,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     interface TransferListParams extends PaginationParams {

--- a/types/2020-08-27/WebhookEndpoints.d.ts
+++ b/types/2020-08-27/WebhookEndpoints.d.ts
@@ -122,7 +122,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
     }
 
     namespace WebhookEndpointCreateParams {
@@ -422,7 +422,7 @@ declare module 'stripe' {
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
-      metadata?: MetadataParam | null;
+      metadata?: Stripe.Emptyable<MetadataParam>;
 
       /**
        * The URL of the webhook endpoint.


### PR DESCRIPTION
Multiple API changes:
  * Improving Typescript types for nullable parameters and introduced `Stripe.Emptyable` as a type
  * Add support for `payment_method_options[card][cvc_token]` on `PaymentIntent`
  * Add support for `cvc_update[cvc]` on `Token` creation

Codegen for openapi e215279

r? @richardm-stripe 
cc @stripe/api-libraries 