### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1162,7 +1162,7 @@ declare module 'stripe' {
 
         interface Ideal {
           /**
-           * The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
+           * The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
            */
           bank: Ideal.Bank | null;
 
@@ -1204,6 +1204,7 @@ declare module 'stripe' {
             | 'moneyou'
             | 'rabobank'
             | 'regiobank'
+            | 'revolut'
             | 'sns_bank'
             | 'triodos_bank'
             | 'van_lanschot';
@@ -1219,6 +1220,7 @@ declare module 'stripe' {
             | 'MOYONL21'
             | 'RABONL2U'
             | 'RBRBNL21'
+            | 'REVOLT21'
             | 'SNSBNL2A'
             | 'TRIONL2U';
         }

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -228,6 +228,11 @@ declare module 'stripe' {
       number: string | null;
 
       /**
+       * The account (if any) for which the funds of the invoice payment are intended. If set, the invoice will be presented with the branding and support information of the specified account. See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
+       */
+      on_behalf_of: string | Stripe.Account | null;
+
+      /**
        * Whether payment was successfully collected for this invoice. An invoice can be paid (most commonly) with a charge or with credit from the customer's account balance.
        */
       paid: boolean;
@@ -799,6 +804,11 @@ declare module 'stripe' {
       metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
 
       /**
+       * The account (if any) for which the funds of the invoice payment are intended. If set, the invoice will be presented with the branding and support information of the specified account. See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
+       */
+      on_behalf_of?: string;
+
+      /**
        * Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
        */
       payment_settings?: InvoiceCreateParams.PaymentSettings;
@@ -1009,6 +1019,11 @@ declare module 'stripe' {
       metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
 
       /**
+       * The account (if any) for which the funds of the invoice payment are intended. If set, the invoice will be presented with the branding and support information of the specified account. See the [Invoices with Connect](https://stripe.com/docs/billing/invoices/connect) documentation for details.
+       */
+      on_behalf_of?: Stripe.Emptyable<string>;
+
+      /**
        * Configuration settings for the PaymentIntent that is generated when the invoice is finalized.
        */
       payment_settings?: InvoiceUpdateParams.PaymentSettings;
@@ -1171,7 +1186,7 @@ declare module 'stripe' {
 
     interface InvoiceFinalizeInvoiceParams {
       /**
-       * Controls whether Stripe will perform [automatic collection](https://stripe.com/docs/billing/invoices/workflow/#auto_advance) of the invoice. When `false`, the invoice's state will not automatically advance without an explicit action.
+       * Controls whether Stripe will perform [automatic collection](https://stripe.com/docs/billing/invoices/overview#auto-advance) of the invoice. When `false`, the invoice's state will not automatically advance without an explicit action.
        */
       auto_advance?: boolean;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -1086,6 +1086,7 @@ declare module 'stripe' {
             | 'moneyou'
             | 'rabobank'
             | 'regiobank'
+            | 'revolut'
             | 'sns_bank'
             | 'triodos_bank'
             | 'van_lanschot';
@@ -1790,6 +1791,7 @@ declare module 'stripe' {
             | 'moneyou'
             | 'rabobank'
             | 'regiobank'
+            | 'revolut'
             | 'sns_bank'
             | 'triodos_bank'
             | 'van_lanschot';
@@ -2608,6 +2610,7 @@ declare module 'stripe' {
             | 'moneyou'
             | 'rabobank'
             | 'regiobank'
+            | 'revolut'
             | 'sns_bank'
             | 'triodos_bank'
             | 'van_lanschot';

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -421,7 +421,7 @@ declare module 'stripe' {
 
       interface Ideal {
         /**
-         * The customer's bank, if provided. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
+         * The customer's bank, if provided. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
          */
         bank: Ideal.Bank | null;
 
@@ -442,6 +442,7 @@ declare module 'stripe' {
           | 'moneyou'
           | 'rabobank'
           | 'regiobank'
+          | 'revolut'
           | 'sns_bank'
           | 'triodos_bank'
           | 'van_lanschot';
@@ -457,6 +458,7 @@ declare module 'stripe' {
           | 'MOYONL21'
           | 'RABONL2U'
           | 'RBRBNL21'
+          | 'REVOLT21'
           | 'SNSBNL2A'
           | 'TRIONL2U';
       }
@@ -897,6 +899,7 @@ declare module 'stripe' {
           | 'moneyou'
           | 'rabobank'
           | 'regiobank'
+          | 'revolut'
           | 'sns_bank'
           | 'triodos_bank'
           | 'van_lanschot';

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -210,7 +210,7 @@ declare module 'stripe' {
 
         interface Ideal {
           /**
-           * The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
+           * The customer's bank. Can be one of `abn_amro`, `asn_bank`, `bunq`, `handelsbanken`, `ing`, `knab`, `moneyou`, `rabobank`, `regiobank`, `revolut`, `sns_bank`, `triodos_bank`, or `van_lanschot`.
            */
           bank: Ideal.Bank | null;
 
@@ -252,6 +252,7 @@ declare module 'stripe' {
             | 'moneyou'
             | 'rabobank'
             | 'regiobank'
+            | 'revolut'
             | 'sns_bank'
             | 'triodos_bank'
             | 'van_lanschot';
@@ -267,6 +268,7 @@ declare module 'stripe' {
             | 'MOYONL21'
             | 'RABONL2U'
             | 'RBRBNL21'
+            | 'REVOLT21'
             | 'SNSBNL2A'
             | 'TRIONL2U';
         }


### PR DESCRIPTION
Codegen for openapi 9918f6f.
r? @ctrudeau-stripe 
cc @stripe/api-libraries

## Changelog
* Add support for `on_behalf_of` to `Invoice`
* Add support for enum member `revolut` on `PaymentIntent.payment_method_data.ideal.bank`, `PaymentMethod.ideal.bank`, `Charge.payment_method_details.ideal.bank` and `SetupAttempt.payment_method_details.ideal.bank`
* Added support for enum member `REVOLT21` on `PaymentMethod.ideal.bic`, `Charge.payment_method_details.ideal.bic` and `SetupAttempt.payment_method_details.ideal.bic`

