### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/AccountLinks.d.ts
+++ b/types/2020-08-27/AccountLinks.d.ts
@@ -49,7 +49,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * The URL that the user will be redirected to if the account link is no longer valid. Your `refresh_url` should trigger a method on your server to create a new account link using this API, with the same parameters, and redirect the user to the new account link.
+       * The URL the user will be redirected to if the account link is expired, has been previously-visited, or is otherwise invalid. The URL you specify should attempt to generate a new account link with the same parameters used to create the original account link, then redirect the user to the new account link's URL so they can continue with Connect Onboarding. If a new account link cannot be generated or the redirect fails you should display a useful error to the user.
        */
       refresh_url?: string;
 

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -388,6 +388,8 @@ declare module 'stripe' {
 
         acss_debit?: PaymentMethodDetails.AcssDebit;
 
+        afterpay_clearpay?: PaymentMethodDetails.AfterpayClearpay;
+
         alipay?: PaymentMethodDetails.Alipay;
 
         au_becs_debit?: PaymentMethodDetails.AuBecsDebit;
@@ -528,6 +530,8 @@ declare module 'stripe' {
            */
           transit_number: string | null;
         }
+
+        interface AfterpayClearpay {}
 
         interface Alipay {
           /**

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -755,6 +755,11 @@ declare module 'stripe' {
 
         interface LineItem {
           /**
+           * When set, provides configuration for this item's quantity to be adjusted by the customer during Checkout.
+           */
+          adjustable_quantity?: LineItem.AdjustableQuantity;
+
+          /**
            * The amount to be collected per unit of the line item. If specified, must also pass `currency` and `name`.
            */
           amount?: number;
@@ -808,6 +813,23 @@ declare module 'stripe' {
         }
 
         namespace LineItem {
+          interface AdjustableQuantity {
+            /**
+             * Set to true if the quantity can be adjusted to any non-negative integer. By default customers will be able to remove the line item by setting the quantity to 0.
+             */
+            enabled: boolean;
+
+            /**
+             * The maximum quantity the customer can purchase for the Checkout Session. By default this value is 99.
+             */
+            maximum?: number;
+
+            /**
+             * The minimum quantity the customer must purchase for the Checkout Session. By default this value is 0.
+             */
+            minimum?: number;
+          }
+
           interface PriceData {
             /**
              * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -1058,6 +1080,7 @@ declare module 'stripe' {
         }
 
         type PaymentMethodType =
+          | 'afterpay_clearpay'
           | 'alipay'
           | 'bacs_debit'
           | 'bancontact'

--- a/types/2020-08-27/Issuing/Authorizations.d.ts
+++ b/types/2020-08-27/Issuing/Authorizations.d.ts
@@ -90,7 +90,7 @@ declare module 'stripe' {
         pending_request: Authorization.PendingRequest | null;
 
         /**
-         * History of every time the authorization was approved/denied (whether approved/denied by you directly or by Stripe based on your `spending_controls`). If the merchant changes the authorization by performing an [incremental authorization or partial capture](https://stripe.com/docs/issuing/purchases/authorizations), you can look at this field to see the previous states of the authorization.
+         * History of every time `pending_request` was approved/denied, either by you directly or by Stripe (e.g. based on your `spending_controls`). If the merchant changes the authorization by performing an [incremental authorization](https://stripe.com/docs/issuing/purchases/authorizations), you can look at this field to see the previous requests for the authorization.
          */
         request_history: Array<Authorization.RequestHistory>;
 
@@ -207,7 +207,7 @@ declare module 'stripe' {
 
         interface RequestHistory {
           /**
-           * The authorization amount in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
+           * The `pending_request.amount` at the time of the request, presented in your card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
            */
           amount: number;
 
@@ -232,7 +232,7 @@ declare module 'stripe' {
           currency: string;
 
           /**
-           * The amount that was authorized at the time of this request. This amount is in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
+           * The `pending_request.merchant_amount` at the time of the request, presented in the `merchant_currency` and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
            */
           merchant_amount: number;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -811,6 +811,11 @@ declare module 'stripe' {
 
       interface PaymentMethodData {
         /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
          * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
          */
         alipay?: PaymentMethodData.Alipay;
@@ -897,6 +902,8 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodData {
+        interface AfterpayClearpay {}
+
         interface Alipay {}
 
         interface AuBecsDebit {
@@ -1143,6 +1150,7 @@ declare module 'stripe' {
         }
 
         type Type =
+          | 'afterpay_clearpay'
           | 'alipay'
           | 'au_becs_debit'
           | 'bacs_debit'
@@ -1507,6 +1515,11 @@ declare module 'stripe' {
     namespace PaymentIntentUpdateParams {
       interface PaymentMethodData {
         /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
          * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
          */
         alipay?: PaymentMethodData.Alipay;
@@ -1593,6 +1606,8 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodData {
+        interface AfterpayClearpay {}
+
         interface Alipay {}
 
         interface AuBecsDebit {
@@ -1839,6 +1854,7 @@ declare module 'stripe' {
         }
 
         type Type =
+          | 'afterpay_clearpay'
           | 'alipay'
           | 'au_becs_debit'
           | 'bacs_debit'
@@ -2317,6 +2333,11 @@ declare module 'stripe' {
 
       interface PaymentMethodData {
         /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
          * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
          */
         alipay?: PaymentMethodData.Alipay;
@@ -2403,6 +2424,8 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodData {
+        interface AfterpayClearpay {}
+
         interface Alipay {}
 
         interface AuBecsDebit {
@@ -2649,6 +2672,7 @@ declare module 'stripe' {
         }
 
         type Type =
+          | 'afterpay_clearpay'
           | 'alipay'
           | 'au_becs_debit'
           | 'bacs_debit'

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -16,6 +16,8 @@ declare module 'stripe' {
        */
       object: 'payment_method';
 
+      afterpay_clearpay?: PaymentMethod.AfterpayClearpay;
+
       alipay?: PaymentMethod.Alipay;
 
       au_becs_debit?: PaymentMethod.AuBecsDebit;
@@ -77,6 +79,8 @@ declare module 'stripe' {
     }
 
     namespace PaymentMethod {
+      interface AfterpayClearpay {}
+
       interface Alipay {}
 
       interface AuBecsDebit {
@@ -551,6 +555,7 @@ declare module 'stripe' {
       }
 
       type Type =
+        | 'afterpay_clearpay'
         | 'alipay'
         | 'au_becs_debit'
         | 'bacs_debit'
@@ -570,6 +575,11 @@ declare module 'stripe' {
     }
 
     interface PaymentMethodCreateParams {
+      /**
+       * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+       */
+      afterpay_clearpay?: PaymentMethodCreateParams.AfterpayClearpay;
+
       /**
        * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
        */
@@ -677,6 +687,8 @@ declare module 'stripe' {
     }
 
     namespace PaymentMethodCreateParams {
+      interface AfterpayClearpay {}
+
       interface Alipay {}
 
       interface AuBecsDebit {
@@ -949,6 +961,7 @@ declare module 'stripe' {
       }
 
       type Type =
+        | 'afterpay_clearpay'
         | 'alipay'
         | 'au_becs_debit'
         | 'bacs_debit'
@@ -1104,6 +1117,7 @@ declare module 'stripe' {
 
     namespace PaymentMethodListParams {
       type Type =
+        | 'afterpay_clearpay'
         | 'alipay'
         | 'au_becs_debit'
         | 'bacs_debit'

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -71,6 +71,10 @@ declare module 'stripe' {
 
     namespace SetupAttempt {
       interface PaymentMethodDetails {
+        au_becs_debit?: PaymentMethodDetails.AuBecsDebit;
+
+        bacs_debit?: PaymentMethodDetails.BacsDebit;
+
         bancontact?: PaymentMethodDetails.Bancontact;
 
         card?: PaymentMethodDetails.Card;
@@ -78,6 +82,8 @@ declare module 'stripe' {
         card_present?: PaymentMethodDetails.CardPresent;
 
         ideal?: PaymentMethodDetails.Ideal;
+
+        sepa_debit?: PaymentMethodDetails.SepaDebit;
 
         sofort?: PaymentMethodDetails.Sofort;
 
@@ -88,6 +94,10 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodDetails {
+        interface AuBecsDebit {}
+
+        interface BacsDebit {}
+
         interface Bancontact {
           /**
            * Bank code of bank associated with the bank account.
@@ -260,6 +270,8 @@ declare module 'stripe' {
             | 'SNSBNL2A'
             | 'TRIONL2U';
         }
+
+        interface SepaDebit {}
 
         interface Sofort {
           /**


### PR DESCRIPTION
Codegen for openapi 546b28b.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Add support for `afterpay_clearpay` on `PaymentMethod`, `PaymentIntent.payment_method_data`, and `Charge.payment_method_details`.
* Add support for `afterpay_clearpay` as a payment method type on `PaymentMethod`, `PaymentIntent` and `Checkout.Session`
* Add support for `adjustable_quantity` on `SessionCreateParams.LineItem`
* Add support for `bacs_debit`, `au_becs_debit` and `sepa_debit` on `SetupAttempt.payment_method_details`

