### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -237,6 +237,11 @@ declare module 'stripe' {
         klarna_payments?: Capabilities.KlarnaPayments;
 
         /**
+         * The status of the konbini payments capability of the account, or whether the account can directly process konbini charges.
+         */
+        konbini_payments?: Capabilities.KonbiniPayments;
+
+        /**
          * The status of the legacy payments capability of the account.
          */
         legacy_payments?: Capabilities.LegacyPayments;
@@ -309,6 +314,8 @@ declare module 'stripe' {
         type JcbPayments = 'active' | 'inactive' | 'pending';
 
         type KlarnaPayments = 'active' | 'inactive' | 'pending';
+
+        type KonbiniPayments = 'active' | 'inactive' | 'pending';
 
         type LegacyPayments = 'active' | 'inactive' | 'pending';
 
@@ -1244,6 +1251,11 @@ declare module 'stripe' {
         klarna_payments?: Capabilities.KlarnaPayments;
 
         /**
+         * The konbini_payments capability.
+         */
+        konbini_payments?: Capabilities.KonbiniPayments;
+
+        /**
          * The legacy_payments capability.
          */
         legacy_payments?: Capabilities.LegacyPayments;
@@ -1391,6 +1403,13 @@ declare module 'stripe' {
         }
 
         interface KlarnaPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface KonbiniPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */
@@ -2314,6 +2333,11 @@ declare module 'stripe' {
         klarna_payments?: Capabilities.KlarnaPayments;
 
         /**
+         * The konbini_payments capability.
+         */
+        konbini_payments?: Capabilities.KonbiniPayments;
+
+        /**
          * The legacy_payments capability.
          */
         legacy_payments?: Capabilities.LegacyPayments;
@@ -2461,6 +2485,13 @@ declare module 'stripe' {
         }
 
         interface KlarnaPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface KonbiniPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */

--- a/types/2020-08-27/BillingPortal/Configurations.d.ts
+++ b/types/2020-08-27/BillingPortal/Configurations.d.ts
@@ -72,12 +72,12 @@ declare module 'stripe' {
           /**
            * A link to the business's publicly available privacy policy.
            */
-          privacy_policy_url: string;
+          privacy_policy_url: string | null;
 
           /**
            * A link to the business's publicly available terms of service.
            */
-          terms_of_service_url: string;
+          terms_of_service_url: string | null;
         }
 
         interface Features {
@@ -273,12 +273,12 @@ declare module 'stripe' {
           /**
            * A link to the business's publicly available privacy policy.
            */
-          privacy_policy_url: string;
+          privacy_policy_url?: string;
 
           /**
            * A link to the business's publicly available terms of service.
            */
-          terms_of_service_url: string;
+          terms_of_service_url?: string;
         }
 
         interface Features {
@@ -509,12 +509,12 @@ declare module 'stripe' {
           /**
            * A link to the business's publicly available privacy policy.
            */
-          privacy_policy_url?: string;
+          privacy_policy_url?: Stripe.Emptyable<string>;
 
           /**
            * A link to the business's publicly available terms of service.
            */
-          terms_of_service_url?: string;
+          terms_of_service_url?: Stripe.Emptyable<string>;
         }
 
         interface Features {

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -418,6 +418,8 @@ declare module 'stripe' {
 
         klarna?: PaymentMethodDetails.Klarna;
 
+        konbini?: PaymentMethodDetails.Konbini;
+
         multibanco?: PaymentMethodDetails.Multibanco;
 
         oxxo?: PaymentMethodDetails.Oxxo;
@@ -1422,6 +1424,26 @@ declare module 'stripe' {
            * Can be one of `de-AT`, `en-AT`, `nl-BE`, `fr-BE`, `en-BE`, `de-DE`, `en-DE`, `da-DK`, `en-DK`, `es-ES`, `en-ES`, `fi-FI`, `sv-FI`, `en-FI`, `en-GB`, `en-IE`, `it-IT`, `en-IT`, `nl-NL`, `en-NL`, `nb-NO`, `en-NO`, `sv-SE`, `en-SE`, `en-US`, `es-US`, `fr-FR`, or `en-FR`
            */
           preferred_locale: string | null;
+        }
+
+        interface Konbini {
+          /**
+           * If the payment succeeded, this contains the details of the convenience store where the payment was completed.
+           */
+          store: Konbini.Store | null;
+        }
+
+        namespace Konbini {
+          interface Store {
+            /**
+             * The name of the convenience store chain where the payment was completed.
+             */
+            chain: Store.Chain | null;
+          }
+
+          namespace Store {
+            type Chain = 'familymart' | 'lawson' | 'ministop' | 'seicomart';
+          }
         }
 
         interface Multibanco {

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -437,6 +437,8 @@ declare module 'stripe' {
 
           boleto?: PaymentMethodOptions.Boleto;
 
+          konbini?: PaymentMethodOptions.Konbini;
+
           oxxo?: PaymentMethodOptions.Oxxo;
         }
 
@@ -496,6 +498,13 @@ declare module 'stripe' {
              * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
              */
             expires_after_days: number;
+          }
+
+          interface Konbini {
+            /**
+             * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
+             */
+            expires_after_days: number | null;
           }
 
           interface Oxxo {
@@ -1507,6 +1516,11 @@ declare module 'stripe' {
           boleto?: PaymentMethodOptions.Boleto;
 
           /**
+           * contains details about the Konbini payment method options.
+           */
+          konbini?: PaymentMethodOptions.Konbini;
+
+          /**
            * contains details about the OXXO payment method options.
            */
           oxxo?: PaymentMethodOptions.Oxxo;
@@ -1585,6 +1599,13 @@ declare module 'stripe' {
             expires_after_days?: number;
           }
 
+          interface Konbini {
+            /**
+             * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST. Defaults to 3 days.
+             */
+            expires_after_days?: Stripe.Emptyable<number>;
+          }
+
           interface Oxxo {
             /**
              * The number of calendar days before an OXXO voucher expires. For example, if you create an OXXO voucher on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
@@ -1624,6 +1645,7 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'klarna'
+          | 'konbini'
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -696,6 +696,7 @@ declare module 'stripe' {
         | 'grabpay'
         | 'ideal'
         | 'klarna'
+        | 'konbini'
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -603,6 +603,11 @@ declare module 'stripe' {
            * If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
            */
           card: PaymentMethodOptions.Card | null;
+
+          /**
+           * If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
+           */
+          konbini: PaymentMethodOptions.Konbini | null;
         }
 
         namespace PaymentMethodOptions {
@@ -651,6 +656,8 @@ declare module 'stripe' {
           namespace Card {
             type RequestThreeDSecure = 'any' | 'automatic';
           }
+
+          interface Konbini {}
         }
 
         type PaymentMethodType =
@@ -666,6 +673,7 @@ declare module 'stripe' {
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'konbini'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
@@ -966,6 +974,11 @@ declare module 'stripe' {
            * If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
            */
           card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
+
+          /**
+           * If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
+           */
+          konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
         }
 
         namespace PaymentMethodOptions {
@@ -1017,6 +1030,8 @@ declare module 'stripe' {
           namespace Card {
             type RequestThreeDSecure = 'any' | 'automatic';
           }
+
+          interface Konbini {}
         }
 
         type PaymentMethodType =
@@ -1032,6 +1047,7 @@ declare module 'stripe' {
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'konbini'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
@@ -1224,6 +1240,11 @@ declare module 'stripe' {
            * If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
            */
           card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
+
+          /**
+           * If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
+           */
+          konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
         }
 
         namespace PaymentMethodOptions {
@@ -1275,6 +1296,8 @@ declare module 'stripe' {
           namespace Card {
             type RequestThreeDSecure = 'any' | 'automatic';
           }
+
+          interface Konbini {}
         }
 
         type PaymentMethodType =
@@ -1290,6 +1313,7 @@ declare module 'stripe' {
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'konbini'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -341,6 +341,8 @@ declare module 'stripe' {
 
         boleto_display_details?: NextAction.BoletoDisplayDetails;
 
+        konbini_display_details?: NextAction.KonbiniDisplayDetails;
+
         oxxo_display_details?: NextAction.OxxoDisplayDetails;
 
         redirect_to_url?: NextAction.RedirectToUrl;
@@ -407,6 +409,94 @@ declare module 'stripe' {
            * The URL to the downloadable boleto voucher PDF.
            */
           pdf: string | null;
+        }
+
+        interface KonbiniDisplayDetails {
+          /**
+           * The timestamp at which the pending Konbini payment expires.
+           */
+          expires_at: number;
+
+          /**
+           * The URL for the Konbini payment instructions page, which allows customers to view and print a Konbini voucher.
+           */
+          hosted_voucher_url: string | null;
+
+          stores: KonbiniDisplayDetails.Stores;
+        }
+
+        namespace KonbiniDisplayDetails {
+          interface Stores {
+            /**
+             * FamilyMart instruction details.
+             */
+            familymart: Stores.Familymart | null;
+
+            /**
+             * Lawson instruction details.
+             */
+            lawson: Stores.Lawson | null;
+
+            /**
+             * Ministop instruction details.
+             */
+            ministop: Stores.Ministop | null;
+
+            /**
+             * Seicomart instruction details.
+             */
+            seicomart: Stores.Seicomart | null;
+          }
+
+          namespace Stores {
+            interface Familymart {
+              /**
+               * The confirmation number.
+               */
+              confirmation_number?: string;
+
+              /**
+               * The payment code.
+               */
+              payment_code: string;
+            }
+
+            interface Lawson {
+              /**
+               * The confirmation number.
+               */
+              confirmation_number?: string;
+
+              /**
+               * The payment code.
+               */
+              payment_code: string;
+            }
+
+            interface Ministop {
+              /**
+               * The confirmation number.
+               */
+              confirmation_number?: string;
+
+              /**
+               * The payment code.
+               */
+              payment_code: string;
+            }
+
+            interface Seicomart {
+              /**
+               * The confirmation number.
+               */
+              confirmation_number?: string;
+
+              /**
+               * The payment code.
+               */
+              payment_code: string;
+            }
+          }
         }
 
         interface OxxoDisplayDetails {
@@ -551,6 +641,8 @@ declare module 'stripe' {
         interac_present?: PaymentMethodOptions.InteracPresent;
 
         klarna?: PaymentMethodOptions.Klarna;
+
+        konbini?: PaymentMethodOptions.Konbini;
 
         oxxo?: PaymentMethodOptions.Oxxo;
 
@@ -889,6 +981,37 @@ declare module 'stripe' {
            * Preferred locale of the Klarna checkout page that the customer is redirected to.
            */
           preferred_locale: string | null;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           */
+          setup_future_usage?: 'none';
+        }
+
+        interface Konbini {
+          /**
+           * An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores.
+           */
+          confirmation_number: string | null;
+
+          /**
+           * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
+           */
+          expires_after_days: number | null;
+
+          /**
+           * The timestamp at which the Konbini payment instructions will expire. Only one of `expires_after_days` or `expires_at` may be set.
+           */
+          expires_at: number | null;
+
+          /**
+           * A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
+           */
+          product_description: string | null;
 
           /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
@@ -1361,6 +1484,11 @@ declare module 'stripe' {
         klarna?: PaymentMethodData.Klarna;
 
         /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
         metadata?: Stripe.MetadataParam;
@@ -1612,6 +1740,8 @@ declare module 'stripe' {
           }
         }
 
+        interface Konbini {}
+
         interface Oxxo {}
 
         interface P24 {
@@ -1682,6 +1812,7 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'klarna'
+          | 'konbini'
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
@@ -1773,6 +1904,11 @@ declare module 'stripe' {
          * If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
          */
         klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
+         */
+        konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
 
         /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
@@ -2192,6 +2328,39 @@ declare module 'stripe' {
             | 'nl-NL'
             | 'sv-FI'
             | 'sv-SE';
+        }
+
+        interface Konbini {
+          /**
+           * An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores. Must not consist of only zeroes and could be rejected in case of insufficient uniqueness. We recommend to use the customer's phone number.
+           */
+          confirmation_number?: string;
+
+          /**
+           * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST. Defaults to 3 days.
+           */
+          expires_after_days?: Stripe.Emptyable<number>;
+
+          /**
+           * The timestamp at which the Konbini payment instructions will expire. Only one of `expires_after_days` or `expires_at` may be set.
+           */
+          expires_at?: Stripe.Emptyable<number>;
+
+          /**
+           * A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
+           */
+          product_description?: string;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: 'none';
         }
 
         interface Oxxo {
@@ -2566,6 +2735,11 @@ declare module 'stripe' {
         klarna?: PaymentMethodData.Klarna;
 
         /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
         metadata?: Stripe.MetadataParam;
@@ -2817,6 +2991,8 @@ declare module 'stripe' {
           }
         }
 
+        interface Konbini {}
+
         interface Oxxo {}
 
         interface P24 {
@@ -2887,6 +3063,7 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'klarna'
+          | 'konbini'
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
@@ -2978,6 +3155,11 @@ declare module 'stripe' {
          * If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
          */
         klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
+         */
+        konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
 
         /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
@@ -3397,6 +3579,39 @@ declare module 'stripe' {
             | 'nl-NL'
             | 'sv-FI'
             | 'sv-SE';
+        }
+
+        interface Konbini {
+          /**
+           * An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores. Must not consist of only zeroes and could be rejected in case of insufficient uniqueness. We recommend to use the customer's phone number.
+           */
+          confirmation_number?: string;
+
+          /**
+           * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST. Defaults to 3 days.
+           */
+          expires_after_days?: Stripe.Emptyable<number>;
+
+          /**
+           * The timestamp at which the Konbini payment instructions will expire. Only one of `expires_after_days` or `expires_at` may be set.
+           */
+          expires_at?: Stripe.Emptyable<number>;
+
+          /**
+           * A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
+           */
+          product_description?: string;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: 'none';
         }
 
         interface Oxxo {
@@ -3885,6 +4100,11 @@ declare module 'stripe' {
         klarna?: PaymentMethodData.Klarna;
 
         /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
         metadata?: Stripe.MetadataParam;
@@ -4136,6 +4356,8 @@ declare module 'stripe' {
           }
         }
 
+        interface Konbini {}
+
         interface Oxxo {}
 
         interface P24 {
@@ -4206,6 +4428,7 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'klarna'
+          | 'konbini'
           | 'oxxo'
           | 'p24'
           | 'sepa_debit'
@@ -4297,6 +4520,11 @@ declare module 'stripe' {
          * If this is a `klarna` PaymentMethod, this sub-hash contains details about the Klarna payment method options.
          */
         klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this sub-hash contains details about the Konbini payment method options.
+         */
+        konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
 
         /**
          * If this is a `oxxo` PaymentMethod, this sub-hash contains details about the OXXO payment method options.
@@ -4716,6 +4944,39 @@ declare module 'stripe' {
             | 'nl-NL'
             | 'sv-FI'
             | 'sv-SE';
+        }
+
+        interface Konbini {
+          /**
+           * An optional 10 to 11 digit numeric-only string determining the confirmation code at applicable convenience stores. Must not consist of only zeroes and could be rejected in case of insufficient uniqueness. We recommend to use the customer's phone number.
+           */
+          confirmation_number?: string;
+
+          /**
+           * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST. Defaults to 3 days.
+           */
+          expires_after_days?: Stripe.Emptyable<number>;
+
+          /**
+           * The timestamp at which the Konbini payment instructions will expire. Only one of `expires_after_days` or `expires_at` may be set.
+           */
+          expires_at?: Stripe.Emptyable<number>;
+
+          /**
+           * A product descriptor of up to 22 characters, which will appear to customers at the convenience store.
+           */
+          product_description?: string;
+
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: 'none';
         }
 
         interface Oxxo {

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -60,6 +60,8 @@ declare module 'stripe' {
 
       klarna?: PaymentMethod.Klarna;
 
+      konbini?: PaymentMethod.Konbini;
+
       /**
        * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
        */
@@ -536,6 +538,8 @@ declare module 'stripe' {
         }
       }
 
+      interface Konbini {}
+
       interface Oxxo {}
 
       interface P24 {
@@ -644,6 +648,7 @@ declare module 'stripe' {
         | 'ideal'
         | 'interac_present'
         | 'klarna'
+        | 'konbini'
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'
@@ -743,6 +748,11 @@ declare module 'stripe' {
        * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
        */
       klarna?: PaymentMethodCreateParams.Klarna;
+
+      /**
+       * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+       */
+      konbini?: PaymentMethodCreateParams.Konbini;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
@@ -1027,6 +1037,8 @@ declare module 'stripe' {
         }
       }
 
+      interface Konbini {}
+
       interface Oxxo {}
 
       interface P24 {
@@ -1098,6 +1110,7 @@ declare module 'stripe' {
         | 'grabpay'
         | 'ideal'
         | 'klarna'
+        | 'konbini'
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'
@@ -1240,6 +1253,7 @@ declare module 'stripe' {
         | 'grabpay'
         | 'ideal'
         | 'klarna'
+        | 'konbini'
         | 'oxxo'
         | 'p24'
         | 'sepa_debit'

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -258,6 +258,11 @@ declare module 'stripe' {
            * This sub-hash contains details about the Card payment method options to pass to invoices created by the subscription.
            */
           card: PaymentMethodOptions.Card | null;
+
+          /**
+           * This sub-hash contains details about the Konbini payment method options to pass to invoices created by the subscription.
+           */
+          konbini: PaymentMethodOptions.Konbini | null;
         }
 
         namespace PaymentMethodOptions {
@@ -329,6 +334,8 @@ declare module 'stripe' {
 
             type RequestThreeDSecure = 'any' | 'automatic';
           }
+
+          interface Konbini {}
         }
 
         type PaymentMethodType =
@@ -344,6 +351,7 @@ declare module 'stripe' {
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'konbini'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
@@ -780,6 +788,11 @@ declare module 'stripe' {
            * This sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
            */
           card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
+
+          /**
+           * This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
+           */
+          konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
         }
 
         namespace PaymentMethodOptions {
@@ -857,6 +870,8 @@ declare module 'stripe' {
 
             type RequestThreeDSecure = 'any' | 'automatic';
           }
+
+          interface Konbini {}
         }
 
         type PaymentMethodType =
@@ -872,6 +887,7 @@ declare module 'stripe' {
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'konbini'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
@@ -1313,6 +1329,11 @@ declare module 'stripe' {
            * This sub-hash contains details about the Card payment method options to pass to the invoice's PaymentIntent.
            */
           card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
+
+          /**
+           * This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
+           */
+          konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
         }
 
         namespace PaymentMethodOptions {
@@ -1390,6 +1411,8 @@ declare module 'stripe' {
 
             type RequestThreeDSecure = 'any' | 'automatic';
           }
+
+          interface Konbini {}
         }
 
         type PaymentMethodType =
@@ -1405,6 +1428,7 @@ declare module 'stripe' {
           | 'giropay'
           | 'grabpay'
           | 'ideal'
+          | 'konbini'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'


### PR DESCRIPTION
Codegen for openapi 3c477c0.
r? @yejia-stripe 
cc @stripe/api-libraries

## Changelog

* Change `BillingPortalConfigurationCreateParams.business_profile.privacy_policy_url` and `BillingPortalConfigurationCreateParams.business_profile.terms_of_service_url` to be optional
* Change type of `BillingPortalConfigurationUpdateParams.business_profile.privacy_policy_url` and `BillingPortalConfigurationUpdateParams.business_profile.terms_of_service_url` from `string` to `emptyStringable(string)`
* Change type of `BillingPortal.Configuration.business_profile.privacy_policy_url` and `BillingPortal.Configuration.business_profile.terms_of_service_url` from `string` to `nullable(string)`

* Add support for `konbini_payments` on `AccountUpdateParams.capabilities`, `AccountCreateParams.capabilities`, and `Account.capabilities`
* Add support for `konbini` on `Charge.payment_method_details`, 
* Add support for `.payment_method_options.konbini` and `.payment_method_data.konbini` on the `PaymentIntent` API.
* Add support for `.payment_settings.payment_method_options.konbini` on the `Invoice` API.
* Add support for `.payment_method_options.konbini` on the `Subscription` API
* Add support for `.payment_method_options.konbini` on the `CheckoutSession` API
* Add support for `konbini` on the `PaymentMethod` API. 
* Add support for `konbini_display_details` on `PaymentIntent.next_action`


