### PR TITLE
Add client name property to HttpClient.

### DIFF
--- a/lib/net/HttpClient.js
+++ b/lib/net/HttpClient.js
@@ -7,13 +7,9 @@
  * experimental interface and is not yet stable.
  */
 class HttpClient {
-  constructor(name) {
-    this._name = name;
-  }
-
   /** The client name used for diagnostics. */
   getClientName() {
-    return this._name;
+    throw new Error('getClientName not implemented.');
   }
 
   makeRequest(

--- a/lib/net/HttpClient.js
+++ b/lib/net/HttpClient.js
@@ -7,6 +7,15 @@
  * experimental interface and is not yet stable.
  */
 class HttpClient {
+  constructor(name) {
+    this._name = name;
+  }
+
+  /** The client name used for diagnostics. */
+  getClientName() {
+    return this._name;
+  }
+
   makeRequest(
     host,
     port,

--- a/lib/net/NodeHttpClient.js
+++ b/lib/net/NodeHttpClient.js
@@ -1,5 +1,7 @@
 'use strict';
 
+/* eslint-disable class-methods-use-this */
+
 const http = require('http');
 const https = require('https');
 
@@ -14,8 +16,13 @@ const defaultHttpsAgent = new https.Agent({keepAlive: true});
  */
 class NodeHttpClient extends HttpClient {
   constructor(agent) {
-    super('node');
+    super();
     this._agent = agent;
+  }
+
+  /** @override. */
+  getClientName() {
+    return 'node';
   }
 
   makeRequest(

--- a/lib/net/NodeHttpClient.js
+++ b/lib/net/NodeHttpClient.js
@@ -14,7 +14,7 @@ const defaultHttpsAgent = new https.Agent({keepAlive: true});
  */
 class NodeHttpClient extends HttpClient {
   constructor(agent) {
-    super();
+    super('node');
     this._agent = agent;
   }
 

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -454,7 +454,7 @@ Stripe.prototype = {
       // URI-encode in case there are unusual characters in the system's uname.
       userAgent.uname = encodeURIComponent(uname || 'UNKNOWN');
 
-      const client = this._getApiField('httpClient');
+      const client = this.getApiField('httpClient');
       if (client) {
         userAgent.httplib = encodeURIComponent(client.getClientName());
       }

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -454,6 +454,11 @@ Stripe.prototype = {
       // URI-encode in case there are unusual characters in the system's uname.
       userAgent.uname = encodeURIComponent(uname || 'UNKNOWN');
 
+      const client = this._getApiField('httpClient');
+      if (client) {
+        userAgent.httplib = encodeURIComponent(client.getClientName());
+      }
+
       if (this._appInfo) {
         userAgent.application = this._appInfo;
       }

--- a/test/stripe.spec.js
+++ b/test/stripe.spec.js
@@ -210,6 +210,17 @@ describe('Stripe Module', function() {
       ).to.eventually.have.property('lang', '%C3%AF');
     });
 
+    it('Should URI-encode the HTTP client name', () => {
+      const userAgent = {lang: 'ï'};
+      return expect(
+        new Promise((resolve, reject) => {
+          stripe.getClientUserAgentSeeded(userAgent, (c) => {
+            resolve(JSON.parse(c));
+          });
+        })
+      ).to.eventually.have.property('httplib', 'node');
+    });
+
     describe('uname', () => {
       let origExec;
       beforeEach(() => {

--- a/types/net/net.d.ts
+++ b/types/net/net.d.ts
@@ -10,6 +10,9 @@ declare module 'stripe' {
     export interface HttpClient<
       ResponseType extends HttpClientResponse = HttpClientResponse
     > {
+      /** The client name to use for diagnostics. */
+      getClientName(): string;
+
       makeRequest(
         host: string,
         port: string | number,


### PR DESCRIPTION
r? @richardm-stripe 

Adds a client name property to be implemented by `HttpClient` which will be shipped in the user agent under the `httplib` property similar to Python.