### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -693,10 +693,10 @@ declare module 'stripe' {
 
         /**
          * A list of items the customer is purchasing. Use this parameter to pass one-time or recurring [Prices](https://stripe.com/docs/api/prices).
-         * One-time Prices in `subscription` mode will be on the initial invoice only.
          *
-         * There is a maximum of 100 line items, however it is recommended to
-         * consolidate line items if there are more than a few dozen.
+         * For `payment` mode, there is a maximum of 100 line items, however it is recommended to consolidate line items if there are more than a few dozen.
+         *
+         * For `subscription` mode, there is a maximum of 20 line items with recurring Prices and 20 line items with one-time Prices. Line items with one-time Prices in will be on the initial invoice only.
          */
         line_items?: Array<SessionCreateParams.LineItem>;
 
@@ -993,7 +993,7 @@ declare module 'stripe' {
           receipt_email?: string;
 
           /**
-           * Indicates that you intend to make future payments with the payment
+           * Indicates that you intend to [make future payments](https://stripe.com/docs/payments/payment-intents#future-usage) with the payment
            * method collected by this Checkout Session.
            *
            * When setting this to `on_session`, Checkout will show a notice to the
@@ -1403,6 +1403,11 @@ declare module 'stripe' {
           metadata?: Stripe.MetadataParam;
 
           /**
+           * If specified, the funds from the subscription's invoices will be transferred to the destination and the ID of the resulting transfers will be found on the resulting charges.
+           */
+          transfer_data?: SubscriptionData.TransferData;
+
+          /**
            * Unix timestamp representing the end of the trial period the customer
            * will get before being charged for the first time. Has to be at least
            * 48 hours in the future.
@@ -1438,6 +1443,18 @@ declare module 'stripe' {
              * on `subscription_data` do not apply to this item.
              */
             tax_rates?: Array<string>;
+          }
+
+          interface TransferData {
+            /**
+             * A non-negative decimal between 0 and 100, with at most two decimal places. This represents the percentage of the subscription invoice subtotal that will be transferred to the destination account. By default, the entire amount is transferred to the destination.
+             */
+            amount_percent?: number;
+
+            /**
+             * ID of an existing, connected Stripe account.
+             */
+            destination: string;
           }
         }
       }

--- a/types/2020-08-27/Reporting/ReportRuns.d.ts
+++ b/types/2020-08-27/Reporting/ReportRuns.d.ts
@@ -29,7 +29,7 @@ declare module 'stripe' {
         error: string | null;
 
         /**
-         * Always `true`: reports can only be run on live-mode data.
+         * `true` if the report is run on live mode data and `false` if it is run on test mode data.
          */
         livemode: boolean;
 
@@ -817,7 +817,7 @@ declare module 'stripe' {
 
       class ReportRunsResource {
         /**
-         * Creates a new object and begin running the report. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
+         * Creates a new object and begin running the report. (Certain report types require a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
          */
         create(
           params: ReportRunCreateParams,
@@ -825,7 +825,7 @@ declare module 'stripe' {
         ): Promise<Stripe.Response<Stripe.Reporting.ReportRun>>;
 
         /**
-         * Retrieves the details of an existing Report Run. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
+         * Retrieves the details of an existing Report Run.
          */
         retrieve(
           id: string,
@@ -838,7 +838,7 @@ declare module 'stripe' {
         ): Promise<Stripe.Response<Stripe.Reporting.ReportRun>>;
 
         /**
-         * Returns a list of Report Runs, with the most recent appearing first. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
+         * Returns a list of Report Runs, with the most recent appearing first.
          */
         list(
           params?: ReportRunListParams,

--- a/types/2020-08-27/Reporting/ReportTypes.d.ts
+++ b/types/2020-08-27/Reporting/ReportTypes.d.ts
@@ -64,7 +64,7 @@ declare module 'stripe' {
 
       class ReportTypesResource {
         /**
-         * Retrieves the details of a Report Type. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
+         * Retrieves the details of a Report Type. (Certain report types require a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
          */
         retrieve(
           id: string,
@@ -77,7 +77,7 @@ declare module 'stripe' {
         ): Promise<Stripe.Response<Stripe.Reporting.ReportType>>;
 
         /**
-         * Returns a full list of Report Types. (Requires a [live-mode API key](https://stripe.com/docs/keys#test-live-modes).)
+         * Returns a full list of Report Types.
          */
         list(
           params?: ReportTypeListParams,

--- a/types/2020-08-27/SubscriptionSchedules.d.ts
+++ b/types/2020-08-27/SubscriptionSchedules.d.ts
@@ -476,7 +476,7 @@ declare module 'stripe' {
 
       interface Phase {
         /**
-         * A list of prices and quantities that will generate invoice items appended to the next invoice. You may pass up to 10 items.
+         * A list of prices and quantities that will generate invoice items appended to the next invoice. You may pass up to 20 items.
          */
         add_invoice_items?: Array<Phase.AddInvoiceItem>;
 
@@ -851,7 +851,7 @@ declare module 'stripe' {
 
       interface Phase {
         /**
-         * A list of prices and quantities that will generate invoice items appended to the next invoice. You may pass up to 10 items.
+         * A list of prices and quantities that will generate invoice items appended to the next invoice. You may pass up to 20 items.
          */
         add_invoice_items?: Array<Phase.AddInvoiceItem>;
 

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -288,7 +288,7 @@ declare module 'stripe' {
       customer: string;
 
       /**
-       * A list of prices and quantities that will generate invoice items appended to the first invoice for this subscription. You may pass up to 10 items.
+       * A list of prices and quantities that will generate invoice items appended to the first invoice for this subscription. You may pass up to 20 items.
        */
       add_invoice_items?: Array<SubscriptionCreateParams.AddInvoiceItem>;
 
@@ -620,7 +620,7 @@ declare module 'stripe' {
 
     interface SubscriptionUpdateParams {
       /**
-       * A list of prices and quantities that will generate invoice items appended to the first invoice for this subscription. You may pass up to 10 items.
+       * A list of prices and quantities that will generate invoice items appended to the first invoice for this subscription. You may pass up to 20 items.
        */
       add_invoice_items?: Array<SubscriptionUpdateParams.AddInvoiceItem>;
 


### PR DESCRIPTION
Codegen for openapi 9458a29.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `transfer_data` on `SessionCreateParams.subscription_data`

