### PR TITLE
Bump nanoid from 3.1.20 to 3.2.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "typescript": "^3.7.2"
   },
   "resolutions": {
-    "ansi-regex": "5.0.1"
+    "ansi-regex": "5.0.1",
+    "nanoid": "3.2.0"
   },
   "dependencies": {
     "@types/node": ">=8.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1494,10 +1494,10 @@ mute-stream@0.0.8:
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.8.tgz#1630c42b2251ff81e2a283de96a5497ea92e5e0d"
   integrity sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA==
 
-nanoid@3.1.20:
-  version "3.1.20"
-  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.1.20.tgz#badc263c6b1dcf14b71efaa85f6ab4c1d6cfc788"
-  integrity sha512-a1cQNyczgKbLX9jwbS/+d7W8fX/RfgYR7lVWwWOGIPNgK2m0MWvrGF6/m4kk6U3QcFMnZf3RIhL0v2Jgh/0Uxw==
+nanoid@3.1.20, nanoid@3.2.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/nanoid/-/nanoid-3.2.0.tgz#62667522da6673971cca916a6d3eff3f415ff80c"
+  integrity sha512-fmsZYa9lpn69Ad5eDn7FMcnnSR+8R34W9qJEijxYhTbfOWzr22n1QxCMzXLK+ODyW2973V3Fux959iQoUxzUIA==
 
 natural-compare@^1.4.0:
   version "1.4.0"


### PR DESCRIPTION
r? @richardm-stripe 

## Summary

Bump nanoid from 3.1.20 to 3.2.0. I had to pin it via `resolutions` due to our Mocha dep. Unfortunately this dependency was only changed in Mocha 9+, which we can't currently update to as it no longer supports Node 10 (https://github.com/mochajs/mocha/blob/master/CHANGELOG.md#boom-breaking-changes).

## Motivation

[CVE-2021-23566](https://github.com/advisories/GHSA-qrpm-p2h7-hrv2)