### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -341,7 +341,7 @@ declare module 'stripe' {
               custom_mandate_url?: string;
 
               /**
-               * Description of the interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+               * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
                */
               interval_description: string | null;
 
@@ -749,6 +749,9 @@ declare module 'stripe' {
          */
         allow_promotion_codes?: boolean;
 
+        /**
+         * Settings for automatic tax lookup for this session and resulting payments, invoices, and subscriptions.
+         */
         automatic_tax?: SessionCreateParams.AutomaticTax;
 
         /**

--- a/types/2020-08-27/Identity/VerificationSessions.d.ts
+++ b/types/2020-08-27/Identity/VerificationSessions.d.ts
@@ -68,7 +68,7 @@ declare module 'stripe' {
         type: VerificationSession.Type;
 
         /**
-         * The short-lived URL that you use to redirect a user to Stripe to submit their identity information. This URL expires after 24 hours and can only be used once. Don't store it, log it, send it in emails or expose it to anyone other than the user. Refer to our docs on [verifying identity documents](https://stripe.com/docs/identity/verify-identity-documents?platform=web&type=redirect) to learn how to redirect users to Stripe.
+         * The short-lived URL that you use to redirect a user to Stripe to submit their identity information. This URL expires after 48 hours and can only be used once. Don't store it, log it, send it in emails or expose it to anyone other than the user. Refer to our docs on [verifying identity documents](https://stripe.com/docs/identity/verify-identity-documents?platform=web&type=redirect) to learn how to redirect users to Stripe.
          */
         url: string | null;
 

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -178,7 +178,7 @@ declare module 'stripe' {
       customer?: string;
 
       /**
-       * Details about the customer you want to invoice
+       * Details about the customer you want to invoice or overrides for an existing customer.
        */
       customer_details?: InvoiceLineItemListUpcomingParams.CustomerDetails;
 

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -1310,7 +1310,7 @@ declare module 'stripe' {
       customer?: string;
 
       /**
-       * Details about the customer you want to invoice
+       * Details about the customer you want to invoice or overrides for an existing customer.
        */
       customer_details?: InvoiceRetrieveUpcomingParams.CustomerDetails;
 

--- a/types/2020-08-27/Mandates.d.ts
+++ b/types/2020-08-27/Mandates.d.ts
@@ -102,7 +102,7 @@ declare module 'stripe' {
       namespace PaymentMethodDetails {
         interface AcssDebit {
           /**
-           * Description of the interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+           * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
            */
           interval_description: string | null;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -538,7 +538,7 @@ declare module 'stripe' {
             custom_mandate_url?: string;
 
             /**
-             * Description of the interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
              */
             interval_description: string | null;
 
@@ -1627,7 +1627,7 @@ declare module 'stripe' {
           /**
            * Language shown to the payer on redirect.
            */
-          preferred_language?: Sofort.PreferredLanguage;
+          preferred_language?: Stripe.Emptyable<Sofort.PreferredLanguage>;
         }
 
         namespace Sofort {
@@ -2467,7 +2467,7 @@ declare module 'stripe' {
           /**
            * Language shown to the payer on redirect.
            */
-          preferred_language?: Sofort.PreferredLanguage;
+          preferred_language?: Stripe.Emptyable<Sofort.PreferredLanguage>;
         }
 
         namespace Sofort {
@@ -3421,7 +3421,7 @@ declare module 'stripe' {
           /**
            * Language shown to the payer on redirect.
            */
-          preferred_language?: Sofort.PreferredLanguage;
+          preferred_language?: Stripe.Emptyable<Sofort.PreferredLanguage>;
         }
 
         namespace Sofort {

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -1205,6 +1205,8 @@ declare module 'stripe' {
     class PaymentMethodsResource {
       /**
        * Creates a PaymentMethod object. Read the [Stripe.js reference](https://stripe.com/docs/stripe-js/reference#stripe-create-payment-method) to learn how to create PaymentMethods via Stripe.js.
+       *
+       * Instead of creating a PaymentMethod directly, we recommend using the [PaymentIntents API to accept a payment immediately or the <a href="/docs/payments/save-and-reuse">SetupIntent](https://stripe.com/docs/payments/accept-a-payment) API to collect payment method details ahead of a future payment.
        */
       create(
         params?: PaymentMethodCreateParams,

--- a/types/2020-08-27/Prices.d.ts
+++ b/types/2020-08-27/Prices.d.ts
@@ -71,7 +71,7 @@ declare module 'stripe' {
       /**
        * Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed.
        */
-      tax_behavior?: Price.TaxBehavior | null;
+      tax_behavior: Price.TaxBehavior | null;
 
       /**
        * Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.

--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -86,7 +86,7 @@ declare module 'stripe' {
       /**
        * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
        */
-      tax_code?: string | Stripe.TaxCode | null;
+      tax_code: string | Stripe.TaxCode | null;
 
       /**
        * The type of the product. The product is either of type `good`, which is eligible for use with Orders and SKUs, or `service`, which is eligible for use with Subscriptions and Plans.

--- a/types/2020-08-27/Quotes.d.ts
+++ b/types/2020-08-27/Quotes.d.ts
@@ -36,7 +36,7 @@ declare module 'stripe' {
        */
       application_fee_percent: number | null;
 
-      automatic_tax?: Quote.AutomaticTax;
+      automatic_tax: Quote.AutomaticTax;
 
       /**
        * Either `charge_automatically`, or `send_invoice`. When charging automatically, Stripe will attempt to pay invoices at the end of the subscription cycle or on finalization using the default payment method attached to the subscription or customer. When sending an invoice, Stripe will email your customer an invoice with payment instructions. Defaults to `charge_automatically`.
@@ -1131,7 +1131,7 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Quote>>;
 
       /**
-       * When retrieving a quote, there is an includable upfront.line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
+       * When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
        */
       listComputedUpfrontLineItems(
         id: string,

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -303,7 +303,7 @@ declare module 'stripe' {
             custom_mandate_url?: string;
 
             /**
-             * Description of the interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+             * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
              */
             interval_description: string | null;
 

--- a/types/2020-08-27/TaxRates.d.ts
+++ b/types/2020-08-27/TaxRates.d.ts
@@ -74,7 +74,7 @@ declare module 'stripe' {
       /**
        * The high-level tax type, such as `vat` or `sales_tax`.
        */
-      tax_type?: TaxRate.TaxType | null;
+      tax_type: TaxRate.TaxType | null;
     }
 
     namespace TaxRate {


### PR DESCRIPTION
Codegen for openapi 1303953.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Change type of `PaymentIntentCreateParams.payment_method_options.sofort.preferred_language`, `PaymentIntentUpdateParams.payment_method_options.sofort.preferred_language`, and `PaymentIntentConfirmParams.payment_method_options.sofort.preferred_language` from `enum` to `emptyStringable(enum)`
* Change `Price.tax_behavior`, `Product.tax_code`, `Quote.automatic_tax`, and `TaxRate.tax_type` to be required