### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1419,7 +1419,7 @@ declare module 'stripe' {
 
           /**
            * Preferred language of the Klarna authorization page that the customer is redirected to.
-           * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `en-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `en-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `en-IE`, `it-IT`, `en-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `fr-FR`, or `en-FR`
+           * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `en-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `en-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `en-IE`, `it-IT`, `en-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `es-US`, `fr-FR`, or `en-FR`
            */
           preferred_locale: string | null;
         }

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -1341,7 +1341,7 @@ declare module 'stripe' {
 
     interface InvoiceFinalizeInvoiceParams {
       /**
-       * Controls whether Stripe will perform [automatic collection](https://stripe.com/docs/billing/invoices/overview#auto-advance) of the invoice. When `false`, the invoice's state will not automatically advance without an explicit action.
+       * Controls whether Stripe will perform [automatic collection](https://stripe.com/docs/invoicing/automatic-charging) of the invoice. When `false`, the invoice's state will not automatically advance without an explicit action.
        */
       auto_advance?: boolean;
 

--- a/types/2020-08-27/Issuing/Cardholders.d.ts
+++ b/types/2020-08-27/Issuing/Cardholders.d.ts
@@ -1109,7 +1109,7 @@ declare module 'stripe' {
         billing: CardholderCreateParams.Billing;
 
         /**
-         * The cardholder's name. This will be printed on cards issued to them.
+         * The cardholder's name. This will be printed on cards issued to them. The maximum length of this field is 24 characters.
          */
         name: string;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -785,7 +785,7 @@ declare module 'stripe' {
         card?: Processing.Card;
 
         /**
-         * Type of the next action to perform, one of `card`.
+         * Type of the payment method for which payment is in `processing` state, one of `card`.
          */
         type: string;
       }
@@ -1751,6 +1751,7 @@ declare module 'stripe' {
             | 'en-DK'
             | 'en-ES'
             | 'en-FI'
+            | 'en-FR'
             | 'en-GB'
             | 'en-IE'
             | 'en-IT'
@@ -1759,8 +1760,10 @@ declare module 'stripe' {
             | 'en-SE'
             | 'en-US'
             | 'es-ES'
+            | 'es-US'
             | 'fi-FI'
             | 'fr-BE'
+            | 'fr-FR'
             | 'it-IT'
             | 'nb-NO'
             | 'nl-BE'
@@ -2692,6 +2695,7 @@ declare module 'stripe' {
             | 'en-DK'
             | 'en-ES'
             | 'en-FI'
+            | 'en-FR'
             | 'en-GB'
             | 'en-IE'
             | 'en-IT'
@@ -2700,8 +2704,10 @@ declare module 'stripe' {
             | 'en-SE'
             | 'en-US'
             | 'es-ES'
+            | 'es-US'
             | 'fi-FI'
             | 'fr-BE'
+            | 'fr-FR'
             | 'it-IT'
             | 'nb-NO'
             | 'nl-BE'
@@ -3747,6 +3753,7 @@ declare module 'stripe' {
             | 'en-DK'
             | 'en-ES'
             | 'en-FI'
+            | 'en-FR'
             | 'en-GB'
             | 'en-IE'
             | 'en-IT'
@@ -3755,8 +3762,10 @@ declare module 'stripe' {
             | 'en-SE'
             | 'en-US'
             | 'es-ES'
+            | 'es-US'
             | 'fi-FI'
             | 'fr-BE'
+            | 'fr-FR'
             | 'it-IT'
             | 'nb-NO'
             | 'nl-BE'

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -79,6 +79,8 @@ declare module 'stripe' {
 
         bancontact?: PaymentMethodDetails.Bancontact;
 
+        boleto?: PaymentMethodDetails.Boleto;
+
         card?: PaymentMethodDetails.Card;
 
         card_present?: PaymentMethodDetails.CardPresent;
@@ -149,6 +151,8 @@ declare module 'stripe' {
         namespace Bancontact {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
         }
+
+        interface Boleto {}
 
         interface Card {
           /**


### PR DESCRIPTION
Codegen for openapi 628e7c2.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new values `en-FR`, `es-US`, and `fr-FR` on enums `PaymentIntentCreateParams.payment_method_options.klarna.preferred_locale`, `PaymentIntentUpdateParams.payment_method_options.klarna.preferred_locale`, and `PaymentIntentConfirmParams.payment_method_options.klarna.preferred_locale`
* Add support for `boleto` on `SetupAttempt.payment_method_details`

