### PR TITLE
make request timeout errors eligible for retry

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -98,17 +98,7 @@ StripeResource.prototype = {
       const timeoutErr = new TypeError('ETIMEDOUT');
       timeoutErr.code = 'ETIMEDOUT';
 
-      req._isAborted = true;
-      req.abort();
-
-      callback.call(
-        this,
-        new StripeConnectionError({
-          message: `Request aborted due to timeout being reached (${timeout}ms)`,
-          detail: timeoutErr,
-        }),
-        null
-      );
+      req.destroy(timeoutErr);
     };
   },
 
@@ -224,11 +214,7 @@ StripeResource.prototype = {
   },
 
   _errorHandler(req, requestRetries, callback) {
-    return (error) => {
-      if (req._isAborted) {
-        // already handled
-        return;
-      }
+    return (message, detail) => {
       callback.call(
         this,
         new StripeConnectionError({
@@ -486,7 +472,23 @@ StripeResource.prototype = {
             null
           );
         } else {
-          return this._errorHandler(req, requestRetries, callback)(error);
+          if (error.code === 'ETIMEDOUT') {
+            return callback.call(
+              this,
+              new StripeConnectionError({
+                message: `Request aborted due to timeout being reached (${timeout}ms)`,
+                detail: error,
+              })
+            );
+          }
+          return callback.call(
+            this,
+            new StripeConnectionError({
+              message: this._generateConnectionErrorMessage(requestRetries),
+              detail: error,
+            }),
+            null
+          );
         }
       });
 


### PR DESCRIPTION
fixes #1058
r? @tjfontaine-stripe @ctrudeau-stripe 

Presently errors that result from the node http request timeout [are not eligible to be retried](https://github.com/stripe/stripe-node/compare/richardm-retry-request-timeouts?expand=1#diff-d5d3bf39549deedcf2b6f61e2f2f7f8398c71b21ba178612e0ff5c81a06d1ce5L227-L231).

I doubt this is deliberate and it seems like these requests should generally be retried, the same as ECONNRESET or any other sort of connection error.

This is technically a behavior change, so my inclination is to wait until the next major version, since there are a lot of open network-related issues and it would be good to address several of them.

