### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Capabilities.d.ts
+++ b/types/2020-08-27/Capabilities.d.ts
@@ -187,7 +187,7 @@ declare module 'stripe' {
          *
          * - [Afterpay Clearpay's terms of service](https://stripe.com/afterpay-clearpay/legal#restricted-businesses)
          *
-         * If you believe that the rejection is in error, please contact support@stripe.com for assistance.
+         * If you believe that the rejection is in error, please contact support at https://support.stripe.com/contact/ for assistance.
          */
         disabled_reason: string | null;
 

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1419,7 +1419,7 @@ declare module 'stripe' {
 
           /**
            * Preferred language of the Klarna authorization page that the customer is redirected to.
-           * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `en-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `en-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `it-IT`, `en-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `fr-FR`, or `en-FR`
+           * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `en-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `en-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `en-IE`, `it-IT`, `en-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `fr-FR`, or `en-FR`
            */
           preferred_locale: string | null;
         }

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -317,7 +317,7 @@ declare module 'stripe' {
 
           interface TaxId {
             /**
-             * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown`
+             * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, or `unknown`
              */
             type: TaxId.Type;
 
@@ -345,6 +345,7 @@ declare module 'stripe' {
               | 'es_cif'
               | 'eu_vat'
               | 'gb_vat'
+              | 'ge_vat'
               | 'hk_br'
               | 'id_npwp'
               | 'il_vat'
@@ -366,6 +367,7 @@ declare module 'stripe' {
               | 'sg_uen'
               | 'th_vat'
               | 'tw_vat'
+              | 'ua_vat'
               | 'unknown'
               | 'us_ein'
               | 'za_vat';

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -420,7 +420,7 @@ declare module 'stripe' {
 
       interface TaxIdDatum {
         /**
-         * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+         * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
          */
         type: TaxIdDatum.Type;
 
@@ -448,6 +448,7 @@ declare module 'stripe' {
           | 'es_cif'
           | 'eu_vat'
           | 'gb_vat'
+          | 'ge_vat'
           | 'hk_br'
           | 'id_npwp'
           | 'il_vat'
@@ -469,6 +470,7 @@ declare module 'stripe' {
           | 'sg_uen'
           | 'th_vat'
           | 'tw_vat'
+          | 'ua_vat'
           | 'us_ein'
           | 'za_vat';
       }

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -268,7 +268,7 @@ declare module 'stripe' {
       subscription_trial_end?: 'now' | number;
 
       /**
-       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
        */
       subscription_trial_from_plan?: boolean;
     }
@@ -347,7 +347,7 @@ declare module 'stripe' {
 
         interface TaxId {
           /**
-           * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+           * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
            */
           type: TaxId.Type;
 
@@ -375,6 +375,7 @@ declare module 'stripe' {
             | 'es_cif'
             | 'eu_vat'
             | 'gb_vat'
+            | 'ge_vat'
             | 'hk_br'
             | 'id_npwp'
             | 'il_vat'
@@ -396,6 +397,7 @@ declare module 'stripe' {
             | 'sg_uen'
             | 'th_vat'
             | 'tw_vat'
+            | 'ua_vat'
             | 'us_ein'
             | 'za_vat';
         }

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -399,7 +399,7 @@ declare module 'stripe' {
 
       interface CustomerTaxId {
         /**
-         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, or `unknown`
+         * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, or `unknown`
          */
         type: CustomerTaxId.Type;
 
@@ -427,6 +427,7 @@ declare module 'stripe' {
           | 'es_cif'
           | 'eu_vat'
           | 'gb_vat'
+          | 'ge_vat'
           | 'hk_br'
           | 'id_npwp'
           | 'il_vat'
@@ -448,6 +449,7 @@ declare module 'stripe' {
           | 'sg_uen'
           | 'th_vat'
           | 'tw_vat'
+          | 'ua_vat'
           | 'unknown'
           | 'us_ein'
           | 'za_vat';
@@ -1497,7 +1499,7 @@ declare module 'stripe' {
       subscription_trial_end?: 'now' | number;
 
       /**
-       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `subscription_trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `subscription_trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
        */
       subscription_trial_from_plan?: boolean;
     }
@@ -1576,7 +1578,7 @@ declare module 'stripe' {
 
         interface TaxId {
           /**
-           * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+           * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
            */
           type: TaxId.Type;
 
@@ -1604,6 +1606,7 @@ declare module 'stripe' {
             | 'es_cif'
             | 'eu_vat'
             | 'gb_vat'
+            | 'ge_vat'
             | 'hk_br'
             | 'id_npwp'
             | 'il_vat'
@@ -1625,6 +1628,7 @@ declare module 'stripe' {
             | 'sg_uen'
             | 'th_vat'
             | 'tw_vat'
+            | 'ua_vat'
             | 'us_ein'
             | 'za_vat';
         }

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -519,6 +519,8 @@ declare module 'stripe' {
 
         card_present?: PaymentMethodOptions.CardPresent;
 
+        giropay?: PaymentMethodOptions.Giropay;
+
         ideal?: PaymentMethodOptions.Ideal;
 
         interac_present?: PaymentMethodOptions.InteracPresent;
@@ -697,6 +699,8 @@ declare module 'stripe' {
         }
 
         interface CardPresent {}
+
+        interface Giropay {}
 
         interface Ideal {}
 
@@ -1200,7 +1204,7 @@ declare module 'stripe' {
           /**
            * Email address.
            */
-          email?: string;
+          email?: Stripe.Emptyable<string>;
 
           /**
            * Full name.
@@ -1477,6 +1481,11 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
+         */
+        giropay?: Stripe.Emptyable<PaymentMethodOptions.Giropay>;
+
+        /**
          * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
          */
         ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
@@ -1676,6 +1685,8 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Giropay {}
+
         interface Ideal {}
 
         interface InteracPresent {}
@@ -1699,6 +1710,7 @@ declare module 'stripe' {
             | 'en-ES'
             | 'en-FI'
             | 'en-GB'
+            | 'en-IE'
             | 'en-IT'
             | 'en-NL'
             | 'en-NO'
@@ -2120,7 +2132,7 @@ declare module 'stripe' {
           /**
            * Email address.
            */
-          email?: string;
+          email?: Stripe.Emptyable<string>;
 
           /**
            * Full name.
@@ -2397,6 +2409,11 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
+         */
+        giropay?: Stripe.Emptyable<PaymentMethodOptions.Giropay>;
+
+        /**
          * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
          */
         ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
@@ -2596,6 +2613,8 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Giropay {}
+
         interface Ideal {}
 
         interface InteracPresent {}
@@ -2619,6 +2638,7 @@ declare module 'stripe' {
             | 'en-ES'
             | 'en-FI'
             | 'en-GB'
+            | 'en-IE'
             | 'en-IT'
             | 'en-NL'
             | 'en-NO'
@@ -3154,7 +3174,7 @@ declare module 'stripe' {
           /**
            * Email address.
            */
-          email?: string;
+          email?: Stripe.Emptyable<string>;
 
           /**
            * Full name.
@@ -3431,6 +3451,11 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
+         */
+        giropay?: Stripe.Emptyable<PaymentMethodOptions.Giropay>;
+
+        /**
          * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
          */
         ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
@@ -3630,6 +3655,8 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Giropay {}
+
         interface Ideal {}
 
         interface InteracPresent {}
@@ -3653,6 +3680,7 @@ declare module 'stripe' {
             | 'en-ES'
             | 'en-FI'
             | 'en-GB'
+            | 'en-IE'
             | 'en-IT'
             | 'en-NL'
             | 'en-NO'

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -842,7 +842,7 @@ declare module 'stripe' {
         /**
          * Email address.
          */
-        email?: string;
+        email?: Stripe.Emptyable<string>;
 
         /**
          * Full name.
@@ -1172,7 +1172,7 @@ declare module 'stripe' {
         /**
          * Email address.
          */
-        email?: string;
+        email?: Stripe.Emptyable<string>;
 
         /**
          * Full name.

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -364,7 +364,7 @@ declare module 'stripe' {
         trial_end: number | null;
 
         /**
-         * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+         * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
          */
         trial_from_plan: boolean | null;
       }
@@ -530,17 +530,17 @@ declare module 'stripe' {
       transfer_data?: SubscriptionCreateParams.TransferData;
 
       /**
-       * Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+       * Unix timestamp representing the end of the trial period the customer will get before being charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. If set, trial_end will override the default trial period of the plan the customer is being subscribed to. The special value `now` can be provided to end the customer's trial immediately. Can be at most two years from `billing_cycle_anchor`. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
        */
       trial_end?: 'now' | number;
 
       /**
-       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
        */
       trial_from_plan?: boolean;
 
       /**
-       * Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+       * Integer representing the number of trial period days before the customer is charged for the first time. This will always overwrite any trials that might apply via a subscribed plan. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
        */
       trial_period_days?: number;
     }
@@ -1013,7 +1013,7 @@ declare module 'stripe' {
       trial_end?: 'now' | number;
 
       /**
-       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](docs/billing/subscriptions/trials) to learn more.
+       * Indicates if a plan's `trial_period_days` should be applied to the subscription. Setting `trial_end` per subscription is preferred, and this defaults to `false`. Setting this flag to `true` together with `trial_end` is not allowed. See [Using trial periods on subscriptions](https://stripe.com/docs/billing/subscriptions/trials) to learn more.
        */
       trial_from_plan?: boolean;
     }

--- a/types/2020-08-27/TaxIds.d.ts
+++ b/types/2020-08-27/TaxIds.d.ts
@@ -39,7 +39,7 @@ declare module 'stripe' {
       livemode: boolean;
 
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`. Note that some legacy tax IDs have type `unknown`
        */
       type: TaxId.Type;
 
@@ -72,6 +72,7 @@ declare module 'stripe' {
         | 'es_cif'
         | 'eu_vat'
         | 'gb_vat'
+        | 'ge_vat'
         | 'hk_br'
         | 'id_npwp'
         | 'il_vat'
@@ -93,6 +94,7 @@ declare module 'stripe' {
         | 'sg_uen'
         | 'th_vat'
         | 'tw_vat'
+        | 'ua_vat'
         | 'unknown'
         | 'us_ein'
         | 'za_vat';
@@ -141,7 +143,7 @@ declare module 'stripe' {
 
     interface TaxIdCreateParams {
       /**
-       * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `us_ein`, or `za_vat`
+       * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `id_npwp`, `il_vat`, `in_gst`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
        */
       type: TaxIdCreateParams.Type;
 
@@ -174,6 +176,7 @@ declare module 'stripe' {
         | 'es_cif'
         | 'eu_vat'
         | 'gb_vat'
+        | 'ge_vat'
         | 'hk_br'
         | 'id_npwp'
         | 'il_vat'
@@ -195,6 +198,7 @@ declare module 'stripe' {
         | 'sg_uen'
         | 'th_vat'
         | 'tw_vat'
+        | 'ua_vat'
         | 'us_ein'
         | 'za_vat';
     }

--- a/types/2020-08-27/Terminal/Locations.d.ts
+++ b/types/2020-08-27/Terminal/Locations.d.ts
@@ -160,6 +160,7 @@ declare module 'stripe' {
       class LocationsResource {
         /**
          * Creates a new Location object.
+         * For further details, including which address fields are required in each country, see the [Manage locations](https://stripe.com/docs/terminal/fleet/locations) guide.
          */
         create(
           params: LocationCreateParams,

--- a/types/2020-08-27/Terminal/Readers.d.ts
+++ b/types/2020-08-27/Terminal/Readers.d.ts
@@ -109,7 +109,7 @@ declare module 'stripe' {
         label?: string;
 
         /**
-         * The location to assign the reader to. If no location is specified, the reader will be assigned to the account's default location.
+         * The location to assign the reader to.
          */
         location?: string;
 


### PR DESCRIPTION
Codegen for openapi 6ec1613.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new values `ge_vat` and `ua_vat` on enums `Checkout.Session.customer_details.tax_ids[].type`, `Invoice.customer_tax_ids[].type`, and `TaxId.type`
* Add support for new values `ge_vat` and `ua_vat` on enums `CustomerCreateParams.tax_id_data[].type`, `InvoiceUpcomingParams.customer_details.tax_ids[].type`, `InvoiceUpcomingLinesParams.customer_details.tax_ids[].type`, and `TaxIdCreateParams.type`
* Change type of `PaymentIntentCreateParams.payment_method_data.billing_details.email`, `PaymentIntentUpdateParams.payment_method_data.billing_details.email`, `PaymentIntentConfirmParams.payment_method_data.billing_details.email`, `PaymentMethodCreateParams.billing_details.email`, and `PaymentMethodUpdateParams.billing_details.email` from `string` to `emptyStringable(string)`
* Add support for `giropay` on `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, and `PaymentIntent.payment_method_options`
* Add support for new value `en-IE` on enums `PaymentIntentCreateParams.payment_method_options.klarna.preferred_locale`, `PaymentIntentUpdateParams.payment_method_options.klarna.preferred_locale`, and `PaymentIntentConfirmParams.payment_method_options.klarna.preferred_locale`

