### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -796,9 +796,9 @@ declare module 'stripe' {
           price_data?: LineItem.PriceData;
 
           /**
-           * The quantity of the line item being purchased.
+           * The quantity of the line item being purchased. Quantity should not be defined when `recurring.usage_type=metered`.
            */
-          quantity: number;
+          quantity?: number;
 
           /**
            * The [tax rates](https://stripe.com/docs/api/tax_rates) which apply to this line item.
@@ -1393,7 +1393,7 @@ declare module 'stripe' {
             plan: string;
 
             /**
-             * Quantity for this item.
+             * The quantity of the subscription item being purchased. Quantity should not be defined when `recurring.usage_type=metered`.
              */
             quantity?: number;
 

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -200,7 +200,7 @@ declare module 'stripe' {
       /**
        * The error encountered during the previous attempt to finalize the invoice. This field is cleared when the invoice is successfully finalized.
        */
-      last_finalization_error?: Invoice.LastFinalizationError | null;
+      last_finalization_error: Invoice.LastFinalizationError | null;
 
       /**
        * The individual line items that make up the invoice. `lines` is sorted as follows: invoice items in reverse chronological order, followed by the subscription, if any.

--- a/types/2020-08-27/Issuing/Disputes.d.ts
+++ b/types/2020-08-27/Issuing/Disputes.d.ts
@@ -20,7 +20,7 @@ declare module 'stripe' {
         /**
          * Disputed amount. Usually the amount of the `disputed_transaction`, but can differ (usually because of currency fluctuation).
          */
-        amount?: number;
+        amount: number;
 
         /**
          * List of balance transactions associated with the dispute.
@@ -30,14 +30,14 @@ declare module 'stripe' {
         /**
          * Time at which the object was created. Measured in seconds since the Unix epoch.
          */
-        created?: number;
+        created: number;
 
         /**
          * The currency the `disputed_transaction` was made in.
          */
-        currency?: string;
+        currency: string;
 
-        evidence?: Dispute.Evidence;
+        evidence: Dispute.Evidence;
 
         /**
          * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -47,12 +47,12 @@ declare module 'stripe' {
         /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
          */
-        metadata?: Stripe.Metadata;
+        metadata: Stripe.Metadata;
 
         /**
          * Current status of the dispute.
          */
-        status?: Dispute.Status;
+        status: Dispute.Status;
 
         /**
          * The transaction being disputed.

--- a/types/2020-08-27/Issuing/Transactions.d.ts
+++ b/types/2020-08-27/Issuing/Transactions.d.ts
@@ -60,7 +60,7 @@ declare module 'stripe' {
         /**
          * If you've disputed the transaction, the ID of the dispute.
          */
-        dispute?: string | Stripe.Issuing.Dispute | null;
+        dispute: string | Stripe.Issuing.Dispute | null;
 
         /**
          * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -286,7 +286,7 @@ declare module 'stripe' {
           }
         }
 
-        type Type = 'capture' | 'dispute' | 'refund';
+        type Type = 'capture' | 'refund';
       }
 
       interface TransactionRetrieveParams {

--- a/types/2020-08-27/LineItems.d.ts
+++ b/types/2020-08-27/LineItems.d.ts
@@ -17,7 +17,7 @@ declare module 'stripe' {
       object: 'item';
 
       /**
-       * Total before any discounts or taxes is applied.
+       * Total before any discounts or taxes are applied.
        */
       amount_subtotal: number | null;
 
@@ -42,14 +42,9 @@ declare module 'stripe' {
       discounts?: Array<LineItem.Discount>;
 
       /**
-       * Prices define the unit cost, currency, and (optional) billing cycle for both recurring and one-time purchases of products.
-       * [Products](https://stripe.com/docs/api#products) help you track inventory or provisioning, and prices help you track payment terms. Different physical goods or levels of service should be represented by products, and pricing options should be represented by prices. This approach lets you change prices without having to change your provisioning scheme.
-       *
-       * For example, you might have a single "gold" product that has prices for $10/month, $100/year, and €9 once.
-       *
-       * Related guides: [Set up a subscription](https://stripe.com/docs/billing/subscriptions/set-up-subscription), [create an invoice](https://stripe.com/docs/billing/invoices/create), and more about [products and prices](https://stripe.com/docs/billing/prices-guide).
+       * The price used to generate the line item.
        */
-      price: Stripe.Price;
+      price: Stripe.Price | null;
 
       /**
        * The quantity of products being purchased.


### PR DESCRIPTION
Codegen for openapi 75e2d85.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* `Issuing.Transaction.type` dropped enum members: 'dispute'
* `LineItem.price` can now be null.

