### PR TITLE
Improve typescript support

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -5,6 +5,13 @@ import {Agent} from 'http';
 
 declare module 'stripe' {
   namespace Stripe {
+    type StripeResourceClass = typeof StripeResource;
+
+    interface StripeResourceExtension<T extends object>
+      extends StripeResourceClass {
+      new (stripe: Stripe): StripeResource & T;
+    }
+
     export class StripeResource {
       static extend<
         // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -13,15 +20,15 @@ declare module 'stripe' {
             'create' | 'retrieve' | 'update' | 'list' | 'del'
           >;
         }
-      >(spec: T): typeof StripeResource & T;
-      static method(spec: {
+      >(spec: T): StripeResourceExtension<T>;
+      static method<ResponseObject = object>(spec: {
         method: string;
         path?: string;
         fullPath?: string;
         // Please note, methodType === 'search' is beta functionality and is subject to
         // change/removal at any time.
         methodType?: 'list' | 'search';
-      }): (...args: any[]) => object; //eslint-disable-line @typescript-eslint/no-explicit-any
+      }): (...args: any[]) => Response<ResponseObject>; //eslint-disable-line @typescript-eslint/no-explicit-any
       static BASIC_METHODS: {
         create<T>(
           params: CouponCreateParams,

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -190,8 +190,11 @@ const Foo = Stripe.StripeResource.extend({
     fullPath: 'foo',
     methodType: 'search',
   }),
+  customer: Stripe.StripeResource.method<Stripe.Customer>({method: 'POST'}),
 });
-new Foo();
+const fooClient = new Foo(stripe);
+const searchResponse: Stripe.Response<object> = fooClient.search();
+const customerResponse: Stripe.Response<Stripe.Customer> = fooClient.customer();
 
 const maxBufferedRequestMetrics: number =
   Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS;


### PR DESCRIPTION
## Notify

r? @richardm-stripe 

## Summary

This improves three friction points when working with Typescript:

1. **`new StripeResource(stripe)` now works.** Prior to this change, attempting to construct `StripeResource` with its one required argument would fail a type check. Support for a constructor was added in #1245 and extended in #1249 (never merged). Thanks @rattrayalex!
2. **`StripeResource.extend` now returns a class that is properly typed when instantiated.** Prior to this change, you could extend `StripeResource` but your extensions wouldn't appear on the object after construction. Now, it does.
3. **`StripeResource.method` returns a function that returns `Response<object>`.** Prior to this change, extensions created with `StripeResource.method` would have a return type of `object`. Returning `Response<object>` makes it possible to call functions like `lastResponse` without casting the value.
4. **`StripeResource.method` now accepts generic type that sets the response object's type.** For example, if you're hitting a customer endpoint, you can do this: `StripeResource.method<Customer>(...)`. When you use that extension, it will return `Response<Customer>`. This eliminates the need to cast when calling StripeResource extension methods.

See changes to `typescriptTest.ts` for these updates in action.

---

fixes #1249