### PR TITLE
Fix TypeScript definitions for `tiers` in `Plan`

### DIFF
--- a/types/2020-08-27/Plans.d.ts
+++ b/types/2020-08-27/Plans.d.ts
@@ -86,7 +86,7 @@ declare module 'stripe' {
       /**
        * Each element represents a pricing tier. This parameter requires `billing_scheme` to be set to `tiered`. See also the documentation for `billing_scheme`.
        */
-      tiers?: Array<Plan.Tier>;
+      tiers?: Array<Plan.Tier> | null;
 
       /**
        * Defines if the tiering price should be `graduated` or `volume` based. In `volume`-based tiering, the maximum quantity within a period determines the per unit price. In `graduated` tiering, pricing can change as the quantity grows.


### PR DESCRIPTION
This PR adds `null` to type definition of `tiers` in `Plan` and removes the ability for `tiers` to be `undefined`.

### Issue

The type definition for the payload delivered for Stripe webhook for event `invoice.payment_succeeded` seems to be incorrect. I copied the JSON request to my endpoint from the dashboard into an unit test, but casting `data.object` of this event to the `Stripe.Invoice` types fails.

This is because `Stripe.Invoice` defines `lines.data.plan.tiers` to be either `undefined` or an array of `Plan.Tiers`, in the payload of the `invoice.payment_succeeded` the `tiers` field in `plan` is set to `null`. Note that the payload of `price` (which also contains the `tiers?: Array<Plan.Tier>` definition is correctly undefined and produces no issues.

### Solution

I propose to make the type definition match to reality by adding the option to be `null` to the `tiers` field of `Plan`. Was thinking of also removing the ability to be undefined in `Plan`, but I cannot be 100% sure it is always the case that this field is `null` when there are no tiers in use.