### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -180,6 +180,11 @@ declare module 'stripe' {
         bancontact_payments?: Capabilities.BancontactPayments;
 
         /**
+         * The status of the boleto payments capability of the account, or whether the account can directly process boleto charges.
+         */
+        boleto_payments?: Capabilities.BoletoPayments;
+
+        /**
          * The status of the card issuing capability of the account, or whether you can use Issuing to distribute funds on cards
          */
         card_issuing?: Capabilities.CardIssuing;
@@ -275,6 +280,8 @@ declare module 'stripe' {
         type BacsDebitPayments = 'active' | 'inactive' | 'pending';
 
         type BancontactPayments = 'active' | 'inactive' | 'pending';
+
+        type BoletoPayments = 'active' | 'inactive' | 'pending';
 
         type CardIssuing = 'active' | 'inactive' | 'pending';
 
@@ -1040,6 +1047,11 @@ declare module 'stripe' {
         bancontact_payments?: Capabilities.BancontactPayments;
 
         /**
+         * The boleto_payments capability.
+         */
+        boleto_payments?: Capabilities.BoletoPayments;
+
+        /**
          * The card_issuing capability.
          */
         card_issuing?: Capabilities.CardIssuing;
@@ -1155,6 +1167,13 @@ declare module 'stripe' {
         }
 
         interface BancontactPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface BoletoPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */
@@ -2138,6 +2157,11 @@ declare module 'stripe' {
         bancontact_payments?: Capabilities.BancontactPayments;
 
         /**
+         * The boleto_payments capability.
+         */
+        boleto_payments?: Capabilities.BoletoPayments;
+
+        /**
          * The card_issuing capability.
          */
         card_issuing?: Capabilities.CardIssuing;
@@ -2253,6 +2277,13 @@ declare module 'stripe' {
         }
 
         interface BancontactPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface BoletoPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -312,6 +312,10 @@ declare module 'stripe' {
 
         interface PaymentMethodOptions {
           acss_debit?: PaymentMethodOptions.AcssDebit;
+
+          boleto?: PaymentMethodOptions.Boleto;
+
+          oxxo?: PaymentMethodOptions.Oxxo;
         }
 
         namespace PaymentMethodOptions {
@@ -356,6 +360,20 @@ declare module 'stripe' {
             }
 
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
+          interface Boleto {
+            /**
+             * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
+             */
+            expires_after_days: number;
+          }
+
+          interface Oxxo {
+            /**
+             * The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+             */
+            expires_after_days: number;
           }
         }
 
@@ -1253,6 +1271,16 @@ declare module 'stripe' {
            * contains details about the ACSS Debit payment method options.
            */
           acss_debit?: PaymentMethodOptions.AcssDebit;
+
+          /**
+           * contains details about the Boleto payment method options.
+           */
+          boleto?: PaymentMethodOptions.Boleto;
+
+          /**
+           * contains details about the OXXO payment method options.
+           */
+          oxxo?: PaymentMethodOptions.Oxxo;
         }
 
         namespace PaymentMethodOptions {
@@ -1308,6 +1336,20 @@ declare module 'stripe' {
 
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
+
+          interface Boleto {
+            /**
+             * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto invoice will expire on Wednesday at 23:59 America/Sao_Paulo time.
+             */
+            expires_after_days?: number;
+          }
+
+          interface Oxxo {
+            /**
+             * The number of calendar days before an OXXO voucher expires. For example, if you create an OXXO voucher on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+             */
+            expires_after_days?: number;
+          }
         }
 
         type PaymentMethodType =
@@ -1316,12 +1358,14 @@ declare module 'stripe' {
           | 'alipay'
           | 'bacs_debit'
           | 'bancontact'
+          | 'boleto'
           | 'card'
           | 'eps'
           | 'fpx'
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'oxxo'
           | 'p24'
           | 'sepa_debit'
           | 'sofort';


### PR DESCRIPTION
Codegen for openapi 3237fde.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Added support for `boleto_payments` on `Account.capabilities`
* Added support for `boleto` and `oxxo` on `Checkout.SessionCreateParams.payment_method_options` and `Checkout.Session.payment_method_options`
* Added support for `boleto` and `oxxo` as members of the `type` enum inside `Checkout.SessionCreateParams.payment_method_types[]`.

