### PR TITLE
API Updates

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -91,4 +91,7 @@ module.exports = {
     Locations: require('./resources/Terminal/Locations'),
     Readers: require('./resources/Terminal/Readers'),
   }),
+  TestHelpers: resourceNamespace('testHelpers', {
+    TestClocks: require('./resources/TestHelpers/TestClocks'),
+  }),
 };

--- a/lib/resources/TestHelpers/TestClocks.js
+++ b/lib/resources/TestHelpers/TestClocks.js
@@ -1,0 +1,36 @@
+// File generated from our OpenAPI spec
+
+'use strict';
+
+const StripeResource = require('../../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'test_helpers/test_clocks',
+
+  create: stripeMethod({
+    method: 'POST',
+    path: '',
+  }),
+
+  retrieve: stripeMethod({
+    method: 'GET',
+    path: '/{testClock}',
+  }),
+
+  list: stripeMethod({
+    method: 'GET',
+    path: '',
+    methodType: 'list',
+  }),
+
+  del: stripeMethod({
+    method: 'DELETE',
+    path: '/{testClock}',
+  }),
+
+  advance: stripeMethod({
+    method: 'POST',
+    path: '/{testClock}/advance',
+  }),
+});

--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -2043,3 +2043,35 @@ describe('PaymentLink', function() {
     expect(paymentLink).not.to.be.null;
   });
 });
