### PR TITLE
API Updates

### DIFF
--- a/lib/resources/EphemeralKeys.js
+++ b/lib/resources/EphemeralKeys.js
@@ -16,7 +16,7 @@ module.exports = StripeResource.extend({
     validator: (data, options) => {
       if (!options.headers || !options.headers['Stripe-Version']) {
         throw new Error(
-          'stripe_version must be specified to create an ephemeral key'
+          'Passing apiVersion in a separate options hash is required to create an ephemeral key. See https://stripe.com/docs/api/versioning?lang=node'
         );
       }
     },

--- a/test/resources/EphemeralKeys.spec.js
+++ b/test/resources/EphemeralKeys.spec.js
@@ -6,7 +6,9 @@ const expect = require('chai').expect;
 function errorsOnNoStripeVersion() {
   return expect(
     stripe.ephemeralKeys.create({customer: 'cus_123'})
-  ).to.be.eventually.rejectedWith(/stripe_version must be specified/i);
+  ).to.be.eventually.rejectedWith(
+    /Passing apiVersion in a separate options hash is required/i
+  );
 }
 
 function sendsCorrectStripeVersion() {

--- a/types/2020-08-27/LineItems.d.ts
+++ b/types/2020-08-27/LineItems.d.ts
@@ -19,12 +19,12 @@ declare module 'stripe' {
       /**
        * Total before any discounts or taxes are applied.
        */
-      amount_subtotal: number | null;
+      amount_subtotal: number;
 
       /**
        * Total after discounts and taxes.
        */
-      amount_total: number | null;
+      amount_total: number;
 
       /**
        * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).


### PR DESCRIPTION
Codegen for openapi 79b5ae3.
r? @remi-stripe
cc @stripe/api-libraries

## Changelog
* `LineItem.amount_subtotal` and `LineItem.amount_total` changed from `nullable(integer)` to `integer`
* Improve error message for `EphemeralKeys.create`
