### PR TITLE
Remove stale test util for detecting await support.

### DIFF
--- a/test/autoPagination.spec.js
+++ b/test/autoPagination.spec.js
@@ -282,21 +282,17 @@ describe('auto pagination', function() {
           ).to.eventually.deep.equal(realCustomerIds));
       }
 
-      if (testUtils.envSupportsAwait()) {
-        // Similarly, `await` throws a syntax error below Node 7.6.
-        const awaitUntil = require('../testUtils/await.node7').awaitUntil;
-
-        it('works with `await` and a while loop when await exists', () =>
-          expect(
-            new Promise((resolve, reject) => {
-              awaitUntil(stripe.customers.list({limit: 3, email}), LIMIT)
-                .then((customers) => {
-                  resolve(customers.map((customer) => customer.id));
-                })
-                .catch(reject);
-            })
-          ).to.eventually.deep.equal(realCustomerIds.slice(0, LIMIT)));
-      }
+      const awaitUntil = require('../testUtils/await.node7').awaitUntil;
+      it('works with `await` and a while loop when await exists', () =>
+        expect(
+          new Promise((resolve, reject) => {
+            awaitUntil(stripe.customers.list({limit: 3, email}), LIMIT)
+              .then((customers) => {
+                resolve(customers.map((customer) => customer.id));
+              })
+              .catch(reject);
+          })
+        ).to.eventually.deep.equal(realCustomerIds.slice(0, LIMIT)));
 
       it('returns an empty object from .return() so that `break;` works in for-await', () =>
         expect(

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -213,15 +213,6 @@ const utils = (module.exports = {
     return typeof Symbol !== 'undefined' && Symbol.asyncIterator;
   },
 
-  envSupportsAwait: () => {
-    try {
-      eval('(async function() {})'); // eslint-disable-line no-eval
-      return true;
-    } catch (err) {
-      return false;
-    }
-  },
-
   FakeCryptoProvider: class extends CryptoProvider {
     computeHMACSignature(payload, secret) {
       return 'fake signature';


### PR DESCRIPTION
### Notify

r? @richardm-stripe 

### Summary
Removes the `envSupportsAwait` test util, as this was only needed for versions of Node prior to 8. We only officially support and test against 8+ so this is no longer necessary.

### Test Plan

Tests pass.