### PR TITLE
Add support for SearchResult.

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -39,6 +39,8 @@ function stripeMethod(spec) {
       callback
     );
 
+    // Please note `spec.methodType === 'search'` is beta functionality and this
+    // interface is subject to change/removal at any time.
     if (spec.methodType === 'list' || spec.methodType === 'search') {
       const autoPaginationMethods = makeAutoPaginationMethods(
         this,

--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -39,7 +39,7 @@ function stripeMethod(spec) {
       callback
     );
 
-    if (spec.methodType === 'list') {
+    if (spec.methodType === 'list' || spec.methodType === 'search') {
       const autoPaginationMethods = makeAutoPaginationMethods(
         this,
         args,

--- a/lib/autoPagination.js
+++ b/lib/autoPagination.js
@@ -6,15 +6,40 @@ const utils = require('./utils');
 function makeAutoPaginationMethods(self, requestArgs, spec, firstPagePromise) {
   const promiseCache = {currentPromise: null};
   const reverseIteration = isReverseIteration(requestArgs);
-  let listPromise = firstPagePromise;
+  let pagePromise = firstPagePromise;
   let i = 0;
 
-  function iterate(listResult) {
+  // Search and List methods iterate differently.
+  // Search relies on a `next_page` token and can only iterate in one direction.
+  // List relies on either an `ending_before` or `starting_after` field with
+  // an item ID to paginate and is bi-directional.
+  let getNextPagePromise;
+  if (spec.methodType === 'search') {
+    getNextPagePromise = (pageResult) => {
+      if (!pageResult.next_page) {
+        throw Error(
+          'Unexpected: Stripe API response does not have a well-formed `next_page` field, but `has_more` was true.'
+        );
+      }
+      return makeRequest(self, requestArgs, spec, {
+        next_page: pageResult.next_page,
+      });
+    };
+  } else {
+    getNextPagePromise = (pageResult) => {
+      const lastId = getLastId(pageResult, reverseIteration);
+      return makeRequest(self, requestArgs, spec, {
+        [reverseIteration ? 'ending_before' : 'starting_after']: lastId,
+      });
+    };
+  }
+
+  function iterate(pageResult) {
     if (
       !(
-        listResult &&
-        listResult.data &&
-        typeof listResult.data.length === 'number'
+        pageResult &&
+        pageResult.data &&
+        typeof pageResult.data.length === 'number'
       )
     ) {
       throw Error(
@@ -22,26 +47,24 @@ function makeAutoPaginationMethods(self, requestArgs, spec, firstPagePromise) {
       );
     }
 
-    if (i < listResult.data.length) {
-      const idx = reverseIteration ? listResult.data.length - 1 - i : i;
-      const value = listResult.data[idx];
+    if (i < pageResult.data.length) {
+      const idx = reverseIteration ? pageResult.data.length - 1 - i : i;
+      const value = pageResult.data[idx];
       i += 1;
+
       return {value, done: false};
-    } else if (listResult.has_more) {
+    } else if (pageResult.has_more) {
       // Reset counter, request next page, and recurse.
       i = 0;
-      const lastId = getLastId(listResult, reverseIteration);
-      listPromise = makeRequest(self, requestArgs, spec, {
-        [reverseIteration ? 'ending_before' : 'starting_after']: lastId,
-      });
-      return listPromise.then(iterate);
+      pagePromise = getNextPagePromise(pageResult);
+      return pagePromise.then(iterate);
     }
     return {value: undefined, done: true};
   }
 
   function asyncIteratorNext() {
     return memoizedPromise(promiseCache, (resolve, reject) => {
-      return listPromise
+      return pagePromise
         .then(iterate)
         .then(resolve)
         .catch(reject);

--- a/lib/autoPagination.js
+++ b/lib/autoPagination.js
@@ -13,6 +13,9 @@ function makeAutoPaginationMethods(self, requestArgs, spec, firstPagePromise) {
   // Search relies on a `next_page` token and can only iterate in one direction.
   // List relies on either an `ending_before` or `starting_after` field with
   // an item ID to paginate and is bi-directional.
+  //
+  // Please note: spec.methodType === 'search' is beta functionality and is
+  // subject to change/removal at any time.
   let getNextPagePromise;
   if (spec.methodType === 'search') {
     getNextPagePromise = (pageResult) => {

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -209,6 +209,9 @@ declare module 'stripe' {
      * The array of objects is on the `.data` property,
      * and `.has_more` indicates whether there are additional objects beyond the end of this list.
      * The `.next_page` field can be used to paginate forwards.
+     *
+     * Please note, ApiSearchResult<T> is beta functionality and is subject to change/removal
+     * at any time.
      */
     export interface ApiSearchResult<T> {
       object: 'search_result';

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -18,7 +18,7 @@ declare module 'stripe' {
         method: string;
         path?: string;
         fullPath?: string;
-        methodType?: 'list';
+        methodType?: 'list' | 'search';
       }): (...args: any[]) => object; //eslint-disable-line @typescript-eslint/no-explicit-any
       static BASIC_METHODS: {
         create<T>(
@@ -194,6 +194,43 @@ declare module 'stripe' {
 
     export interface ApiListPromise<T>
       extends Promise<Response<ApiList<T>>>,
+        AsyncIterableIterator<T> {
+      autoPagingEach(
+        handler: (item: T) => boolean | void | Promise<boolean | void>
+      ): Promise<void>;
+
+      autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
+    }
+
+    /**
+     * A container for paginated lists of search results.
+     * The array of objects is on the `.data` property,
+     * and `.has_more` indicates whether there are additional objects beyond the end of this list.
+     * The `.next_page` field can be used to paginate forwards.
+     */
+    export interface ApiSearchResult<T> {
+      object: 'search_result';
+
+      data: Array<T>;
+
+      /**
+       * True if this list has another page of items after this one that can be fetched.
+       */
+      has_more: boolean;
+
+      /**
+       * The URL where this list can be accessed.
+       */
+      url: string;
+
+      /**
+       * The page token to use to get the next page of results. If `has_more` is
+       * true, this will be set.
+       */
+      next_page?: string;
+    }
+    export interface ApiSearchResultPromise<T>
+      extends Promise<Response<ApiSearchResult<T>>>,
         AsyncIterableIterator<T> {
       autoPagingEach(
         handler: (item: T) => boolean | void | Promise<boolean | void>

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -18,6 +18,8 @@ declare module 'stripe' {
         method: string;
         path?: string;
         fullPath?: string;
+        // Please note, methodType === 'search' is beta functionality and is subject to
+        // change/removal at any time.
         methodType?: 'list' | 'search';
       }): (...args: any[]) => object; //eslint-disable-line @typescript-eslint/no-explicit-any
       static BASIC_METHODS: {

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -184,6 +184,11 @@ Stripe.StripeResource.extend({
     method: 'create',
     fullPath: '/v1/full/path',
   }),
+  search: Stripe.StripeResource.method({
+    method: 'create',
+    fullPath: 'foo',
+    methodType: 'search',
+  }),
 });
 
 const maxBufferedRequestMetrics: number =


### PR DESCRIPTION
### Notify

r? @richardm-stripe 

### Summary

Adds support for search methods and `search_result` objects returned by the Stripe API. This requires updating auto pagination to support this. These paginate similarly to lists, however they rely on a `next_page` token included in the response rather than using object IDs + `starting_before`/`ending_after`. Thus, only forward pagination is supported

### Test plan

Added unit tests. We'll want to add some more rigorous tests once a resource is using this.