### PR TITLE
Add a CryptoProvider interface and NodeCryptoProvider implementation.

### DIFF
--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -1,19 +1,18 @@
 'use strict';
 
-const crypto = require('crypto');
-
 const utils = require('./utils');
 const {StripeError, StripeSignatureVerificationError} = require('./Error');
 
 const Webhook = {
   DEFAULT_TOLERANCE: 300, // 5 minutes
 
-  constructEvent(payload, header, secret, tolerance) {
+  constructEvent(payload, header, secret, tolerance, cryptoProvider) {
     this.signature.verifyHeader(
       payload,
       header,
       secret,
-      tolerance || Webhook.DEFAULT_TOLERANCE
+      tolerance || Webhook.DEFAULT_TOLERANCE,
+      cryptoProvider
     );
 
     const jsonPayload = JSON.parse(payload);
@@ -29,6 +28,7 @@ const Webhook = {
    * @property {string} secret - Stripe webhook secret 'whsec_...'
    * @property {string} scheme - Version of API to hit. Defaults to 'v1'.
    * @property {string} signature - Computed webhook signature
+   * @property {CryptoProvider} cryptoProvider - Crypto provider to use for computing the signature if none was provided. Defaults to NodeCryptoProvider.
    */
   generateTestHeaderString: function(opts) {
     if (!opts) {
@@ -41,9 +41,11 @@ const Webhook = {
       Math.floor(opts.timestamp) || Math.floor(Date.now() / 1000);
     opts.scheme = opts.scheme || signature.EXPECTED_SCHEME;
 
+    opts.cryptoProvider = opts.cryptoProvider || getNodeCryptoProvider();
+
     opts.signature =
       opts.signature ||
-      signature._computeSignature(
+      opts.cryptoProvider.computeHMACSignature(
         opts.timestamp + '.' + opts.payload,
         opts.secret
       );
@@ -60,14 +62,7 @@ const Webhook = {
 const signature = {
   EXPECTED_SCHEME: 'v1',
 
-  _computeSignature: (payload, secret) => {
-    return crypto
-      .createHmac('sha256', secret)
-      .update(payload, 'utf8')
-      .digest('hex');
-  },
-
-  verifyHeader(payload, header, secret, tolerance) {
+  verifyHeader(payload, header, secret, tolerance, cryptoProvider) {
     payload = Buffer.isBuffer(payload) ? payload.toString('utf8') : payload;
 
     // Express's type for `Request#headers` is `string | []string`
@@ -104,7 +99,8 @@ const signature = {
       });
     }
 
-    const expectedSignature = this._computeSignature(
+    cryptoProvider = cryptoProvider || getNodeCryptoProvider();
+    const expectedSignature = cryptoProvider.computeHMACSignature(
       `${details.timestamp}.${payload}`,
       secret
     );
@@ -166,6 +162,20 @@ function parseHeader(header, scheme) {
       signatures: [],
     }
   );
+}
+
+let webhooksNodeCryptoProviderInstance = null;
+
+/**
+ * Lazily instantiate a NodeCryptoProvider instance. This is a stateless object
+ * so a singleton can be used here.
+ */
+function getNodeCryptoProvider() {
+  if (!webhooksNodeCryptoProviderInstance) {
+    const NodeCryptoProvider = require('./crypto/NodeCryptoProvider');
+    webhooksNodeCryptoProviderInstance = new NodeCryptoProvider();
+  }
+  return webhooksNodeCryptoProviderInstance;
 }
 
 Webhook.signature = signature;

--- a/lib/crypto/CryptoProvider.js
+++ b/lib/crypto/CryptoProvider.js
@@ -1,0 +1,21 @@
+'use strict';
+
+/**
+ * Interface encapsulating the various crypto computations used by the library,
+ * allowing pluggable underlying crypto implementations.
+ */
+class CryptoProvider {
+  /**
+   * Computes a SHA-256 HMAC given a secret and a payload (encoded in UTF-8).
+   * The output HMAC should be encoded in hexadecimal.
+   *
+   * Sample values for implementations:
+   * - computeHMACSignature('', 'test_secret') => 'f7f9bd47fb987337b5796fdc1fdb9ba221d0d5396814bfcaf9521f43fd8927fd'
+   * - computeHMACSignature('\ud83d\ude00', 'test_secret') => '837da296d05c4fe31f61d5d7ead035099d9585a5bcde87de952012a78f0b0c43
+   */
+  computeHMACSignature(payload, secret) {
+    throw new Error('computeHMACSignature not implemented.');
+  }
+}
+
+module.exports = CryptoProvider;

--- a/lib/crypto/NodeCryptoProvider.js
+++ b/lib/crypto/NodeCryptoProvider.js
@@ -1,0 +1,20 @@
+'use strict';
+
+const crypto = require('crypto');
+
+const CryptoProvider = require('./CryptoProvider');
+
+/**
+ * `CryptoProvider which uses the Node `crypto` package for its computations.
+ */
+class NodeCryptoProvider extends CryptoProvider {
+  /** @override */
+  computeHMACSignature(payload, secret) {
+    return crypto
+      .createHmac('sha256', secret)
+      .update(payload, 'utf8')
+      .digest('hex');
+  }
+}
+
+module.exports = NodeCryptoProvider;

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -54,6 +54,9 @@ const {HttpClient, HttpClientResponse} = require('./net/HttpClient');
 Stripe.HttpClient = HttpClient;
 Stripe.HttpClientResponse = HttpClientResponse;
 
+const CryptoProvider = require('./crypto/CryptoProvider');
+Stripe.CryptoProvider = CryptoProvider;
+
 function Stripe(key, config = {}) {
   if (!(this instanceof Stripe)) {
     return new Stripe(key, config);

--- a/test/crypto/NodeCryptoProvider.spec.js
+++ b/test/crypto/NodeCryptoProvider.spec.js
@@ -1,0 +1,9 @@
+'use strict';
+
+const NodeCryptoProvider = require('../../lib/crypto/NodeCryptoProvider');
+
+const {createCryptoProviderTestSuite} = require('./helpers');
+
+describe('NodeCryptoProvider', () => {
+  createCryptoProviderTestSuite(new NodeCryptoProvider());
+});

--- a/test/crypto/helpers.js
+++ b/test/crypto/helpers.js
@@ -1,0 +1,42 @@
+'use strict';
+
+const expect = require('chai').expect;
+
+const SECRET = 'test_secret';
+
+/**
+ * Test runner which runs a common set of tests for a given CryptoProvider to
+ * make sure it satisfies the expected contract.
+ */
+const createCryptoProviderTestSuite = (cryptoProvider) => {
+  describe('CryptoProviderTestSuite', () => {
+    describe('computeHMACSignature', () => {
+      it('empty payload', () => {
+        expect(cryptoProvider.computeHMACSignature('', SECRET)).to.equal(
+          'f7f9bd47fb987337b5796fdc1fdb9ba221d0d5396814bfcaf9521f43fd8927fd'
+        );
+      });
+
+      it('sample payload', () => {
+        expect(
+          cryptoProvider.computeHMACSignature(
+            JSON.stringify({obj1: 'hello', obj2: 'world'}),
+            SECRET
+          )
+        ).to.equal(
+          'bebb1a643997f419b315ddba19e6f5411e1ce7f810ba6d3617ce72823092f363'
+        );
+      });
+
+      it('payload with utf-8', () => {
+        expect(
+          cryptoProvider.computeHMACSignature('\ud83d\ude00', SECRET)
+        ).to.equal(
+          '837da296d05c4fe31f61d5d7ead035099d9585a5bcde87de952012a78f0b0c43'
+        );
+      });
+    });
+  });
+};
+
+module.exports = {createCryptoProviderTestSuite};

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -8,6 +8,7 @@ require('chai').use(require('chai-as-promised'));
 
 const http = require('http');
 
+const CryptoProvider = require('../lib/crypto/CryptoProvider');
 const ResourceNamespace = require('../lib/ResourceNamespace').ResourceNamespace;
 
 const testingHttpAgent = new http.Agent({keepAlive: false});
@@ -208,6 +209,12 @@ const utils = (module.exports = {
       return true;
     } catch (err) {
       return false;
+    }
+  },
+
+  FakeCryptoProvider: class extends CryptoProvider {
+    computeHMACSignature(payload, secret) {
+      return 'fake signature';
     }
   },
 });

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 
 ///<reference path='../lib.d.ts' />
+///<reference path='../crypto/crypto.d.ts' />
 ///<reference path='../net/net.d.ts' />
 ///<reference path='../shared.d.ts' />
 ///<reference path='../Errors.d.ts' />

--- a/types/Webhooks.d.ts
+++ b/types/Webhooks.d.ts
@@ -35,7 +35,12 @@ declare module 'stripe' {
         /**
          * Seconds of tolerance on timestamps.
          */
-        tolerance?: number
+        tolerance?: number,
+
+        /**
+         * Optional CryptoProvider to use for computing HMAC signatures.
+         */
+        cryptoProvider?: CryptoProvider
       ): Stripe.Event;
 
       /**
@@ -66,6 +71,12 @@ declare module 'stripe' {
          * Computed webhook signature.
          */
         signature?: string;
+
+        /**
+         * Optional CryptoProvider to use for computing HMAC signatures, if no
+         * signature is given.
+         */
+        cryptoProvider?: CryptoProvider;
       }): string;
 
       signature: Signature;
@@ -79,7 +90,8 @@ declare module 'stripe' {
         payload: string,
         header: string,
         secret: string,
-        tolerance?: number
+        tolerance?: number,
+        cryptoProvider?: CryptoProvider
       ): void;
       parseHeader(
         header: string,

--- a/types/crypto/crypto.d.ts
+++ b/types/crypto/crypto.d.ts
@@ -1,0 +1,19 @@
+declare module 'stripe' {
+  namespace Stripe {
+    /**
+     * Interface encapsulating the various crypto computations used by the library,
+     * allowing pluggable underlying crypto implementations.
+     */
+    export interface CryptoProvider {
+      /**
+       * Computes a SHA-256 HMAC given a secret and a payload (encoded in UTF-8).
+       * The output HMAC should be encoded in hexadecimal.
+       *
+       * Sample values for implementations:
+       * - computeHMACSignature('', 'test_secret') => 'f7f9bd47fb987337b5796fdc1fdb9ba221d0d5396814bfcaf9521f43fd8927fd'
+       * - computeHMACSignature('\ud83d\ude00', 'test_secret') => '837da296d05c4fe31f61d5d7ead035099d9585a5bcde87de952012a78f0b0c43
+       */
+      computeHMACSignature: (payload: string, secret: string) => string;
+    }
+  }
+}


### PR DESCRIPTION
### Notify

r? @richardm-stripe

### Summary

Adds an `CryptoProvider` interface and moves out the Node `crypto` logic into a `NodeCryptoProvider` implementation. 

This initially only supports computing HMAC signatures, but lets us support this in a pluggable way. The Webhooks functions are updated to support passing in a custom provider. This can be used in environments where no 'crypto' package is available (removing another Node dependency for https://github.com/stripe/stripe-node/issues/997).

### Test plan

Added a small common set of test cases which can be re-used by any implementation to ensure they meet the contract.

### Looking forwards

Some crypto APIs (eg. the [Web Crypto API](https://developer.mozilla.org/en-US/docs/Web/API/Web_Crypto_API)) only provide async functions for computing HMACs (and other primitives). In the future, we may want to extend this interface with an `asyncComputeHMACSignature` function that returns a promise alongside `computeHMACSignature`. We would need to update the Webhooks code to support both sync and async computations (eg. providing `asyncConstructEvent` and `asyncVerifyHeader`).