### PR TITLE
Fix Typescript definition for `StripeResource.LastResponse.headers`

### DIFF
--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -404,6 +404,8 @@ describe('Stripe Module', function() {
                 const headers = customer.lastResponse.headers;
                 expect(headers).to.contain.keys('request-id');
 
+                expect(customer.headers).to.be.undefined;
+
                 resolve('Called!');
               });
             })

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -156,8 +156,8 @@ declare module 'stripe' {
     }
 
     export type Response<T> = T & {
-      headers: {[key: string]: string};
       lastResponse: {
+        headers: {[key: string]: string};
         requestId: string;
         statusCode: number;
         apiVersion?: string;

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -144,8 +144,8 @@ stripe.setHost('host', 'port', 'protocol');
     const statusCode: number = lr.statusCode;
     const apiVersion: string | undefined = lr.apiVersion;
     const idempotencyKey: string | undefined = lr.idempotencyKey;
-    const headers = custs.headers;
-    const header: string | undefined = custs.headers['request-id'];
+    const headers = lr.headers;
+    const header: string | undefined = headers['request-id'];
   }
 
   {
@@ -155,8 +155,8 @@ stripe.setHost('host', 'port', 'protocol');
     const statusCode: number = lr.statusCode;
     const apiVersion: string | undefined = lr.apiVersion;
     const idempotencyKey: string | undefined = lr.idempotencyKey;
-    const headers = cust.headers;
-    const header: string | undefined = cust.headers['request-id'];
+    const headers = lr.headers;
+    const header: string | undefined = lr.headers['request-id'];
   }
   {
     const acct = await stripe.accounts.createExternalAccount('foo', {


### PR DESCRIPTION
## Notify
cc @stripe/api-libraries 

## Summary
Move typescript definition for `headers` to the correct location. 

You can see that they are added to the object that eventually becomes `.lastResponse` [here](https://github.com/stripe/stripe-node/blob/master/lib/StripeResource.js#L174)

## Motivation
Fixes https://github.com/stripe/stripe-node/issues/1204