### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -726,6 +726,11 @@ declare module 'stripe' {
           last4: string | null;
 
           /**
+           * ID of the mandate used to make this payment or created by it.
+           */
+          mandate: string | null;
+
+          /**
            * True if this payment was marked as MOTO and out of scope for SCA.
            */
           moto?: boolean | null;

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -341,6 +341,8 @@ declare module 'stripe' {
 
         boleto_display_details?: NextAction.BoletoDisplayDetails;
 
+        card_await_notification?: NextAction.CardAwaitNotification;
+
         konbini_display_details?: NextAction.KonbiniDisplayDetails;
 
         oxxo_display_details?: NextAction.OxxoDisplayDetails;
@@ -409,6 +411,18 @@ declare module 'stripe' {
            * The URL to the downloadable boleto voucher PDF.
            */
           pdf: string | null;
+        }
+
+        interface CardAwaitNotification {
+          /**
+           * The time that payment will be attempted. If customer approval is required, they need to provide approval before this time.
+           */
+          charge_attempt_at: number | null;
+
+          /**
+           * For payments greater than INR 5000, the customer must provide explicit approval of the payment with their bank. For payments of lower amount, no customer action is required.
+           */
+          customer_approval_required: boolean | null;
         }
 
         interface KonbiniDisplayDetails {
@@ -821,6 +835,11 @@ declare module 'stripe' {
           installments: Card.Installments | null;
 
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options: Card.MandateOptions | null;
+
+          /**
            * Selected network to process this payment intent on. Depends on the available networks of the card attached to the payment intent. Can be only set confirm-time.
            */
           network: Card.Network | null;
@@ -894,6 +913,59 @@ declare module 'stripe' {
                */
               type: 'fixed_count';
             }
+          }
+
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description: string | null;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date: number | null;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count: number | null;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types: Array<'india'> | null;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
           }
 
           type Network =
@@ -1134,7 +1206,23 @@ declare module 'stripe' {
       }
 
       namespace Processing {
-        interface Card {}
+        interface Card {
+          customer_notification?: Card.CustomerNotification;
+        }
+
+        namespace Card {
+          interface CustomerNotification {
+            /**
+             * Whether customer approval has been requested for this payment. For payments greater than INR 5000 or mandate amount, the customer must provide explicit approval of the payment with their bank.
+             */
+            approval_requested: boolean | null;
+
+            /**
+             * If customer approval is required, they need to provide approval before this time.
+             */
+            completes_at: number | null;
+          }
+        }
       }
 
       type SetupFutureUsage = 'off_session' | 'on_session';
@@ -2126,6 +2214,11 @@ declare module 'stripe' {
           installments?: Card.Installments;
 
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options?: Card.MandateOptions;
+
+          /**
            * When specified, this parameter indicates that a transaction will be marked
            * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
            * parameter can only be provided during confirmation.
@@ -2188,6 +2281,59 @@ declare module 'stripe' {
                */
               type: 'fixed_count';
             }
+          }
+
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description?: string;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date?: number;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count?: number;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types?: Array<'india'>;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
           }
 
           type Network =
@@ -3377,6 +3523,11 @@ declare module 'stripe' {
           installments?: Card.Installments;
 
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options?: Card.MandateOptions;
+
+          /**
            * When specified, this parameter indicates that a transaction will be marked
            * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
            * parameter can only be provided during confirmation.
@@ -3439,6 +3590,59 @@ declare module 'stripe' {
                */
               type: 'fixed_count';
             }
+          }
+
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description?: string;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date?: number;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count?: number;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types?: Array<'india'>;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
           }
 
           type Network =
@@ -4742,6 +4946,11 @@ declare module 'stripe' {
           installments?: Card.Installments;
 
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options?: Card.MandateOptions;
+
+          /**
            * When specified, this parameter indicates that a transaction will be marked
            * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
            * parameter can only be provided during confirmation.
@@ -4804,6 +5013,59 @@ declare module 'stripe' {
                */
               type: 'fixed_count';
             }
+          }
+
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description?: string;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date?: number;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count?: number;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types?: Array<'india'>;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
           }
 
           type Network =

