### PR TITLE
Standardize on CRULD order for method definitions

### DIFF
--- a/lib/resources/Accounts.js
+++ b/lib/resources/Accounts.js
@@ -14,22 +14,6 @@ module.exports = StripeResource.extend({
     path: 'accounts',
   }),
 
-  del: stripeMethod({
-    method: 'DELETE',
-    path: 'accounts/{account}',
-  }),
-
-  list: stripeMethod({
-    method: 'GET',
-    path: 'accounts',
-    methodType: 'list',
-  }),
-
-  reject: stripeMethod({
-    method: 'POST',
-    path: 'accounts/{account}/reject',
-  }),
-
   retrieve(id) {
     // No longer allow an api key to be passed as the first string to this function due to ambiguity between
     // old account ids and api keys. To request the account for an api key, send null as the id
@@ -53,6 +37,22 @@ module.exports = StripeResource.extend({
   update: stripeMethod({
     method: 'POST',
     path: 'accounts/{account}',
+  }),
+
+  list: stripeMethod({
+    method: 'GET',
+    path: 'accounts',
+    methodType: 'list',
+  }),
+
+  del: stripeMethod({
+    method: 'DELETE',
+    path: 'accounts/{account}',
+  }),
+
+  reject: stripeMethod({
+    method: 'POST',
+    path: 'accounts/{account}/reject',
   }),
 
   listCapabilities: stripeMethod({

--- a/lib/resources/ApplePayDomains.js
+++ b/lib/resources/ApplePayDomains.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'apple_pay/domains',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve'],
+  includeBasic: ['create', 'retrieve', 'list', 'del'],
 });

--- a/lib/resources/ApplicationFees.js
+++ b/lib/resources/ApplicationFees.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'application_fees',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 
   createRefund: stripeMethod({
     method: 'POST',

--- a/lib/resources/BalanceTransactions.js
+++ b/lib/resources/BalanceTransactions.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'balance_transactions',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/Charges.js
+++ b/lib/resources/Charges.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'charges',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   capture: stripeMethod({
     method: 'POST',

--- a/lib/resources/Checkout/Sessions.js
+++ b/lib/resources/Checkout/Sessions.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'checkout/sessions',
 
-  includeBasic: ['create', 'list', 'retrieve'],
+  includeBasic: ['create', 'retrieve', 'list'],
 
   listLineItems: stripeMethod({
     method: 'GET',

--- a/lib/resources/CountrySpecs.js
+++ b/lib/resources/CountrySpecs.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'country_specs',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/Coupons.js
+++ b/lib/resources/Coupons.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'coupons',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/CreditNotes.js
+++ b/lib/resources/CreditNotes.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'credit_notes',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   preview: stripeMethod({
     method: 'GET',

--- a/lib/resources/Customers.js
+++ b/lib/resources/Customers.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'customers',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 
   deleteDiscount: stripeMethod({
     method: 'DELETE',
@@ -41,11 +41,6 @@ module.exports = StripeResource.extend({
     path: '/{customer}/sources',
   }),
 
-  deleteSource: stripeMethod({
-    method: 'DELETE',
-    path: '/{customer}/sources/{id}',
-  }),
-
   listSources: stripeMethod({
     method: 'GET',
     path: '/{customer}/sources',
@@ -59,6 +54,11 @@ module.exports = StripeResource.extend({
 
   updateSource: stripeMethod({
     method: 'POST',
+    path: '/{customer}/sources/{id}',
+  }),
+
+  deleteSource: stripeMethod({
+    method: 'DELETE',
     path: '/{customer}/sources/{id}',
   }),
 

--- a/lib/resources/Disputes.js
+++ b/lib/resources/Disputes.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'disputes',
 
-  includeBasic: ['list', 'retrieve', 'update'],
+  includeBasic: ['retrieve', 'update', 'list'],
 
   close: stripeMethod({
     method: 'POST',

--- a/lib/resources/Events.js
+++ b/lib/resources/Events.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'events',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/ExchangeRates.js
+++ b/lib/resources/ExchangeRates.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'exchange_rates',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/FileLinks.js
+++ b/lib/resources/FileLinks.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'file_links',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 });

--- a/lib/resources/Files.js
+++ b/lib/resources/Files.js
@@ -9,7 +9,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'files',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 
   create: stripeMethod({
     method: 'POST',

--- a/lib/resources/InvoiceItems.js
+++ b/lib/resources/InvoiceItems.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'invoiceitems',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/Invoices.js
+++ b/lib/resources/Invoices.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'invoices',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 
   finalizeInvoice: stripeMethod({
     method: 'POST',

--- a/lib/resources/IssuerFraudRecords.js
+++ b/lib/resources/IssuerFraudRecords.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'issuer_fraud_records',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/Issuing/Authorizations.js
+++ b/lib/resources/Issuing/Authorizations.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'issuing/authorizations',
 
-  includeBasic: ['list', 'retrieve', 'update'],
+  includeBasic: ['retrieve', 'update', 'list'],
 
   approve: stripeMethod({
     method: 'POST',

--- a/lib/resources/Issuing/Cardholders.js
+++ b/lib/resources/Issuing/Cardholders.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'issuing/cardholders',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 });

--- a/lib/resources/Issuing/Cards.js
+++ b/lib/resources/Issuing/Cards.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'issuing/cards',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   retrieveDetails: stripeMethod({
     method: 'GET',

--- a/lib/resources/Issuing/Disputes.js
+++ b/lib/resources/Issuing/Disputes.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'issuing/disputes',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   submit: stripeMethod({
     method: 'POST',

--- a/lib/resources/Issuing/Transactions.js
+++ b/lib/resources/Issuing/Transactions.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'issuing/transactions',
 
-  includeBasic: ['list', 'retrieve', 'update'],
+  includeBasic: ['retrieve', 'update', 'list'],
 });

--- a/lib/resources/OrderReturns.js
+++ b/lib/resources/OrderReturns.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'order_returns',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/Orders.js
+++ b/lib/resources/Orders.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'orders',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   pay: stripeMethod({
     method: 'POST',

--- a/lib/resources/PaymentIntents.js
+++ b/lib/resources/PaymentIntents.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'payment_intents',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   cancel: stripeMethod({
     method: 'POST',

--- a/lib/resources/PaymentMethods.js
+++ b/lib/resources/PaymentMethods.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'payment_methods',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   attach: stripeMethod({
     method: 'POST',

--- a/lib/resources/Payouts.js
+++ b/lib/resources/Payouts.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'payouts',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   cancel: stripeMethod({
     method: 'POST',

--- a/lib/resources/Plans.js
+++ b/lib/resources/Plans.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'plans',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/Prices.js
+++ b/lib/resources/Prices.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'prices',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 });

--- a/lib/resources/Products.js
+++ b/lib/resources/Products.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'products',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/PromotionCodes.js
+++ b/lib/resources/PromotionCodes.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'promotion_codes',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 });

--- a/lib/resources/Radar/EarlyFraudWarnings.js
+++ b/lib/resources/Radar/EarlyFraudWarnings.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'radar/early_fraud_warnings',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/Radar/ValueListItems.js
+++ b/lib/resources/Radar/ValueListItems.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'radar/value_list_items',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve'],
+  includeBasic: ['create', 'retrieve', 'list', 'del'],
 });

--- a/lib/resources/Radar/ValueLists.js
+++ b/lib/resources/Radar/ValueLists.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'radar/value_lists',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/Refunds.js
+++ b/lib/resources/Refunds.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'refunds',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 });

--- a/lib/resources/Reporting/ReportRuns.js
+++ b/lib/resources/Reporting/ReportRuns.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'reporting/report_runs',
 
-  includeBasic: ['create', 'list', 'retrieve'],
+  includeBasic: ['create', 'retrieve', 'list'],
 });

--- a/lib/resources/Reporting/ReportTypes.js
+++ b/lib/resources/Reporting/ReportTypes.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'reporting/report_types',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/Reviews.js
+++ b/lib/resources/Reviews.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'reviews',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 
   approve: stripeMethod({
     method: 'POST',

--- a/lib/resources/SKUs.js
+++ b/lib/resources/SKUs.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'skus',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/SetupIntents.js
+++ b/lib/resources/SetupIntents.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'setup_intents',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   cancel: stripeMethod({
     method: 'POST',

--- a/lib/resources/Sigma/ScheduledQueryRuns.js
+++ b/lib/resources/Sigma/ScheduledQueryRuns.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'sigma/scheduled_query_runs',
 
-  includeBasic: ['list', 'retrieve'],
+  includeBasic: ['retrieve', 'list'],
 });

--- a/lib/resources/SubscriptionItems.js
+++ b/lib/resources/SubscriptionItems.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'subscription_items',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 
   createUsageRecord: stripeMethod({
     method: 'POST',

--- a/lib/resources/SubscriptionSchedules.js
+++ b/lib/resources/SubscriptionSchedules.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'subscription_schedules',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   cancel: stripeMethod({
     method: 'POST',

--- a/lib/resources/Subscriptions.js
+++ b/lib/resources/Subscriptions.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'subscriptions',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 
   deleteDiscount: stripeMethod({
     method: 'DELETE',

--- a/lib/resources/TaxRates.js
+++ b/lib/resources/TaxRates.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'tax_rates',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 });

--- a/lib/resources/Terminal/Locations.js
+++ b/lib/resources/Terminal/Locations.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'terminal/locations',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/Terminal/Readers.js
+++ b/lib/resources/Terminal/Readers.js
@@ -7,5 +7,5 @@ const StripeResource = require('../../StripeResource');
 module.exports = StripeResource.extend({
   path: 'terminal/readers',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });

--- a/lib/resources/Topups.js
+++ b/lib/resources/Topups.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'topups',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   cancel: stripeMethod({
     method: 'POST',

--- a/lib/resources/Transfers.js
+++ b/lib/resources/Transfers.js
@@ -8,7 +8,7 @@ const stripeMethod = StripeResource.method;
 module.exports = StripeResource.extend({
   path: 'transfers',
 
-  includeBasic: ['create', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list'],
 
   createReversal: stripeMethod({
     method: 'POST',

--- a/lib/resources/WebhookEndpoints.js
+++ b/lib/resources/WebhookEndpoints.js
@@ -7,5 +7,5 @@ const StripeResource = require('../StripeResource');
 module.exports = StripeResource.extend({
   path: 'webhook_endpoints',
 
-  includeBasic: ['create', 'del', 'list', 'retrieve', 'update'],
+  includeBasic: ['create', 'retrieve', 'update', 'list', 'del'],
 });


### PR DESCRIPTION
## Summary
In the typescript definitions, the order of methods has always been "create, retrieve, update, list, delete, ...customMethods". This standardizes on that order in the node resource definitions as well

## Notify
r? @ctrudeau-stripe 
cc @stripe/api-libraries 