### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -153,6 +153,11 @@ declare module 'stripe' {
 
       interface Capabilities {
         /**
+         * The status of the ACSS Direct Debits payments capability of the account, or whether the account can directly process ACSS Direct Debits charges.
+         */
+        acss_debit_payments?: Capabilities.AcssDebitPayments;
+
+        /**
          * The status of the Afterpay Clearpay capability of the account, or whether the account can directly process Afterpay Clearpay charges.
          */
         afterpay_clearpay_payments?: Capabilities.AfterpayClearpayPayments;
@@ -259,6 +264,8 @@ declare module 'stripe' {
       }
 
       namespace Capabilities {
+        type AcssDebitPayments = 'active' | 'inactive' | 'pending';
+
         type AfterpayClearpayPayments = 'active' | 'inactive' | 'pending';
 
         type AuBecsDebitPayments = 'active' | 'inactive' | 'pending';
@@ -985,6 +992,11 @@ declare module 'stripe' {
 
       interface Capabilities {
         /**
+         * The acss_debit_payments capability.
+         */
+        acss_debit_payments?: Capabilities.AcssDebitPayments;
+
+        /**
          * The afterpay_clearpay_payments capability.
          */
         afterpay_clearpay_payments?: Capabilities.AfterpayClearpayPayments;
@@ -1091,6 +1103,13 @@ declare module 'stripe' {
       }
 
       namespace Capabilities {
+        interface AcssDebitPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
         interface AfterpayClearpayPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
@@ -2029,6 +2048,11 @@ declare module 'stripe' {
 
       interface Capabilities {
         /**
+         * The acss_debit_payments capability.
+         */
+        acss_debit_payments?: Capabilities.AcssDebitPayments;
+
+        /**
          * The afterpay_clearpay_payments capability.
          */
         afterpay_clearpay_payments?: Capabilities.AfterpayClearpayPayments;
@@ -2135,6 +2159,13 @@ declare module 'stripe' {
       }
 
       namespace Capabilities {
+        interface AcssDebitPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
         interface AfterpayClearpayPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -29,7 +29,7 @@ declare module 'stripe' {
       /**
        * The account tax IDs associated with the invoice. Only editable when the invoice is a draft.
        */
-      account_tax_ids?: Array<
+      account_tax_ids: Array<
         string | Stripe.TaxId | Stripe.DeletedTaxId
       > | null;
 

--- a/types/2020-08-27/Mandates.d.ts
+++ b/types/2020-08-27/Mandates.d.ts
@@ -83,6 +83,8 @@ declare module 'stripe' {
       interface MultiUse {}
 
       interface PaymentMethodDetails {
+        acss_debit?: PaymentMethodDetails.AcssDebit;
+
         au_becs_debit?: PaymentMethodDetails.AuBecsDebit;
 
         bacs_debit?: PaymentMethodDetails.BacsDebit;
@@ -98,6 +100,29 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodDetails {
+        interface AcssDebit {
+          /**
+           * Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+           */
+          interval_description: string | null;
+
+          /**
+           * Payment schedule for the mandate.
+           */
+          payment_schedule: AcssDebit.PaymentSchedule;
+
+          /**
+           * Transaction type of the mandate.
+           */
+          transaction_type: AcssDebit.TransactionType;
+        }
+
+        namespace AcssDebit {
+          type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+          type TransactionType = 'business' | 'personal';
+        }
+
         interface AuBecsDebit {
           /**
            * The URL of the mandate. This URL generally contains sensitive information about the customer and should be shared with them exclusively.

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -338,6 +338,8 @@ declare module 'stripe' {
          * When confirming a PaymentIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js.
          */
         use_stripe_sdk?: NextAction.UseStripeSdk;
+
+        verify_with_microdeposits?: NextAction.VerifyWithMicrodeposits;
       }
 
       namespace NextAction {
@@ -393,9 +395,23 @@ declare module 'stripe' {
         }
 
         interface UseStripeSdk {}
+
+        interface VerifyWithMicrodeposits {
+          /**
+           * The timestamp when the microdeposits are expected to land.
+           */
+          arrival_date: number;
+
+          /**
+           * The URL for the hosted verification page, which allows customers to verify their bank account.
+           */
+          hosted_verification_url: string;
+        }
       }
 
       interface PaymentMethodOptions {
+        acss_debit?: PaymentMethodOptions.AcssDebit;
+
         alipay?: PaymentMethodOptions.Alipay;
 
         bancontact?: PaymentMethodOptions.Bancontact;
@@ -412,6 +428,47 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Bank account verification method.
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text
+             */
+            custom_mandate_url?: string;
+
+            /**
+             * Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+             */
+            interval_description: string | null;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule: MandateOptions.PaymentSchedule | null;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type: MandateOptions.TransactionType | null;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Alipay {}
 
         interface Bancontact {
@@ -811,6 +868,11 @@ declare module 'stripe' {
 
       interface PaymentMethodData {
         /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
          * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
          */
         afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
@@ -902,6 +964,23 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
         interface AfterpayClearpay {}
 
         interface Alipay {}
@@ -1151,6 +1230,7 @@ declare module 'stripe' {
         }
 
         type Type =
+          | 'acss_debit'
           | 'afterpay_clearpay'
           | 'alipay'
           | 'au_becs_debit'
@@ -1168,6 +1248,11 @@ declare module 'stripe' {
       }
 
       interface PaymentMethodOptions {
+        /**
+         * If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
+         */
+        acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
         /**
          * If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
          */
@@ -1205,6 +1290,52 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Additional fields for Mandate creation
+           */
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text to render during confirmation step.
+             * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+             * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+             */
+            custom_mandate_url?: Stripe.Emptyable<string>;
+
+            /**
+             * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             */
+            interval_description?: string;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule?: MandateOptions.PaymentSchedule;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type?: MandateOptions.TransactionType;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Alipay {}
 
         interface Bancontact {
@@ -1516,6 +1647,11 @@ declare module 'stripe' {
     namespace PaymentIntentUpdateParams {
       interface PaymentMethodData {
         /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
          * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
          */
         afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
@@ -1607,6 +1743,23 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
         interface AfterpayClearpay {}
 
         interface Alipay {}
@@ -1856,6 +2009,7 @@ declare module 'stripe' {
         }
 
         type Type =
+          | 'acss_debit'
           | 'afterpay_clearpay'
           | 'alipay'
           | 'au_becs_debit'
@@ -1873,6 +2027,11 @@ declare module 'stripe' {
       }
 
       interface PaymentMethodOptions {
+        /**
+         * If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
+         */
+        acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
         /**
          * If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
          */
@@ -1910,6 +2069,52 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Additional fields for Mandate creation
+           */
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text to render during confirmation step.
+             * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+             * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+             */
+            custom_mandate_url?: Stripe.Emptyable<string>;
+
+            /**
+             * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             */
+            interval_description?: string;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule?: MandateOptions.PaymentSchedule;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type?: MandateOptions.TransactionType;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Alipay {}
 
         interface Bancontact {
@@ -2335,6 +2540,11 @@ declare module 'stripe' {
 
       interface PaymentMethodData {
         /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
          * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
          */
         afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
@@ -2426,6 +2636,23 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
         interface AfterpayClearpay {}
 
         interface Alipay {}
@@ -2675,6 +2902,7 @@ declare module 'stripe' {
         }
 
         type Type =
+          | 'acss_debit'
           | 'afterpay_clearpay'
           | 'alipay'
           | 'au_becs_debit'
@@ -2692,6 +2920,11 @@ declare module 'stripe' {
       }
 
       interface PaymentMethodOptions {
+        /**
+         * If this is a `acss_debit` PaymentMethod, this sub-hash contains details about the ACSS Debit payment method options.
+         */
+        acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
         /**
          * If this is a `alipay` PaymentMethod, this sub-hash contains details about the Alipay payment method options.
          */
@@ -2729,6 +2962,52 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Additional fields for Mandate creation
+           */
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text to render during confirmation step.
+             * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+             * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+             */
+            custom_mandate_url?: Stripe.Emptyable<string>;
+
+            /**
+             * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             */
+            interval_description?: string;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule?: MandateOptions.PaymentSchedule;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type?: MandateOptions.TransactionType;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Alipay {}
 
         interface Bancontact {

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -16,6 +16,8 @@ declare module 'stripe' {
        */
       object: 'payment_method';
 
+      acss_debit?: PaymentMethod.AcssDebit;
+
       afterpay_clearpay?: PaymentMethod.AfterpayClearpay;
 
       alipay?: PaymentMethod.Alipay;
@@ -79,6 +81,33 @@ declare module 'stripe' {
     }
 
     namespace PaymentMethod {
+      interface AcssDebit {
+        /**
+         * Name of the bank associated with the bank account.
+         */
+        bank_name: string | null;
+
+        /**
+         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+         */
+        fingerprint: string | null;
+
+        /**
+         * Institution number of the bank account.
+         */
+        institution_number: string | null;
+
+        /**
+         * Last four digits of the bank account number.
+         */
+        last4: string | null;
+
+        /**
+         * Transit number of the bank account.
+         */
+        transit_number: string | null;
+      }
+
       interface AfterpayClearpay {}
 
       interface Alipay {}
@@ -559,6 +588,7 @@ declare module 'stripe' {
       }
 
       type Type =
+        | 'acss_debit'
         | 'afterpay_clearpay'
         | 'alipay'
         | 'au_becs_debit'
@@ -579,6 +609,11 @@ declare module 'stripe' {
     }
 
     interface PaymentMethodCreateParams {
+      /**
+       * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+       */
+      acss_debit?: PaymentMethodCreateParams.AcssDebit;
+
       /**
        * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
        */
@@ -691,6 +726,23 @@ declare module 'stripe' {
     }
 
     namespace PaymentMethodCreateParams {
+      interface AcssDebit {
+        /**
+         * Customer's bank account number.
+         */
+        account_number: string;
+
+        /**
+         * Institution number of the customer's bank.
+         */
+        institution_number: string;
+
+        /**
+         * Transit number of the customer's bank.
+         */
+        transit_number: string;
+      }
+
       interface AfterpayClearpay {}
 
       interface Alipay {}
@@ -966,6 +1018,7 @@ declare module 'stripe' {
       }
 
       type Type =
+        | 'acss_debit'
         | 'afterpay_clearpay'
         | 'alipay'
         | 'au_becs_debit'
@@ -1122,6 +1175,7 @@ declare module 'stripe' {
 
     namespace PaymentMethodListParams {
       type Type =
+        | 'acss_debit'
         | 'afterpay_clearpay'
         | 'alipay'
         | 'au_becs_debit'

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -71,6 +71,8 @@ declare module 'stripe' {
 
     namespace SetupAttempt {
       interface PaymentMethodDetails {
+        acss_debit?: PaymentMethodDetails.AcssDebit;
+
         au_becs_debit?: PaymentMethodDetails.AuBecsDebit;
 
         bacs_debit?: PaymentMethodDetails.BacsDebit;
@@ -94,6 +96,8 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodDetails {
+        interface AcssDebit {}
+
         interface AuBecsDebit {}
 
         interface BacsDebit {}

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -241,6 +241,8 @@ declare module 'stripe' {
          * When confirming a SetupIntent with Stripe.js, Stripe.js depends on the contents of this dictionary to invoke authentication flows. The shape of the contents is subject to change and is only intended to be used by Stripe.js.
          */
         use_stripe_sdk?: NextAction.UseStripeSdk;
+
+        verify_with_microdeposits?: NextAction.VerifyWithMicrodeposits;
       }
 
       namespace NextAction {
@@ -257,15 +259,77 @@ declare module 'stripe' {
         }
 
         interface UseStripeSdk {}
+
+        interface VerifyWithMicrodeposits {
+          /**
+           * The timestamp when the microdeposits are expected to land.
+           */
+          arrival_date: number;
+
+          /**
+           * The URL for the hosted verification page, which allows customers to verify their bank account.
+           */
+          hosted_verification_url: string;
+        }
       }
 
       interface PaymentMethodOptions {
+        acss_debit?: PaymentMethodOptions.AcssDebit;
+
         card?: PaymentMethodOptions.Card;
 
         sepa_debit?: PaymentMethodOptions.SepaDebit;
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Currency supported by the bank account
+           */
+          currency: AcssDebit.Currency | null;
+
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Bank account verification method.
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          type Currency = 'cad' | 'usd';
+
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text
+             */
+            custom_mandate_url?: string;
+
+            /**
+             * Description of the interval. Only required if 'payment_schedule' parmeter is 'interval' or 'combined'.
+             */
+            interval_description: string | null;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule: MandateOptions.PaymentSchedule | null;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type: MandateOptions.TransactionType | null;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Card {
           /**
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
@@ -416,6 +480,11 @@ declare module 'stripe' {
 
       interface PaymentMethodOptions {
         /**
+         * If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
+         */
+        acss_debit?: PaymentMethodOptions.AcssDebit;
+
+        /**
          * Configuration for any card setup attempted on this SetupIntent.
          */
         card?: PaymentMethodOptions.Card;
@@ -427,6 +496,59 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency?: AcssDebit.Currency;
+
+          /**
+           * Additional fields for Mandate creation
+           */
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          type Currency = 'cad' | 'usd';
+
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text to render during confirmation step.
+             * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+             * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+             */
+            custom_mandate_url?: Stripe.Emptyable<string>;
+
+            /**
+             * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             */
+            interval_description?: string;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule?: MandateOptions.PaymentSchedule;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type?: MandateOptions.TransactionType;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Card {
           /**
            * When specified, this parameter signals that a card has been collected
@@ -526,6 +648,11 @@ declare module 'stripe' {
     namespace SetupIntentUpdateParams {
       interface PaymentMethodOptions {
         /**
+         * If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
+         */
+        acss_debit?: PaymentMethodOptions.AcssDebit;
+
+        /**
          * Configuration for any card setup attempted on this SetupIntent.
          */
         card?: PaymentMethodOptions.Card;
@@ -537,6 +664,59 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency?: AcssDebit.Currency;
+
+          /**
+           * Additional fields for Mandate creation
+           */
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          type Currency = 'cad' | 'usd';
+
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text to render during confirmation step.
+             * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+             * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+             */
+            custom_mandate_url?: Stripe.Emptyable<string>;
+
+            /**
+             * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             */
+            interval_description?: string;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule?: MandateOptions.PaymentSchedule;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type?: MandateOptions.TransactionType;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Card {
           /**
            * When specified, this parameter signals that a card has been collected
@@ -727,6 +907,11 @@ declare module 'stripe' {
 
       interface PaymentMethodOptions {
         /**
+         * If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
+         */
+        acss_debit?: PaymentMethodOptions.AcssDebit;
+
+        /**
          * Configuration for any card setup attempted on this SetupIntent.
          */
         card?: PaymentMethodOptions.Card;
@@ -738,6 +923,59 @@ declare module 'stripe' {
       }
 
       namespace PaymentMethodOptions {
+        interface AcssDebit {
+          /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency?: AcssDebit.Currency;
+
+          /**
+           * Additional fields for Mandate creation
+           */
+          mandate_options?: AcssDebit.MandateOptions;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: AcssDebit.VerificationMethod;
+        }
+
+        namespace AcssDebit {
+          type Currency = 'cad' | 'usd';
+
+          interface MandateOptions {
+            /**
+             * A URL for custom mandate text to render during confirmation step.
+             * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+             * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+             */
+            custom_mandate_url?: Stripe.Emptyable<string>;
+
+            /**
+             * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             */
+            interval_description?: string;
+
+            /**
+             * Payment schedule for the mandate.
+             */
+            payment_schedule?: MandateOptions.PaymentSchedule;
+
+            /**
+             * Transaction type of the mandate.
+             */
+            transaction_type?: MandateOptions.TransactionType;
+          }
+
+          namespace MandateOptions {
+            type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+            type TransactionType = 'business' | 'personal';
+          }
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
+
         interface Card {
           /**
            * When specified, this parameter signals that a card has been collected


### PR DESCRIPTION
Codegen for openapi 3e77877.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `acss_debit_payments` on `Account.capabilities`
* Added support for `payment_method_options` on `Checkout.Session`
* Added support for `acss_debit` on `SetupIntent.payment_method_options`, `SetupAttempt.payment_method_details`, `PaymentMethod`, `PaymentIntent.payment_method_options`,  `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_data`, `PaymentIntentUpdateParams.payment_method_data`, `PaymentIntentCreateParams.payment_method_data`, `Mandate.payment_method_details` and `SetupIntent.payment_method_options`
* Added support for `verify_with_microdeposits` on `PaymentIntent.next_action` and `SetupIntent.next_action`
* Added support for `acss_debit` as member of the `type` enum on `PaymentMethod` and `PaymentIntent`, and inside `Checkout.SessionCreateParams.payment_method_types[]`.
