### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -1348,10 +1348,70 @@ declare module 'stripe' {
          * One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement. Must be a document associated with the account's primary active bank account that displays the last 4 digits of the account number, either a statement or a voided check.
          */
         bank_account_ownership_verification?: Documents.BankAccountOwnershipVerification;
+
+        /**
+         * One or more documents that demonstrate proof of a company's license to operate.
+         */
+        company_license?: Documents.CompanyLicense;
+
+        /**
+         * One or more documents showing the company's Memorandum of Association.
+         */
+        company_memorandum_of_association?: Documents.CompanyMemorandumOfAssociation;
+
+        /**
+         * (Certain countries only) One or more documents showing the ministerial decree legalizing the company's establishment.
+         */
+        company_ministerial_decree?: Documents.CompanyMinisterialDecree;
+
+        /**
+         * One or more documents that demonstrate proof of a company's registration with the appropriate local authorities.
+         */
+        company_registration_verification?: Documents.CompanyRegistrationVerification;
+
+        /**
+         * One or more documents that demonstrate proof of a company's tax ID.
+         */
+        company_tax_id_verification?: Documents.CompanyTaxIdVerification;
       }
 
       namespace Documents {
         interface BankAccountOwnershipVerification {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyLicense {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyMemorandumOfAssociation {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyMinisterialDecree {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyRegistrationVerification {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyTaxIdVerification {
           /**
            * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
            */
@@ -2289,10 +2349,70 @@ declare module 'stripe' {
          * One or more documents that support the [Bank account ownership verification](https://support.stripe.com/questions/bank-account-ownership-verification) requirement. Must be a document associated with the account's primary active bank account that displays the last 4 digits of the account number, either a statement or a voided check.
          */
         bank_account_ownership_verification?: Documents.BankAccountOwnershipVerification;
+
+        /**
+         * One or more documents that demonstrate proof of a company's license to operate.
+         */
+        company_license?: Documents.CompanyLicense;
+
+        /**
+         * One or more documents showing the company's Memorandum of Association.
+         */
+        company_memorandum_of_association?: Documents.CompanyMemorandumOfAssociation;
+
+        /**
+         * (Certain countries only) One or more documents showing the ministerial decree legalizing the company's establishment.
+         */
+        company_ministerial_decree?: Documents.CompanyMinisterialDecree;
+
+        /**
+         * One or more documents that demonstrate proof of a company's registration with the appropriate local authorities.
+         */
+        company_registration_verification?: Documents.CompanyRegistrationVerification;
+
+        /**
+         * One or more documents that demonstrate proof of a company's tax ID.
+         */
+        company_tax_id_verification?: Documents.CompanyTaxIdVerification;
       }
 
       namespace Documents {
         interface BankAccountOwnershipVerification {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyLicense {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyMemorandumOfAssociation {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyMinisterialDecree {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyRegistrationVerification {
+          /**
+           * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
+           */
+          files?: Array<string>;
+        }
+
+        interface CompanyTaxIdVerification {
           /**
            * One or more document ids returned by a [file upload](https://stripe.com/docs/api#create_file) with a `purpose` value of `account_requirement`.
            */

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -662,7 +662,7 @@ declare module 'stripe' {
       account_tax_ids?: Stripe.Emptyable<Array<string>>;
 
       /**
-       * A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](https://stripe.com/docs/connect/subscriptions#invoices).
+       * A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](https://stripe.com/docs/billing/invoices/connect#collecting-fees).
        */
       application_fee_amount?: number;
 
@@ -801,7 +801,7 @@ declare module 'stripe' {
       account_tax_ids?: Stripe.Emptyable<Array<string>>;
 
       /**
-       * A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](https://stripe.com/docs/connect/subscriptions#invoices).
+       * A fee in %s that will be applied to the invoice and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees [documentation](https://stripe.com/docs/billing/invoices/connect#collecting-fees).
        */
       application_fee_amount?: number;
 


### PR DESCRIPTION
Codegen for openapi 383c876.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `company_registration_verification`, `company_ministerial_decree`, `company_memorandum_of_association`, `company_license` and `company_tax_id_verification` on `AccountUpdateParams.documents` and `AccountCreateParams.documents`

