### PR TITLE
API Updates

### DIFF
--- a/lib/resources/Quotes.js
+++ b/lib/resources/Quotes.js
@@ -28,11 +28,13 @@ module.exports = StripeResource.extend({
   listComputedUpfrontLineItems: stripeMethod({
     method: 'GET',
     path: '/{quote}/computed_upfront_line_items',
+    methodType: 'list',
   }),
 
   listLineItems: stripeMethod({
     method: 'GET',
     path: '/{quote}/line_items',
+    methodType: 'list',
   }),
 
   pdf: stripeMethod({

--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -981,36 +981,8 @@ declare module 'stripe' {
       }
 
       namespace BusinessProfile {
-        interface SupportAddress {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface SupportAddress extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 
@@ -1383,36 +1355,8 @@ declare module 'stripe' {
       }
 
       namespace Company {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         type Structure =
@@ -1670,36 +1614,8 @@ declare module 'stripe' {
       }
 
       namespace Individual {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         interface Dob {
@@ -1966,13 +1882,6 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface AccountRetrieveParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
     interface AccountUpdateParams {
       /**
        * An [account token](https://stripe.com/docs/api#create_account_token), used to securely provide details to the account.
@@ -2091,36 +2000,8 @@ declare module 'stripe' {
       }
 
       namespace BusinessProfile {
-        interface SupportAddress {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface SupportAddress extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 
@@ -2493,36 +2374,8 @@ declare module 'stripe' {
       }
 
       namespace Company {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         type Structure =
@@ -2743,36 +2596,8 @@ declare module 'stripe' {
       }
 
       namespace Individual {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         interface Dob {

--- a/types/2020-08-27/BankAccounts.d.ts
+++ b/types/2020-08-27/BankAccounts.d.ts
@@ -32,6 +32,11 @@ declare module 'stripe' {
       account_holder_type: string | null;
 
       /**
+       * The bank account type. This can only be `checking` or `savings` in most countries. In Japan, this can only be `futsu` or `toza`.
+       */
+      account_type: string | null;
+
+      /**
        * A set of available payout methods for this bank account. Only values from this set should be passed as the `method` when creating a payout.
        */
       available_payout_methods?: Array<

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1729,7 +1729,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -1750,6 +1750,12 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
 
       interface TransferData {
@@ -1830,7 +1836,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -1851,6 +1857,12 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
     }
 

--- a/types/2020-08-27/CustomerSources.d.ts
+++ b/types/2020-08-27/CustomerSources.d.ts
@@ -121,36 +121,8 @@ declare module 'stripe' {
       }
 
       namespace Owner {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
     }

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -390,7 +390,7 @@ declare module 'stripe' {
         /**
          * Customer shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * Customer name.
@@ -401,6 +401,12 @@ declare module 'stripe' {
          * Customer phone (including extension).
          */
         phone?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
 
       interface Tax {
@@ -610,7 +616,7 @@ declare module 'stripe' {
         /**
          * Customer shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * Customer name.
@@ -621,6 +627,12 @@ declare module 'stripe' {
          * Customer phone (including extension).
          */
         phone?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
 
       interface Tax {

--- a/types/2020-08-27/ExternalAccounts.d.ts
+++ b/types/2020-08-27/ExternalAccounts.d.ts
@@ -45,6 +45,11 @@ declare module 'stripe' {
       >;
 
       /**
+       * The bank account type. This can only be `checking` or `savings` in most countries. In Japan, this can only be `futsu` or `toza`.
+       */
+      account_type?: ExternalAccountUpdateParams.AccountType;
+
+      /**
        * City/District/Suburb/Town/Village.
        */
       address_city?: string;
@@ -107,6 +112,8 @@ declare module 'stripe' {
 
     namespace ExternalAccountUpdateParams {
       type AccountHolderType = 'company' | 'individual';
+
+      type AccountType = 'checking' | 'futsu' | 'savings' | 'toza';
     }
 
     interface ExternalAccountListParams extends PaginationParams {

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -309,43 +309,15 @@ declare module 'stripe' {
       }
 
       namespace CustomerDetails {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         interface Shipping {
           /**
            * Customer shipping address.
            */
-          address: Stripe.AddressParam;
+          address: Shipping.Address;
 
           /**
            * Customer name.
@@ -356,6 +328,12 @@ declare module 'stripe' {
            * Customer phone (including extension).
            */
           phone?: string;
+        }
+
+        namespace Shipping {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
         }
 
         interface Tax {
@@ -599,7 +577,7 @@ declare module 'stripe' {
         plan?: string;
 
         /**
-         * The ID of the price object.
+         * The ID of the price object. When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
          */
         price?: string;
 

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -1441,43 +1441,15 @@ declare module 'stripe' {
       }
 
       namespace CustomerDetails {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         interface Shipping {
           /**
            * Customer shipping address.
            */
-          address: Stripe.AddressParam;
+          address: Shipping.Address;
 
           /**
            * Customer name.
@@ -1488,6 +1460,12 @@ declare module 'stripe' {
            * Customer phone (including extension).
            */
           phone?: string;
+        }
+
+        namespace Shipping {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
         }
 
         interface Tax {
@@ -1731,7 +1709,7 @@ declare module 'stripe' {
         plan?: string;
 
         /**
-         * The ID of the price object.
+         * The ID of the price object. When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
          */
         price?: string;
 

--- a/types/2020-08-27/Issuing/Authorizations.d.ts
+++ b/types/2020-08-27/Issuing/Authorizations.d.ts
@@ -134,6 +134,11 @@ declare module 'stripe' {
           category: string;
 
           /**
+           * The merchant category code for the seller's business
+           */
+          category_code: string;
+
+          /**
            * City where the seller is located
            */
           city: string | null;

--- a/types/2020-08-27/Issuing/Transactions.d.ts
+++ b/types/2020-08-27/Issuing/Transactions.d.ts
@@ -115,6 +115,11 @@ declare module 'stripe' {
           category: string;
 
           /**
+           * The merchant category code for the seller's business
+           */
+          category_code: string;
+
+          /**
            * City where the seller is located
            */
           city: string | null;

--- a/types/2020-08-27/Orders.d.ts
+++ b/types/2020-08-27/Orders.d.ts
@@ -292,7 +292,7 @@ declare module 'stripe' {
         /**
          * Customer shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * Customer name.
@@ -303,6 +303,12 @@ declare module 'stripe' {
          * Customer phone (including extension).
          */
         phone?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
     }
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -1172,36 +1172,8 @@ declare module 'stripe' {
         }
 
         namespace BillingDetails {
-          interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
             line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
           }
         }
 
@@ -1692,7 +1664,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -1713,6 +1685,12 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
 
       interface TransferData {
@@ -2034,36 +2012,8 @@ declare module 'stripe' {
         }
 
         namespace BillingDetails {
-          interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
             line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
           }
         }
 
@@ -2554,7 +2504,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -2575,6 +2525,12 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
 
       interface TransferData {
@@ -3010,36 +2966,8 @@ declare module 'stripe' {
         }
 
         namespace BillingDetails {
-          interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
             line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
           }
         }
 
@@ -3530,7 +3458,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Stripe.AddressParam;
+        address: Shipping.Address;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -3551,6 +3479,12 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
+      }
+
+      namespace Shipping {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
       }
     }
 

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -821,36 +821,8 @@ declare module 'stripe' {
       }
 
       namespace BillingDetails {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 
@@ -1151,36 +1123,8 @@ declare module 'stripe' {
       }
 
       namespace BillingDetails {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -562,36 +562,8 @@ declare module 'stripe' {
     }
 
     namespace PersonCreateParams {
-      interface Address {
-        /**
-         * City, district, suburb, town, or village.
-         */
-        city?: string;
-
-        /**
-         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-         */
-        country?: string;
-
-        /**
-         * Address line 1 (e.g., street, PO Box, or company name).
-         */
+      interface Address extends Omit<Stripe.AddressParam, 'line1'> {
         line1?: string;
-
-        /**
-         * Address line 2 (e.g., apartment, suite, unit, or building).
-         */
-        line2?: string;
-
-        /**
-         * ZIP or postal code.
-         */
-        postal_code?: string;
-
-        /**
-         * State, county, province, or region.
-         */
-        state?: string;
       }
 
       interface Dob {
@@ -852,36 +824,8 @@ declare module 'stripe' {
     }
 
     namespace PersonUpdateParams {
-      interface Address {
-        /**
-         * City, district, suburb, town, or village.
-         */
-        city?: string;
-
-        /**
-         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-         */
-        country?: string;
-
-        /**
-         * Address line 1 (e.g., street, PO Box, or company name).
-         */
+      interface Address extends Omit<Stripe.AddressParam, 'line1'> {
         line1?: string;
-
-        /**
-         * Address line 2 (e.g., apartment, suite, unit, or building).
-         */
-        line2?: string;
-
-        /**
-         * ZIP or postal code.
-         */
-        postal_code?: string;
-
-        /**
-         * State, county, province, or region.
-         */
-        state?: string;
       }
 
       interface Dob {

--- a/types/2020-08-27/Reviews.d.ts
+++ b/types/2020-08-27/Reviews.d.ts
@@ -27,7 +27,7 @@ declare module 'stripe' {
       charge: string | Stripe.Charge | null;
 
       /**
-       * The reason the review was closed, or null if it has not yet been closed. One of `approved`, `refunded`, `refunded_as_fraud`, or `disputed`.
+       * The reason the review was closed, or null if it has not yet been closed. One of `approved`, `refunded`, `refunded_as_fraud`, `disputed`, or `redacted`.
        */
       closed_reason: Review.ClosedReason | null;
 
@@ -67,7 +67,7 @@ declare module 'stripe' {
       payment_intent?: string | Stripe.PaymentIntent;
 
       /**
-       * The reason the review is currently open or closed. One of `rule`, `manual`, `approved`, `refunded`, `refunded_as_fraud`, or `disputed`.
+       * The reason the review is currently open or closed. One of `rule`, `manual`, `approved`, `refunded`, `refunded_as_fraud`, `disputed`, or `redacted`.
        */
       reason: string;
 
@@ -81,6 +81,7 @@ declare module 'stripe' {
       type ClosedReason =
         | 'approved'
         | 'disputed'
+        | 'redacted'
         | 'refunded'
         | 'refunded_as_fraud';
 

--- a/types/2020-08-27/SKUs.d.ts
+++ b/types/2020-08-27/SKUs.d.ts
@@ -168,7 +168,9 @@ declare module 'stripe' {
       /**
        * A dictionary of attributes and values for the attributes defined by the product. If, for example, a product's attributes are `["size", "gender"]`, a valid SKU has the following dictionary of attributes: `{"size": "Medium", "gender": "Unisex"}`.
        */
-      attributes?: Stripe.Metadata;
+      attributes?: {
+        [key: string]: string;
+      };
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -259,7 +261,9 @@ declare module 'stripe' {
       /**
        * A dictionary of attributes and values for the attributes defined by the product. When specified, `attributes` will partially update the existing attributes dictionary on the product, with the postcondition that a value must be present for each attribute key on the product.
        */
-      attributes?: Stripe.Metadata;
+      attributes?: {
+        [key: string]: string;
+      };
 
       /**
        * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -358,7 +362,9 @@ declare module 'stripe' {
       /**
        * Only return SKUs that have the specified key-value pairs in this partially constructed dictionary. Can be specified only if `product` is also supplied. For instance, if the associated product has attributes `["color", "size"]`, passing in `attributes[color]=red` returns all the SKUs for this product that have `color` set to `red`.
        */
-      attributes?: Stripe.Metadata;
+      attributes?: {
+        [key: string]: string;
+      };
 
       /**
        * Specifies which fields in the response should be expanded.

--- a/types/2020-08-27/Sources.d.ts
+++ b/types/2020-08-27/Sources.d.ts
@@ -934,36 +934,8 @@ declare module 'stripe' {
       }
 
       namespace Owner {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 
@@ -1226,36 +1198,8 @@ declare module 'stripe' {
       }
 
       namespace Owner {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 

--- a/types/2020-08-27/SubscriptionItems.d.ts
+++ b/types/2020-08-27/SubscriptionItems.d.ts
@@ -290,7 +290,7 @@ declare module 'stripe' {
       plan?: string;
 
       /**
-       * The ID of the price object.
+       * The ID of the price object. When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
        */
       price?: string;
 

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -1066,7 +1066,7 @@ declare module 'stripe' {
         plan?: string;
 
         /**
-         * The ID of the price object.
+         * The ID of the price object. When changing a subscription item's price, `quantity` is set to 1 unless a `quantity` parameter is provided.
          */
         price?: string;
 

--- a/types/2020-08-27/Terminal/Locations.d.ts
+++ b/types/2020-08-27/Terminal/Locations.d.ts
@@ -143,36 +143,8 @@ declare module 'stripe' {
       }
 
       namespace LocationUpdateParams {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
       }
 

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -214,36 +214,8 @@ declare module 'stripe' {
         }
 
         namespace Company {
-          interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
             line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
           }
 
           type Structure =
@@ -388,36 +360,8 @@ declare module 'stripe' {
         }
 
         namespace Individual {
-          interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
             line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
           }
 
           interface Dob {
@@ -496,6 +440,11 @@ declare module 'stripe' {
         account_number: string;
 
         /**
+         * The bank account type. This can only be `checking` or `savings` in most countries. In Japan, this can only be `futsu` or `toza`.
+         */
+        account_type?: BankAccount.AccountType;
+
+        /**
          * The country in which the bank account is located.
          */
         country: string;
@@ -513,6 +462,8 @@ declare module 'stripe' {
 
       namespace BankAccount {
         type AccountHolderType = 'company' | 'individual';
+
+        type AccountType = 'checking' | 'futsu' | 'savings' | 'toza';
       }
 
       interface Card {
@@ -661,36 +612,8 @@ declare module 'stripe' {
       }
 
       namespace Person {
-        interface Address {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
         }
 
         interface Dob {

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -173,7 +173,9 @@ declare module 'stripe' {
       configurations: Stripe.BillingPortal.ConfigurationsResource;
       sessions: Stripe.BillingPortal.SessionsResource;
     };
-    checkout: {sessions: Stripe.Checkout.SessionsResource};
+    checkout: {
+      sessions: Stripe.Checkout.SessionsResource;
+    };
     identity: {
       verificationReports: Stripe.Identity.VerificationReportsResource;
       verificationSessions: Stripe.Identity.VerificationSessionsResource;
@@ -194,13 +196,14 @@ declare module 'stripe' {
       reportRuns: Stripe.Reporting.ReportRunsResource;
       reportTypes: Stripe.Reporting.ReportTypesResource;
     };
-    sigma: {scheduledQueryRuns: Stripe.Sigma.ScheduledQueryRunsResource};
+    sigma: {
+      scheduledQueryRuns: Stripe.Sigma.ScheduledQueryRunsResource;
+    };
     terminal: {
       connectionTokens: Stripe.Terminal.ConnectionTokensResource;
       locations: Stripe.Terminal.LocationsResource;
       readers: Stripe.Terminal.ReadersResource;
     };
-
     /**
      * API Errors
      */


### PR DESCRIPTION
Codegen for openapi face0c6.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Bugfix: add missing autopagination methods to `Quote.listLineItems` and `Quote.listComputedUpfrontLineItems`
* Add support for `account_type` on `BankAccount`, `ExternalAccountUpdateParams`, and `TokenCreateParams.bank_account`
* Add support for `category_code` on `Issuing.Authorization.merchant_data` and `Issuing.Transaction.merchant_data`
* Add support for new value `redacted` on enum `Review.closed_reason`
* Remove duplicate type definition for `Account.retrieve`.
* Fix some `attributes` fields mistakenly defined as `Stripe.Metadata`

