### PR TITLE
Add comment documenting makeRequest#headers type.

### DIFF
--- a/types/net/net.d.ts
+++ b/types/net/net.d.ts
@@ -19,6 +19,11 @@ declare module 'stripe' {
         port: string | number,
         path: string,
         method: 'GET' | 'POST' | 'PUT' | 'DELETE',
+        // object is used here as this is implementation-specific. This is
+        // generally {[key: string]: string}, but various underlying clients
+        // support other types as well. As examples:
+        // - Node supports {[key: string]: string | number | string[]}.
+        // - Fetch supports a Headers object.
         headers: object,
         requestData: string | null,
         protocol: Stripe.HttpProtocol,


### PR DESCRIPTION
r? @richardm-stripe 

### Summary

Adds a comment documenting why `HttpClient#makeRequest(headers)` doesn't use a stricter type. Unfortunately this is implementation-specific and enforcing a stricter type could break some integrations.

As examples, we cannot just use `{[key: string]: string}` since:
1. Node actually supports `{[key: string]: string | number | string[]}`
2. Fetch actually also supports `string[][]` as well as a `Headers` object.