### PR TITLE
Updating readme to use correct instantiation

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,9 @@ Or using ES modules and `async`/`await`:
 
 ```js
 import Stripe from 'stripe';
-const stripe = new Stripe('sk_test_...');
+const stripe = new Stripe('sk_test_...', {
+  apiVersion: '2020-08-27',
+});
 
 (async () => {
   const customer = await stripe.customers.create({


### PR DESCRIPTION
When I first tried to use Stripe with Typescript, following [the official documentation](https://stripe.com/docs/api), it didn't work at all. Googling lead me to answers like [this one](https://stackoverflow.com/questions/41998980/import-stripe-using-node-js-typescript) which have the correct instantiation.

I don't know why the official documentation is more wrong wrong (no `new`, and no config object):

> const Stripe = require('stripe');
> const stripe = Stripe('...');

At least we can update this repo to satisfy typescript. I also wonder if t the types are wrong, since the API config object seems to expect a hard coded `LatestApiVersion` type.

For what it's worth, I was surprised to see this level of inconsistent documentation and unusual types from such a mature library. I may be missing something, but wanted to put up this PR to at least make the onboarding experience better for other users.