### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -286,14 +286,14 @@ declare module 'stripe' {
 
         namespace PaymentMethodOptions {
           interface AcssDebit {
+            currency?: string;
+
             mandate_options?: AcssDebit.MandateOptions;
 
             /**
              * Bank account verification method.
              */
             verification_method?: AcssDebit.VerificationMethod;
-
-            currency?: string;
           }
 
           namespace AcssDebit {

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -418,6 +418,8 @@ declare module 'stripe' {
 
         card?: PaymentMethodOptions.Card;
 
+        card_present?: PaymentMethodOptions.CardPresent;
+
         oxxo?: PaymentMethodOptions.Oxxo;
 
         p24?: PaymentMethodOptions.P24;
@@ -491,7 +493,7 @@ declare module 'stripe' {
           installments: Card.Installments | null;
 
           /**
-           * Selected network to process this PaymentIntent on. Depends on the available networks of the card attached to the PaymentIntent. Can be only set confirm-time.
+           * Selected network to process this payment intent on. Depends on the available networks of the card attached to the payment intent. Can be only set confirm-time.
            */
           network: Card.Network | null;
 
@@ -571,6 +573,8 @@ declare module 'stripe' {
 
           type RequestThreeDSecure = 'any' | 'automatic' | 'challenge_only';
         }
+
+        interface CardPresent {}
 
         interface Oxxo {
           /**
@@ -1269,6 +1273,11 @@ declare module 'stripe' {
         card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
 
         /**
+         * If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
+         */
+        card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
+
+        /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
         oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
@@ -1430,6 +1439,8 @@ declare module 'stripe' {
 
           type RequestThreeDSecure = 'any' | 'automatic';
         }
+
+        interface CardPresent {}
 
         interface Oxxo {
           /**
@@ -2048,6 +2059,11 @@ declare module 'stripe' {
         card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
 
         /**
+         * If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
+         */
+        card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
+
+        /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
         oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
@@ -2209,6 +2225,8 @@ declare module 'stripe' {
 
           type RequestThreeDSecure = 'any' | 'automatic';
         }
+
+        interface CardPresent {}
 
         interface Oxxo {
           /**
@@ -2941,6 +2959,11 @@ declare module 'stripe' {
         card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
 
         /**
+         * If this is a `card_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
+         */
+        card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
+
+        /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
         oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
@@ -3102,6 +3125,8 @@ declare module 'stripe' {
 
           type RequestThreeDSecure = 'any' | 'automatic';
         }
+
+        interface CardPresent {}
 
         interface Oxxo {
           /**

--- a/types/2020-08-27/SubscriptionItems.d.ts
+++ b/types/2020-08-27/SubscriptionItems.d.ts
@@ -126,6 +126,8 @@ declare module 'stripe' {
       /**
        * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
        *
+       * Use `default_incomplete` to transition the subscription to `status=past_due` when payment is required and await explicit confirmation of the invoice's payment intent. This allows simpler management of scenarios where additional user actions are needed to pay a subscription's invoice. Such as failed payments, [SCA regulation](https://stripe.com/docs/billing/migration/strong-customer-authentication), or collecting a mandate for a bank debit payment method.
+       *
        * Use `pending_if_incomplete` to update the subscription using [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates). When you use `pending_if_incomplete` you can only pass the parameters [supported by pending updates](https://stripe.com/docs/billing/pending-updates-reference#supported-attributes).
        *
        * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not update the subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
@@ -182,6 +184,7 @@ declare module 'stripe' {
 
       type PaymentBehavior =
         | 'allow_incomplete'
+        | 'default_incomplete'
         | 'error_if_incomplete'
         | 'pending_if_incomplete';
 
@@ -266,6 +269,8 @@ declare module 'stripe' {
       /**
        * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
        *
+       * Use `default_incomplete` to transition the subscription to `status=past_due` when payment is required and await explicit confirmation of the invoice's payment intent. This allows simpler management of scenarios where additional user actions are needed to pay a subscription's invoice. Such as failed payments, [SCA regulation](https://stripe.com/docs/billing/migration/strong-customer-authentication), or collecting a mandate for a bank debit payment method.
+       *
        * Use `pending_if_incomplete` to update the subscription using [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates). When you use `pending_if_incomplete` you can only pass the parameters [supported by pending updates](https://stripe.com/docs/billing/pending-updates-reference#supported-attributes).
        *
        * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not update the subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
@@ -322,6 +327,7 @@ declare module 'stripe' {
 
       type PaymentBehavior =
         | 'allow_incomplete'
+        | 'default_incomplete'
         | 'error_if_incomplete'
         | 'pending_if_incomplete';
 

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -377,6 +377,8 @@ declare module 'stripe' {
       /**
        * Use `allow_incomplete` to create subscriptions with `status=incomplete` if the first invoice cannot be paid. Creating subscriptions with this status allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
        *
+       * Use `default_incomplete` to create Subscriptions with `status=incomplete` when the first invoice requires payment, otherwise start as active. Subscriptions transition to `status=active` when successfully confirming the payment intent on the first invoice. This allows simpler management of scenarios where additional user actions are needed to pay a subscription's invoice. Such as failed payments, [SCA regulation](https://stripe.com/docs/billing/migration/strong-customer-authentication), or collecting a mandate for a bank debit payment method. If the payment intent is not confirmed within 23 hours subscriptions transition to `status=expired_incomplete`, which is a terminal state.
+       *
        * Use `error_if_incomplete` if you want Stripe to return an HTTP 402 status code if a subscription's first invoice cannot be paid. For example, if a payment method requires 3DS authentication due to SCA regulation and further user action is needed, this parameter does not create a subscription and returns an error instead. This was the default behavior for API versions prior to 2019-03-14. See the [changelog](https://stripe.com/docs/upgrades#2019-03-14) to learn more.
        *
        * `pending_if_incomplete` is only used with updates and cannot be passed when creating a subscription.
@@ -577,6 +579,7 @@ declare module 'stripe' {
 
       type PaymentBehavior =
         | 'allow_incomplete'
+        | 'default_incomplete'
         | 'error_if_incomplete'
         | 'pending_if_incomplete';
 
@@ -710,6 +713,8 @@ declare module 'stripe' {
 
       /**
        * Use `allow_incomplete` to transition the subscription to `status=past_due` if a payment is required but cannot be paid. This allows you to manage scenarios where additional user actions are needed to pay a subscription's invoice. For example, SCA regulation may require 3DS authentication to complete payment. See the [SCA Migration Guide](https://stripe.com/docs/billing/migration/strong-customer-authentication) for Billing to learn more. This is the default behavior.
+       *
+       * Use `default_incomplete` to transition the subscription to `status=past_due` when payment is required and await explicit confirmation of the invoice's payment intent. This allows simpler management of scenarios where additional user actions are needed to pay a subscription's invoice. Such as failed payments, [SCA regulation](https://stripe.com/docs/billing/migration/strong-customer-authentication), or collecting a mandate for a bank debit payment method.
        *
        * Use `pending_if_incomplete` to update the subscription using [pending updates](https://stripe.com/docs/billing/subscriptions/pending-updates). When you use `pending_if_incomplete` you can only pass the parameters [supported by pending updates](https://stripe.com/docs/billing/pending-updates-reference#supported-attributes).
        *
@@ -946,6 +951,7 @@ declare module 'stripe' {
 
       type PaymentBehavior =
         | 'allow_incomplete'
+        | 'default_incomplete'
         | 'error_if_incomplete'
         | 'pending_if_incomplete';
 
@@ -1013,7 +1019,7 @@ declare module 'stripe' {
       price?: string;
 
       /**
-       * The status of the subscriptions to retrieve. Passing in a value of `canceled` will return all canceled subscriptions, including those belonging to deleted customers. Pass `ended` to find subscriptions that are canceled and subscriptions that are expired due to [incomplete payment](https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses). Passing in a value of `all` will return subscriptions of all statuses.
+       * The status of the subscriptions to retrieve. Passing in a value of `canceled` will return all canceled subscriptions, including those belonging to deleted customers. Pass `ended` to find subscriptions that are canceled and subscriptions that are expired due to [incomplete payment](https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses). Passing in a value of `all` will return subscriptions of all statuses. If no value is supplied, all subscriptions that have not been canceled are returned.
        */
       status?: SubscriptionListParams.Status;
     }


### PR DESCRIPTION
Codegen for openapi 9c11715.
r? @remi-stripe 
cc @stripe/api-libraries

## Changelog
* Added support for `currency` on `Checkout.Session.payment_method_options.acss_debit`
* Added support for `card_present` on `PaymentIntent#confirm.payment_method_options`, `PaymentIntent#update.payment_method_options`, `PaymentIntent#create.payment_method_options` and `PaymentIntent.payment_method_options`
* `SubscriptionItem#create.payment_behavior`, `Subscription#update.payment_behavior`, `Subscription#create.payment_behavior` and `SubscriptionItem#update.payment_behavior` added new enum members: `default_incomplete`

