### PR TITLE
Force update minimist dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
   },
   "resolutions": {
     "ansi-regex": "5.0.1",
+    "minimist": "1.2.6",
     "nanoid": "3.2.0"
   },
   "dependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1420,10 +1420,10 @@ minimatch@3.0.4, minimatch@^3.0.4:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@^1.2.5:
-  version "1.2.5"
-  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.5.tgz#67d66014b66a6a8aaa0c083c5fd58df4e4e97602"
-  integrity sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+minimist@1.2.6, minimist@^1.2.5:
+  version "1.2.6"
+  resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
+  integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
 
 mkdirp@^0.5.1, mkdirp@~0.5.1:
   version "0.5.5"


### PR DESCRIPTION
Bumps [minimist](https://github.com/substack/minimist)[](https://docs.github.com/en/github/managing-security-vulnerabilities/about-dependabot-security-updates#about-compatibility-scores)[](https://github.com/apps/dependabot)[](https://github.com/apps/dependabot)[](https://github.com/apps/github-actions)[](https://github.com/apps/github-actions)[](https://github.com/apps/github-actions)[](https://github.com/apps/github-actions)[](https://stripe.com/)[](https://cla-assistant.io/)[](https://stripe.com/)[](https://stripe.com/)[](https://github.com/kamil-stripe)[](https://docs.github.com/github/writing-on-github/getting-started-with-writing-and-formatting-on-github/basic-writing-and-formatting-syntax)[](https://github.com/) from 1.2.5 to 1.2.6.

Affected versions of this package are vulnerable to Prototype Pollution due to a missing handler to Function.prototype. Note: this is a bypass to [CVE-2020-7598](https://security.snyk.io/vuln/SNYK-JS-MINIMIST-559764)