### PR TITLE
Update user agent computation to handle environments without process.

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -11,14 +11,16 @@ const DEFAULT_TIMEOUT = 80000;
 
 Stripe.PACKAGE_VERSION = require('../package.json').version;
 
+const utils = require('./utils');
+const {determineProcessUserAgentProperties, emitWarning} = utils;
+
 Stripe.USER_AGENT = {
   bindings_version: Stripe.PACKAGE_VERSION,
   lang: 'node',
-  lang_version: process.version,
-  platform: process.platform,
   publisher: 'stripe',
   uname: null,
   typescript: false,
+  ...determineProcessUserAgentProperties(),
 };
 
 /** @private */
@@ -44,8 +46,6 @@ const ALLOWED_CONFIG_PROPERTIES = [
 ];
 
 const EventEmitter = require('events').EventEmitter;
-const utils = require('./utils');
-const {emitWarning} = utils;
 
 Stripe.StripeResource = require('./StripeResource');
 Stripe.resources = resources;

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -429,6 +429,15 @@ const utils = (module.exports = {
 
     return n;
   },
+
+  determineProcessUserAgentProperties: () => {
+    return typeof process === 'undefined'
+      ? {}
+      : {
+          lang_version: process.version,
+          platform: process.platform,
+        };
+  },
 });
 
 function emitWarning(warning) {

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -160,6 +160,21 @@ describe('Stripe Module', function() {
         })
       ).to.eventually.have.property('lang', 'node'));
 
+    it('Should return platform and version in the serialized user agent JSON object', async () => {
+      // Check that the testing environment actually has a process global.
+      expect(process.version).to.not.be.empty;
+      expect(process.platform).to.not.be.empty;
+
+      const userAgent = await new Promise((resolve, reject) => {
+        stripe.getClientUserAgent((c) => {
+          resolve(JSON.parse(c));
+        });
+      });
+
+      expect(userAgent).to.have.property('lang_version', process.version);
+      expect(userAgent).to.have.property('platform', process.platform);
+    });
+
     it('Should include whether typescript: true was passed, respecting reinstantiations', () => {
       return new Promise((resolve) => resolve())
         .then(() => {


### PR DESCRIPTION
### Notify

r? @richardm-stripe

### Summary

Updates the user agent computation to handle JS environments which don't have a global `process` variable (eg. browser, Cloudflare Worker). This moves towards unblocking https://github.com/stripe/stripe-node/issues/997.
