### PR TITLE
Fix StripeResource constructor type

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -1,14 +1,14 @@
 ///<reference lib="esnext.asynciterable" />
 /// <reference types="node" />
 
-import { Agent } from 'http';
+import {Agent} from 'http';
 
 declare module 'stripe' {
   namespace Stripe {
     export class StripeResource {
       static extend<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        T extends { [prop: string]: any } & {
+        T extends {[prop: string]: any} & {
           includeBasic?: Array<
             'create' | 'retrieve' | 'update' | 'list' | 'del'
           >;
@@ -172,7 +172,7 @@ declare module 'stripe' {
 
     export type Response<T> = T & {
       lastResponse: {
-        headers: { [key: string]: string };
+        headers: {[key: string]: string};
         requestId: string;
         statusCode: number;
         apiVersion?: string;
@@ -209,12 +209,12 @@ declare module 'stripe' {
 
     export interface ApiListPromise<T>
       extends Promise<Response<ApiList<T>>>,
-      AsyncIterableIterator<T> {
+        AsyncIterableIterator<T> {
       autoPagingEach(
         handler: (item: T) => boolean | void | Promise<boolean | void>
       ): Promise<void>;
 
-      autoPagingToArray(opts: { limit: number }): Promise<Array<T>>;
+      autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
     }
 
     /**
@@ -249,12 +249,12 @@ declare module 'stripe' {
     }
     export interface ApiSearchResultPromise<T>
       extends Promise<Response<ApiSearchResult<T>>>,
-      AsyncIterableIterator<T> {
+        AsyncIterableIterator<T> {
       autoPagingEach(
         handler: (item: T) => boolean | void | Promise<boolean | void>
       ): Promise<void>;
 
-      autoPagingToArray(opts: { limit: number }): Promise<Array<T>>;
+      autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
     }
 
     export type StripeStreamResponse = NodeJS.ReadableStream;

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -1,19 +1,20 @@
 ///<reference lib="esnext.asynciterable" />
 /// <reference types="node" />
 
-import {Agent} from 'http';
+import { Agent } from 'http';
 
 declare module 'stripe' {
   namespace Stripe {
     export class StripeResource {
       static extend<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
-        T extends {[prop: string]: any} & {
+        T extends { [prop: string]: any } & {
           includeBasic?: Array<
             'create' | 'retrieve' | 'update' | 'list' | 'del'
           >;
         }
       >(spec: T): typeof StripeResource & T;
+
       static method(spec: {
         method: string;
         path?: string;
@@ -22,6 +23,7 @@ declare module 'stripe' {
         // change/removal at any time.
         methodType?: 'list' | 'search';
       }): (...args: any[]) => object; //eslint-disable-line @typescript-eslint/no-explicit-any
+
       static BASIC_METHODS: {
         create<T>(
           params: CouponCreateParams,
@@ -43,7 +45,10 @@ declare module 'stripe' {
         ): ApiListPromise<T>;
         del<T>(id: string, options?: RequestOptions): Promise<T>;
       };
+
       static MAX_BUFFERED_REQUEST_METRICS: number;
+
+      constructor(stripe: Stripe);
     }
     export type LatestApiVersion = '2020-08-27';
     export type HttpAgent = Agent;
@@ -167,7 +172,7 @@ declare module 'stripe' {
 
     export type Response<T> = T & {
       lastResponse: {
-        headers: {[key: string]: string};
+        headers: { [key: string]: string };
         requestId: string;
         statusCode: number;
         apiVersion?: string;
@@ -204,12 +209,12 @@ declare module 'stripe' {
 
     export interface ApiListPromise<T>
       extends Promise<Response<ApiList<T>>>,
-        AsyncIterableIterator<T> {
+      AsyncIterableIterator<T> {
       autoPagingEach(
         handler: (item: T) => boolean | void | Promise<boolean | void>
       ): Promise<void>;
 
-      autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
+      autoPagingToArray(opts: { limit: number }): Promise<Array<T>>;
     }
 
     /**
@@ -244,12 +249,12 @@ declare module 'stripe' {
     }
     export interface ApiSearchResultPromise<T>
       extends Promise<Response<ApiSearchResult<T>>>,
-        AsyncIterableIterator<T> {
+      AsyncIterableIterator<T> {
       autoPagingEach(
         handler: (item: T) => boolean | void | Promise<boolean | void>
       ): Promise<void>;
 
-      autoPagingToArray(opts: {limit: number}): Promise<Array<T>>;
+      autoPagingToArray(opts: { limit: number }): Promise<Array<T>>;
     }
 
     export type StripeStreamResponse = NodeJS.ReadableStream;

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -63,7 +63,7 @@ stripe.setHost('host', 'port', 'protocol');
 
   // Check multiple dispatch:
   let product = await stripe.products.retrieve('prod_123', opts);
-  product = await stripe.products.retrieve('prod_123', { expand: [] }, opts);
+  product = await stripe.products.retrieve('prod_123', {expand: []}, opts);
 
   const charge: Stripe.Charge = await stripe.charges.retrieve('ch_123', {
     expand: ['customer'],
@@ -100,7 +100,7 @@ stripe.setHost('host', 'port', 'protocol');
   }
 
   for await (const customer of stripe.customers.list()) {
-    const { id } = customer as Stripe.Customer;
+    const {id} = customer as Stripe.Customer;
     if (id === 'hi') {
       break;
     }
@@ -110,7 +110,7 @@ stripe.setHost('host', 'port', 'protocol');
 
   const aThousandCustomers: Array<Stripe.Customer> = await stripe.customers
     .list()
-    .autoPagingToArray({ limit: 1000 });
+    .autoPagingToArray({limit: 1000});
 
   const nothing: void = await stripe.customers
     .list()
@@ -128,7 +128,7 @@ stripe.setHost('host', 'port', 'protocol');
     });
 
   try {
-    await stripe.paymentIntents.create({ amount: 100, currency: 'USD' });
+    await stripe.paymentIntents.create({amount: 100, currency: 'USD'});
   } catch (err) {
     if (err instanceof stripe.errors.StripeCardError) {
       const declineCode: string = err.decline_code;
@@ -197,7 +197,7 @@ const maxBufferedRequestMetrics: number =
   Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS;
 
 // Test NodeHttpClient request processing.
-import { Agent } from 'http';
+import {Agent} from 'http';
 async (): Promise<void> => {
   const client = Stripe.createNodeHttpClient(new Agent());
 

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -63,7 +63,7 @@ stripe.setHost('host', 'port', 'protocol');
 
   // Check multiple dispatch:
   let product = await stripe.products.retrieve('prod_123', opts);
-  product = await stripe.products.retrieve('prod_123', {expand: []}, opts);
+  product = await stripe.products.retrieve('prod_123', { expand: [] }, opts);
 
   const charge: Stripe.Charge = await stripe.charges.retrieve('ch_123', {
     expand: ['customer'],
@@ -100,7 +100,7 @@ stripe.setHost('host', 'port', 'protocol');
   }
 
   for await (const customer of stripe.customers.list()) {
-    const {id} = customer as Stripe.Customer;
+    const { id } = customer as Stripe.Customer;
     if (id === 'hi') {
       break;
     }
@@ -110,7 +110,7 @@ stripe.setHost('host', 'port', 'protocol');
 
   const aThousandCustomers: Array<Stripe.Customer> = await stripe.customers
     .list()
-    .autoPagingToArray({limit: 1000});
+    .autoPagingToArray({ limit: 1000 });
 
   const nothing: void = await stripe.customers
     .list()
@@ -128,7 +128,7 @@ stripe.setHost('host', 'port', 'protocol');
     });
 
   try {
-    await stripe.paymentIntents.create({amount: 100, currency: 'USD'});
+    await stripe.paymentIntents.create({ amount: 100, currency: 'USD' });
   } catch (err) {
     if (err instanceof stripe.errors.StripeCardError) {
       const declineCode: string = err.decline_code;
@@ -191,13 +191,13 @@ const Foo = Stripe.StripeResource.extend({
     methodType: 'search',
   }),
 });
-new Foo();
+new Foo(stripe);
 
 const maxBufferedRequestMetrics: number =
   Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS;
 
 // Test NodeHttpClient request processing.
-import {Agent} from 'http';
+import { Agent } from 'http';
 async (): Promise<void> => {
   const client = Stripe.createNodeHttpClient(new Agent());
 


### PR DESCRIPTION
In https://github.com/stripe/stripe-node/pull/1245, I fixed `.extend`'s type, but I forgot to include another change I had made locally – a `StripeResource` is instantiated with an instance of `stripe` ([src](https://github.com/stripe/stripe-node/blob/master/lib/StripeResource.js#L30-L31), [usage](https://github.com/stripe/stripe-node/blob/master/lib/stripe.js#L523)).