### PR TITLE
Update FetchHttpClient to make fetch function optional.

### DIFF
--- a/lib/net/FetchHttpClient.js
+++ b/lib/net/FetchHttpClient.js
@@ -3,9 +3,12 @@
 const {HttpClient, HttpClientResponse} = require('./HttpClient');
 
 /**
- * HTTP client which uses a `fetch` function to issue requests. This fetch
- * function is expected to be the Web Fetch API function or an equivalent, such
- * as the function provided by the node-fetch package (https://github.com/node-fetch/node-fetch).
+ * HTTP client which uses a `fetch` function to issue requests.
+ *
+ * By default relies on the global `fetch` function, but an optional function
+ * can be passed in. If passing in a function, it is expected to match the Web
+ * Fetch API. As an example, this could be the function provided by the
+ * node-fetch package (https://github.com/node-fetch/node-fetch).
  */
 class FetchHttpClient extends HttpClient {
   constructor(fetchFn) {
@@ -36,7 +39,8 @@ class FetchHttpClient extends HttpClient {
     );
     url.port = port;
 
-    const fetchPromise = this._fetchFn(url.toString(), {
+    const fetchFn = this._fetchFn || fetch;
+    const fetchPromise = fetchFn(url.toString(), {
       method,
       headers,
       body: requestData || undefined,


### PR DESCRIPTION
### Notify

r? @richardm-stripe 
cc? @tomer-stripe 

### Summary

Updates the `FetchHttpClient` to make the `fetch` function optional, defaulting to the global if not provided. 

This also purposefully avoids calling `this._fetchFn()` directly and instead storing it and calling it via the variable. This ensures we call the passed in function with the global scope instead of accidentally calling it with the `FetchHttpClient` as `this`. Calling `this._fetchFn()` caused issues on Cloudflare Workers as it would invoke `fetch` in the wrong scope, resulting in code failing with:

> A hanging Promise was canceled. This happens when the worker runtime is waiting for a Promise from JavaScript to resolve, but has detected that the Promise cannot possibly ever resolve because all code and events related to the Promise's request context have already finished.

This is likely because the global fetch stores state to track pending work, and calling it within a different scope resulted in the work not being tracked.

### Examples

Default global fetch
```
new FetchHttpClient();
```

Explicitly passing in global fetch
```
new FetchHttpClient(fetch);
```

Passing in a custom fetch (eg. node-fetch)
```
const fetch = require('node-fetch');
new FetchHttpClient(fetch);
```