### PR TITLE
More consistent type definitions

### DIFF
--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -698,7 +698,7 @@ declare module 'stripe' {
         id: string,
         params: CustomerSourceCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<CustomerSource>>;
+      ): Promise<Stripe.Response<Stripe.CustomerSource>>;
 
       /**
        * Retrieve a specified source for a given customer.
@@ -708,12 +708,12 @@ declare module 'stripe' {
         id: string,
         params?: CustomerSourceRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<CustomerSource>>;
+      ): Promise<Stripe.Response<Stripe.CustomerSource>>;
       retrieveSource(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Response<CustomerSource>>;
+      ): Promise<Stripe.Response<Stripe.CustomerSource>>;
 
       /**
        * Update a specified source for a given customer.
@@ -726,13 +726,6 @@ declare module 'stripe' {
       ): Promise<
         Stripe.Response<Stripe.Card | Stripe.BankAccount | Stripe.Source>
       >;
-      updateSource(
-        customerId: string,
-        id: string,
-        options?: RequestOptions
-      ): Promise<
-        Stripe.Response<Stripe.Card | Stripe.BankAccount | Stripe.Source>
-      >;
 
       /**
        * List sources for a specified customer.
@@ -741,11 +734,11 @@ declare module 'stripe' {
         id: string,
         params?: CustomerSourceListParams,
         options?: RequestOptions
-      ): ApiListPromise<CustomerSource>;
+      ): ApiListPromise<Stripe.CustomerSource>;
       listSources(
         id: string,
         options?: RequestOptions
-      ): ApiListPromise<CustomerSource>;
+      ): ApiListPromise<Stripe.CustomerSource>;
 
       /**
        * Delete a specified source for a given customer.
@@ -757,7 +750,7 @@ declare module 'stripe' {
         options?: RequestOptions
       ): Promise<
         Stripe.Response<
-          | CustomerSource
+          | Stripe.CustomerSource
           | Stripe.DeletedAlipayAccount
           | Stripe.DeletedBankAccount
           | Stripe.DeletedBitcoinReceiver
@@ -770,7 +763,7 @@ declare module 'stripe' {
         options?: RequestOptions
       ): Promise<
         Stripe.Response<
-          | CustomerSource
+          | Stripe.CustomerSource
           | Stripe.DeletedAlipayAccount
           | Stripe.DeletedBankAccount
           | Stripe.DeletedBitcoinReceiver

--- a/types/2020-08-27/Refunds.d.ts
+++ b/types/2020-08-27/Refunds.d.ts
@@ -127,13 +127,6 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface RefundRetrieveParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
     interface RefundUpdateParams {
       /**
        * Specifies which fields in the response should be expanded.
@@ -144,13 +137,6 @@ declare module 'stripe' {
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
       metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
-    }
-
-    interface RefundListParams extends PaginationParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
     }
 
     interface RefundListParams extends PaginationParams {
@@ -186,21 +172,6 @@ declare module 'stripe' {
        * Retrieves the details of an existing refund.
        */
       retrieve(
-        chargeId: string,
-        id: string,
-        params?: RefundRetrieveParams,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.Refund>>;
-      retrieve(
-        chargeId: string,
-        id: string,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.Refund>>;
-
-      /**
-       * Retrieves the details of an existing refund.
-       */
-      retrieve(
         id: string,
         params?: RefundRetrieveParams,
         options?: RequestOptions
@@ -220,16 +191,6 @@ declare module 'stripe' {
         params?: RefundUpdateParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Refund>>;
-
-      /**
-       * You can see a list of the refunds belonging to a specific charge. Note that the 10 most recent refunds are always available by default on the charge object. If you need more than those 10, you can use this API method and the limit and starting_after parameters to page through additional refunds.
-       */
-      list(
-        id: string,
-        params?: RefundListParams,
-        options?: RequestOptions
-      ): ApiListPromise<Stripe.Refund>;
-      list(id: string, options?: RequestOptions): ApiListPromise<Stripe.Refund>;
 
       /**
        * Returns a list of all refunds you've previously created. The refunds are returned in sorted order, with the most recent refunds appearing first. For convenience, the 10 most recent refunds are always available by default on the charge object.


### PR DESCRIPTION
r? @stripe/api-library-reviewers 

A change in our codegen infra revealed a few inconsistencies/bugs in the Typescript definitions. This PR resolves those.

1. `CustomerSource` is now qualified as `Stripe.CustomerSource` inside `Customers.d.ts`, which is more consistent with similar references. This is a no-op. 

 2. Extra method definitions have been removed from `Refund.d.ts`. This is a bug fix. The cause of this was that the openapi spec defines methods for both `/v1/refunds/{refund}` and `/v1/charges/{charge}/refunds/{refund}`. However, the actual Javascript code in `refunds.js` only supports making requests to the `/v1/refunds/{refund}` routes, so I have removed the extra type definitions because they are incorrect and do not describe valid uses of the library.
 
3. The type definition of `stripe.customers.updateSource` without the `params` field has been removed. It doesn't make sense to call an "update" method without specifying params (although the API will accept it), and this is more consistent with what we do with other "update" methods. This is also more consistent with how we handle the multiple dispatch for `updateSource` in Java, which doesn't provide a paramsless signature.