### PR TITLE
Update request reasons

### DIFF
--- a/types/2020-08-27/Issuing/Authorizations.d.ts
+++ b/types/2020-08-27/Issuing/Authorizations.d.ts
@@ -269,6 +269,7 @@ declare module 'stripe' {
             | 'insufficient_funds'
             | 'not_allowed'
             | 'spending_controls'
+            | 'authorization_controls'
             | 'suspected_fraud'
             | 'verification_failed'
             | 'webhook_approved'


### PR DESCRIPTION
Include `authorization_controls` as a Reason, which is returned in legacy API versions.