### PR TITLE
Remove DOM type references.

### DIFF
--- a/types/crypto/crypto.d.ts
+++ b/types/crypto/crypto.d.ts
@@ -47,7 +47,13 @@ declare module 'stripe' {
      * defaults to the `crypto.subtle` object in the global scope.
      */
     export const createSubtleCryptoProvider: (
-      subtleCrypto?: WindowOrWorkerGlobalScope['crypto']['subtle']
+      /**
+       * The SubtleCrypto type cannot be specified without pulling in DOM types.
+       * This corresponds to WindowOrWorkerGlobalScope['crypto']['subtle'] for
+       * applications which pull in DOM types.
+       */
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      subtleCrypto?: any
     ) => CryptoProvider;
   }
 }

--- a/types/net/net.d.ts
+++ b/types/net/net.d.ts
@@ -1,5 +1,4 @@
 /// <reference types="node" />
-/// <reference lib="dom" />
 
 import {IncomingMessage} from 'http';
 declare module 'stripe' {
@@ -76,11 +75,24 @@ declare module 'stripe' {
      * passed, will default to the default `fetch` function in the global scope.
      */
     export const createFetchHttpClient: (
-      fetchFn?: WindowOrWorkerGlobalScope['fetch']
+      /** When specified, interface should match the Web Fetch API function. */
+      fetchFn?: Function
     ) => HttpClient<
       HttpClientResponse<
-        ReturnType<WindowOrWorkerGlobalScope['fetch']>,
-        ReadableStream<Uint8Array>
+        /**
+         * The response type cannot be specified without pulling in DOM types.
+         * This corresponds to ReturnType<WindowOrWorkerGlobalScope['fetch']>
+         * for applications which pull in DOM types.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any,
+        /**
+         * The stream type cannot be specified without pulling in DOM types.
+         * This corresponds to ReadableStream<Uint8Array> for applications which
+         * pull in DOM types.
+         */
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        any
       >
     >;
   }

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -228,7 +228,7 @@ async (): Promise<void> => {
 
 // Test FetchHttpClient request processing.
 async (): Promise<void> => {
-  const client = Stripe.createFetchHttpClient(window.fetch);
+  const client = Stripe.createFetchHttpClient();
 
   const response = await client.makeRequest(
     'api.stripe.com',
@@ -244,7 +244,7 @@ async (): Promise<void> => {
     80000
   );
 
-  const stream: ReadableStream = response.toStream(() => {
+  const stream = response.toStream(() => {
     return;
   });
 


### PR DESCRIPTION
r? @richardm-stripe 

### Summary

Removes the references to DOM types, specifically the fetch function (and its return/stream types) as well as the SubtleCrypto interface.

Unfortunately this reference pollutes the global namespace for Node packages, which don't include these DOM APIs.

We lose some type-safety here by switching to `any` but the alternative would be copying in the types from the DOM typescript definitions. These are quite substantial (eg. the `fetch` input arguments require many types) and would require keeping these types in sync with moving web standards.

### Motivation

https://github.com/stripe/stripe-node/issues/1326