### PR TITLE
if no content-length, do not add the header

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -369,7 +369,6 @@ StripeResource.prototype = {
       Authorization: auth ? `Bearer ${auth}` : this._stripe.getApiField('auth'),
       Accept: 'application/json',
       'Content-Type': 'application/x-www-form-urlencoded',
-      'Content-Length': contentLength,
       'User-Agent': this._getUserAgentString(),
       'X-Stripe-Client-User-Agent': clientUserAgent,
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
@@ -380,6 +379,10 @@ StripeResource.prototype = {
         userSuppliedSettings
       ),
     };
+
+    if (contentLength) {
+      defaultHeaders['Content-Length'] = contentLength;
+    }
 
     return Object.assign(
       utils.removeNullish(defaultHeaders),


### PR DESCRIPTION
Fixes errors thrown by Cloudflare. If content-length is 0, the request will error out.