### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -398,6 +398,8 @@ declare module 'stripe' {
 
         bancontact?: PaymentMethodDetails.Bancontact;
 
+        boleto?: PaymentMethodDetails.Boleto;
+
         card?: PaymentMethodDetails.Card;
 
         card_present?: PaymentMethodDetails.CardPresent;
@@ -640,6 +642,13 @@ declare module 'stripe' {
 
         namespace Bancontact {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
+        interface Boleto {
+          /**
+           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           */
+          tax_id: string;
         }
 
         interface Card {

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -215,7 +215,7 @@ declare module 'stripe' {
 
           interface TaxId {
             /**
-             * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, or `unknown`
+             * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown`
              */
             type: TaxId.Type;
 
@@ -244,6 +244,7 @@ declare module 'stripe' {
               | 'gb_vat'
               | 'hk_br'
               | 'id_npwp'
+              | 'il_vat'
               | 'in_gst'
               | 'jp_cn'
               | 'jp_rn'

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -414,7 +414,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+         * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
          */
         type: TaxIdDatum.Type;
 
@@ -443,6 +443,7 @@ declare module 'stripe' {
           | 'gb_vat'
           | 'hk_br'
           | 'id_npwp'
+          | 'il_vat'
           | 'in_gst'
           | 'jp_cn'
           | 'jp_rn'

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -369,7 +369,7 @@ declare module 'stripe' {
 
         interface TaxId {
           /**
-           * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+           * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
            */
           type: TaxId.Type;
 
@@ -398,6 +398,7 @@ declare module 'stripe' {
             | 'gb_vat'
             | 'hk_br'
             | 'id_npwp'
+            | 'il_vat'
             | 'in_gst'
             | 'jp_cn'
             | 'jp_rn'

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -393,7 +393,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -422,6 +422,7 @@ declare module 'stripe' {
           | 'gb_vat'
           | 'hk_br'
           | 'id_npwp'
+          | 'il_vat'
           | 'in_gst'
           | 'jp_cn'
           | 'jp_rn'
@@ -1491,7 +1492,7 @@ declare module 'stripe' {
 
         interface TaxId {
           /**
-           * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+           * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
            */
           type: TaxId.Type;
 
@@ -1520,6 +1521,7 @@ declare module 'stripe' {
             | 'gb_vat'
             | 'hk_br'
             | 'id_npwp'
+            | 'il_vat'
             | 'in_gst'
             | 'jp_cn'
             | 'jp_rn'

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -325,6 +325,8 @@ declare module 'stripe' {
       interface NextAction {
         alipay_handle_redirect?: NextAction.AlipayHandleRedirect;
 
+        boleto_display_details?: NextAction.BoletoDisplayDetails;
+
         oxxo_display_details?: NextAction.OxxoDisplayDetails;
 
         redirect_to_url?: NextAction.RedirectToUrl;
@@ -363,6 +365,28 @@ declare module 'stripe' {
            * The URL you must redirect your customer to in order to authenticate the payment.
            */
           url: string | null;
+        }
+
+        interface BoletoDisplayDetails {
+          /**
+           * The timestamp after which the boleto expires.
+           */
+          expires_at: number | null;
+
+          /**
+           * The URL to the hosted boleto voucher page, which allows customers to view the boleto voucher.
+           */
+          hosted_voucher_url: string | null;
+
+          /**
+           * The boleto number.
+           */
+          number: string | null;
+
+          /**
+           * The URL to the downloadable boleto voucher PDF.
+           */
+          pdf: string | null;
         }
 
         interface OxxoDisplayDetails {
@@ -417,6 +441,8 @@ declare module 'stripe' {
         alipay?: PaymentMethodOptions.Alipay;
 
         bancontact?: PaymentMethodOptions.Bancontact;
+
+        boleto?: PaymentMethodOptions.Boleto;
 
         card?: PaymentMethodOptions.Card;
 
@@ -492,6 +518,13 @@ declare module 'stripe' {
 
         namespace Bancontact {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
+        interface Boleto {
+          /**
+           * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
+           */
+          expires_after_days: number;
         }
 
         interface Card {
@@ -917,6 +950,11 @@ declare module 'stripe' {
         billing_details?: PaymentMethodData.BillingDetails;
 
         /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
          * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
          */
         eps?: PaymentMethodData.Eps;
@@ -1079,6 +1117,13 @@ declare module 'stripe' {
              */
             state?: string;
           }
+        }
+
+        interface Boleto {
+          /**
+           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           */
+          tax_id: string;
         }
 
         interface Eps {
@@ -1250,6 +1295,7 @@ declare module 'stripe' {
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
+          | 'boleto'
           | 'eps'
           | 'fpx'
           | 'giropay'
@@ -1283,6 +1329,11 @@ declare module 'stripe' {
          * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
          */
         bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
+         */
+        boleto?: Stripe.Emptyable<PaymentMethodOptions.Boleto>;
 
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
@@ -1381,6 +1432,13 @@ declare module 'stripe' {
 
         namespace Bancontact {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
+        interface Boleto {
+          /**
+           * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto invoice will expire on Wednesday at 23:59 America/Sao_Paulo time.
+           */
+          expires_after_days?: number;
         }
 
         interface Card {
@@ -1718,6 +1776,11 @@ declare module 'stripe' {
         billing_details?: PaymentMethodData.BillingDetails;
 
         /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
          * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
          */
         eps?: PaymentMethodData.Eps;
@@ -1880,6 +1943,13 @@ declare module 'stripe' {
              */
             state?: string;
           }
+        }
+
+        interface Boleto {
+          /**
+           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           */
+          tax_id: string;
         }
 
         interface Eps {
@@ -2051,6 +2121,7 @@ declare module 'stripe' {
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
+          | 'boleto'
           | 'eps'
           | 'fpx'
           | 'giropay'
@@ -2084,6 +2155,11 @@ declare module 'stripe' {
          * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
          */
         bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
+         */
+        boleto?: Stripe.Emptyable<PaymentMethodOptions.Boleto>;
 
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
@@ -2182,6 +2258,13 @@ declare module 'stripe' {
 
         namespace Bancontact {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
+        interface Boleto {
+          /**
+           * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto invoice will expire on Wednesday at 23:59 America/Sao_Paulo time.
+           */
+          expires_after_days?: number;
         }
 
         interface Card {
@@ -2633,6 +2716,11 @@ declare module 'stripe' {
         billing_details?: PaymentMethodData.BillingDetails;
 
         /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
          * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
          */
         eps?: PaymentMethodData.Eps;
@@ -2795,6 +2883,13 @@ declare module 'stripe' {
              */
             state?: string;
           }
+        }
+
+        interface Boleto {
+          /**
+           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           */
+          tax_id: string;
         }
 
         interface Eps {
@@ -2966,6 +3061,7 @@ declare module 'stripe' {
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
+          | 'boleto'
           | 'eps'
           | 'fpx'
           | 'giropay'
@@ -2999,6 +3095,11 @@ declare module 'stripe' {
          * If this is a `bancontact` PaymentMethod, this sub-hash contains details about the Bancontact payment method options.
          */
         bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this sub-hash contains details about the Boleto payment method options.
+         */
+        boleto?: Stripe.Emptyable<PaymentMethodOptions.Boleto>;
 
         /**
          * Configuration for any card payments attempted on this PaymentIntent.
@@ -3097,6 +3198,13 @@ declare module 'stripe' {
 
         namespace Bancontact {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+        }
+
+        interface Boleto {
+          /**
+           * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto invoice will expire on Wednesday at 23:59 America/Sao_Paulo time.
+           */
+          expires_after_days?: number;
         }
 
         interface Card {

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -30,6 +30,8 @@ declare module 'stripe' {
 
       billing_details: PaymentMethod.BillingDetails;
 
+      boleto?: PaymentMethod.Boleto;
+
       card?: PaymentMethod.Card;
 
       card_present?: PaymentMethod.CardPresent;
@@ -168,6 +170,13 @@ declare module 'stripe' {
          * Billing phone number (including extension).
          */
         phone: string | null;
+      }
+
+      interface Boleto {
+        /**
+         * Uniquely identifies the customer tax id (CNPJ or CPF)
+         */
+        tax_id: string;
       }
 
       interface Card {
@@ -594,6 +603,7 @@ declare module 'stripe' {
         | 'au_becs_debit'
         | 'bacs_debit'
         | 'bancontact'
+        | 'boleto'
         | 'card'
         | 'card_present'
         | 'eps'
@@ -643,6 +653,11 @@ declare module 'stripe' {
        * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
        */
       billing_details?: PaymentMethodCreateParams.BillingDetails;
+
+      /**
+       * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+       */
+      boleto?: PaymentMethodCreateParams.Boleto;
 
       /**
        * If this is a `card` PaymentMethod, this hash contains the user's card details. For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`. When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance). We strongly recommend using Stripe.js instead of interacting with this API directly.
@@ -827,6 +842,13 @@ declare module 'stripe' {
            */
           state?: string;
         }
+      }
+
+      interface Boleto {
+        /**
+         * Uniquely identifies this customer tax_id (CNPJ or CPF)
+         */
+        tax_id: string;
       }
 
       interface Card1 {
@@ -1024,6 +1046,7 @@ declare module 'stripe' {
         | 'au_becs_debit'
         | 'bacs_debit'
         | 'bancontact'
+        | 'boleto'
         | 'card'
         | 'eps'
         | 'fpx'
@@ -1188,6 +1211,7 @@ declare module 'stripe' {
         | 'au_becs_debit'
         | 'bacs_debit'
         | 'bancontact'
+        | 'boleto'
         | 'card'
         | 'card_present'
         | 'eps'

--- a/types/2020-08-27/TaxIds.d.ts
+++ b/types/2020-08-27/TaxIds.d.ts
@@ -39,7 +39,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -73,6 +73,7 @@ declare module 'stripe' {
         | 'gb_vat'
         | 'hk_br'
         | 'id_npwp'
+        | 'il_vat'
         | 'in_gst'
         | 'jp_cn'
         | 'jp_rn'
@@ -139,7 +140,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
        */
       type: TaxIdCreateParams.Type;
 
@@ -173,6 +174,7 @@ declare module 'stripe' {
         | 'gb_vat'
         | 'hk_br'
         | 'id_npwp'
+        | 'il_vat'
         | 'in_gst'
         | 'jp_cn'
         | 'jp_rn'


### PR DESCRIPTION
Codegen for openapi d12f3f1.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `boleto` on `PaymentMethodCreateParams`, `PaymentIntent.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_data`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_data`, `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentCreateParams.payment_method_data`, `Charge.payment_method_details` and `PaymentMethod`
* `PaymentMethodListParams.type`, `PaymentMethodCreateParams.type`, `PaymentIntentConfirmParams.payment_method_data.type`, `PaymentIntentUpdateParams.payment_method_data.type`, `PaymentIntentCreataParams.payment_method_data.type` and `PaymentMethod.type` added new enum members: `boleto`
* Added support for `boleto_display_details` on `PaymentIntent.next_action`
* `TaxIdCreateParams.type`, `Invoice.customer_tax_ids[].type`, `InvoiceLineItemListUpcomingParams.customer_details.tax_ids[].type`, `InvoiceUpcomingParams.customer_details.tax_ids[].type`, `CustomerCreateParams.tax_id_data[].type`, `Checkout.Session.customer_details.tax_ids[].type` and `TaxId.type` added new enum members: `il_vat`.


