### PR TITLE
external_account can be an object

### DIFF
--- a/types/2020-08-27/ExternalAccounts.d.ts
+++ b/types/2020-08-27/ExternalAccounts.d.ts
@@ -6,7 +6,7 @@ declare module 'stripe' {
       /**
        * Please refer to full [documentation](https://stripe.com/docs/api) instead.
        */
-      external_account: string;
+      external_account: string | ExternalAccount;
 
       /**
        * When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.


### PR DESCRIPTION
The documentation says that the value of `external_account` when creating a bank account can be either a token generated by the SDK (aka string) or a dictionary/object with required fields (see https://stripe.com/docs/api/external_account_bank_accounts/create?lang=node).

The TS type currently says that only `string` is supported.

## Right now
<img width="735" alt="Screen Shot 2021-09-10 at 8 22 44 PM" src="https://user-images.githubusercontent.com/8062245/132929877-a453474e-ba2c-4936-9219-3b663202d097.png">

## After change
<img width="602" alt="Screen Shot 2021-09-10 at 8 22 30 PM" src="https://user-images.githubusercontent.com/8062245/132929882-98524173-d9a2-4e7a-9ad7-d92681a9f58a.png">
