### PR TITLE
fix(http-client): use named import

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -12,7 +12,7 @@ const {
   StripeAPIError,
 } = require('./Error');
 
-const HttpClient = require('./net/HttpClient');
+const {HttpClient} = require('./net/HttpClient');
 
 // Provide extension mechanism for Stripe Resource Sub-Classes
 StripeResource.extend = utils.protoExtend;

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -210,6 +210,9 @@ describe('StripeResource', () => {
             }
             stripe.charges.create(options.data, (err, result) => {
               expect(err.detail.message).to.deep.equal('ETIMEDOUT');
+              expect(err.message).to.deep.equal(
+                'Request aborted due to timeout being reached (10ms)'
+              );
               closeServer();
               done();
             });


### PR DESCRIPTION
Custom request timeout message was never used since we were incorrectly
requiring the HttpClient class.

I believe this has stopped working on #1218.