### PR TITLE
Replace unused mocha.opts with Mocha configuration file.

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-yarn-
 
       - name: Start stripe-mock
-        run: docker run -d -p 12111-12112:12111-12112 stripemock/stripe-mock && sleep 5
+        run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
       - name: Lint, typecheck, and test
         run: yarn && yarn test

--- a/package.json
+++ b/package.json
@@ -54,8 +54,8 @@
   "license": "MIT",
   "scripts": {
     "clean": "rm -rf ./.nyc_output ./node_modules/.cache ./coverage",
-    "mocha": "nyc mocha",
-    "mocha-only": "mocha",
+    "mocha": "nyc mocha --config=test/.mocharc.js",
+    "mocha-only": "mocha --config=test/.mocharc.js",
     "test": "yarn lint && yarn test-typescript && yarn mocha",
     "test-typescript": "tsc --build types/test",
     "lint": "eslint --ext .js,.jsx,.ts .",

--- a/test/.mocharc.js
+++ b/test/.mocharc.js
@@ -1,0 +1,10 @@
+'use strict';
+
+// Configuration for our Mocha test suite.
+module.exports = {
+  color: true,
+  // Run tests in parallel.
+  parallel: true,
+  // Recurse through all tests in the test directory.
+  recursive: true,
+};

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,1 +1,0 @@
---recursive

--- a/test/net/NodeHttpClient.spec.js
+++ b/test/net/NodeHttpClient.spec.js
@@ -3,7 +3,7 @@
 const http = require('http');
 const expect = require('chai').expect;
 
-const {createNodeHttpClient} = require('../../lib/Stripe');
+const {createNodeHttpClient} = require('../../lib/stripe');
 
 const {createHttpClientTestSuite, ArrayReadable} = require('./helpers');
 


### PR DESCRIPTION
### Notify

r? @richardm-stripe 

### Summary

Replaces the mocha.opts file with a new Mocha configuration file. The mocha.opts file was deprecated and removed entirely in Mocha v8 ([CHANGELOG](https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#800--2020-06-10)). The end result is that after we upgraded from Mocha 6 to 8 we were no longer running Mocha with `--recursive` and were only running a subset of our tests. 

I also added the [new `--parallel` option](https://mochajs.org/#parallel-tests) here, which runs tests in parallel and speeds up our test suite (locally it's going from ~70-80s -> 35s).

To get tests to pass I had to update:
1. the stripe-mock Docker image, which was stale
2. a broken require in the NodeHttpClient test 

### Test Plan

See CI.