### PR TITLE
Remove client name param from createHttpClientTestSuite.

### DIFF
--- a/test/net/FetchHttpClient.spec.js
+++ b/test/net/FetchHttpClient.spec.js
@@ -11,10 +11,8 @@ const createFetchHttpClient = () => {
 
 const {createHttpClientTestSuite, ArrayReadable} = require('./helpers');
 
-createHttpClientTestSuite(
-  'FetchHttpClient',
-  createFetchHttpClient,
-  (setupNock, sendRequest) => {
+describe('FetchHttpClient', () => {
+  createHttpClientTestSuite(createFetchHttpClient, (setupNock, sendRequest) => {
     describe('raw stream', () => {
       it('getRawResponse()', async () => {
         setupNock().reply(200);
@@ -57,5 +55,5 @@ createHttpClientTestSuite(
         });
       });
     });
-  }
-);
+  });
+});

--- a/test/net/NodeHttpClient.spec.js
+++ b/test/net/NodeHttpClient.spec.js
@@ -7,10 +7,8 @@ const {createNodeHttpClient} = require('../../lib/Stripe');
 
 const {createHttpClientTestSuite, ArrayReadable} = require('./helpers');
 
-createHttpClientTestSuite(
-  'NodeHttpClient',
-  createNodeHttpClient,
-  (setupNock, sendRequest) => {
+describe('NodeHttpClient', () => {
+  createHttpClientTestSuite(createNodeHttpClient, (setupNock, sendRequest) => {
     describe('raw stream', () => {
       it('getRawResponse()', async () => {
         setupNock().reply(200);
@@ -60,5 +58,5 @@ createHttpClientTestSuite(
         });
       });
     });
-  }
-);
+  });
+});

--- a/test/net/helpers.js
+++ b/test/net/helpers.js
@@ -34,18 +34,13 @@ class ArrayReadable extends Readable {
  * Test runner which runs a common set of tests for a given HTTP client to make
  * sure the client meets the interface expectations.
  *
- * This takes in a client name (for the test description) and function to create
- * a client.
+ * This takes in a function to create the client.
  *
  * This can be configured to run extra tests, providing the nock setup function
  * and request function for those tests.
  */
-const createHttpClientTestSuite = (
-  httpClientName,
-  createHttpClientFn,
-  extraTestsFn
-) => {
-  describe(`${httpClientName}`, () => {
+const createHttpClientTestSuite = (createHttpClientFn, extraTestsFn) => {
+  describe('HttpClientTestSuite', () => {
     const setupNock = () => {
       return nock('http://stripe.com').get('/test');
     };


### PR DESCRIPTION
r? @richardm-stripe 

Removes the `httpClientName` param from `createHttpClientTestSuite`. This isn't necessary and callers can just wrap the all in a describe as needed.