### PR TITLE
Added paper_check to Invoices/PaymentMethodType

### DIFF
--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -617,6 +617,7 @@ declare module 'stripe' {
           | 'fpx'
           | 'giropay'
           | 'ideal'
+          | 'paper_check'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort';
@@ -947,6 +948,7 @@ declare module 'stripe' {
           | 'fpx'
           | 'giropay'
           | 'ideal'
+          | 'paper_check'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort';
@@ -1169,6 +1171,7 @@ declare module 'stripe' {
           | 'fpx'
           | 'giropay'
           | 'ideal'
+          | 'paper_check'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort';


### PR DESCRIPTION
Payment Methods includes `paper_check`, but the types don't include it. 

See here: https://stripe.com/docs/invoicing/overview#payment-methods

![image](https://user-images.githubusercontent.com/6189367/122446313-85064700-cf70-11eb-8005-c4532e86aa69.png)

There is another instance of PaymentMethods in `types/2020-08-27/Checkout/Sessions.d.ts` but I'm not sure if paper checks are supported in that case.