### PR TITLE
#857 Allow default stripeAccount in options

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -342,6 +342,7 @@ StripeResource.prototype = {
       'X-Stripe-Client-User-Agent': clientUserAgent,
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
       'Stripe-Version': apiVersion,
+      'Stripe-Account': this._stripe.getApiField('stripeAccount'),
       'Idempotency-Key': this._defaultIdempotencyKey(
         method,
         userSuppliedSettings

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -38,6 +38,7 @@ const ALLOWED_CONFIG_PROPERTIES = [
   'protocol',
   'telemetry',
   'appInfo',
+  'stripeAccount',
 ];
 
 const EventEmitter = require('events').EventEmitter;
@@ -92,6 +93,7 @@ function Stripe(key, config = {}) {
     ),
     agent: props.httpAgent || null,
     dev: false,
+    stripeAccount: props.stripeAccount || null,
   };
 
   const typescript = props.typescript || false;

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -103,6 +103,11 @@ declare module 'stripe' {
        * @docs https://stripe.com/docs/building-plugins?lang=node#setappinfo
        */
       appInfo?: AppInfo;
+
+      /**
+       * An account id on whose behalf you wish to make every request.
+       */
+      stripeAccount?: string;
     }
 
     export interface RequestOptions {


### PR DESCRIPTION
This is a pretty minor code change allowing a new option in the StripeConfig interface **stripeAccount**
When building an API request, the Stripe-Account header is now added to the default request headers.