### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -1256,7 +1256,7 @@ declare module 'stripe' {
             product_data?: PriceData.ProductData;
 
             /**
-             * The recurring components of a price such as `interval` and `usage_type`.
+             * The recurring components of a price such as `interval` and `interval_count`.
              */
             recurring?: PriceData.Recurring;
 

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -671,6 +671,11 @@ declare module 'stripe' {
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
+
+      /**
+       * Provides a list of customers that are associated with the specified test clock. If no list is provided, the response won't include customers with test clocks.
+       */
+      test_clock?: string;
     }
 
     interface CustomerDeleteParams {}

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -673,7 +673,7 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * Provides a list of customers that are associated with the specified test clock. If no list is provided, the response won't include customers with test clocks.
+       * Provides a list of customers that are associated with the specified test clock. The response will not include customers with test clocks if this parameter is not set.
        */
       test_clock?: string;
     }

--- a/types/2020-08-27/InvoiceItems.d.ts
+++ b/types/2020-08-27/InvoiceItems.d.ts
@@ -108,7 +108,7 @@ declare module 'stripe' {
       /**
        * ID of the test clock this invoice item belongs to.
        */
-      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+      test_clock: string | Stripe.TestHelpers.TestClock | null;
 
       /**
        * Unit amount (in the `currency` specified) of the invoice item.

--- a/types/2020-08-27/InvoiceLineItems.d.ts
+++ b/types/2020-08-27/InvoiceLineItems.d.ts
@@ -647,7 +647,7 @@ declare module 'stripe' {
           product: string;
 
           /**
-           * The recurring components of a price such as `interval` and `usage_type`.
+           * The recurring components of a price such as `interval` and `interval_count`.
            */
           recurring: PriceData.Recurring;
 

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -321,7 +321,7 @@ declare module 'stripe' {
       /**
        * ID of the test clock this invoice belongs to.
        */
-      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+      test_clock: string | Stripe.TestHelpers.TestClock | null;
 
       threshold_reason?: Invoice.ThresholdReason;
 
@@ -900,7 +900,7 @@ declare module 'stripe' {
       payment_settings?: InvoiceCreateParams.PaymentSettings;
 
       /**
-       * How to handle pending invoice items on invoice creation. One of `include`, `include_and_require`, or `exclude`. `include` will include any pending invoice items, and will create an empty draft invoice if no pending invoice items exist. `include_and_require` will include any pending invoice items, if no pending invoice items exist then the request will fail. `exclude` will always create an empty invoice draft regardless if there are pending invoice items or not. Defaults to `include_and_require` if the parameter is omitted.
+       * How to handle pending invoice items on invoice creation. One of `include`, `exclude`, or `include_and_require`. `include` will include any pending invoice items, and will create an empty draft invoice if no pending invoice items exist. `include_and_require` will include any pending invoice items, if no pending invoice items exist then the request will fail. `exclude` will always create an empty invoice draft regardless if there are pending invoice items or not. Defaults to `include_and_require` if the parameter is omitted.
        */
       pending_invoice_items_behavior?: InvoiceCreateParams.PendingInvoiceItemsBehavior;
 
@@ -1900,7 +1900,7 @@ declare module 'stripe' {
           product: string;
 
           /**
-           * The recurring components of a price such as `interval` and `usage_type`.
+           * The recurring components of a price such as `interval` and `interval_count`.
            */
           recurring: PriceData.Recurring;
 

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -1344,7 +1344,7 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
 
       /**
-       * Detaches a PaymentMethod object from a Customer.
+       * Detaches a PaymentMethod object from a Customer. After a PaymentMethod is detached, it can no longer be used for a payment or re-attached to a Customer.
        */
       detach(
         id: string,

--- a/types/2020-08-27/Quotes.d.ts
+++ b/types/2020-08-27/Quotes.d.ts
@@ -152,7 +152,7 @@ declare module 'stripe' {
       /**
        * ID of the test clock this quote belongs to.
        */
-      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+      test_clock: string | Stripe.TestHelpers.TestClock | null;
 
       total_details: Quote.TotalDetails;
 
@@ -682,7 +682,7 @@ declare module 'stripe' {
           product: string;
 
           /**
-           * The recurring components of a price such as `interval` and `usage_type`.
+           * The recurring components of a price such as `interval` and `interval_count`.
            */
           recurring?: PriceData.Recurring;
 
@@ -921,7 +921,7 @@ declare module 'stripe' {
           product: string;
 
           /**
-           * The recurring components of a price such as `interval` and `usage_type`.
+           * The recurring components of a price such as `interval` and `interval_count`.
            */
           recurring?: PriceData.Recurring;
 

--- a/types/2020-08-27/SubscriptionItems.d.ts
+++ b/types/2020-08-27/SubscriptionItems.d.ts
@@ -200,7 +200,7 @@ declare module 'stripe' {
         product: string;
 
         /**
-         * The recurring components of a price such as `interval` and `usage_type`.
+         * The recurring components of a price such as `interval` and `interval_count`.
          */
         recurring: PriceData.Recurring;
 
@@ -350,7 +350,7 @@ declare module 'stripe' {
         product: string;
 
         /**
-         * The recurring components of a price such as `interval` and `usage_type`.
+         * The recurring components of a price such as `interval` and `interval_count`.
          */
         recurring: PriceData.Recurring;
 

--- a/types/2020-08-27/SubscriptionSchedules.d.ts
+++ b/types/2020-08-27/SubscriptionSchedules.d.ts
@@ -86,7 +86,7 @@ declare module 'stripe' {
       /**
        * ID of the test clock this subscription schedule belongs to.
        */
-      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+      test_clock: string | Stripe.TestHelpers.TestClock | null;
     }
 
     namespace SubscriptionSchedule {
@@ -734,7 +734,7 @@ declare module 'stripe' {
             product: string;
 
             /**
-             * The recurring components of a price such as `interval` and `usage_type`.
+             * The recurring components of a price such as `interval` and `interval_count`.
              */
             recurring: PriceData.Recurring;
 
@@ -1154,7 +1154,7 @@ declare module 'stripe' {
             product: string;
 
             /**
-             * The recurring components of a price such as `interval` and `usage_type`.
+             * The recurring components of a price such as `interval` and `interval_count`.
              */
             recurring: PriceData.Recurring;
 

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -179,7 +179,7 @@ declare module 'stripe' {
       /**
        * ID of the test clock this subscription belongs to.
        */
-      test_clock?: string | Stripe.TestHelpers.TestClock | null;
+      test_clock: string | Stripe.TestHelpers.TestClock | null;
 
       /**
        * The account (if any) the subscription's payments will be attributed to for tax reporting, and where funds from each payment will be transferred to for each of the subscription's invoices.
@@ -716,7 +716,7 @@ declare module 'stripe' {
           product: string;
 
           /**
-           * The recurring components of a price such as `interval` and `usage_type`.
+           * The recurring components of a price such as `interval` and `interval_count`.
            */
           recurring: PriceData.Recurring;
 
@@ -1241,7 +1241,7 @@ declare module 'stripe' {
           product: string;
 
           /**
-           * The recurring components of a price such as `interval` and `usage_type`.
+           * The recurring components of a price such as `interval` and `interval_count`.
            */
           recurring: PriceData.Recurring;
 


### PR DESCRIPTION
Codegen for openapi d65ebba.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `test_clock` on `CustomerListParams`
* Change `Invoice.test_clock`, `InvoiceItem.test_clock`, `Quote.test_clock`, `Subscription.test_clock`, and `SubscriptionSchedule.test_clock` to be required

