### PR TITLE
search-beta: typescript, default version, and README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,518 +1,57 @@
-# Stripe Node.js Library
+# stripe-search-beta
 
-[![Version](https://img.shields.io/npm/v/stripe.svg)](https://www.npmjs.org/package/stripe)
-[![Build Status](https://travis-ci.org/stripe/stripe-node.svg?branch=master)](https://travis-ci.org/stripe/stripe-node)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-node/badge.svg)](https://coveralls.io/github/stripe/stripe-node)
-[![Downloads](https://img.shields.io/npm/dm/stripe.svg)](https://www.npmjs.com/package/stripe)
-[![Try on RunKit](https://badge.runkitcdn.com/stripe.svg)](https://runkit.com/npm/stripe)
+This is a branch of [stripe-node](https://github.com/stripe/stripe-node) specialized for the use of the [Search API beta](https://stripe.com/docs/search-api).
 
-The Stripe Node library provides convenient access to the Stripe API from
-applications written in server-side JavaScript.
+It is experimental, and support for this package will end on 2022-01-01.
 
-For collecting customer and payment information in the browser, use [Stripe.js][stripe-js].
+It is branched off of the 8.174.0 release of `stripe-node`, and acts as a complete replacement for the library.
 
-## Documentation
+We publish a separate [npm package](https://www.npmjs.com/package/stripe-search-beta), `stripe-search-beta`, with the contents of this branch.
 
-See the [`stripe-node` API docs](https://stripe.com/docs/api?lang=node) for Node.js.
+To use it
 
-See [video demonstrations][youtube-playlist] covering how to use the library.
-
-## Requirements
-
-Node 8, 10 or higher.
-
-## Installation
-
-Install the package with:
-
-```sh
-npm install stripe --save
-# or
-yarn add stripe
+```shell
+$ npm uninstall stripe
+$ npm install stripe-search-beta
 ```
 
-## Usage
+And then inside your application code
 
-The package needs to be configured with your account's secret key, which is
-available in the [Stripe Dashboard][api-keys]. Require it with the key's
-value:
-
-<!-- prettier-ignore -->
-```js
-const stripe = require('stripe')('sk_test_...');
-
-stripe.customers.create({
-  email: 'customer@example.com',
-})
-  .then(customer => console.log(customer.id))
-  .catch(error => console.error(error));
+```diff
+-const stripe = require('stripe')("<your-api-key>")
++const stripe = require('stripe-search-beta')("<your-api-key>")
 ```
 
-Or using ES modules and `async`/`await`:
+## Version Header
 
-```js
-import Stripe from 'stripe';
-const stripe = new Stripe('sk_test_...');
+Note, unlike the standard stripe client, which passes no `stripe-version` header by default, causing the requests to be subject to your account's global API version which is configured in [the dashboard](https://dashboard.stripe.com/developers), the stripe-search-beta client passes `2020-08-27;search_api_beta=v1` as the default header on all requests, so these requests will not be subject to your account's global API version.
 
-(async () => {
-  const customer = await stripe.customers.create({
-    email: 'customer@example.com',
-  });
+## Contents
 
-  console.log(customer.id);
-})();
-```
+This branch adds support for the `search` method on the `Charge`, `Customer`, `Invoice`, `PaymentIntent`, and `Subscription` resources.
 
-### Usage with TypeScript
+## Example Usage (typescript):
 
-As of 8.0.1, Stripe maintains types for the latest [API version][api-versions].
-
-Import Stripe as a default import (not `* as Stripe`, unlike the DefinitelyTyped version)
-and instantiate it as `new Stripe()` with the latest API version.
-
-```ts
-import Stripe from 'stripe';
-const stripe = new Stripe('sk_test_...', {
-  apiVersion: '2020-08-27',
-});
-
-const createCustomer = async () => {
-  const params: Stripe.CustomerCreateParams = {
-    description: 'test customer',
-  };
-
-  const customer: Stripe.Customer = await stripe.customers.create(params);
-
-  console.log(customer.id);
-};
-createCustomer();
-```
-
-You can find a full TS server example in [stripe-samples](https://github.com/stripe-samples/accept-a-card-payment/tree/master/using-webhooks/server/node-typescript).
-
-#### Using old API versions with TypeScript
-
-Types can change between API versions (e.g., Stripe may have changed a field from a string to a hash),
-so our types only reflect the latest API version.
-
-We therefore encourage [upgrading your API version][api-version-upgrading]
-if you would like to take advantage of Stripe's TypeScript definitions.
-
-If you are on an older API version (e.g., `2019-10-17`) and not able to upgrade,
-you may pass another version or `apiVersion: null` to use your account's default API version,
-and use a comment like `// @ts-ignore stripe-version-2019-10-17` to silence type errors here
-and anywhere the types differ between your API version and the latest.
-When you upgrade, you should remove these comments.
-
-We also recommend using `// @ts-ignore` if you have access to a beta feature and need to send parameters beyond the type definitions.
-
-#### Using `expand` with TypeScript
-
-[Expandable][expanding_objects] fields are typed as `string | Foo`,
-so you must cast them appropriately, e.g.,
-
-```ts
-const paymentIntent: Stripe.PaymentIntent = await stripe.paymentIntents.retrieve(
-  'pi_123456789',
+```typescript
+const stripe = new Stripe(
+  process.env.STRIPE_API_KEY,
   {
-    expand: ['customer'],
+    apiVersion: "2020-08-27;search_api_beta=v1",
   }
 );
-const customerEmail: string = (paymentIntent.customer as Stripe.Customer).email;
-```
 
-### Using Promises
-
-Every method returns a chainable promise which can be used instead of a regular
-callback:
-
-```js
-// Create a new customer and then create an invoice item then invoice it:
-stripe.customers
-  .create({
-    email: 'customer@example.com',
+await stripe.charges
+  .search({
+    query: 'metadata["foo"]:"bar"',
   })
-  .then((customer) => {
-    // have access to the customer object
-    return stripe.invoiceItems
-      .create({
-        customer: customer.id, // set the customer id
-        amount: 2500, // 25
-        currency: 'usd',
-        description: 'One-time setup fee',
-      })
-      .then((invoiceItem) => {
-        return stripe.invoices.create({
-          collection_method: 'send_invoice',
-          customer: invoiceItem.customer,
-        });
-      })
-      .then((invoice) => {
-        // New invoice created on a new customer
-      })
-      .catch((err) => {
-        // Deal with an error
-      });
+  .autoPagingEach((matchingCharge: Stripe.Charge) => {
+    console.log(matchingCharge.id);
   });
 ```
 
-## Configuration
+## More
 
-### Initialize with config object
-
-The package can be initialized with several options:
-
-```js
-import ProxyAgent from 'https-proxy-agent';
-
-const stripe = Stripe('sk_test_...', {
-  apiVersion: '2019-08-08',
-  maxNetworkRetries: 1,
-  httpAgent: new ProxyAgent(process.env.http_proxy),
-  timeout: 1000,
-  host: 'api.example.com',
-  port: 123,
-  telemetry: true,
-});
-```
-
-| Option              | Default            | Description                                                                                                                                                                                                                                       |
-| ------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiVersion`        | `null`             | Stripe API version to be used. If not set the account's default version will be used.                                                                                                                                                             |
-| `maxNetworkRetries` | 0                  | The amount of times a request should be [retried](#network-retries).                                                                                                                                                                              |
-| `httpAgent`         | `null`             | [Proxy](#configuring-a-proxy) agent to be used by the library.                                                                                                                                                                                    |
-| `timeout`           | 80000              | [Maximum time each request can take in ms.](#configuring-timeout)                                                                                                                                                                                 |
-| `host`              | `'api.stripe.com'` | Host that requests are made to.                                                                                                                                                                                                                   |
-| `port`              | 443                | Port that requests are made to.                                                                                                                                                                                                                   |
-| `protocol`          | `'https'`          | `'https'` or `'http'`. `http` is never appropriate for sending requests to Stripe servers, and we strongly discourage `http`, even in local testing scenarios, as this can result in your credentials being transmitted over an insecure channel. |
-| `telemetry`         | `true`             | Allow Stripe to send latency [telemetry](#request-latency-telemetry).                                                                                                                                                                             |
-
-Note: Both `maxNetworkRetries` and `timeout` can be overridden on a per-request basis.
-
-### Configuring Timeout
-
-Timeout can be set globally via the config object:
-
-```js
-const stripe = Stripe('sk_test_...', {
-  timeout: 20 * 1000, // 20 seconds
-});
-```
-
-And overridden on a per-request basis:
-
-```js
-stripe.customers.create(
-  {
-    email: 'customer@example.com',
-  },
-  {
-    timeout: 1000, // 1 second
-  }
-);
-```
-
-### Configuring For Connect
-
-A per-request `Stripe-Account` header for use with [Stripe Connect][connect]
-can be added to any method:
-
-```js
-// List the balance transactions for a connected account:
-stripe.balanceTransactions.list(
-  {
-    limit: 10,
-  },
-  {
-    stripeAccount: 'acct_foo',
-  }
-);
-```
-
-### Configuring a Proxy
-
-To use stripe behind a proxy you can pass an [https-proxy-agent][https-proxy-agent] on initialization:
-
-```js
-if (process.env.http_proxy) {
-  const ProxyAgent = require('https-proxy-agent');
-
-  const stripe = Stripe('sk_test_...', {
-    httpProxy: new ProxyAgent(process.env.http_proxy),
-  });
-}
-```
-
-### Network retries
-
-Automatic network retries can be enabled with the `maxNetworkRetries` config option.
-This will retry requests `n` times with exponential backoff if they fail due to an intermittent network problem.
-[Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
-
-```js
-const stripe = Stripe('sk_test_...', {
-  maxNetworkRetries: 2, // Retry a request twice before giving up
-});
-```
-
-Network retries can also be set on a per-request basis:
-
-```js
-stripe.customers.create(
-  {
-    email: 'customer@example.com',
-  },
-  {
-    maxNetworkRetries: 2, // Retry this specific request twice before giving up
-  }
-);
-```
-
-### Examining Responses
-
-Some information about the response which generated a resource is available
-with the `lastResponse` property:
-
-```js
-customer.lastResponse.requestId; // see: https://stripe.com/docs/api/request_ids?lang=node
-customer.lastResponse.statusCode;
-```
-
-### `request` and `response` events
-
-The Stripe object emits `request` and `response` events. You can use them like this:
-
-```js
-const stripe = require('stripe')('sk_test_...');
-
-const onRequest = (request) => {
-  // Do something.
-};
-
-// Add the event handler function:
-stripe.on('request', onRequest);
-
-// Remove the event handler function:
-stripe.off('request', onRequest);
-```
-
-#### `request` object
-
-```js
-{
-  api_version: 'latest',
-  account: 'acct_TEST',              // Only present if provided
-  idempotency_key: 'abc123',         // Only present if provided
-  method: 'POST',
-  path: '/v1/customers',
-  request_start_time: 1565125303932  // Unix timestamp in milliseconds
-}
-```
-
-#### `response` object
-
-```js
-{
-  api_version: 'latest',
-  account: 'acct_TEST',              // Only present if provided
-  idempotency_key: 'abc123',         // Only present if provided
-  method: 'POST',
-  path: '/v1/customers',
-  status: 402,
-  request_id: 'req_Ghc9r26ts73DRf',
-  elapsed: 445,                      // Elapsed time in milliseconds
-  request_start_time: 1565125303932, // Unix timestamp in milliseconds
-  request_end_time: 1565125304377    // Unix timestamp in milliseconds
-}
-```
-
-### Webhook signing
-
-Stripe can optionally sign the webhook events it sends to your endpoint, allowing you to validate that they were not sent by a third-party. You can read more about it [here](https://stripe.com/docs/webhooks/signatures).
-
-Please note that you must pass the _raw_ request body, exactly as received from Stripe, to the `constructEvent()` function; this will not work with a parsed (i.e., JSON) request body.
-
-You can find an example of how to use this with [Express](https://expressjs.com/) in the [`examples/webhook-signing`](examples/webhook-signing) folder, but here's what it looks like:
-
-```js
-const event = stripe.webhooks.constructEvent(
-  webhookRawBody,
-  webhookStripeSignatureHeader,
-  webhookSecret
-);
-```
-
-#### Testing Webhook signing
-
-You can use `stripe.webhooks.generateTestHeaderString` to mock webhook events that come from Stripe:
-
-```js
-const payload = {
-  id: 'evt_test_webhook',
-  object: 'event',
-};
-
-const payloadString = JSON.stringify(payload, null, 2);
-const secret = 'whsec_test_secret';
-
-const header = stripe.webhooks.generateTestHeaderString({
-  payload: payloadString,
-  secret,
-});
-
-const event = stripe.webhooks.constructEvent(payloadString, header, secret);
-
-// Do something with mocked signed event
-expect(event.id).to.equal(payload.id);
-```
-
-### Writing a Plugin
-
-If you're writing a plugin that uses the library, we'd appreciate it if you identified using `stripe.setAppInfo()`:
-
-```js
-stripe.setAppInfo({
-  name: 'MyAwesomePlugin',
-  version: '1.2.34', // Optional
-  url: 'https://myawesomeplugin.info', // Optional
-});
-```
-
-This information is passed along when the library makes calls to the Stripe API.
-
-### Auto-pagination
-
-We provide a few different APIs for this to aid with a variety of node versions and styles.
-
-#### Async iterators (`for-await-of`)
-
-If you are in a Node environment that has support for [async iteration](https://github.com/tc39/proposal-async-iteration#the-async-iteration-statement-for-await-of),
-such as Node 10+ or [babel](https://babeljs.io/docs/en/babel-plugin-transform-async-generator-functions),
-the following will auto-paginate:
-
-```js
-for await (const customer of stripe.customers.list()) {
-  doSomething(customer);
-  if (shouldStop()) {
-    break;
-  }
-}
-```
-
-#### `autoPagingEach`
-
-If you are in a Node environment that has support for `await`, such as Node 7.9 and greater,
-you may pass an async function to `.autoPagingEach`:
-
-```js
-await stripe.customers.list().autoPagingEach(async (customer) => {
-  await doSomething(customer);
-  if (shouldBreak()) {
-    return false;
-  }
-});
-console.log('Done iterating.');
-```
-
-Equivalently, without `await`, you may return a Promise, which can resolve to `false` to break:
-
-```js
-stripe.customers
-  .list()
-  .autoPagingEach((customer) => {
-    return doSomething(customer).then(() => {
-      if (shouldBreak()) {
-        return false;
-      }
-    });
-  })
-  .then(() => {
-    console.log('Done iterating.');
-  })
-  .catch(handleError);
-```
-
-#### `autoPagingToArray`
-
-This is a convenience for cases where you expect the number of items
-to be relatively small; accordingly, you must pass a `limit` option
-to prevent runaway list growth from consuming too much memory.
-
-Returns a promise of an array of all items across pages for a list request.
-
-```js
-const allNewCustomers = await stripe.customers
-  .list({created: {gt: lastMonth}})
-  .autoPagingToArray({limit: 10000});
-```
-
-### Request latency telemetry
-
-By default, the library sends request latency telemetry to Stripe. These
-numbers help Stripe improve the overall latency of its API for all users.
-
-You can disable this behavior if you prefer:
-
-```js
-const stripe = new Stripe('sk_test_...', {
-  telemetry: false,
-});
-```
-
-## More Information
-
-- [REST API Version](https://github.com/stripe/stripe-node/wiki/REST-API-Version)
-- [Error Handling](https://github.com/stripe/stripe-node/wiki/Error-Handling)
-- [Passing Options](https://github.com/stripe/stripe-node/wiki/Passing-Options)
-- [Using Stripe Connect](https://github.com/stripe/stripe-node/wiki/Using-Stripe-Connect-with-node.js)
-
-## Development
-
-Run all tests:
-
-```bash
-$ yarn install
-$ yarn test
-```
-
-If you do not have `yarn` installed, you can get it with `npm install --global yarn`.
-
-Run a single test suite without a coverage report:
-
-```bash
-$ yarn mocha-only test/Error.spec.js
-```
-
-Run a single test (case sensitive) in watch mode:
-
-```bash
-$ yarn mocha-only test/Error.spec.js --grep 'Populates with type' --watch
-```
-
-If you wish, you may run tests using your Stripe _Test_ API key by setting the
-environment variable `STRIPE_TEST_API_KEY` before running the tests:
-
-```bash
-$ export STRIPE_TEST_API_KEY='sk_test....'
-$ yarn test
-```
-
-Run prettier:
-
-Add an [editor integration](https://prettier.io/docs/en/editors.html) or:
-
-```bash
-$ yarn fix
-```
-
-[api-keys]: https://dashboard.stripe.com/account/apikeys
-[api-versions]: https://stripe.com/docs/api/versioning
-[api-version-upgrading]: https://stripe.com/docs/upgrades#how-can-i-upgrade-my-api
-[connect]: https://stripe.com/connect
-[expanding_objects]: https://stripe.com/docs/api/expanding_objects
-[https-proxy-agent]: https://github.com/TooTallNate/node-https-proxy-agent
-[stripe-js]: https://stripe.com/docs/js
-[youtube-playlist]: https://www.youtube.com/playlist?list=PLy1nL-pvL2M5xNIuNapwmABwEy2uifAlY
+For more detailed usage instructions, see the [README.md](https://github.com/stripe/stripe-node/blob/master/README.md) from the [master branch of stripe-node](https://github.com/stripe/stripe-node).
 
 <!--
 # vim: set tw=79:

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -5,7 +5,7 @@ const resources = require('./resources');
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';
 const DEFAULT_BASE_PATH = '/v1/';
-const DEFAULT_API_VERSION = null;
+const DEFAULT_API_VERSION = '2020-08-27;search_api_beta=v1';
 
 const DEFAULT_TIMEOUT = 80000;
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-search-beta",
-  "version": "0.0.1",
+  "version": "0.0.2",
   "description": "Stripe API wrapper",
   "keywords": [
     "stripe",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "stripe-search-beta",
-  "version": "0.0.2",
+  "version": "8.174.0",
   "description": "Stripe API wrapper",
   "keywords": [
     "stripe",

--- a/types/2020-08-27/AccountLinks.d.ts
+++ b/types/2020-08-27/AccountLinks.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The AccountLink object.

--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Account object.

--- a/types/2020-08-27/AlipayAccounts.d.ts
+++ b/types/2020-08-27/AlipayAccounts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The AlipayAccount object.

--- a/types/2020-08-27/ApplePayDomains.d.ts
+++ b/types/2020-08-27/ApplePayDomains.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The ApplePayDomain object.

--- a/types/2020-08-27/ApplicationFees.d.ts
+++ b/types/2020-08-27/ApplicationFees.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The ApplicationFee object.

--- a/types/2020-08-27/Applications.d.ts
+++ b/types/2020-08-27/Applications.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Application object.

--- a/types/2020-08-27/Balance.d.ts
+++ b/types/2020-08-27/Balance.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Balance object.

--- a/types/2020-08-27/BalanceTransactions.d.ts
+++ b/types/2020-08-27/BalanceTransactions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The BalanceTransaction object.

--- a/types/2020-08-27/BankAccounts.d.ts
+++ b/types/2020-08-27/BankAccounts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The BankAccount object.

--- a/types/2020-08-27/BillingPortal/Configurations.d.ts
+++ b/types/2020-08-27/BillingPortal/Configurations.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace BillingPortal {
       /**

--- a/types/2020-08-27/BillingPortal/Sessions.d.ts
+++ b/types/2020-08-27/BillingPortal/Sessions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace BillingPortal {
       /**

--- a/types/2020-08-27/BitcoinReceivers.d.ts
+++ b/types/2020-08-27/BitcoinReceivers.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The BitcoinReceiver object.

--- a/types/2020-08-27/BitcoinTransactions.d.ts
+++ b/types/2020-08-27/BitcoinTransactions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The BitcoinTransaction object.

--- a/types/2020-08-27/Capabilities.d.ts
+++ b/types/2020-08-27/Capabilities.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Capability object.

--- a/types/2020-08-27/Cards.d.ts
+++ b/types/2020-08-27/Cards.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Card object.

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Charge object.

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Checkout {
       /**

--- a/types/2020-08-27/ConnectCollectionTransfers.d.ts
+++ b/types/2020-08-27/ConnectCollectionTransfers.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The ConnectCollectionTransfer object.

--- a/types/2020-08-27/CountrySpecs.d.ts
+++ b/types/2020-08-27/CountrySpecs.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The CountrySpec object.

--- a/types/2020-08-27/Coupons.d.ts
+++ b/types/2020-08-27/Coupons.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Coupon object.

--- a/types/2020-08-27/CreditNoteLineItems.d.ts
+++ b/types/2020-08-27/CreditNoteLineItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The CreditNoteLineItem object.

--- a/types/2020-08-27/CreditNotes.d.ts
+++ b/types/2020-08-27/CreditNotes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The CreditNote object.

--- a/types/2020-08-27/CustomerBalanceTransactions.d.ts
+++ b/types/2020-08-27/CustomerBalanceTransactions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The CustomerBalanceTransaction object.

--- a/types/2020-08-27/CustomerSources.d.ts
+++ b/types/2020-08-27/CustomerSources.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     interface CustomerSourceCreateParams {
       /**

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Customer object.

--- a/types/2020-08-27/Discounts.d.ts
+++ b/types/2020-08-27/Discounts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Discount object.

--- a/types/2020-08-27/Disputes.d.ts
+++ b/types/2020-08-27/Disputes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Dispute object.

--- a/types/2020-08-27/EphemeralKeys.d.ts
+++ b/types/2020-08-27/EphemeralKeys.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The EphemeralKey object.

--- a/types/2020-08-27/Events.d.ts
+++ b/types/2020-08-27/Events.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Event object.

--- a/types/2020-08-27/ExchangeRates.d.ts
+++ b/types/2020-08-27/ExchangeRates.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The ExchangeRate object.

--- a/types/2020-08-27/ExternalAccounts.d.ts
+++ b/types/2020-08-27/ExternalAccounts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     interface ExternalAccountCreateParams {
       /**

--- a/types/2020-08-27/FeeRefunds.d.ts
+++ b/types/2020-08-27/FeeRefunds.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The FeeRefund object.

--- a/types/2020-08-27/FileLinks.d.ts
+++ b/types/2020-08-27/FileLinks.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The FileLink object.

--- a/types/2020-08-27/Files.d.ts
+++ b/types/2020-08-27/Files.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The File object.

--- a/types/2020-08-27/Identity/VerificationReports.d.ts
+++ b/types/2020-08-27/Identity/VerificationReports.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Identity {
       /**

--- a/types/2020-08-27/Identity/VerificationSessions.d.ts
+++ b/types/2020-08-27/Identity/VerificationSessions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Identity {
       /**

--- a/types/2020-08-27/InvoiceItems.d.ts
+++ b/types/2020-08-27/InvoiceItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The InvoiceItem object.

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The InvoiceLineItem object.

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Invoice object.

--- a/types/2020-08-27/IssuerFraudRecords.d.ts
+++ b/types/2020-08-27/IssuerFraudRecords.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The IssuerFraudRecord object.

--- a/types/2020-08-27/Issuing/Authorizations.d.ts
+++ b/types/2020-08-27/Issuing/Authorizations.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Issuing {
       /**

--- a/types/2020-08-27/Issuing/CardDetails.d.ts
+++ b/types/2020-08-27/Issuing/CardDetails.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Issuing {
       /**

--- a/types/2020-08-27/Issuing/Cardholders.d.ts
+++ b/types/2020-08-27/Issuing/Cardholders.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Issuing {
       /**

--- a/types/2020-08-27/Issuing/Cards.d.ts
+++ b/types/2020-08-27/Issuing/Cards.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Issuing {
       /**

--- a/types/2020-08-27/Issuing/Disputes.d.ts
+++ b/types/2020-08-27/Issuing/Disputes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Issuing {
       /**

--- a/types/2020-08-27/Issuing/Transactions.d.ts
+++ b/types/2020-08-27/Issuing/Transactions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Issuing {
       /**

--- a/types/2020-08-27/LineItems.d.ts
+++ b/types/2020-08-27/LineItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The LineItem object.

--- a/types/2020-08-27/LoginLinks.d.ts
+++ b/types/2020-08-27/LoginLinks.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The LoginLink object.

--- a/types/2020-08-27/Mandates.d.ts
+++ b/types/2020-08-27/Mandates.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Mandate object.

--- a/types/2020-08-27/OrderItems.d.ts
+++ b/types/2020-08-27/OrderItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The OrderItem object.

--- a/types/2020-08-27/OrderReturns.d.ts
+++ b/types/2020-08-27/OrderReturns.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The OrderReturn object.

--- a/types/2020-08-27/Orders.d.ts
+++ b/types/2020-08-27/Orders.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Order object.

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The PaymentIntent object.

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The PaymentMethod object.

--- a/types/2020-08-27/Payouts.d.ts
+++ b/types/2020-08-27/Payouts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Payout object.

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Person object.

--- a/types/2020-08-27/Plans.d.ts
+++ b/types/2020-08-27/Plans.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Plan object.

--- a/types/2020-08-27/PlatformTaxFees.d.ts
+++ b/types/2020-08-27/PlatformTaxFees.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The PlatformTaxFee object.

--- a/types/2020-08-27/Prices.d.ts
+++ b/types/2020-08-27/Prices.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Price object.

--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Product object.

--- a/types/2020-08-27/PromotionCodes.d.ts
+++ b/types/2020-08-27/PromotionCodes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The PromotionCode object.

--- a/types/2020-08-27/Quotes.d.ts
+++ b/types/2020-08-27/Quotes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Quote object.

--- a/types/2020-08-27/Radar/EarlyFraudWarnings.d.ts
+++ b/types/2020-08-27/Radar/EarlyFraudWarnings.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Radar {
       /**

--- a/types/2020-08-27/Radar/ValueListItems.d.ts
+++ b/types/2020-08-27/Radar/ValueListItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Radar {
       /**

--- a/types/2020-08-27/Radar/ValueLists.d.ts
+++ b/types/2020-08-27/Radar/ValueLists.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Radar {
       /**

--- a/types/2020-08-27/Recipients.d.ts
+++ b/types/2020-08-27/Recipients.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Recipient object.

--- a/types/2020-08-27/Refunds.d.ts
+++ b/types/2020-08-27/Refunds.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Refund object.

--- a/types/2020-08-27/Reporting/ReportRuns.d.ts
+++ b/types/2020-08-27/Reporting/ReportRuns.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Reporting {
       /**

--- a/types/2020-08-27/Reporting/ReportTypes.d.ts
+++ b/types/2020-08-27/Reporting/ReportTypes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Reporting {
       /**

--- a/types/2020-08-27/ReserveTransactions.d.ts
+++ b/types/2020-08-27/ReserveTransactions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The ReserveTransaction object.

--- a/types/2020-08-27/Reviews.d.ts
+++ b/types/2020-08-27/Reviews.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Review object.

--- a/types/2020-08-27/SKUs.d.ts
+++ b/types/2020-08-27/SKUs.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Sku object.

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The SetupAttempt object.

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The SetupIntent object.

--- a/types/2020-08-27/Sigma/ScheduledQueryRuns.d.ts
+++ b/types/2020-08-27/Sigma/ScheduledQueryRuns.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Sigma {
       /**

--- a/types/2020-08-27/SourceMandateNotifications.d.ts
+++ b/types/2020-08-27/SourceMandateNotifications.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The SourceMandateNotification object.

--- a/types/2020-08-27/SourceTransactions.d.ts
+++ b/types/2020-08-27/SourceTransactions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The SourceTransaction object.

--- a/types/2020-08-27/Sources.d.ts
+++ b/types/2020-08-27/Sources.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Source object.

--- a/types/2020-08-27/SubscriptionItems.d.ts
+++ b/types/2020-08-27/SubscriptionItems.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The SubscriptionItem object.

--- a/types/2020-08-27/SubscriptionSchedules.d.ts
+++ b/types/2020-08-27/SubscriptionSchedules.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The SubscriptionSchedule object.

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Subscription object.

--- a/types/2020-08-27/TaxCodes.d.ts
+++ b/types/2020-08-27/TaxCodes.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The TaxCode object.

--- a/types/2020-08-27/TaxDeductedAtSources.d.ts
+++ b/types/2020-08-27/TaxDeductedAtSources.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The TaxDeductedAtSource object.

--- a/types/2020-08-27/TaxIds.d.ts
+++ b/types/2020-08-27/TaxIds.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The TaxId object.

--- a/types/2020-08-27/TaxRates.d.ts
+++ b/types/2020-08-27/TaxRates.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The TaxRate object.

--- a/types/2020-08-27/Terminal/ConnectionTokens.d.ts
+++ b/types/2020-08-27/Terminal/ConnectionTokens.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Terminal {
       /**

--- a/types/2020-08-27/Terminal/Locations.d.ts
+++ b/types/2020-08-27/Terminal/Locations.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Terminal {
       /**

--- a/types/2020-08-27/Terminal/Readers.d.ts
+++ b/types/2020-08-27/Terminal/Readers.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     namespace Terminal {
       /**

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Token object.

--- a/types/2020-08-27/Topups.d.ts
+++ b/types/2020-08-27/Topups.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Topup object.

--- a/types/2020-08-27/TransferReversals.d.ts
+++ b/types/2020-08-27/TransferReversals.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The TransferReversal object.

--- a/types/2020-08-27/Transfers.d.ts
+++ b/types/2020-08-27/Transfers.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The Transfer object.

--- a/types/2020-08-27/UsageRecordSummaries.d.ts
+++ b/types/2020-08-27/UsageRecordSummaries.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The UsageRecordSummary object.

--- a/types/2020-08-27/UsageRecords.d.ts
+++ b/types/2020-08-27/UsageRecords.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The UsageRecord object.

--- a/types/2020-08-27/WebhookEndpoints.d.ts
+++ b/types/2020-08-27/WebhookEndpoints.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * The WebhookEndpoint object.

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -102,7 +102,7 @@
 ///<reference path='./UsageRecords.d.ts' />
 ///<reference path='./WebhookEndpoints.d.ts' />
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   // Added to in other modules, referenced above.
   export namespace Stripe {}
 

--- a/types/Errors.d.ts
+++ b/types/Errors.d.ts
@@ -1,4 +1,4 @@
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     export type Errors = {
       generate: typeof StripeError.generate;

--- a/types/OAuth.d.ts
+++ b/types/OAuth.d.ts
@@ -1,4 +1,4 @@
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     interface OAuthToken {
       /**

--- a/types/Webhooks.d.ts
+++ b/types/Webhooks.d.ts
@@ -1,6 +1,6 @@
 /// <reference types="node" />
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     export class Webhooks {
       /**

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -3,7 +3,7 @@
 
 import {Agent} from 'http';
 
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     export class StripeResource {
       static extend<
@@ -45,7 +45,7 @@ declare module 'stripe' {
       };
       static MAX_BUFFERED_REQUEST_METRICS: number;
     }
-    export type LatestApiVersion = '2020-08-27';
+    export type LatestApiVersion = '2020-08-27;search_api_beta=v1';
     export type HttpAgent = Agent;
     export type HttpProtocol = 'http' | 'https';
 

--- a/types/net/net.d.ts
+++ b/types/net/net.d.ts
@@ -1,7 +1,7 @@
 /// <reference types="node" />
 
 import {IncomingMessage} from 'http';
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * Encapsulates the logic for issuing a request to the Stripe API. This is

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -1,4 +1,4 @@
-declare module 'stripe' {
+declare module 'stripe-search-beta' {
   namespace Stripe {
     /**
      * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.


### PR DESCRIPTION
Note: the target for this pr is `search-beta`, not master.
## Notify
r? @dcr-stripe 
cc @stripe/api-libraries 

## Summary
* Bumped the version from `0.0.2` to `8.174.0` to match the mainline library.
* beta-specific README.md.
* Changed the library so that `stripe-version:2020-08-27;search_api_beta=v1` header is sent by default on all requests.
* Fix the typescript types:
  * Changed the module name to `stripe-search-beta` - in my testing this was necessary for the Typescript types to be picked up my by example project after changing the import statement.
  * Changed the `apiVersion` type to "2020-08-27;search_api_beta=v1" -- so that users will get a Typescript error if they are not configuring their library to send that API version.