+
+describe('TestHelpers.TestClock', function() {
+  it('create method', async function() {
+    const testClock = await stripe.testHelpers.testClocks.create({
+      frozen_time: 123,
+      name: 'cogsworth',
+    });
+    expect(testClock).not.to.be.null;
+  });
+
+  it('retrieve method', async function() {
+    const testClock = await stripe.testHelpers.testClocks.retrieve('clock_xyz');
+    expect(testClock).not.to.be.null;
+  });
+
+  it('list method', async function() {
+    const testClocks = await stripe.testHelpers.testClocks.list();
+    expect(testClocks).not.to.be.null;
+  });
+
+  it('del method', async function() {
+    const deleted = await stripe.testHelpers.testClocks.del('clock_xyz');
+    expect(deleted).not.to.be.null;
+  });
+
+  it('advance method', async function() {
+    const testClock = await stripe.testHelpers.testClocks.advance('clock_xyz', {
+      frozen_time: 142,
+    });
+    expect(testClock).not.to.be.null;
+  });
+});

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -130,6 +130,11 @@ declare module 'stripe' {
        * The customer's tax IDs.
        */
       tax_ids?: ApiList<Stripe.TaxId>;
+
+      /**
+       * ID of the test clock this customer belongs to.
+       */
+      test_clock?: string | Stripe.TestHelpers.TestClock | null;
     }
 
     namespace Customer {
@@ -352,6 +357,11 @@ declare module 'stripe' {
        * The customer's tax IDs.
        */
       tax_id_data?: Array<CustomerCreateParams.TaxIdDatum>;
+
+      /**
+       * ID of the test clock to attach to the customer.
+       */
+      test_clock?: string;
     }
 
     namespace CustomerCreateParams {

--- a/types/2020-08-27/InvoiceItems.d.ts
+++ b/types/2020-08-27/InvoiceItems.d.ts
@@ -106,6 +106,11 @@ declare module 'stripe' {
       tax_rates: Array<Stripe.TaxRate> | null;
 
       /**
+       * ID of the test clock this invoice item belongs to.
+       */
+      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+
+      /**
        * Unit amount (in the `currency` specified) of the invoice item.
        */
       unit_amount: number | null;

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -318,6 +318,11 @@ declare module 'stripe' {
        */
       tax: number | null;
 
+      /**
+       * ID of the test clock this invoice belongs to.
+       */
+      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+
       threshold_reason?: Invoice.ThresholdReason;
 
       /**
@@ -895,6 +900,11 @@ declare module 'stripe' {
       payment_settings?: InvoiceCreateParams.PaymentSettings;
 
       /**
+       * How to handle pending invoice items on invoice creation. One of `include`, `include_and_require`, or `exclude`. `include` will include any pending invoice items, and will create an empty draft invoice if no pending invoice items exist. `include_and_require` will include any pending invoice items, if no pending invoice items exist then the request will fail. `exclude` will always create an empty invoice draft regardless if there are pending invoice items or not. Defaults to `include_and_require` if the parameter is omitted.
+       */
+      pending_invoice_items_behavior?: InvoiceCreateParams.PendingInvoiceItemsBehavior;
+
+      /**
        * Extra information about a charge for the customer's credit card statement. It must contain at least one letter. If not specified and this invoice is part of a subscription, the default `statement_descriptor` will be set to the first subscription item's product's `statement_descriptor`.
        */
       statement_descriptor?: string;
@@ -1053,6 +1063,11 @@ declare module 'stripe' {
           | 'sofort'
           | 'wechat_pay';
       }
+
+      type PendingInvoiceItemsBehavior =
+        | 'exclude'
+        | 'include'
+        | 'include_and_require';
 
       interface TransferData {
         /**

--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -357,7 +357,7 @@ declare module 'stripe' {
       /**
        * A URL of a publicly-accessible webpage for this product.
        */
-      url?: string;
+      url?: Stripe.Emptyable<string>;
     }
 
     namespace ProductUpdateParams {

--- a/types/2020-08-27/Quotes.d.ts
+++ b/types/2020-08-27/Quotes.d.ts
@@ -149,6 +149,11 @@ declare module 'stripe' {
        */
       subscription_schedule: string | Stripe.SubscriptionSchedule | null;
 
+      /**
+       * ID of the test clock this quote belongs to.
+       */
+      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+
       total_details: Quote.TotalDetails;
 
       /**
@@ -589,6 +594,11 @@ declare module 'stripe' {
        * When creating a subscription or subscription schedule, the specified configuration data will be used. There must be at least one line item with a recurring price for a subscription or subscription schedule to be created. A subscription schedule is created if `subscription_data[effective_date]` is present and in the future, otherwise a subscription is created.
        */
       subscription_data?: QuoteCreateParams.SubscriptionData;
+
+      /**
+       * ID of the test clock to attach to the quote.
+       */
+      test_clock?: string;
 
       /**
        * The data with which to automatically create a Transfer for each of the invoices.

--- a/types/2020-08-27/Refunds.d.ts
+++ b/types/2020-08-27/Refunds.d.ts
@@ -61,6 +61,8 @@ declare module 'stripe' {
        */
       metadata: Stripe.Metadata | null;
 
+      next_action?: Refund.NextAction;
+
       /**
        * ID of the PaymentIntent that was refunded.
        */
@@ -93,6 +95,43 @@ declare module 'stripe' {
     }
 
     namespace Refund {
+      interface NextAction {
+        /**
+         * Contains the refund details.
+         */
+        display_details: NextAction.DisplayDetails | null;
+
+        /**
+         * Type of the next action to perform.
+         */
+        type: string;
+      }
+
+      namespace NextAction {
+        interface DisplayDetails {
+          email_sent: DisplayDetails.EmailSent;
+
+          /**
+           * The expiry timestamp.
+           */
+          expires_at: number;
+        }
+
+        namespace DisplayDetails {
+          interface EmailSent {
+            /**
+             * The timestamp when the email was sent.
+             */
+            email_sent_at: number;
+
+            /**
+             * The recipient's email address.
+             */
+            email_sent_to: string;
+          }
+        }
+      }
+
       type Reason =
         | 'duplicate'
         | 'expired_uncaptured_charge'

--- a/types/2020-08-27/SubscriptionSchedules.d.ts
+++ b/types/2020-08-27/SubscriptionSchedules.d.ts
@@ -82,6 +82,11 @@ declare module 'stripe' {
        * ID of the subscription managed by the subscription schedule.
        */
       subscription: string | Stripe.Subscription | null;
+
+      /**
+       * ID of the test clock this subscription schedule belongs to.
+       */
+      test_clock?: string | Stripe.TestHelpers.TestClock | null;
     }
 
     namespace SubscriptionSchedule {

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -177,6 +177,11 @@ declare module 'stripe' {
       status: Subscription.Status;
 
       /**
+       * ID of the test clock this subscription belongs to.
+       */
+      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+
+      /**
        * The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
        */
       transfer_data: Subscription.TransferData | null;

--- a/types/2020-08-27/Terminal/Locations.d.ts
+++ b/types/2020-08-27/Terminal/Locations.d.ts
@@ -174,11 +174,19 @@ declare module 'stripe' {
           id: string,
           params?: LocationRetrieveParams,
           options?: RequestOptions
-        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
+        ): Promise<
+          Stripe.Response<
+            Stripe.Terminal.Location | Stripe.Terminal.DeletedLocation
+          >
+        >;
         retrieve(
           id: string,
           options?: RequestOptions
-        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
+        ): Promise<
+          Stripe.Response<
+            Stripe.Terminal.Location | Stripe.Terminal.DeletedLocation
+          >
+        >;
 
         /**
          * Updates a Location object by setting the values of the parameters passed. Any parameters not provided will be left unchanged.
@@ -187,7 +195,11 @@ declare module 'stripe' {
           id: string,
           params?: LocationUpdateParams,
           options?: RequestOptions
-        ): Promise<Stripe.Response<Stripe.Terminal.Location>>;
+        ): Promise<
+          Stripe.Response<
+            Stripe.Terminal.Location | Stripe.Terminal.DeletedLocation
+          >
+        >;
 
         /**
          * Returns a list of Location objects.

--- a/types/2020-08-27/TestHelpers/TestClocks.d.ts
+++ b/types/2020-08-27/TestHelpers/TestClocks.d.ts
@@ -1,0 +1,174 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    namespace TestHelpers {
+      /**
+       * The TestClock object.
+       */
+      interface TestClock {
+        /**
+         * Unique identifier for the object.
+         */
+        id: string;
+
+        /**
+         * String representing the object's type. Objects of the same type share the same value.
+         */
+        object: 'test_helpers.test_clock';
+
+        /**
+         * Time at which the object was created. Measured in seconds since the Unix epoch.
+         */
+        created: number;
+
+        deleted?: void;
+
+        /**
+         * Time at which all objects belonging to this clock are frozen.
+         */
+        frozen_time: number;
+
+        /**
+         * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+         */
+        livemode: boolean;
+
+        /**
+         * The custom name supplied at creation.
+         */
+        name: string | null;
+
+        /**
+         * The status of the Test Clock.
+         */
+        status: TestClock.Status;
+      }
+
+      namespace TestClock {
+        type Status = 'advancing' | 'internal_failure' | 'ready';
+      }
+
+      /**
+       * The DeletedTestClock object.
+       */
+      interface DeletedTestClock {
+        /**
+         * Unique identifier for the object.
+         */
+        id: string;
+
+        /**
+         * String representing the object's type. Objects of the same type share the same value.
+         */
+        object: 'test_helpers.test_clock';
+
+        /**
+         * Always true for a deleted object
+         */
+        deleted: true;
+      }
+
+      interface TestClockCreateParams {
+        /**
+         * The initial frozen time for this test clock.
+         */
+        frozen_time: number;
+
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+
+        /**
+         * The name for this test clock.
+         */
+        name?: string;
+      }
+
+      interface TestClockRetrieveParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      interface TestClockListParams extends PaginationParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      interface TestClockDeleteParams {}
+
+      interface TestClockAdvanceParams {
+        /**
+         * The time to advance the test clock. Must be after the test clock's current frozen time. Cannot be more than two intervals in the future from the shortest subscription in this test clock. If there are no subscriptions in this test clock, it cannot be more than two years in the future.
+         */
+        frozen_time: number;
+
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      class TestClocksResource {
+        /**
+         * Creates a new test clock that can be attached to new customers and quotes.
+         */
+        create(
+          params: TestClockCreateParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.TestHelpers.TestClock>>;
+
+        /**
+         * Retrieves a test clock.
+         */
+        retrieve(
+          id: string,
+          params?: TestClockRetrieveParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.TestHelpers.TestClock>>;
+        retrieve(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.TestHelpers.TestClock>>;
+
+        /**
+         * Returns a list of your test clocks.
+         */
+        list(
+          params?: TestClockListParams,
+          options?: RequestOptions
+        ): ApiListPromise<Stripe.TestHelpers.TestClock>;
+        list(
+          options?: RequestOptions
+        ): ApiListPromise<Stripe.TestHelpers.TestClock>;
+
+        /**
+         * Deletes a test clock.
+         */
+        del(
+          id: string,
+          params?: TestClockDeleteParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.TestHelpers.DeletedTestClock>>;
+        del(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.TestHelpers.DeletedTestClock>>;
+
+        /**
+         * Starts advancing a test clock to a specified time in the future. Advancement is done when status changes to Ready.
+         */
+        advance(
+          id: string,
+          params: TestClockAdvanceParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.TestHelpers.TestClock>>;
+      }
+    }
+  }
+}

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -97,6 +97,7 @@
 ///<reference path='./Terminal/ConnectionTokens.d.ts' />
 ///<reference path='./Terminal/Locations.d.ts' />
 ///<reference path='./Terminal/Readers.d.ts' />
+///<reference path='./TestHelpers/TestClocks.d.ts' />
 ///<reference path='./Tokens.d.ts' />
 ///<reference path='./Topups.d.ts' />
 ///<reference path='./TransferReversals.d.ts' />
@@ -209,6 +210,9 @@ declare module 'stripe' {
       connectionTokens: Stripe.Terminal.ConnectionTokensResource;
       locations: Stripe.Terminal.LocationsResource;
       readers: Stripe.Terminal.ReadersResource;
+    };
+    testHelpers: {
+      testClocks: Stripe.TestHelpers.TestClocksResource;
     };
     /**
      * API Errors


### PR DESCRIPTION
Codegen for openapi 1707cb8.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resource `TestHelpers.TestClock`
* Add support for `test_clock` on `CustomerCreateParams`, `Customer`, `Invoice`, `InvoiceItem`, `QuoteCreateParams`, `Quote`, `Subscription`, and `SubscriptionSchedule`
* Add support for `pending_invoice_items_behavior` on `InvoiceCreateParams`
* Change type of `ProductUpdateParams.url` from `string` to `emptyStringable(string)`
* Add support for `next_action` on `Refund`

