### PR TITLE
Fix StripeResource.extend type

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -13,7 +13,7 @@ declare module 'stripe' {
             'create' | 'retrieve' | 'update' | 'list' | 'del'
           >;
         }
-      >(spec: T): StripeResource & T;
+      >(spec: T): typeof StripeResource & T;
       static method(spec: {
         method: string;
         path?: string;

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -175,7 +175,7 @@ const stripeCardError: Stripe.StripeCardError = Stripe.errors.generate({
   charge: 'ch_123',
 });
 
-Stripe.StripeResource.extend({
+const Foo = Stripe.StripeResource.extend({
   includeBasic: ['retrieve'],
   foo: Stripe.StripeResource.method({
     method: 'create',
@@ -191,6 +191,7 @@ Stripe.StripeResource.extend({
     methodType: 'search',
   }),
 });
+new Foo();
 
 const maxBufferedRequestMetrics: number =
   Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS;


### PR DESCRIPTION
I have access to a beta feature, which I wanted to use with the stripe library. 

In the process, I found that the result of `Stripe.StripeResource.extend()` did not have a constructor, so TypeScript would not let you do this:

```ts
const Foo = Stripe.StripeResource.extend(); 
new Foo(stripe)
```

This fixes that.

For context, I use this like so:
```ts
class Foos extends Stripe.StripeResource.extend({ path: "foos" }) {
  create = Stripe.StripeResource.method({ method: "POST", path: "" }) as (
    params: Stripe.FooBetaFeatureCreateParams,
    options: Stripe.RequestOptions
  ) => Promise<Stripe.Response<Stripe.FooBetaFeature>>;

  update = Stripe.StripeResource.method({ method: "POST", path: "/{foo}" }) as (
    id: string,
    params: Stripe.FooBetaFeatureUpdateParams,
    options: Stripe.RequestOptions
  ) => Promise<Stripe.Response<Stripe.FooBetaFeature>>;

  retrieve = Stripe.StripeResource.method({ method: "GET", path: "/{foo}" }) as (
    id: string,
    options: Stripe.RequestOptions
  ) => Promise<Stripe.Response<Stripe.FooBetaFeature>>;
}

class StripeWithFooBeta extends Stripe {
  foos: Foos;

  constructor(key: string, opts: Stripe.StripeConfig) {
    super(key, opts);
    this.foos = new Foos(this);
  }
}

export const stripe = new StripeWithFooBeta(process.env.STRIPE_SECRET!, {
  apiVersion,
});

declare module "stripe" {
  namespace Stripe {
    interface FooBetaFeature {...}
    interface FooBetaFeatureCreateParams {...}
    interface FooBetaFeatureUpdateParams {...}
  }
}
```

since the transformation of `this.path` which takes place [here](https://github.com/stripe/stripe-node/blob/master/lib/StripeResource.js#L42) does not play nicely with ES6 classes.