### PR TITLE
fix: types for unsetting subscription paused state

### DIFF
--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -1272,7 +1272,7 @@ declare module 'stripe' {
       }
 
       namespace PauseCollection {
-        type Behavior = 'keep_as_draft' | 'mark_uncollectible' | 'void';
+        type Behavior = 'keep_as_draft' | 'mark_uncollectible' | 'void' | '';
       }
 
       type PaymentBehavior =


### PR DESCRIPTION
From https://stripe.com/docs/billing/subscriptions/pause#unpausing you should be able to supply an empty string to manually un-pause a subscription

![image](https://user-images.githubusercontent.com/61694629/152832103-87b475c8-3260-4888-aa3a-72756bb61260.png)
