### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -905,7 +905,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * A card or bank account to attach to the account for receiving [payouts](https://stripe.com/docs/connect/bank-debit-card-payouts) (you won't be able to use it for top-ups). You can provide either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary, as documented in the `external_account` parameter for [bank account](https://stripe.com/docs/api#account_create_bank_account) creation.
+       * A card or bank account to attach to the account for receiving [payouts](https://stripe.com/docs/connect/bank-debit-card-payouts) (you won't be able to use it for top-ups). You can provide either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe-js), or a dictionary, as documented in the `external_account` parameter for [bank account](https://stripe.com/docs/api#account_create_bank_account) creation.
        *
        * By default, providing an external account sets it as the new default external account for its currency, and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API.
        */
@@ -1619,7 +1619,7 @@ declare module 'stripe' {
         gender?: string;
 
         /**
-         * The government-issued ID number of the individual, as appropriate for the representative's country. (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada). Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://stripe.com/docs/stripe.js#collecting-pii-data).
+         * The government-issued ID number of the individual, as appropriate for the representative's country. (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada). Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://stripe.com/docs/js/tokens_sources/create_token?type=pii).
          */
         id_number?: string;
 
@@ -2020,7 +2020,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * A card or bank account to attach to the account for receiving [payouts](https://stripe.com/docs/connect/bank-debit-card-payouts) (you won't be able to use it for top-ups). You can provide either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe.js), or a dictionary, as documented in the `external_account` parameter for [bank account](https://stripe.com/docs/api#account_create_bank_account) creation.
+       * A card or bank account to attach to the account for receiving [payouts](https://stripe.com/docs/connect/bank-debit-card-payouts) (you won't be able to use it for top-ups). You can provide either a token, like the ones returned by [Stripe.js](https://stripe.com/docs/stripe-js), or a dictionary, as documented in the `external_account` parameter for [bank account](https://stripe.com/docs/api#account_create_bank_account) creation.
        *
        * By default, providing an external account sets it as the new default external account for its currency, and deletes the old default if one exists. To add additional external accounts without replacing the existing default for the currency, use the bank account or card creation API.
        */
@@ -2692,7 +2692,7 @@ declare module 'stripe' {
         gender?: string;
 
         /**
-         * The government-issued ID number of the individual, as appropriate for the representative's country. (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada). Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://stripe.com/docs/stripe.js#collecting-pii-data).
+         * The government-issued ID number of the individual, as appropriate for the representative's country. (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada). Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://stripe.com/docs/js/tokens_sources/create_token?type=pii).
          */
         id_number?: string;
 

--- a/types/2020-08-27/CreditNoteLineItems.d.ts
+++ b/types/2020-08-27/CreditNoteLineItems.d.ts
@@ -177,7 +177,7 @@ declare module 'stripe' {
     namespace CreditNoteLineItemListPreviewParams {
       interface Line {
         /**
-         * The line item amount to credit. Only valid when `type` is `invoice_line_item` and the referenced invoice line item does not have a quantity, only an amount.
+         * The line item amount to credit. Only valid when `type` is `invoice_line_item`.
          */
         amount?: number;
 

--- a/types/2020-08-27/CreditNotes.d.ts
+++ b/types/2020-08-27/CreditNotes.d.ts
@@ -236,7 +236,7 @@ declare module 'stripe' {
     namespace CreditNoteCreateParams {
       interface Line {
         /**
-         * The line item amount to credit. Only valid when `type` is `invoice_line_item` and the referenced invoice line item does not have a quantity, only an amount.
+         * The line item amount to credit. Only valid when `type` is `invoice_line_item`.
          */
         amount?: number;
 
@@ -388,7 +388,7 @@ declare module 'stripe' {
     namespace CreditNotePreviewParams {
       interface Line {
         /**
-         * The line item amount to credit. Only valid when `type` is `invoice_line_item` and the referenced invoice line item does not have a quantity, only an amount.
+         * The line item amount to credit. Only valid when `type` is `invoice_line_item`.
          */
         amount?: number;
 

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -553,20 +553,17 @@ declare module 'stripe' {
         source?: Stripe.CustomerSource;
 
         /**
-         * The type of error returned. One of `api_connection_error`, `api_error`, `authentication_error`, `card_error`, `idempotency_error`, `invalid_request_error`, or `rate_limit_error`
+         * The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
          */
         type: LastFinalizationError.Type;
       }
 
       namespace LastFinalizationError {
         type Type =
-          | 'api_connection_error'
           | 'api_error'
-          | 'authentication_error'
           | 'card_error'
           | 'idempotency_error'
-          | 'invalid_request_error'
-          | 'rate_limit_error';
+          | 'invalid_request_error';
       }
 
       interface PaymentSettings {

--- a/types/2020-08-27/Issuing/Transactions.d.ts
+++ b/types/2020-08-27/Issuing/Transactions.d.ts
@@ -93,6 +93,11 @@ declare module 'stripe' {
          * The nature of the transaction.
          */
         type: Transaction.Type;
+
+        /**
+         * The digital wallet used for this transaction. One of `apple_pay`, `google_pay`, or `samsung_pay`.
+         */
+        wallet: Transaction.Wallet | null;
       }
 
       namespace Transaction {
@@ -287,6 +292,8 @@ declare module 'stripe' {
         }
 
         type Type = 'capture' | 'refund';
+
+        type Wallet = 'apple_pay' | 'google_pay' | 'samsung_pay';
       }
 
       interface TransactionRetrieveParams {

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -306,20 +306,17 @@ declare module 'stripe' {
         source?: Stripe.CustomerSource;
 
         /**
-         * The type of error returned. One of `api_connection_error`, `api_error`, `authentication_error`, `card_error`, `idempotency_error`, `invalid_request_error`, or `rate_limit_error`
+         * The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
          */
         type: LastPaymentError.Type;
       }
 
       namespace LastPaymentError {
         type Type =
-          | 'api_connection_error'
           | 'api_error'
-          | 'authentication_error'
           | 'card_error'
           | 'idempotency_error'
-          | 'invalid_request_error'
-          | 'rate_limit_error';
+          | 'invalid_request_error';
       }
 
       interface NextAction {
@@ -510,6 +507,8 @@ declare module 'stripe' {
 
         card_present?: PaymentMethodOptions.CardPresent;
 
+        ideal?: PaymentMethodOptions.Ideal;
+
         oxxo?: PaymentMethodOptions.Oxxo;
 
         p24?: PaymentMethodOptions.P24;
@@ -682,6 +681,8 @@ declare module 'stripe' {
         }
 
         interface CardPresent {}
+
+        interface Ideal {}
 
         interface Oxxo {
           /**
@@ -1434,6 +1435,11 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
+         */
+        ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
+
+        /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
         oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
@@ -1617,6 +1623,8 @@ declare module 'stripe' {
         }
 
         interface CardPresent {}
+
+        interface Ideal {}
 
         interface Oxxo {
           /**
@@ -2289,6 +2297,11 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
+         */
+        ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
+
+        /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
         oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
@@ -2472,6 +2485,8 @@ declare module 'stripe' {
         }
 
         interface CardPresent {}
+
+        interface Ideal {}
 
         interface Oxxo {
           /**
@@ -3258,6 +3273,11 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
+         */
+        ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
+
+        /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
          */
         oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
@@ -3441,6 +3461,8 @@ declare module 'stripe' {
         }
 
         interface CardPresent {}
+
+        interface Ideal {}
 
         interface Oxxo {
           /**

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -496,7 +496,7 @@ declare module 'stripe' {
       gender?: string;
 
       /**
-       * The person's ID number, as appropriate for their country. For example, a social security number in the U.S., social insurance number in Canada, etc. Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://stripe.com/docs/stripe.js#collecting-pii-data).
+       * The person's ID number, as appropriate for their country. For example, a social security number in the U.S., social insurance number in Canada, etc. Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://stripe.com/docs/js/tokens_sources/create_token?type=pii).
        */
       id_number?: string;
 
@@ -786,7 +786,7 @@ declare module 'stripe' {
       gender?: string;
 
       /**
-       * The person's ID number, as appropriate for their country. For example, a social security number in the U.S., social insurance number in Canada, etc. Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://stripe.com/docs/stripe.js#collecting-pii-data).
+       * The person's ID number, as appropriate for their country. For example, a social security number in the U.S., social insurance number in Canada, etc. Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://stripe.com/docs/js/tokens_sources/create_token?type=pii).
        */
       id_number?: string;
 

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -417,20 +417,17 @@ declare module 'stripe' {
         source?: Stripe.CustomerSource;
 
         /**
-         * The type of error returned. One of `api_connection_error`, `api_error`, `authentication_error`, `card_error`, `idempotency_error`, `invalid_request_error`, or `rate_limit_error`
+         * The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
          */
         type: SetupError.Type;
       }
 
       namespace SetupError {
         type Type =
-          | 'api_connection_error'
           | 'api_error'
-          | 'authentication_error'
           | 'card_error'
           | 'idempotency_error'
-          | 'invalid_request_error'
-          | 'rate_limit_error';
+          | 'invalid_request_error';
       }
     }
 

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -213,20 +213,17 @@ declare module 'stripe' {
         source?: Stripe.CustomerSource;
 
         /**
-         * The type of error returned. One of `api_connection_error`, `api_error`, `authentication_error`, `card_error`, `idempotency_error`, `invalid_request_error`, or `rate_limit_error`
+         * The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
          */
         type: LastSetupError.Type;
       }
 
       namespace LastSetupError {
         type Type =
-          | 'api_connection_error'
           | 'api_error'
-          | 'authentication_error'
           | 'card_error'
           | 'idempotency_error'
-          | 'invalid_request_error'
-          | 'rate_limit_error';
+          | 'invalid_request_error';
       }
 
       interface NextAction {

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -337,7 +337,7 @@ declare module 'stripe' {
           gender?: string;
 
           /**
-           * The government-issued ID number of the individual, as appropriate for the representative's country. (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada). Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://stripe.com/docs/stripe.js#collecting-pii-data).
+           * The government-issued ID number of the individual, as appropriate for the representative's country. (Examples are a Social Security Number in the U.S., or a Social Insurance Number in Canada). Instead of the number itself, you can also provide a [PII token created with Stripe.js](https://stripe.com/docs/js/tokens_sources/create_token?type=pii).
            */
           id_number?: string;
 
@@ -600,7 +600,7 @@ declare module 'stripe' {
         gender?: string;
 
         /**
-         * The person's ID number, as appropriate for their country. For example, a social security number in the U.S., social insurance number in Canada, etc. Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://stripe.com/docs/stripe.js#collecting-pii-data).
+         * The person's ID number, as appropriate for their country. For example, a social security number in the U.S., social insurance number in Canada, etc. Instead of the number itself, you can also provide a [PII token provided by Stripe.js](https://stripe.com/docs/js/tokens_sources/create_token?type=pii).
          */
         id_number?: string;
 


### PR DESCRIPTION
Codegen for openapi adfc63f.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Remove support for values `api_connection_error`, `authentication_error`, and `rate_limit_error` from enums `StripeError.type`, `StripeErrorResponse.error.type`, `Invoice.last_finalization_error.type`, `PaymentIntent.last_payment_error.type`, `SetupAttempt.setup_error.type`, and `SetupIntent.last_setup_error.type`
* Add support for `wallet` on `Issuing.Transaction`
* Add support for `ideal` on `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, and `PaymentIntent.payment_method_options`

