### PR TITLE
Add stripe-mock for testing along with a sample integration test.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -28,7 +28,7 @@ jobs:
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"
-      
+
       - uses: actions/cache@v2
         id: yarn-cache
         with:
@@ -36,6 +36,9 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
+
+      - name: Start stripe-mock
+        run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
 
       - name: Lint, typecheck, and test
         run: yarn && yarn test

--- a/README.md
+++ b/README.md
@@ -477,6 +477,15 @@ $ yarn test
 
 If you do not have `yarn` installed, you can get it with `npm install --global yarn`.
 
+The tests also depends on [stripe-mock][stripe-mock], so make sure to fetch and
+run it from a background terminal ([stripe-mock's README][stripe-mock-usage]
+also contains instructions for installing via Homebrew and other methods):
+
+```bash
+go get -u github.com/stripe/stripe-mock
+stripe-mock
+```
+
 Run a single test suite without a coverage report:
 
 ```bash

--- a/test/resources/Integration.spec.js
+++ b/test/resources/Integration.spec.js
@@ -1,0 +1,16 @@
+'use strict';
+
+// Resource integration tests which use stripe-mock.
+
+const stripe = require('../../testUtils').getStripeMockClient();
+const expect = require('chai').expect;
+
+describe('Customers Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', async () => {
+      const customer = await stripe.customers.retrieve('cus_123');
+      expect(customer).to.not.be.null;
+      expect(customer.id).to.equal('cus_123');
+    });
+  });
+});

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -41,6 +41,16 @@ const utils = (module.exports = {
     });
   },
 
+  getStripeMockClient: () => {
+    const stripe = require('../lib/stripe');
+
+    return stripe('sk_test_123', {
+      host: process.env.STRIPE_MOCK_HOST || 'localhost',
+      port: process.env.STRIPE_MOCK_PORT || 12111,
+      protocol: 'http',
+    });
+  },
+
   getUserStripeKey: () => {
     const key =
       process.env.STRIPE_TEST_API_KEY || 'tGN0bIwXnHdwOa85VABjPdSn8nWY7G7I';


### PR DESCRIPTION
### Notify

r? @richardm-stripe 

### Summary

Adds support for `stripe-mock` tests by running the Docker image as part of CI and adding utility functions for creating a stripe-mock client.

### Test plan

Added a sample integration test which uses this client.