### PR TITLE
ts declaration for onDone on autoPagingEach and autoPagingToArray

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -190,10 +190,14 @@ declare module 'stripe' {
       extends Promise<Response<ApiList<T>>>,
         AsyncIterableIterator<T> {
       autoPagingEach(
-        handler: (item: T) => boolean | void | Promise<boolean | void>
+        handler: (item: T) => boolean | void | Promise<boolean | void>,
+        onDone?: (err: any) => void
       ): Promise<void>;
 
-      autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
+      autoPagingToArray(
+        opts: {limit: number},
+        onDone?: (err: any) => void
+      ): Promise<Array<T>>;
     }
 
     /**


### PR DESCRIPTION
add ts declaration for `onDone` callback parameter on `autoPagingEach` and `autoPagingToArray`

as implemented:
- https://github.com/stripe/stripe-node/blob/ec960ead66f9942d68804f1a91dce8988d8d9660/lib/autoPagination.js#L170
- https://github.com/stripe/stripe-node/blob/ec960ead66f9942d68804f1a91dce8988d8d9660/lib/autoPagination.js#L187