### PR TITLE
Customer tax_ids is not included by default

### DIFF
--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -129,7 +129,7 @@ declare module 'stripe' {
       /**
        * The customer's tax IDs.
        */
-      tax_ids: ApiList<Stripe.TaxId>;
+      tax_ids?: ApiList<Stripe.TaxId>;
     }
 
     namespace Customer {


### PR DESCRIPTION
According to the documentation https://stripe.com/docs/api/customers/object#customer_object-tax_ids

> This field is not included by default.

Typing suppose it is.

Doing `stripe.customers.retrieve` show it is indeed not included by default.