### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -715,7 +715,7 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Customer>>;
 
       /**
-       * Retrieves the details of an existing customer. You need only supply the unique customer identifier that was returned upon customer creation.
+       * Retrieves a Customer object.
        */
       retrieve(
         id: string,

--- a/types/2020-08-27/Discounts.d.ts
+++ b/types/2020-08-27/Discounts.d.ts
@@ -24,7 +24,7 @@ declare module 'stripe' {
       /**
        * A coupon contains information about a percent-off or amount-off discount you
        * might want to apply to a customer. Coupons may be applied to [invoices](https://stripe.com/docs/api#invoices) or
-       * [orders](https://stripe.com/docs/api#create_order-coupon). Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge).
+       * [orders](https://stripe.com/docs/api#create_order_legacy-coupon). Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge).
        */
       coupon: Stripe.Coupon;
 
@@ -88,7 +88,7 @@ declare module 'stripe' {
       /**
        * A coupon contains information about a percent-off or amount-off discount you
        * might want to apply to a customer. Coupons may be applied to [invoices](https://stripe.com/docs/api#invoices) or
-       * [orders](https://stripe.com/docs/api#create_order-coupon). Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge).
+       * [orders](https://stripe.com/docs/api#create_order_legacy-coupon). Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge).
        */
       coupon: Stripe.Coupon;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -625,6 +625,15 @@ declare module 'stripe' {
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
            */
           request_three_d_secure: Card.RequestThreeDSecure | null;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           */
+          setup_future_usage?: Card.SetupFutureUsage;
         }
 
         namespace Card {
@@ -696,6 +705,8 @@ declare module 'stripe' {
             | 'visa';
 
           type RequestThreeDSecure = 'any' | 'automatic' | 'challenge_only';
+
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
         }
 
         interface CardPresent {}
@@ -1630,6 +1641,17 @@ declare module 'stripe' {
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
            */
           request_three_d_secure?: Card.RequestThreeDSecure;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: Stripe.Emptyable<Card.SetupFutureUsage>;
         }
 
         namespace Card {
@@ -1681,6 +1703,8 @@ declare module 'stripe' {
             | 'visa';
 
           type RequestThreeDSecure = 'any' | 'automatic';
+
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
         }
 
         interface CardPresent {}
@@ -2558,6 +2582,17 @@ declare module 'stripe' {
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
            */
           request_three_d_secure?: Card.RequestThreeDSecure;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: Stripe.Emptyable<Card.SetupFutureUsage>;
         }
 
         namespace Card {
@@ -2609,6 +2644,8 @@ declare module 'stripe' {
             | 'visa';
 
           type RequestThreeDSecure = 'any' | 'automatic';
+
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
         }
 
         interface CardPresent {}
@@ -3600,6 +3637,17 @@ declare module 'stripe' {
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
            */
           request_three_d_secure?: Card.RequestThreeDSecure;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: Stripe.Emptyable<Card.SetupFutureUsage>;
         }
 
         namespace Card {
@@ -3651,6 +3699,8 @@ declare module 'stripe' {
             | 'visa';
 
           type RequestThreeDSecure = 'any' | 'automatic';
+
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
         }
 
         interface CardPresent {}

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -345,7 +345,7 @@ declare module 'stripe' {
 
       interface Relationship {
         /**
-         * Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
+         * Whether the person is a director of the account's legal entity. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
          */
         director: boolean | null;
 
@@ -769,7 +769,7 @@ declare module 'stripe' {
 
       interface Relationship {
         /**
-         * Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
+         * Whether the person is a director of the account's legal entity. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
          */
         director?: boolean;
 
@@ -1036,7 +1036,7 @@ declare module 'stripe' {
 
       interface Relationship {
         /**
-         * Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
+         * Whether the person is a director of the account's legal entity. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
          */
         director?: boolean;
 

--- a/types/2020-08-27/PromotionCodes.d.ts
+++ b/types/2020-08-27/PromotionCodes.d.ts
@@ -29,7 +29,7 @@ declare module 'stripe' {
       /**
        * A coupon contains information about a percent-off or amount-off discount you
        * might want to apply to a customer. Coupons may be applied to [invoices](https://stripe.com/docs/api#invoices) or
-       * [orders](https://stripe.com/docs/api#create_order-coupon). Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge).
+       * [orders](https://stripe.com/docs/api#create_order_legacy-coupon). Coupons do not work with conventional one-off [charges](https://stripe.com/docs/api#create_charge).
        */
       coupon: Stripe.Coupon;
 
@@ -222,7 +222,7 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.PromotionCode>>;
 
       /**
-       * Retrieves the promotion code with the given ID.
+       * Retrieves the promotion code with the given ID. In order to retrieve a promotion code by the customer-facing code use [list](https://stripe.com/docs/api/promotion_codes/list) with the desired code.
        */
       retrieve(
         id: string,

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -712,7 +712,7 @@ declare module 'stripe' {
 
         interface Relationship {
           /**
-           * Whether the person is a director of the account's legal entity. Currently only required for accounts in the EU. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
+           * Whether the person is a director of the account's legal entity. Directors are typically members of the governing board of the company, or responsible for ensuring the company meets its regulatory obligations.
            */
           director?: boolean;
 


### PR DESCRIPTION
Codegen for openapi 64b4f72.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resource `PaymentIntentTypeSpecificPaymentMethodOptionsClient`
* Add support for `setup_future_usage` on `PaymentIntentCreateParams.payment_method_options.card`, `PaymentIntentUpdateParams.payment_method_options.card`, `PaymentIntentConfirmParams.payment_method_options.card`, and `PaymentIntent.payment_method_options.card`

