### PR TITLE
Replace object spread operator with Object.assign

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -149,7 +149,7 @@ const utils = (module.exports = {
       if (typeof arg === 'string') {
         opts.auth = args.pop();
       } else if (utils.isOptionsHash(arg)) {
-        const params = {...args.pop()};
+        const params = Object.assign({}, args.pop());
 
         const extraKeys = Object.keys(params).filter(
           (key) => !OPTIONS_KEYS.includes(key)


### PR DESCRIPTION
This preserves Node 6 support, as the spread operator is not supported for objects until Node 8.