### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/BillingPortal/Configurations.d.ts
+++ b/types/2020-08-27/BillingPortal/Configurations.d.ts
@@ -126,7 +126,7 @@ declare module 'stripe' {
           }
 
           interface SubscriptionCancel {
-            cancellation_reason?: SubscriptionCancel.CancellationReason;
+            cancellation_reason: SubscriptionCancel.CancellationReason;
 
             /**
              * Whether the feature is enabled.

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -924,7 +924,7 @@ declare module 'stripe' {
           brand: string | null;
 
           /**
-           * The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`).
+           * The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). In some cases, the cardholder name may not be available depending on how the issuer has configured the card. Cardholder name is typically not available on swipe or contactless payments, such as those made with Apple Pay and Google Pay.
            */
           cardholder_name: string | null;
 
@@ -1252,7 +1252,7 @@ declare module 'stripe' {
           brand: string | null;
 
           /**
-           * The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`).
+           * The cardholder name as read from the card, in [ISO 7813](https://en.wikipedia.org/wiki/ISO/IEC_7813) format. May include alphanumeric characters, special characters and first/last name separator (`/`). In some cases, the cardholder name may not be available depending on how the issuer has configured the card. Cardholder name is typically not available on swipe or contactless payments, such as those made with Apple Pay and Google Pay.
            */
           cardholder_name: string | null;
 

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -423,6 +423,11 @@ declare module 'stripe' {
               custom_mandate_url?: string;
 
               /**
+               * List of Stripe products where this mandate can be selected automatically. Returned when the Session is in `setup` mode.
+               */
+              default_for?: Array<MandateOptions.DefaultFor>;
+
+              /**
                * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
                */
               interval_description: string | null;
@@ -439,6 +444,8 @@ declare module 'stripe' {
             }
 
             namespace MandateOptions {
+              type DefaultFor = 'invoice' | 'subscription';
+
               type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
               type TransactionType = 'business' | 'personal';
@@ -1457,6 +1464,11 @@ declare module 'stripe' {
               custom_mandate_url?: Stripe.Emptyable<string>;
 
               /**
+               * List of Stripe products where this mandate can be selected automatically. Only usable in `setup` mode.
+               */
+              default_for?: Array<MandateOptions.DefaultFor>;
+
+              /**
                * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
                */
               interval_description?: string;
@@ -1473,6 +1485,8 @@ declare module 'stripe' {
             }
 
             namespace MandateOptions {
+              type DefaultFor = 'invoice' | 'subscription';
+
               type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
               type TransactionType = 'business' | 'personal';

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -582,6 +582,11 @@ declare module 'stripe' {
       namespace PaymentSettings {
         interface PaymentMethodOptions {
           /**
+           * If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          acss_debit: PaymentMethodOptions.AcssDebit | null;
+
+          /**
            * If paying by `bancontact`, this sub-hash contains details about the Bancontact payment method options to pass to the invoice's PaymentIntent.
            */
           bancontact: PaymentMethodOptions.Bancontact | null;
@@ -593,6 +598,30 @@ declare module 'stripe' {
         }
 
         namespace PaymentMethodOptions {
+          interface AcssDebit {
+            mandate_options?: AcssDebit.MandateOptions;
+
+            /**
+             * Bank account verification method.
+             */
+            verification_method?: AcssDebit.VerificationMethod;
+          }
+
+          namespace AcssDebit {
+            interface MandateOptions {
+              /**
+               * Transaction type of the mandate.
+               */
+              transaction_type: MandateOptions.TransactionType | null;
+            }
+
+            namespace MandateOptions {
+              type TransactionType = 'business' | 'personal';
+            }
+
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
           interface Bancontact {
             /**
              * Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -619,6 +648,7 @@ declare module 'stripe' {
         type PaymentMethodType =
           | 'ach_credit_transfer'
           | 'ach_debit'
+          | 'acss_debit'
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
@@ -914,6 +944,11 @@ declare module 'stripe' {
       namespace PaymentSettings {
         interface PaymentMethodOptions {
           /**
+           * If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
+          /**
            * If paying by `bancontact`, this sub-hash contains details about the Bancontact payment method options to pass to the invoice's PaymentIntent.
            */
           bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
@@ -925,6 +960,33 @@ declare module 'stripe' {
         }
 
         namespace PaymentMethodOptions {
+          interface AcssDebit {
+            /**
+             * Additional fields for Mandate creation
+             */
+            mandate_options?: AcssDebit.MandateOptions;
+
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: AcssDebit.VerificationMethod;
+          }
+
+          namespace AcssDebit {
+            interface MandateOptions {
+              /**
+               * Transaction type of the mandate.
+               */
+              transaction_type?: MandateOptions.TransactionType;
+            }
+
+            namespace MandateOptions {
+              type TransactionType = 'business' | 'personal';
+            }
+
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
           interface Bancontact {
             /**
              * Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -951,6 +1013,7 @@ declare module 'stripe' {
         type PaymentMethodType =
           | 'ach_credit_transfer'
           | 'ach_debit'
+          | 'acss_debit'
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
@@ -1138,6 +1201,11 @@ declare module 'stripe' {
       namespace PaymentSettings {
         interface PaymentMethodOptions {
           /**
+           * If paying by `acss_debit`, this sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
+          /**
            * If paying by `bancontact`, this sub-hash contains details about the Bancontact payment method options to pass to the invoice's PaymentIntent.
            */
           bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
@@ -1149,6 +1217,33 @@ declare module 'stripe' {
         }
 
         namespace PaymentMethodOptions {
+          interface AcssDebit {
+            /**
+             * Additional fields for Mandate creation
+             */
+            mandate_options?: AcssDebit.MandateOptions;
+
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: AcssDebit.VerificationMethod;
+          }
+
+          namespace AcssDebit {
+            interface MandateOptions {
+              /**
+               * Transaction type of the mandate.
+               */
+              transaction_type?: MandateOptions.TransactionType;
+            }
+
+            namespace MandateOptions {
+              type TransactionType = 'business' | 'personal';
+            }
+
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
           interface Bancontact {
             /**
              * Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -1175,6 +1270,7 @@ declare module 'stripe' {
         type PaymentMethodType =
           | 'ach_credit_transfer'
           | 'ach_debit'
+          | 'acss_debit'
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'

--- a/types/2020-08-27/Mandates.d.ts
+++ b/types/2020-08-27/Mandates.d.ts
@@ -102,6 +102,11 @@ declare module 'stripe' {
       namespace PaymentMethodDetails {
         interface AcssDebit {
           /**
+           * List of Stripe products where this mandate can be selected automatically.
+           */
+          default_for?: Array<AcssDebit.DefaultFor>;
+
+          /**
            * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
            */
           interval_description: string | null;
@@ -118,6 +123,8 @@ declare module 'stripe' {
         }
 
         namespace AcssDebit {
+          type DefaultFor = 'invoice' | 'subscription';
+
           type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
           type TransactionType = 'business' | 'personal';

--- a/types/2020-08-27/Reporting/ReportTypes.d.ts
+++ b/types/2020-08-27/Reporting/ReportTypes.d.ts
@@ -33,6 +33,11 @@ declare module 'stripe' {
         default_columns: Array<string> | null;
 
         /**
+         * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+         */
+        livemode: boolean;
+
+        /**
          * Human-readable name of the Report Type
          */
         name: string;

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -303,6 +303,11 @@ declare module 'stripe' {
             custom_mandate_url?: string;
 
             /**
+             * List of Stripe products where this mandate can be selected automatically.
+             */
+            default_for?: Array<MandateOptions.DefaultFor>;
+
+            /**
              * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
              */
             interval_description: string | null;
@@ -319,6 +324,8 @@ declare module 'stripe' {
           }
 
           namespace MandateOptions {
+            type DefaultFor = 'invoice' | 'subscription';
+
             type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
             type TransactionType = 'business' | 'personal';
@@ -522,6 +529,11 @@ declare module 'stripe' {
             custom_mandate_url?: Stripe.Emptyable<string>;
 
             /**
+             * List of Stripe products where this mandate can be selected automatically.
+             */
+            default_for?: Array<MandateOptions.DefaultFor>;
+
+            /**
              * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
              */
             interval_description?: string;
@@ -538,6 +550,8 @@ declare module 'stripe' {
           }
 
           namespace MandateOptions {
+            type DefaultFor = 'invoice' | 'subscription';
+
             type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
             type TransactionType = 'business' | 'personal';
@@ -690,6 +704,11 @@ declare module 'stripe' {
             custom_mandate_url?: Stripe.Emptyable<string>;
 
             /**
+             * List of Stripe products where this mandate can be selected automatically.
+             */
+            default_for?: Array<MandateOptions.DefaultFor>;
+
+            /**
              * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
              */
             interval_description?: string;
@@ -706,6 +725,8 @@ declare module 'stripe' {
           }
 
           namespace MandateOptions {
+            type DefaultFor = 'invoice' | 'subscription';
+
             type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
             type TransactionType = 'business' | 'personal';
@@ -949,6 +970,11 @@ declare module 'stripe' {
             custom_mandate_url?: Stripe.Emptyable<string>;
 
             /**
+             * List of Stripe products where this mandate can be selected automatically.
+             */
+            default_for?: Array<MandateOptions.DefaultFor>;
+
+            /**
              * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
              */
             interval_description?: string;
@@ -965,6 +991,8 @@ declare module 'stripe' {
           }
 
           namespace MandateOptions {
+            type DefaultFor = 'invoice' | 'subscription';
+
             type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
             type TransactionType = 'business' | 'personal';

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -245,6 +245,11 @@ declare module 'stripe' {
       namespace PaymentSettings {
         interface PaymentMethodOptions {
           /**
+           * This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to invoices created by the subscription.
+           */
+          acss_debit: PaymentMethodOptions.AcssDebit | null;
+
+          /**
            * This sub-hash contains details about the Bancontact payment method options to pass to invoices created by the subscription.
            */
           bancontact: PaymentMethodOptions.Bancontact | null;
@@ -256,6 +261,30 @@ declare module 'stripe' {
         }
 
         namespace PaymentMethodOptions {
+          interface AcssDebit {
+            mandate_options?: AcssDebit.MandateOptions;
+
+            /**
+             * Bank account verification method.
+             */
+            verification_method?: AcssDebit.VerificationMethod;
+          }
+
+          namespace AcssDebit {
+            interface MandateOptions {
+              /**
+               * Transaction type of the mandate.
+               */
+              transaction_type: MandateOptions.TransactionType | null;
+            }
+
+            namespace MandateOptions {
+              type TransactionType = 'business' | 'personal';
+            }
+
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
           interface Bancontact {
             /**
              * Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -282,6 +311,7 @@ declare module 'stripe' {
         type PaymentMethodType =
           | 'ach_credit_transfer'
           | 'ach_debit'
+          | 'acss_debit'
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
@@ -713,6 +743,11 @@ declare module 'stripe' {
       namespace PaymentSettings {
         interface PaymentMethodOptions {
           /**
+           * This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
+          /**
            * This sub-hash contains details about the Bancontact payment method options to pass to the invoice's PaymentIntent.
            */
           bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
@@ -724,6 +759,33 @@ declare module 'stripe' {
         }
 
         namespace PaymentMethodOptions {
+          interface AcssDebit {
+            /**
+             * Additional fields for Mandate creation
+             */
+            mandate_options?: AcssDebit.MandateOptions;
+
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: AcssDebit.VerificationMethod;
+          }
+
+          namespace AcssDebit {
+            interface MandateOptions {
+              /**
+               * Transaction type of the mandate.
+               */
+              transaction_type?: MandateOptions.TransactionType;
+            }
+
+            namespace MandateOptions {
+              type TransactionType = 'business' | 'personal';
+            }
+
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
           interface Bancontact {
             /**
              * Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -750,6 +812,7 @@ declare module 'stripe' {
         type PaymentMethodType =
           | 'ach_credit_transfer'
           | 'ach_debit'
+          | 'acss_debit'
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'
@@ -1186,6 +1249,11 @@ declare module 'stripe' {
       namespace PaymentSettings {
         interface PaymentMethodOptions {
           /**
+           * This sub-hash contains details about the Canadian pre-authorized debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
+          /**
            * This sub-hash contains details about the Bancontact payment method options to pass to the invoice's PaymentIntent.
            */
           bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
@@ -1197,6 +1265,33 @@ declare module 'stripe' {
         }
 
         namespace PaymentMethodOptions {
+          interface AcssDebit {
+            /**
+             * Additional fields for Mandate creation
+             */
+            mandate_options?: AcssDebit.MandateOptions;
+
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: AcssDebit.VerificationMethod;
+          }
+
+          namespace AcssDebit {
+            interface MandateOptions {
+              /**
+               * Transaction type of the mandate.
+               */
+              transaction_type?: MandateOptions.TransactionType;
+            }
+
+            namespace MandateOptions {
+              type TransactionType = 'business' | 'personal';
+            }
+
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
+
           interface Bancontact {
             /**
              * Preferred language of the Bancontact authorization page that the customer is redirected to.
@@ -1223,6 +1318,7 @@ declare module 'stripe' {
         type PaymentMethodType =
           | 'ach_credit_transfer'
           | 'ach_debit'
+          | 'acss_debit'
           | 'au_becs_debit'
           | 'bacs_debit'
           | 'bancontact'

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -1,6 +1,7 @@
 // File generated from our OpenAPI spec
 
 ///<reference path='../lib.d.ts' />
+///<reference path='../crypto/crypto.d.ts' />
 ///<reference path='../net/net.d.ts' />
 ///<reference path='../shared.d.ts' />
 ///<reference path='../Errors.d.ts' />

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -1,7 +1,6 @@
 // File generated from our OpenAPI spec
 
 ///<reference path='../lib.d.ts' />
-///<reference path='../crypto/crypto.d.ts' />
 ///<reference path='../net/net.d.ts' />
 ///<reference path='../shared.d.ts' />
 ///<reference path='../Errors.d.ts' />


### PR DESCRIPTION
Codegen for openapi 95a1ab8.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Change `BillingPortal.Configuration.features.subscription_cancel.cancellation_reason` to be required
* Add support for `default_for` on `CheckoutSessionCreateParams.payment_method_options.acss_debit.mandate_options`, `Checkout.Session.payment_method_options.acss_debit.mandate_options`, `Mandate.payment_method_details.acss_debit`, `SetupIntentCreateParams.payment_method_options.acss_debit.mandate_options`, `SetupIntentUpdateParams.payment_method_options.acss_debit.mandate_options`, `SetupIntentConfirmParams.payment_method_options.acss_debit.mandate_options`, and `SetupIntent.payment_method_options.acss_debit.mandate_options`
* Add support for `acss_debit` on `InvoiceCreateParams.payment_settings.payment_method_options`, `InvoiceUpdateParams.payment_settings.payment_method_options`, `Invoice.payment_settings.payment_method_options`, `SubscriptionCreateParams.payment_settings.payment_method_options`, `SubscriptionUpdateParams.payment_settings.payment_method_options`, and `Subscription.payment_settings.payment_method_options`
* Add support for new value `acss_debit` on enums `InvoiceCreateParams.payment_settings.payment_method_types[]`, `InvoiceUpdateParams.payment_settings.payment_method_types[]`, `Invoice.payment_settings.payment_method_types[]`, `SubscriptionCreateParams.payment_settings.payment_method_types[]`, `SubscriptionUpdateParams.payment_settings.payment_method_types[]`, and `Subscription.payment_settings.payment_method_types[]`
* Add support for `livemode` on `Reporting.ReportType`

