### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -704,7 +704,7 @@ declare module 'stripe' {
         currently_due: Array<string> | null;
 
         /**
-         * If the account is disabled, this string describes why. Can be `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.listed`, `rejected.terms_of_service`, `rejected.card_casher`, `rejected.auto_fraud_shutdown`, `rejected.fraud`, `rejected.dishonest_merchant`, `rejected.identity_fraud`, `rejected.platform_fraud`, `rejected.platform_terms_of_service`, `rejected.other`, `under_review`, or `other`.
+         * If the account is disabled, this string describes why. Can be `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.fraud`, `rejected.listed`, `rejected.terms_of_service`, `rejected.other`, `under_review`, or `other`.
          */
         disabled_reason: string | null;
 

--- a/types/2020-08-27/Capabilities.d.ts
+++ b/types/2020-08-27/Capabilities.d.ts
@@ -181,7 +181,7 @@ declare module 'stripe' {
         currently_due: Array<string>;
 
         /**
-         * If the capability is disabled, this string describes why. Can be `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.listed`, `rejected.terms_of_service`, `rejected.card_casher`, `rejected.auto_fraud_shutdown`, `rejected.fraud`, `rejected.dishonest_merchant`, `rejected.identity_fraud`, `rejected.platform_fraud`, `rejected.platform_terms_of_service`, `rejected.other`, `under_review`, or `other`.
+         * If the capability is disabled, this string describes why. Can be `requirements.past_due`, `requirements.pending_verification`, `listed`, `platform_paused`, `rejected.fraud`, `rejected.listed`, `rejected.terms_of_service`, `rejected.other`, `under_review`, or `other`.
          *
          * `rejected.unsupported_business` means that the account's business is not supported by the capability. For example, payment methods may restrict the businesses they support in their terms of service:
          *

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -521,6 +521,8 @@ declare module 'stripe' {
 
         ideal?: PaymentMethodOptions.Ideal;
 
+        interac_present?: PaymentMethodOptions.InteracPresent;
+
         klarna?: PaymentMethodOptions.Klarna;
 
         oxxo?: PaymentMethodOptions.Oxxo;
@@ -697,6 +699,8 @@ declare module 'stripe' {
         interface CardPresent {}
 
         interface Ideal {}
+
+        interface InteracPresent {}
 
         interface Klarna {
           /**
@@ -1478,6 +1482,11 @@ declare module 'stripe' {
         ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
 
         /**
+         * If this is a `interac_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
+         */
+        interac_present?: Stripe.Emptyable<PaymentMethodOptions.InteracPresent>;
+
+        /**
          * If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
          */
         klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
@@ -1668,6 +1677,8 @@ declare module 'stripe' {
         interface CardPresent {}
 
         interface Ideal {}
+
+        interface InteracPresent {}
 
         interface Klarna {
           /**
@@ -2391,6 +2402,11 @@ declare module 'stripe' {
         ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
 
         /**
+         * If this is a `interac_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
+         */
+        interac_present?: Stripe.Emptyable<PaymentMethodOptions.InteracPresent>;
+
+        /**
          * If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
          */
         klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
@@ -2581,6 +2597,8 @@ declare module 'stripe' {
         interface CardPresent {}
 
         interface Ideal {}
+
+        interface InteracPresent {}
 
         interface Klarna {
           /**
@@ -3418,6 +3436,11 @@ declare module 'stripe' {
         ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
 
         /**
+         * If this is a `interac_present` PaymentMethod, this sub-hash contains details about the Card Present payment method options.
+         */
+        interac_present?: Stripe.Emptyable<PaymentMethodOptions.InteracPresent>;
+
+        /**
          * If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
          */
         klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
@@ -3608,6 +3631,8 @@ declare module 'stripe' {
         interface CardPresent {}
 
         interface Ideal {}
+
+        interface InteracPresent {}
 
         interface Klarna {
           /**
@@ -3800,7 +3825,7 @@ declare module 'stripe' {
       list(options?: RequestOptions): ApiListPromise<Stripe.PaymentIntent>;
 
       /**
-       * A PaymentIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, or requires_action.
+       * A PaymentIntent object can be canceled when it is in one of these statuses: requires_payment_method, requires_capture, requires_confirmation, requires_action, or processing.
        *
        * Once canceled, no additional charges will be made by the PaymentIntent and any operations on the PaymentIntent will fail with an error. For PaymentIntents with status='requires_capture', the remaining amount_capturable will automatically be refunded.
        */

--- a/types/2020-08-27/TaxRates.d.ts
+++ b/types/2020-08-27/TaxRates.d.ts
@@ -81,6 +81,7 @@ declare module 'stripe' {
       type TaxType =
         | 'gst'
         | 'hst'
+        | 'jct'
         | 'pst'
         | 'qst'
         | 'rst'
@@ -149,6 +150,7 @@ declare module 'stripe' {
       type TaxType =
         | 'gst'
         | 'hst'
+        | 'jct'
         | 'pst'
         | 'qst'
         | 'rst'
@@ -214,6 +216,7 @@ declare module 'stripe' {
       type TaxType =
         | 'gst'
         | 'hst'
+        | 'jct'
         | 'pst'
         | 'qst'
         | 'rst'


### PR DESCRIPTION
Codegen for openapi 08ff630.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `interac_present` on `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, and `PaymentIntent.payment_method_options`
* Add support for new value `jct` on enums `TaxRateCreateParams.tax_type`, `TaxRateUpdateParams.tax_type`, and `TaxRate.tax_type`

