### PR TITLE
Typescript: better types for non-optional CheckoutSession fields

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -212,14 +212,14 @@ declare module 'stripe' {
             /**
              * Enables user redeemable promotion codes on the recovered Checkout Sessions. Defaults to `false`
              */
-            allow_promotion_codes: boolean | null;
+            allow_promotion_codes: boolean;
 
             /**
              * If `true`, a recovery url will be generated to recover this Checkout Session if it
              * expires before a transaction is completed. It will be attached to the
              * Checkout Session object upon expiration.
              */
-            enabled: boolean | null;
+            enabled: boolean;
 
             /**
              * The timestamp at which the recovery URL will expire.


### PR DESCRIPTION
r? @remi-stripe 
cc @stripe/api-libraries 
`CheckoutSession.AfterExpiration.Recovery.allow_promotion_codes` and `CheckoutSession.AfterExpiration.Recovery.enabled` will always be present. This PR changes the typescript bindings to reflect this.