### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -440,6 +440,8 @@ declare module 'stripe' {
         type: string;
 
         wechat?: PaymentMethodDetails.Wechat;
+
+        wechat_pay?: PaymentMethodDetails.WechatPay;
       }
 
       namespace PaymentMethodDetails {
@@ -1573,6 +1575,18 @@ declare module 'stripe' {
         interface StripeAccount {}
 
         interface Wechat {}
+
+        interface WechatPay {
+          /**
+           * Uniquely identifies this particular WeChat Pay account. You can use this attribute to check whether two WeChat accounts are the same.
+           */
+          fingerprint: string | null;
+
+          /**
+           * Transaction ID of this particular WeChat Pay transaction.
+           */
+          transaction_id: string | null;
+        }
       }
 
       interface Shipping {

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -1281,6 +1281,11 @@ declare module 'stripe' {
            * contains details about the OXXO payment method options.
            */
           oxxo?: PaymentMethodOptions.Oxxo;
+
+          /**
+           * contains details about the Wechat Pay payment method options.
+           */
+          wechat_pay?: PaymentMethodOptions.WechatPay;
         }
 
         namespace PaymentMethodOptions {
@@ -1350,6 +1355,22 @@ declare module 'stripe' {
              */
             expires_after_days?: number;
           }
+
+          interface WechatPay {
+            /**
+             * The app ID registered with WeChat Pay. Only required when client is ios or android.
+             */
+            app_id?: string;
+
+            /**
+             * The client type that the end customer will pay from
+             */
+            client: WechatPay.Client;
+          }
+
+          namespace WechatPay {
+            type Client = 'android' | 'ios' | 'web';
+          }
         }
 
         type PaymentMethodType =
@@ -1368,7 +1389,8 @@ declare module 'stripe' {
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
 
         interface SetupIntentData {
           /**

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -624,7 +624,8 @@ declare module 'stripe' {
           | 'ideal'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
       }
 
       type Status =
@@ -954,7 +955,8 @@ declare module 'stripe' {
           | 'ideal'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
       }
 
       interface TransferData {
@@ -1176,7 +1178,8 @@ declare module 'stripe' {
           | 'ideal'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
       }
 
       interface TransferData {

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -342,6 +342,12 @@ declare module 'stripe' {
         use_stripe_sdk?: NextAction.UseStripeSdk;
 
         verify_with_microdeposits?: NextAction.VerifyWithMicrodeposits;
+
+        wechat_pay_display_qr_code?: NextAction.WechatPayDisplayQrCode;
+
+        wechat_pay_redirect_to_android_app?: NextAction.WechatPayRedirectToAndroidApp;
+
+        wechat_pay_redirect_to_ios_app?: NextAction.WechatPayRedirectToIosApp;
       }
 
       namespace NextAction {
@@ -431,6 +437,62 @@ declare module 'stripe' {
            */
           hosted_verification_url: string;
         }
+
+        interface WechatPayDisplayQrCode {
+          /**
+           * The data being used to generate QR code
+           */
+          data: string;
+
+          /**
+           * The base64 image data for a pre-generated QR code
+           */
+          image_data_url: string;
+        }
+
+        interface WechatPayRedirectToAndroidApp {
+          /**
+           * app_id is the APP ID registered on WeChat open platform
+           */
+          app_id: string;
+
+          /**
+           * nonce_str is a random string
+           */
+          nonce_str: string;
+
+          /**
+           * package is static value
+           */
+          package: string;
+
+          /**
+           * an unique merchant ID assigned by Wechat Pay
+           */
+          partner_id: string;
+
+          /**
+           * an unique trading ID assigned by Wechat Pay
+           */
+          prepay_id: string;
+
+          /**
+           * A signature
+           */
+          sign: string;
+
+          /**
+           * Specifies the current time in epoch format
+           */
+          timestamp: string;
+        }
+
+        interface WechatPayRedirectToIosApp {
+          /**
+           * An universal link that redirect to Wechat Pay APP
+           */
+          native_url: string;
+        }
       }
 
       interface PaymentMethodOptions {
@@ -455,6 +517,8 @@ declare module 'stripe' {
         sepa_debit?: PaymentMethodOptions.SepaDebit;
 
         sofort?: PaymentMethodOptions.Sofort;
+
+        wechat_pay?: PaymentMethodOptions.WechatPay;
       }
 
       namespace PaymentMethodOptions {
@@ -652,6 +716,22 @@ declare module 'stripe' {
             | 'it'
             | 'nl'
             | 'pl';
+        }
+
+        interface WechatPay {
+          /**
+           * The app ID registered with WeChat Pay. Only required when client is ios or android.
+           */
+          app_id: string | null;
+
+          /**
+           * The client type that the end customer will pay from
+           */
+          client: WechatPay.Client | null;
+        }
+
+        namespace WechatPay {
+          type Client = 'android' | 'ios' | 'web';
         }
       }
 
@@ -1013,6 +1093,11 @@ declare module 'stripe' {
          * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
          */
         type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
       }
 
       namespace PaymentMethodData {
@@ -1304,7 +1389,10 @@ declare module 'stripe' {
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {
@@ -1364,6 +1452,11 @@ declare module 'stripe' {
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
         sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+        /**
+         * If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
+         */
+        wechat_pay?: Stripe.Emptyable<PaymentMethodOptions.WechatPay>;
       }
 
       namespace PaymentMethodOptions {
@@ -1566,6 +1659,22 @@ declare module 'stripe' {
             | 'it'
             | 'nl'
             | 'pl';
+        }
+
+        interface WechatPay {
+          /**
+           * The app ID registered with WeChat Pay. Only required when client is ios or android.
+           */
+          app_id?: string;
+
+          /**
+           * The client type that the end customer will pay from
+           */
+          client: WechatPay.Client;
+        }
+
+        namespace WechatPay {
+          type Client = 'android' | 'ios' | 'web';
         }
       }
 
@@ -1839,6 +1948,11 @@ declare module 'stripe' {
          * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
          */
         type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
       }
 
       namespace PaymentMethodData {
@@ -2130,7 +2244,10 @@ declare module 'stripe' {
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {
@@ -2190,6 +2307,11 @@ declare module 'stripe' {
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
         sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+        /**
+         * If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
+         */
+        wechat_pay?: Stripe.Emptyable<PaymentMethodOptions.WechatPay>;
       }
 
       namespace PaymentMethodOptions {
@@ -2392,6 +2514,22 @@ declare module 'stripe' {
             | 'it'
             | 'nl'
             | 'pl';
+        }
+
+        interface WechatPay {
+          /**
+           * The app ID registered with WeChat Pay. Only required when client is ios or android.
+           */
+          app_id?: string;
+
+          /**
+           * The client type that the end customer will pay from
+           */
+          client: WechatPay.Client;
+        }
+
+        namespace WechatPay {
+          type Client = 'android' | 'ios' | 'web';
         }
       }
 
@@ -2779,6 +2917,11 @@ declare module 'stripe' {
          * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
          */
         type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
       }
 
       namespace PaymentMethodData {
@@ -3070,7 +3213,10 @@ declare module 'stripe' {
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
-          | 'sofort';
+          | 'sofort'
+          | 'wechat_pay';
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {
@@ -3130,6 +3276,11 @@ declare module 'stripe' {
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
         sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+        /**
+         * If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
+         */
+        wechat_pay?: Stripe.Emptyable<PaymentMethodOptions.WechatPay>;
       }
 
       namespace PaymentMethodOptions {
@@ -3332,6 +3483,22 @@ declare module 'stripe' {
             | 'it'
             | 'nl'
             | 'pl';
+        }
+
+        interface WechatPay {
+          /**
+           * The app ID registered with WeChat Pay. Only required when client is ios or android.
+           */
+          app_id?: string;
+
+          /**
+           * The client type that the end customer will pay from
+           */
+          client: WechatPay.Client;
+        }
+
+        namespace WechatPay {
+          type Client = 'android' | 'ios' | 'web';
         }
       }
 

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -80,6 +80,8 @@ declare module 'stripe' {
        * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
        */
       type: PaymentMethod.Type;
+
+      wechat_pay?: PaymentMethod.WechatPay;
     }
 
     namespace PaymentMethod {
@@ -615,7 +617,10 @@ declare module 'stripe' {
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'
-        | 'sofort';
+        | 'sofort'
+        | 'wechat_pay';
+
+      interface WechatPay {}
     }
 
     interface PaymentMethodCreateParams {
@@ -738,6 +743,11 @@ declare module 'stripe' {
        * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
        */
       type?: PaymentMethodCreateParams.Type;
+
+      /**
+       * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+       */
+      wechat_pay?: PaymentMethodCreateParams.WechatPay;
     }
 
     namespace PaymentMethodCreateParams {
@@ -1056,7 +1066,10 @@ declare module 'stripe' {
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'
-        | 'sofort';
+        | 'sofort'
+        | 'wechat_pay';
+
+      interface WechatPay {}
     }
 
     interface PaymentMethodRetrieveParams {
@@ -1222,7 +1235,8 @@ declare module 'stripe' {
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'
-        | 'sofort';
+        | 'sofort'
+        | 'wechat_pay';
     }
 
     interface PaymentMethodAttachParams {


### PR DESCRIPTION
Codegen for openapi 49d7fd2.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `wechat_pay` on `Charge.payment_method_details`, `CheckoutSessionCreateParams.payment_method_options`, `PaymentIntentCreateParams.payment_method_data`, `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_data`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_data`, `PaymentIntentConfirmParams.payment_method_options`, `PaymentIntent.payment_method_options`, `PaymentMethodCreateParams`, and `PaymentMethod`
* Add support for new value `wechat_pay` on enums `CheckoutSessionCreateParams.payment_method_types[]`, `InvoiceCreateParams.payment_settings.payment_method_types[]`, `InvoiceUpdateParams.payment_settings.payment_method_types[]`, `Invoice.payment_settings.payment_method_types[]`, `PaymentIntentCreateParams.payment_method_data.type`, `PaymentIntentUpdateParams.payment_method_data.type`, `PaymentIntentConfirmParams.payment_method_data.type`, `PaymentMethodCreateParams.type`, `PaymentMethodListParams.type`, and `PaymentMethod.type`
* Add support for `wechat_pay_display_qr_code`, `wechat_pay_redirect_to_android_app`, and `wechat_pay_redirect_to_ios_app` on `PaymentIntent.next_action`


