### PR TITLE
Fix webhook signatures docs link

### DIFF
--- a/README.md
+++ b/README.md
@@ -328,7 +328,7 @@ stripe.off('request', onRequest);
 
 ### Webhook signing
 
-Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party. You can read more about it [here](https://stripe.com/docs/webhooks#signatures).
+Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party. You can read more about it [here](https://stripe.com/docs/webhooks/signatures).
 
 Please note that you must pass the _raw_ request body, exactly as received from Stripe, to the `constructEvent()` function; this will not work with a parsed (i.e., JSON) request body.
 


### PR DESCRIPTION
Webhook signatures are documented on their own page now. This PR updates a README link to reflect that.