### PR TITLE
Test for global `stripeAccount`

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -351,6 +351,7 @@ StripeResource.prototype = {
       'X-Stripe-Client-User-Agent': clientUserAgent,
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
       'Stripe-Version': apiVersion,
+      'Stripe-Account': this._stripe.getApiField('stripeAccount'),
       'Idempotency-Key': this._defaultIdempotencyKey(
         method,
         userSuppliedSettings

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -38,6 +38,7 @@ const ALLOWED_CONFIG_PROPERTIES = [
   'protocol',
   'telemetry',
   'appInfo',
+  'stripeAccount',
 ];
 
 const EventEmitter = require('events').EventEmitter;
@@ -92,6 +93,7 @@ function Stripe(key, config = {}) {
     ),
     agent: props.httpAgent || null,
     dev: false,
+    stripeAccount: props.stripeAccount || null,
   };
 
   const typescript = props.typescript || false;

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -474,6 +474,29 @@ describe('Stripe Module', function() {
     });
   });
 
+  describe('stripeAccount', () => {
+    describe('when passed in via the config object', () => {
+      it('is respected', () => {
+        const newStripe = testUtils.getSpyableStripe((token) =>
+          Stripe(token, {
+            stripeAccount: 'my_stripe_account',
+          })
+        );
+        expect(newStripe.getApiField('stripeAccount')).to.equal(
+          'my_stripe_account'
+        );
+        newStripe.customers.create();
+        expect(newStripe.LAST_REQUEST).to.deep.equal({
+          data: {},
+          headers: {'stripe-account': 'my_stripe_account'},
+          settings: {},
+          method: 'POST',
+          url: '/v1/customers',
+        });
+      });
+    });
+  });
+
   describe('setMaxNetworkRetries', () => {
     describe('when given an empty or non-number variable', () => {
       it('should error', () => {

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -44,12 +44,12 @@ const utils = (module.exports = {
     return key;
   },
 
-  getSpyableStripe: () => {
+  getSpyableStripe: (getClient) => {
     // Provide a testable stripe instance
     // That is, with mock-requests built in and hookable
 
     const stripe = require('../lib/stripe');
-    const stripeInstance = stripe('fakeAuthToken');
+    const stripeInstance = (getClient || stripe)('fakeAuthToken');
 
     stripeInstance.REQUESTS = [];
 

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -44,12 +44,12 @@ const utils = (module.exports = {
     return key;
   },
 
-  getSpyableStripe: (getClient) => {
+  getSpyableStripe: () => {
     // Provide a testable stripe instance
     // That is, with mock-requests built in and hookable
 
     const stripe = require('../lib/stripe');
-    const stripeInstance = (getClient || stripe)('fakeAuthToken');
+    const stripeInstance = stripe('fakeAuthToken');
 
     stripeInstance.REQUESTS = [];
 

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -103,6 +103,11 @@ declare module 'stripe' {
        * @docs https://stripe.com/docs/building-plugins?lang=node#setappinfo
        */
       appInfo?: AppInfo;
+
+      /**
+       * An account id on whose behalf you wish to make every request.
+       */
+      stripeAccount?: string;
     }
 
     export interface RequestOptions {


### PR DESCRIPTION
## Notify
r? @stripe/api-library-reviewers 
cc @stripe/api-libraries 

## Summary
Adds a test on top of user @lyndonbuckley's contribution #1102 (which I will merge first), to let stripeAccount be settable when initializing the stripe client, plus a test.