### PR TITLE
Adding check to verify secret passed in is for webhooks

### DIFF
--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -104,6 +104,13 @@ const signature = {
       });
     }
 
+    if (secret.substring(0, 6) != 'whsec_') {
+      throw new StripeSignatureVerificationError({
+        message:
+          'Webhook secret key passed in does not start with whsec_. Webhook secrets can be found here: https://dashboard.stripe.com/webhooks.',
+      });
+    }
+
     const expectedSignature = this._computeSignature(
       `${details.timestamp}.${payload}`,
       secret

--- a/test/Webhook.spec.js
+++ b/test/Webhook.spec.js
@@ -127,6 +127,24 @@ describe('Webhooks', () => {
       }).to.throw(expectedMessage);
     });
 
+    it('should raise a SignatureVerificationError when the secret key does not contain whsec_', () => {
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: EVENT_PAYLOAD_STRING,
+        secret: SECRET,
+      });
+
+      const expectedMessage =
+        'Webhook secret key passed in does not start with whsec_. Webhook secrets can be found here: https://dashboard.stripe.com/webhooks.';
+
+      expect(() => {
+        stripe.webhooks.signature.verifyHeader(
+          EVENT_PAYLOAD_STRING,
+          header,
+          'SECRET'
+        );
+      }).to.throw(expectedMessage);
+    });
+
     it('should raise a SignatureVerificationError when there are no signatures with the expected scheme', () => {
       const header = stripe.webhooks.generateTestHeaderString({
         payload: EVENT_PAYLOAD_STRING,


### PR DESCRIPTION
When using webhooks you need to pass in the `whsec_` found in the dashboard webhooks section. If you pass in the secret key not related to webhooks it leads to a confusing error. This adds a check to verify it's the webhook secret being passed in. 

r? @richardm-stripe 