### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -1720,7 +1720,7 @@ declare module 'stripe' {
         /**
          * A list of alternate names or aliases that the individual is known by.
          */
-        full_name_aliases?: Array<string>;
+        full_name_aliases?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The individual's gender (International regulations require either "male" or "female").
@@ -2719,7 +2719,7 @@ declare module 'stripe' {
         /**
          * A list of alternate names or aliases that the individual is known by.
          */
-        full_name_aliases?: Array<string>;
+        full_name_aliases?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The individual's gender (International regulations require either "male" or "female").

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -653,7 +653,7 @@ declare module 'stripe' {
 
         interface Boleto {
           /**
-           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           * The tax ID of the customer (CPF for individuals consumers or CNPJ for businesses consumers)
            */
           tax_id: string;
         }
@@ -1418,7 +1418,7 @@ declare module 'stripe' {
 
           /**
            * Preferred language of the Klarna authorization page that the customer is redirected to.
-           * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `it-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `fr-FR`, or `en-FR`
+           * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `en-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `en-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `it-IT`, `en-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `fr-FR`, or `en-FR`
            */
           preferred_locale: string | null;
         }

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -842,8 +842,8 @@ declare module 'stripe' {
         /**
          * The URL to which Stripe should send customers when payment or setup
          * is complete.
-         * If you'd like access to the Checkout Session for the successful
-         * payment, read more about it in the guide on [fulfilling orders](https://stripe.com/docs/payments/checkout/fulfill-orders).
+         * If you'd like to use information from the successful Checkout Session on your page,
+         * read the guide on [customizing your success page](https://stripe.com/docs/payments/checkout/custom-success-page).
          */
         success_url: string;
 
@@ -1158,7 +1158,7 @@ declare module 'stripe' {
             enabled: boolean;
 
             /**
-             * The maximum quantity the customer can purchase for the Checkout Session. By default this value is 99.
+             * The maximum quantity the customer can purchase for the Checkout Session. By default this value is 99. You can specify a value up to 999.
              */
             maximum?: number;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -1193,7 +1193,7 @@ declare module 'stripe' {
 
         interface Boleto {
           /**
-           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
            */
           tax_id: string;
         }
@@ -1657,10 +1657,13 @@ declare module 'stripe' {
             | 'de-AT'
             | 'de-DE'
             | 'en-AT'
+            | 'en-BE'
             | 'en-DE'
             | 'en-DK'
+            | 'en-ES'
             | 'en-FI'
             | 'en-GB'
+            | 'en-IT'
             | 'en-NL'
             | 'en-NO'
             | 'en-SE'
@@ -2102,7 +2105,7 @@ declare module 'stripe' {
 
         interface Boleto {
           /**
-           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
            */
           tax_id: string;
         }
@@ -2566,10 +2569,13 @@ declare module 'stripe' {
             | 'de-AT'
             | 'de-DE'
             | 'en-AT'
+            | 'en-BE'
             | 'en-DE'
             | 'en-DK'
+            | 'en-ES'
             | 'en-FI'
             | 'en-GB'
+            | 'en-IT'
             | 'en-NL'
             | 'en-NO'
             | 'en-SE'
@@ -3125,7 +3131,7 @@ declare module 'stripe' {
 
         interface Boleto {
           /**
-           * Uniquely identifies this customer tax_id (CNPJ or CPF)
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
            */
           tax_id: string;
         }
@@ -3589,10 +3595,13 @@ declare module 'stripe' {
             | 'de-AT'
             | 'de-DE'
             | 'en-AT'
+            | 'en-BE'
             | 'en-DE'
             | 'en-DK'
+            | 'en-ES'
             | 'en-FI'
             | 'en-GB'
+            | 'en-IT'
             | 'en-NL'
             | 'en-NO'
             | 'en-SE'

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -862,7 +862,7 @@ declare module 'stripe' {
 
       interface Boleto {
         /**
-         * Uniquely identifies this customer tax_id (CNPJ or CPF)
+         * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
          */
         tax_id: string;
       }

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -632,7 +632,7 @@ declare module 'stripe' {
       /**
        * A list of alternate names or aliases that the person is known by.
        */
-      full_name_aliases?: Array<string>;
+      full_name_aliases?: Stripe.Emptyable<Array<string>>;
 
       /**
        * The person's gender (International regulations require either "male" or "female").
@@ -899,7 +899,7 @@ declare module 'stripe' {
       /**
        * A list of alternate names or aliases that the person is known by.
        */
-      full_name_aliases?: Array<string>;
+      full_name_aliases?: Stripe.Emptyable<Array<string>>;
 
       /**
        * The person's gender (International regulations require either "male" or "female").

--- a/types/2020-08-27/Prices.d.ts
+++ b/types/2020-08-27/Prices.d.ts
@@ -44,7 +44,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * A lookup key used to retrieve prices dynamically from a static string.
+       * A lookup key used to retrieve prices dynamically from a static string. This may be up to 200 characters.
        */
       lookup_key: string | null;
 
@@ -238,7 +238,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * A lookup key used to retrieve prices dynamically from a static string.
+       * A lookup key used to retrieve prices dynamically from a static string. This may be up to 200 characters.
        */
       lookup_key?: string;
 
@@ -451,7 +451,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * A lookup key used to retrieve prices dynamically from a static string.
+       * A lookup key used to retrieve prices dynamically from a static string. This may be up to 200 characters.
        */
       lookup_key?: string;
 

--- a/types/2020-08-27/Terminal/ConnectionTokens.d.ts
+++ b/types/2020-08-27/Terminal/ConnectionTokens.d.ts
@@ -13,7 +13,7 @@ declare module 'stripe' {
         object: 'terminal.connection_token';
 
         /**
-         * The id of the location that this connection token is scoped to. Note that location scoping only applies to internet-connected readers. For more details, see [the docs on scoping connection tokens](https://stripe.com/docs/terminal/readers/fleet-management#connection-tokens).
+         * The id of the location that this connection token is scoped to. Note that location scoping only applies to internet-connected readers. For more details, see [the docs on scoping connection tokens](https://stripe.com/docs/terminal/fleet/locations#connection-tokens).
          */
         location?: string;
 
@@ -30,7 +30,7 @@ declare module 'stripe' {
         expand?: Array<string>;
 
         /**
-         * The id of the location that this connection token is scoped to. If specified the connection token will only be usable with readers assigned to that location, otherwise the connection token will be usable with all readers. Note that location scoping only applies to internet-connected readers. For more details, see [the docs on scoping connection tokens](https://stripe.com/docs/terminal/readers/fleet-management#connection-tokens).
+         * The id of the location that this connection token is scoped to. If specified the connection token will only be usable with readers assigned to that location, otherwise the connection token will be usable with all readers. Note that location scoping only applies to internet-connected readers. For more details, see [the docs on scoping connection tokens](https://stripe.com/docs/terminal/fleet/locations#connection-tokens).
          */
         location?: string;
       }

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -306,7 +306,7 @@ declare module 'stripe' {
           /**
            * A list of alternate names or aliases that the individual is known by.
            */
-          full_name_aliases?: Array<string>;
+          full_name_aliases?: Stripe.Emptyable<Array<string>>;
 
           /**
            * The individual's gender (International regulations require either "male" or "female").
@@ -553,7 +553,7 @@ declare module 'stripe' {
         /**
          * A list of alternate names or aliases that the person is known by.
          */
-        full_name_aliases?: Array<string>;
+        full_name_aliases?: Stripe.Emptyable<Array<string>>;
 
         /**
          * The person's gender (International regulations require either "male" or "female").


### PR DESCRIPTION
Codegen for openapi ae9cb84.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Change type of `AccountUpdateParams.individual.full_name_aliases`, `AccountCreateParams.individual.full_name_aliases`, `PersonCreateParams.full_name_aliases`, `PersonUpdateParams.full_name_aliases`, `TokenCreateParams.account.individual.full_name_aliases`, and `TokenCreateParams.person.full_name_aliases` from `array(string)` to `emptyStringable(array(string))`
* Add support for new values `en-BE`, `en-ES`, and `en-IT` on enums `PaymentIntentCreateParams.payment_method_options.klarna.preferred_locale`, `PaymentIntentUpdateParams.payment_method_options.klarna.preferred_locale`, and `PaymentIntentConfirmParams.payment_method_options.klarna.preferred_locale`

