### PR TITLE
Properly handle API errors with unknown error types

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -49,7 +49,7 @@ class StripeError extends Error {
       case 'invalid_grant':
         return new StripeInvalidGrantError(rawStripeError);
       default:
-        return new GenericError('Generic', 'Unknown Error');
+        return new StripeUnknownError(rawStripeError);
     }
   }
 }
@@ -122,6 +122,11 @@ class StripeIdempotencyError extends StripeError {}
  */
 class StripeInvalidGrantError extends StripeError {}
 
+/**
+ * Any other error from Stripe not specifically captured above
+ */
+class StripeUnknownError extends StripeError {}
+
 module.exports.generate = StripeError.generate;
 module.exports.StripeError = StripeError;
 module.exports.StripeCardError = StripeCardError;
@@ -134,3 +139,4 @@ module.exports.StripeConnectionError = StripeConnectionError;
 module.exports.StripeSignatureVerificationError = StripeSignatureVerificationError;
 module.exports.StripeIdempotencyError = StripeIdempotencyError;
 module.exports.StripeInvalidGrantError = StripeInvalidGrantError;
+module.exports.StripeUnknownError = StripeUnknownError;

--- a/test/Error.spec.js
+++ b/test/Error.spec.js
@@ -20,6 +20,9 @@ describe('Error', () => {
       expect(
         Error.StripeError.generate({type: 'idempotency_error'})
       ).to.be.instanceOf(Error.StripeIdempotencyError);
+      expect(
+        Error.StripeError.generate({type: 'weird_error'})
+      ).to.be.instanceOf(Error.StripeUnknownError);
     });
 
     it('copies whitelisted properties', () => {


### PR DESCRIPTION
When the API returns an error of a type which isn't explicitly enumerated, `StripeError.generate` tries to return a `GenericError`. However, that class doesn't exist - it was deleted as part of the refactor in https://github.com/stripe/stripe-node/pull/672. This causes stripe-node to return an especially confusing error - it complains about the undefined `GenericError` class, instead of telling us anything useful about the actual error.

This patch defines a fallback subclass of StripeError to use in these cases. (As a bonus, this means that the default error rendering will also contain the error message from the API, instead of a fixed `Unknown Error` string.)

AFAICT, the only way it was possible to hit this branch is to get the oauth flow to return weird errors. Since this is served from `connect.stripe.com` instead of `api.stripe.com`, it can return non-standard error types. It's not clear to me whether it's worth creating new error classes for these cases - for now, I've just fixed the type error.