### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/BillingPortal/Configurations.d.ts
+++ b/types/2020-08-27/BillingPortal/Configurations.d.ts
@@ -442,7 +442,7 @@ declare module 'stripe' {
 
             interface Product {
               /**
-               * The list of prices IDs that a subscription can be updated to.
+               * The list of price IDs for the product that a subscription can be updated to.
                */
               prices: Array<string>;
 
@@ -678,7 +678,7 @@ declare module 'stripe' {
 
             interface Product {
               /**
-               * The list of prices IDs that a subscription can be updated to.
+               * The list of price IDs for the product that a subscription can be updated to.
                */
               prices: Array<string>;
 

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -82,6 +82,11 @@ declare module 'stripe' {
         customer: string | Stripe.Customer | Stripe.DeletedCustomer | null;
 
         /**
+         * Configure whether a Checkout Session creates a Customer when the Checkout Session completes.
+         */
+        customer_creation: Session.CustomerCreation | null;
+
+        /**
          * The customer details including the customer's tax exempt status and the customer's tax IDs. Only present on Sessions in `payment` or `subscription` mode.
          */
         customer_details: Session.CustomerDetails | null;
@@ -288,6 +293,8 @@ declare module 'stripe' {
            */
           promotions: 'auto' | null;
         }
+
+        type CustomerCreation = 'always' | 'if_required';
 
         interface CustomerDetails {
           /**
@@ -914,7 +921,7 @@ declare module 'stripe' {
          * ID of an existing Customer, if one exists. In `payment` mode, the customer's most recent card
          * payment method will be used to prefill the email, name, card details, and billing address
          * on the Checkout page. In `subscription` mode, the customer's [default payment method](https://stripe.com/docs/api/customers/update#update_customer-invoice_settings-default_payment_method)
-         * will be used if it's a card, and otherwise the most recent card will be used. A valid billing address is required for Checkout to prefill the customer's card details.
+         * will be used if it's a card, and otherwise the most recent card will be used. A valid billing address, billing name and billing email are required on the payment method for Checkout to prefill the customer's card details.
          *
          * If the Customer already has a valid [email](https://stripe.com/docs/api/customers/object#customer_object-email) set, the email will be prefilled and not editable in Checkout.
          * If the Customer does not have a valid `email`, Checkout will set the email entered during the session on the Customer.
@@ -924,6 +931,18 @@ declare module 'stripe' {
          * You can set [`payment_intent_data.setup_future_usage`](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_intent_data-setup_future_usage) to have Checkout automatically attach the payment method to the Customer you pass in for future reuse.
          */
         customer?: string;
+
+        /**
+         * Configure whether a Checkout Session creates a [Customer](https://stripe.com/docs/api/customers) during Session confirmation.
+         *
+         * When a Customer is not created, you can still retrieve email, address, and other customer data entered in Checkout
+         * with [customer_details](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-customer_details).
+         *
+         * Sessions that do not create Customers will instead create [Guest Customers](https://support.stripe.com/questions/guest-customer-faq) in the Dashboard.
+         *
+         * Can only be set in `payment` and `setup` mode.
+         */
+        customer_creation?: SessionCreateParams.CustomerCreation;
 
         /**
          * If provided, this value will be used when the Customer object is created.
@@ -1088,6 +1107,8 @@ declare module 'stripe' {
            */
           promotions?: 'auto';
         }
+
+        type CustomerCreation = 'always' | 'if_required';
 
         interface CustomerUpdate {
           /**
@@ -1383,9 +1404,12 @@ declare module 'stripe' {
            * customer that their payment details will be saved and used for future
            * payments.
            *
-           * For both values, Checkout will attach the payment method to either the
-           * provided Customer for the session, or a new Customer created by Checkout
-           * if one has not been provided.
+           * If a Customer has been provided or Checkout creates a new Customer,
+           * Checkout will attach the payment method to the Customer.
+           *
+           * If Checkout does not create a Customer, the payment method is not attached
+           * to a Customer. To reuse the payment method, you can retrieve it from the
+           * Checkout Session's PaymentIntent.
            *
            * When processing card payments, Checkout also uses `setup_future_usage`
            * to dynamically optimize your payment flow and comply with regional

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -526,7 +526,11 @@ declare module 'stripe' {
 
         card_present?: PaymentMethodOptions.CardPresent;
 
+        fpx?: PaymentMethodOptions.Fpx;
+
         giropay?: PaymentMethodOptions.Giropay;
+
+        grabpay?: PaymentMethodOptions.Grabpay;
 
         ideal?: PaymentMethodOptions.Ideal;
 
@@ -720,7 +724,11 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Fpx {}
+
         interface Giropay {}
+
+        interface Grabpay {}
 
         interface Ideal {}
 
@@ -1519,9 +1527,19 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `fpx` PaymentMethod, this sub-hash contains details about the FPX payment method options.
+         */
+        fpx?: Stripe.Emptyable<PaymentMethodOptions.Fpx>;
+
+        /**
          * If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
          */
         giropay?: Stripe.Emptyable<PaymentMethodOptions.Giropay>;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this sub-hash contains details about the Grabpay payment method options.
+         */
+        grabpay?: Stripe.Emptyable<PaymentMethodOptions.Grabpay>;
 
         /**
          * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
@@ -1738,7 +1756,11 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Fpx {}
+
         interface Giropay {}
+
+        interface Grabpay {}
 
         interface Ideal {}
 
@@ -2470,9 +2492,19 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `fpx` PaymentMethod, this sub-hash contains details about the FPX payment method options.
+         */
+        fpx?: Stripe.Emptyable<PaymentMethodOptions.Fpx>;
+
+        /**
          * If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
          */
         giropay?: Stripe.Emptyable<PaymentMethodOptions.Giropay>;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this sub-hash contains details about the Grabpay payment method options.
+         */
+        grabpay?: Stripe.Emptyable<PaymentMethodOptions.Grabpay>;
 
         /**
          * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
@@ -2689,7 +2721,11 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Fpx {}
+
         interface Giropay {}
+
+        interface Grabpay {}
 
         interface Ideal {}
 
@@ -3535,9 +3571,19 @@ declare module 'stripe' {
         card_present?: Stripe.Emptyable<PaymentMethodOptions.CardPresent>;
 
         /**
+         * If this is a `fpx` PaymentMethod, this sub-hash contains details about the FPX payment method options.
+         */
+        fpx?: Stripe.Emptyable<PaymentMethodOptions.Fpx>;
+
+        /**
          * If this is a `giropay` PaymentMethod, this sub-hash contains details about the Giropay payment method options.
          */
         giropay?: Stripe.Emptyable<PaymentMethodOptions.Giropay>;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this sub-hash contains details about the Grabpay payment method options.
+         */
+        grabpay?: Stripe.Emptyable<PaymentMethodOptions.Grabpay>;
 
         /**
          * If this is a `ideal` PaymentMethod, this sub-hash contains details about the Ideal payment method options.
@@ -3754,7 +3800,11 @@ declare module 'stripe' {
 
         interface CardPresent {}
 
+        interface Fpx {}
+
         interface Giropay {}
+
+        interface Grabpay {}
 
         interface Ideal {}
 


### PR DESCRIPTION
Codegen for openapi 31569c9.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `customer_creation` on `CheckoutSessionCreateParams` and `Checkout.Session`
* Add support for `fpx` and `grabpay` on `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentIntentConfirmParams.payment_method_options`, and `PaymentIntent.payment_method_options`

