### PR TITLE
Streaming method support fixes

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -481,7 +481,7 @@ StripeResource.prototype = {
             ((res || {}).headers || {})['retry-after']
           );
         } else {
-          if (options.streaming && res.statusCode <= 400) {
+          if (options.streaming && res.statusCode < 400) {
             return this._streamingResponseHandler(req, callback)(res);
           }
           return this._jsonResponseHandler(req, callback)(res);

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -196,6 +196,8 @@ declare module 'stripe' {
       autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
     }
 
+    export type StripeStreamResponse = NodeJS.ReadableStream;
+
     /**
      * The Stripe API uses url-encoding for requests, and stripe-node encodes a
      * `null` param as an empty string, because there is no concept of `null`


### PR DESCRIPTION
r? @dcr-stripe 
## Summary
Contains two changes that should have been in #1157 but were not.

1. Successful HTTP requests are those with status codes *strictly less* than 400, not `<=` 400. Luckily I made a bad request while testing and caught this.
2. Expose a `StripeStreamResponse` typescript type to describe the return types of binary streaming methods.