### PR TITLE
Remove deprecated bodyParser dep in webhook examples

### DIFF
--- a/examples/webhook-signing/node-express/express.js
+++ b/examples/webhook-signing/node-express/express.js
@@ -1,7 +1,6 @@
 require('dotenv').config();
 const stripe = require('stripe')(process.env.STRIPE_SECRET_KEY);
 const express = require('express');
-const bodyParser = require('body-parser');
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
@@ -12,12 +11,12 @@ app.use((req, res, next) => {
   if (req.originalUrl === '/webhook') {
     next();
   } else {
-    bodyParser.json()(req, res, next);
+    express.json()(req, res, next);
   }
 });
 
 // Stripe requires the raw body to construct the event
-app.post('/webhook', bodyParser.raw({type: 'application/json'}), (req, res) => {
+app.post('/webhook', express.raw({type: 'application/json'}), (req, res) => {
   const sig = req.headers['stripe-signature'];
 
   let event;

--- a/examples/webhook-signing/typescript-node-express/express-ts.ts
+++ b/examples/webhook-signing/typescript-node-express/express-ts.ts
@@ -1,6 +1,5 @@
 import Stripe from 'stripe';
 import express from 'express';
-import bodyParser from 'body-parser';
 import env from 'dotenv';
 
 env.config();
@@ -23,7 +22,7 @@ app.use(
     if (req.originalUrl === '/webhook') {
       next();
     } else {
-      bodyParser.json()(req, res, next);
+      express.json()(req, res, next);
     }
   }
 );
@@ -31,7 +30,7 @@ app.use(
 app.post(
   '/webhook',
   // Stripe requires the raw body to construct the event
-  bodyParser.raw({type: 'application/json'}),
+  express.raw({type: 'application/json'}),
   (req: express.Request, res: express.Response): void => {
     const sig = req.headers['stripe-signature'];
 


### PR DESCRIPTION
In express 4.16+, bodyParser is now accessible through the `express` module directly: https://stackoverflow.com/questions/66525078/bodyparser-is-deprecated

![image](https://user-images.githubusercontent.com/1611510/117175643-5b81c980-adcf-11eb-86b5-2c7c49eb02bd.png)

Tada!

![image](https://user-images.githubusercontent.com/1611510/117175665-60df1400-adcf-11eb-955d-7e28b3841934.png)

Thanks!
