### PR TITLE
[codegen] Multiple API changes

### DIFF
--- a/types/2020-08-27/Cards.d.ts
+++ b/types/2020-08-27/Cards.d.ts
@@ -98,7 +98,7 @@ declare module 'stripe' {
       deleted?: void;
 
       /**
-       * Card description. (For internal use only and not typically available in standard API requests.)
+       * A high-level description of the type of cards issued in this range. (For internal use only and not typically available in standard API requests.)
        */
       description?: string;
 
@@ -133,7 +133,7 @@ declare module 'stripe' {
       iin?: string;
 
       /**
-       * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+       * The name of the card's issuing bank. (For internal use only and not typically available in standard API requests.)
        */
       issuer?: string;
 

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -647,7 +647,7 @@ declare module 'stripe' {
           country: string | null;
 
           /**
-           * Card description. (For internal use only and not typically available in standard API requests.)
+           * A high-level description of the type of cards issued in this range. (For internal use only and not typically available in standard API requests.)
            */
           description?: string | null;
 
@@ -684,7 +684,7 @@ declare module 'stripe' {
           installments: Card.Installments | null;
 
           /**
-           * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+           * The name of the card's issuing bank. (For internal use only and not typically available in standard API requests.)
            */
           issuer?: string | null;
 
@@ -909,7 +909,7 @@ declare module 'stripe' {
           country: string | null;
 
           /**
-           * Card description. (For internal use only and not typically available in standard API requests.)
+           * A high-level description of the type of cards issued in this range. (For internal use only and not typically available in standard API requests.)
            */
           description?: string | null;
 
@@ -949,7 +949,7 @@ declare module 'stripe' {
           iin?: string | null;
 
           /**
-           * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+           * The name of the card's issuing bank. (For internal use only and not typically available in standard API requests.)
            */
           issuer?: string | null;
 
@@ -1190,7 +1190,7 @@ declare module 'stripe' {
           country: string | null;
 
           /**
-           * Card description. (For internal use only and not typically available in standard API requests.)
+           * A high-level description of the type of cards issued in this range. (For internal use only and not typically available in standard API requests.)
            */
           description?: string | null;
 
@@ -1230,7 +1230,7 @@ declare module 'stripe' {
           iin?: string | null;
 
           /**
-           * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+           * The name of the card's issuing bank. (For internal use only and not typically available in standard API requests.)
            */
           issuer?: string | null;
 

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -552,7 +552,7 @@ declare module 'stripe' {
       created?: RangeQueryParam | number;
 
       /**
-       * A filter on the list based on the customer's `email` field. The value must be a string.
+       * A case-sensitive filter on the list based on the customer's `email` field. The value must be a string.
        */
       email?: string;
 

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -95,12 +95,12 @@ declare module 'stripe' {
       /**
        * The amount of tax calculated per tax rate for this line item
        */
-      tax_amounts?: Array<InvoiceLineItem.TaxAmount> | null;
+      tax_amounts?: Array<InvoiceLineItem.TaxAmount>;
 
       /**
        * The tax rates which apply to the line item.
        */
-      tax_rates?: Array<Stripe.TaxRate> | null;
+      tax_rates?: Array<Stripe.TaxRate>;
 
       /**
        * A string identifying the type of the source of this line item, either an `invoiceitem` or a `subscription`.

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -143,7 +143,7 @@ declare module 'stripe' {
       /**
        * The tax rates applied to this invoice, if any.
        */
-      default_tax_rates: Array<Stripe.TaxRate> | null;
+      default_tax_rates: Array<Stripe.TaxRate>;
 
       deleted?: void;
 
@@ -306,7 +306,7 @@ declare module 'stripe' {
       /**
        * The aggregate amounts calculated per tax rate for all line items.
        */
-      total_tax_amounts: Array<Invoice.TotalTaxAmount> | null;
+      total_tax_amounts: Array<Invoice.TotalTaxAmount>;
 
       /**
        * The account (if any) the payment will be attributed to for tax reporting, and where funds from the payment will be transferred to for the invoice.

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -36,7 +36,7 @@ declare module 'stripe' {
       application: string | Stripe.Application | null;
 
       /**
-       * The amount of the application fee (if any) requested for the resulting payment. See the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts) for details.
+       * The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account. The amount of the application fee collected will be capped at the total payment amount. For more information, see the PaymentIntents [use case for connected accounts](https://stripe.com/docs/payments/connected-accounts).
        */
       application_fee_amount: number | null;
 
@@ -65,7 +65,7 @@ declare module 'stripe' {
        *
        * The client secret can be used to complete a payment from your frontend. It should not be stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
        *
-       * Refer to our docs to [accept a payment](https://stripe.com/docs/payments/accept-a-payment) and learn about how `client_secret` should be handled.
+       * Refer to our docs to [accept a payment](https://stripe.com/docs/payments/accept-a-payment?integration=elements) and learn about how `client_secret` should be handled.
        */
       client_secret: string | null;
 

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -151,7 +151,7 @@ declare module 'stripe' {
         country: string | null;
 
         /**
-         * Card description. (For internal use only and not typically available in standard API requests.)
+         * A high-level description of the type of cards issued in this range. (For internal use only and not typically available in standard API requests.)
          */
         description?: string | null;
 
@@ -181,7 +181,7 @@ declare module 'stripe' {
         iin?: string | null;
 
         /**
-         * Issuer bank name of the card. (For internal use only and not typically available in standard API requests.)
+         * The name of the card's issuing bank. (For internal use only and not typically available in standard API requests.)
          */
         issuer?: string | null;
 

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -260,6 +260,8 @@ declare module 'stripe' {
 
       interface PaymentMethodOptions {
         card?: PaymentMethodOptions.Card;
+
+        sepa_debit?: PaymentMethodOptions.SepaDebit;
       }
 
       namespace PaymentMethodOptions {
@@ -273,6 +275,8 @@ declare module 'stripe' {
         namespace Card {
           type RequestThreeDSecure = 'any' | 'automatic' | 'challenge_only';
         }
+
+        interface SepaDebit {}
       }
 
       type Status =
@@ -408,6 +412,11 @@ declare module 'stripe' {
          * Configuration for any card setup attempted on this SetupIntent.
          */
         card?: PaymentMethodOptions.Card;
+
+        /**
+         * If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the Sepa Debit payment method options.
+         */
+        sepa_debit?: PaymentMethodOptions.SepaDebit;
       }
 
       namespace PaymentMethodOptions {
@@ -428,6 +437,8 @@ declare module 'stripe' {
         namespace Card {
           type RequestThreeDSecure = 'any' | 'automatic';
         }
+
+        interface SepaDebit {}
       }
 
       interface SingleUse {
@@ -502,6 +513,11 @@ declare module 'stripe' {
          * Configuration for any card setup attempted on this SetupIntent.
          */
         card?: PaymentMethodOptions.Card;
+
+        /**
+         * If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the Sepa Debit payment method options.
+         */
+        sepa_debit?: PaymentMethodOptions.SepaDebit;
       }
 
       namespace PaymentMethodOptions {
@@ -522,6 +538,8 @@ declare module 'stripe' {
         namespace Card {
           type RequestThreeDSecure = 'any' | 'automatic';
         }
+
+        interface SepaDebit {}
       }
     }
 
@@ -687,6 +705,11 @@ declare module 'stripe' {
          * Configuration for any card setup attempted on this SetupIntent.
          */
         card?: PaymentMethodOptions.Card;
+
+        /**
+         * If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the Sepa Debit payment method options.
+         */
+        sepa_debit?: PaymentMethodOptions.SepaDebit;
       }
 
       namespace PaymentMethodOptions {
@@ -707,6 +730,8 @@ declare module 'stripe' {
         namespace Card {
           type RequestThreeDSecure = 'any' | 'automatic';
         }
+
+        interface SepaDebit {}
       }
     }
 


### PR DESCRIPTION
Codegen for openapi 5a94a49.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `sepa_debit` on `SetupIntent.PaymentMethodOptions`
* `Invoice.tax_amounts` and `InvoiceLineItem.tax_rates` are no longer nullable
* `Invoice.default_tax_rates` and `InvoiceLineItem.tax_amounts` are no longer nullable