--- a/types/2020-08-27/PaymentLinks.d.ts
+++ b/types/2020-08-27/PaymentLinks.d.ts
@@ -409,6 +409,11 @@ declare module 'stripe' {
 
     interface PaymentLinkCreateParams {
       /**
+       * The line items representing what is being sold. Each line item represents an item being sold. Up to 20 line items are supported.
+       */
+      line_items: Array<PaymentLinkCreateParams.LineItem>;
+
+      /**
        * Behavior after the purchase is complete.
        */
       after_completion?: PaymentLinkCreateParams.AfterCompletion;
@@ -442,11 +447,6 @@ declare module 'stripe' {
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
-
-      /**
-       * The line items representing what is being sold. Each line item represents an item being sold. Up to 20 line items are supported.
-       */
-      line_items?: Array<PaymentLinkCreateParams.LineItem>;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`. Metadata associated with this Payment Link will automatically be copied to [checkout sessions](https://stripe.com/docs/api/checkout/sessions) created by this payment link.
@@ -1262,10 +1262,7 @@ declare module 'stripe' {
        * Creates a payment link.
        */
       create(
-        params?: PaymentLinkCreateParams,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.PaymentLink>>;
-      create(
+        params: PaymentLinkCreateParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.PaymentLink>>;
 

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -336,12 +336,75 @@ declare module 'stripe' {
 
         interface Card {
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options: Card.MandateOptions | null;
+
+          /**
            * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://stripe.com/docs/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. Permitted values include: `automatic` or `any`. If not provided, defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://stripe.com/docs/payments/3d-secure#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
            */
           request_three_d_secure: Card.RequestThreeDSecure | null;
         }
 
         namespace Card {
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+             */
+            currency: string;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description: string | null;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date: number | null;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count: number | null;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types: Array<'india'> | null;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
+          }
+
           type RequestThreeDSecure = 'any' | 'automatic' | 'challenge_only';
         }
 
@@ -562,6 +625,11 @@ declare module 'stripe' {
 
         interface Card {
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options?: Card.MandateOptions;
+
+          /**
            * When specified, this parameter signals that a card has been collected
            * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
            * parameter can only be provided during confirmation.
@@ -575,6 +643,64 @@ declare module 'stripe' {
         }
 
         namespace Card {
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * Currency in which future payments will be charged. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+             */
+            currency: string;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description?: string;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date?: number;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count?: number;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types?: Array<'india'>;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
+          }
+
           type RequestThreeDSecure = 'any' | 'automatic';
         }
 
@@ -737,6 +863,11 @@ declare module 'stripe' {
 
         interface Card {
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options?: Card.MandateOptions;
+
+          /**
            * When specified, this parameter signals that a card has been collected
            * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
            * parameter can only be provided during confirmation.
@@ -750,6 +881,64 @@ declare module 'stripe' {
         }
 
         namespace Card {
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * Currency in which future payments will be charged. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+             */
+            currency: string;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description?: string;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date?: number;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count?: number;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types?: Array<'india'>;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
+          }
+
           type RequestThreeDSecure = 'any' | 'automatic';
         }
 
@@ -1003,6 +1192,11 @@ declare module 'stripe' {
 
         interface Card {
           /**
+           * Configuration options for setting up an eMandate for cards issued in India.
+           */
+          mandate_options?: Card.MandateOptions;
+
+          /**
            * When specified, this parameter signals that a card has been collected
            * as MOTO (Mail Order Telephone Order) and thus out of scope for SCA. This
            * parameter can only be provided during confirmation.
@@ -1016,6 +1210,64 @@ declare module 'stripe' {
         }
 
         namespace Card {
+          interface MandateOptions {
+            /**
+             * Amount to be charged for future payments.
+             */
+            amount: number;
+
+            /**
+             * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+             */
+            amount_type: MandateOptions.AmountType;
+
+            /**
+             * Currency in which future payments will be charged. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+             */
+            currency: string;
+
+            /**
+             * A description of the mandate or subscription that is meant to be displayed to the customer.
+             */
+            description?: string;
+
+            /**
+             * End date of the mandate or subscription. If not provided, the mandate will be active until canceled. If provided, end date should be after start date.
+             */
+            end_date?: number;
+
+            /**
+             * Specifies payment frequency. One of `day`, `week`, `month`, `year`, or `sporadic`.
+             */
+            interval: MandateOptions.Interval;
+
+            /**
+             * The number of intervals between payments. For example, `interval=month` and `interval_count=3` indicates one payment every three months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks). This parameter is optional when `interval=sporadic`.
+             */
+            interval_count?: number;
+
+            /**
+             * Unique identifier for the mandate or subscription.
+             */
+            reference: string;
+
+            /**
+             * Start date of the mandate or subscription. Start date should not be lesser than yesterday.
+             */
+            start_date: number;
+
+            /**
+             * Specifies the type of mandates supported. Possible values are `india`.
+             */
+            supported_types?: Array<'india'>;
+          }
+
+          namespace MandateOptions {
+            type AmountType = 'fixed' | 'maximum';
+
+            type Interval = 'day' | 'month' | 'sporadic' | 'week' | 'year';
+          }
+
           type RequestThreeDSecure = 'any' | 'automatic';
         }
 


### PR DESCRIPTION
Codegen for openapi c671651.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `mandate` on `Charge.payment_method_details.card`
* Add support for `mandate_options` on `PaymentIntentCreateParams.payment_method_options.card`, `PaymentIntentUpdateParams.payment_method_options.card`, `PaymentIntentConfirmParams.payment_method_options.card`, `PaymentIntent.payment_method_options.card`, `SetupIntentCreateParams.payment_method_options.card`, `SetupIntentUpdateParams.payment_method_options.card`, `SetupIntentConfirmParams.payment_method_options.card`, and `SetupIntent.payment_method_options.card`
* Add support for `card_await_notification` on `PaymentIntent.next_action`
* Add support for `customer_notification` on `PaymentIntent.processing.card`
* Change `PaymentLinkCreateParams.line_items` to be required, and change `PaymentLink.create` to require `PaymentLinkCreateParams`

