### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/UsageRecords.d.ts
+++ b/types/2020-08-27/UsageRecords.d.ts
@@ -44,11 +44,6 @@ declare module 'stripe' {
       quantity: number;
 
       /**
-       * The timestamp for the usage event. This timestamp must be within the current billing period of the subscription of the provided `subscription_item`.
-       */
-      timestamp: number;
-
-      /**
        * Valid values are `increment` (default) or `set`. When using `increment` the specified `quantity` will be added to the usage at the specified timestamp. The `set` action will overwrite the usage quantity at that timestamp. If the subscription has [billing thresholds](https://stripe.com/docs/api/subscriptions/object#subscription_object-billing_thresholds), `increment` is the only allowed value.
        */
       action?: UsageRecordCreateParams.Action;
@@ -57,6 +52,11 @@ declare module 'stripe' {
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
+
+      /**
+       * The timestamp for the usage event. This timestamp must be within the current billing period of the subscription of the provided `subscription_item`, and must not be in the future. When passing `"now"`, Stripe records usage for the current time. Default is `"now"` if a value is not provided.
+       */
+      timestamp?: 'now' | number;
     }
 
     namespace UsageRecordCreateParams {


### PR DESCRIPTION
Codegen for openapi 1f5d304.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Change type of `UsageRecordCreateParams.timestamp` from `integer` to `literal('now') | integer`
* Change `UsageRecordCreateParams.timestamp` to be optional

