### PR TITLE
update documentation to use appInfo

### DIFF
--- a/README.md
+++ b/README.md
@@ -367,13 +367,27 @@ expect(event.id).to.equal(payload.id);
 
 ### Writing a Plugin
 
-If you're writing a plugin that uses the library, we'd appreciate it if you identified using `stripe.setAppInfo()`:
+If you're writing a plugin that uses the library, we'd appreciate it if you instantiated your stripe client with `appInfo`, eg;
 
 ```js
-stripe.setAppInfo({
-  name: 'MyAwesomePlugin',
-  version: '1.2.34', // Optional
-  url: 'https://myawesomeplugin.info', // Optional
+const stripe = require('stripe')('sk_test_...', {
+  appInfo: {
+    name: 'MyAwesomePlugin',
+    version: '1.2.34', // Optional
+    url: 'https://myawesomeplugin.info', // Optional
+  }
+});
+```
+
+Or using ES modules or TypeScript:
+
+```js
+const stripe = new Stripe(apiKey, {
+  appInfo: {
+    name: 'MyAwesomePlugin',
+    version: '1.2.34', // Optional
+    url: 'https://myawesomeplugin.info', // Optional
+  }
 });
 ```
 


### PR DESCRIPTION
This request updates the documentation to use the correct way to send appInfo, taken from the PR found [here](https://github.com/stripe/stripe-node/pull/752#issue-547115745): 

The current documentation references a deprecated method `stripe.setAppInfo({})` for setting appInfo on requests.  Using the current documentation results in this error:

```
stripe.appInfo({
       ^

TypeError: stripe.appInfo is not a function
    at Object.<anonymous> (/Users/caranda/Documents/Ignitio/repositories/stripe-collector/index.js:7:8)
    at Module._compile (node:internal/modules/cjs/loader:1101:14)
    at Object.Module._extensions..js (node:internal/modules/cjs/loader:1153:10)
    at Module.load (node:internal/modules/cjs/loader:981:32)
    at Function.Module._load (node:internal/modules/cjs/loader:822:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:81:12)
    at node:internal/main/run_main_module:17:47
```