### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -43,7 +43,7 @@ declare module 'stripe' {
       country: string;
 
       /**
-       * Time at which the object was created. Measured in seconds since the Unix epoch.
+       * Time at which the account was connected. Measured in seconds since the Unix epoch.
        */
       created?: number;
 
@@ -257,6 +257,11 @@ declare module 'stripe' {
         p24_payments?: Capabilities.P24Payments;
 
         /**
+         * The status of the paynow payments capability of the account, or whether the account can directly process paynow charges.
+         */
+        paynow_payments?: Capabilities.PaynowPayments;
+
+        /**
          * The status of the SEPA Direct Debits payments capability of the account, or whether the account can directly process SEPA Direct Debits charges.
          */
         sepa_debit_payments?: Capabilities.SepaDebitPayments;
@@ -280,6 +285,11 @@ declare module 'stripe' {
          * The status of the transfers capability of the account, or whether your platform can transfer funds to the account.
          */
         transfers?: Capabilities.Transfers;
+
+        /**
+         * The status of the US bank account ACH payments capability of the account, or whether the account can directly process US bank account charges.
+         */
+        us_bank_account_ach_payments?: Capabilities.UsBankAccountAchPayments;
       }
 
       namespace Capabilities {
@@ -323,6 +333,8 @@ declare module 'stripe' {
 
         type P24Payments = 'active' | 'inactive' | 'pending';
 
+        type PaynowPayments = 'active' | 'inactive' | 'pending';
+
         type SepaDebitPayments = 'active' | 'inactive' | 'pending';
 
         type SofortPayments = 'active' | 'inactive' | 'pending';
@@ -332,6 +344,8 @@ declare module 'stripe' {
         type TaxReportingUs1099Misc = 'active' | 'inactive' | 'pending';
 
         type Transfers = 'active' | 'inactive' | 'pending';
+
+        type UsBankAccountAchPayments = 'active' | 'inactive' | 'pending';
       }
 
       interface Company {
@@ -1271,6 +1285,11 @@ declare module 'stripe' {
         p24_payments?: Capabilities.P24Payments;
 
         /**
+         * The paynow_payments capability.
+         */
+        paynow_payments?: Capabilities.PaynowPayments;
+
+        /**
          * The sepa_debit_payments capability.
          */
         sepa_debit_payments?: Capabilities.SepaDebitPayments;
@@ -1294,6 +1313,11 @@ declare module 'stripe' {
          * The transfers capability.
          */
         transfers?: Capabilities.Transfers;
+
+        /**
+         * The us_bank_account_ach_payments capability.
+         */
+        us_bank_account_ach_payments?: Capabilities.UsBankAccountAchPayments;
       }
 
       namespace Capabilities {
@@ -1437,6 +1461,13 @@ declare module 'stripe' {
           requested?: boolean;
         }
 
+        interface PaynowPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
         interface SepaDebitPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
@@ -1466,6 +1497,13 @@ declare module 'stripe' {
         }
 
         interface Transfers {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface UsBankAccountAchPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */
@@ -2353,6 +2391,11 @@ declare module 'stripe' {
         p24_payments?: Capabilities.P24Payments;
 
         /**
+         * The paynow_payments capability.
+         */
+        paynow_payments?: Capabilities.PaynowPayments;
+
+        /**
          * The sepa_debit_payments capability.
          */
         sepa_debit_payments?: Capabilities.SepaDebitPayments;
@@ -2376,6 +2419,11 @@ declare module 'stripe' {
          * The transfers capability.
          */
         transfers?: Capabilities.Transfers;
+
+        /**
+         * The us_bank_account_ach_payments capability.
+         */
+        us_bank_account_ach_payments?: Capabilities.UsBankAccountAchPayments;
       }
 
       namespace Capabilities {
@@ -2519,6 +2567,13 @@ declare module 'stripe' {
           requested?: boolean;
         }
 
+        interface PaynowPayments {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
         interface SepaDebitPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
@@ -2548,6 +2603,13 @@ declare module 'stripe' {
         }
 
         interface Transfers {
+          /**
+           * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
+           */
+          requested?: boolean;
+        }
+
+        interface UsBankAccountAchPayments {
           /**
            * Passing true requests the capability for the account, if it is not already requested. A requested capability may not immediately become active. Any requirements to activate the capability are returned in the `requirements` arrays.
            */

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -106,6 +106,11 @@ declare module 'stripe' {
       disputed: boolean;
 
       /**
+       * ID of the balance transaction that describes the reversal of the balance on your account due to payment failure.
+       */
+      failure_balance_transaction?: string | Stripe.BalanceTransaction | null;
+
+      /**
        * Error code explaining reason for charge failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes).
        */
       failure_code: string | null;
@@ -426,6 +431,8 @@ declare module 'stripe' {
 
         p24?: PaymentMethodDetails.P24;
 
+        paynow?: PaymentMethodDetails.Paynow;
+
         sepa_credit_transfer?: PaymentMethodDetails.SepaCreditTransfer;
 
         sepa_debit?: PaymentMethodDetails.SepaDebit;
@@ -440,6 +447,8 @@ declare module 'stripe' {
          * It contains information specific to the payment method.
          */
         type: string;
+
+        us_bank_account?: PaymentMethodDetails.UsBankAccount;
 
         wechat?: PaymentMethodDetails.Wechat;
 
@@ -1518,6 +1527,13 @@ declare module 'stripe' {
             | 'volkswagen_bank';
         }
 
+        interface Paynow {
+          /**
+           * Reference number associated with this PayNow payment
+           */
+          reference: string | null;
+        }
+
         interface SepaCreditTransfer {
           /**
            * Name of the bank associated with the bank account.
@@ -1628,6 +1644,44 @@ declare module 'stripe' {
         }
 
         interface StripeAccount {}
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type: UsBankAccount.AccountHolderType | null;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type: UsBankAccount.AccountType | null;
+
+          /**
+           * Name of the bank associated with the bank account.
+           */
+          bank_name: string | null;
+
+          /**
+           * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+           */
+          fingerprint: string | null;
+
+          /**
+           * Last four digits of the bank account number.
+           */
+          last4: string | null;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number: string | null;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
 
         interface Wechat {}
 

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -443,6 +443,8 @@ declare module 'stripe' {
           konbini?: PaymentMethodOptions.Konbini;
 
           oxxo?: PaymentMethodOptions.Oxxo;
+
+          us_bank_account?: PaymentMethodOptions.UsBankAccount;
         }
 
         namespace PaymentMethodOptions {
@@ -515,6 +517,17 @@ declare module 'stripe' {
              * The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
              */
             expires_after_days: number;
+          }
+
+          interface UsBankAccount {
+            /**
+             * Bank account verification method.
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant';
           }
         }
 
@@ -1529,6 +1542,11 @@ declare module 'stripe' {
           oxxo?: PaymentMethodOptions.Oxxo;
 
           /**
+           * contains details about the Us Bank Account payment method options.
+           */
+          us_bank_account?: PaymentMethodOptions.UsBankAccount;
+
+          /**
            * contains details about the WeChat Pay payment method options.
            */
           wechat_pay?: PaymentMethodOptions.WechatPay;
@@ -1616,6 +1634,17 @@ declare module 'stripe' {
             expires_after_days?: number;
           }
 
+          interface UsBankAccount {
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant';
+          }
+
           interface WechatPay {
             /**
              * The app ID registered with WeChat Pay. Only required when client is ios or android.
@@ -1651,8 +1680,10 @@ declare module 'stripe' {
           | 'konbini'
           | 'oxxo'
           | 'p24'
+          | 'paynow'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
 
         interface PhoneNumberCollection {

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -717,8 +717,10 @@ declare module 'stripe' {
         | 'konbini'
         | 'oxxo'
         | 'p24'
+        | 'paynow'
         | 'sepa_debit'
         | 'sofort'
+        | 'us_bank_account'
         | 'wechat_pay';
     }
 

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -616,6 +616,11 @@ declare module 'stripe' {
            * If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
            */
           konbini: PaymentMethodOptions.Konbini | null;
+
+          /**
+           * If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          us_bank_account?: PaymentMethodOptions.UsBankAccount | null;
         }
 
         namespace PaymentMethodOptions {
@@ -666,6 +671,17 @@ declare module 'stripe' {
           }
 
           interface Konbini {}
+
+          interface UsBankAccount {
+            /**
+             * Bank account verification method.
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
         }
 
         type PaymentMethodType =
@@ -682,9 +698,11 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'konbini'
+          | 'paynow'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
       }
 
@@ -992,6 +1010,13 @@ declare module 'stripe' {
            * If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
            */
           konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
+
+          /**
+           * If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          us_bank_account?: Stripe.Emptyable<
+            PaymentMethodOptions.UsBankAccount
+          >;
         }
 
         namespace PaymentMethodOptions {
@@ -1045,6 +1070,17 @@ declare module 'stripe' {
           }
 
           interface Konbini {}
+
+          interface UsBankAccount {
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
         }
 
         type PaymentMethodType =
@@ -1061,9 +1097,11 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'konbini'
+          | 'paynow'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
       }
 
@@ -1263,6 +1301,13 @@ declare module 'stripe' {
            * If paying by `konbini`, this sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
            */
           konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
+
+          /**
+           * If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          us_bank_account?: Stripe.Emptyable<
+            PaymentMethodOptions.UsBankAccount
+          >;
         }
 
         namespace PaymentMethodOptions {
@@ -1316,6 +1361,17 @@ declare module 'stripe' {
           }
 
           interface Konbini {}
+
+          interface UsBankAccount {
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
         }
 
         type PaymentMethodType =
@@ -1332,9 +1388,11 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'konbini'
+          | 'paynow'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
       }
 

--- a/types/2020-08-27/Mandates.d.ts
+++ b/types/2020-08-27/Mandates.d.ts
@@ -97,6 +97,8 @@ declare module 'stripe' {
          * The type of the payment method associated with this mandate. An additional hash is included on `payment_method_details` with a name matching this value. It contains mandate information specific to the payment method.
          */
         type: string;
+
+        us_bank_account?: PaymentMethodDetails.UsBankAccount;
       }
 
       namespace PaymentMethodDetails {
@@ -171,6 +173,8 @@ declare module 'stripe' {
            */
           url: string;
         }
+
+        interface UsBankAccount {}
       }
 
       interface SingleUse {

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -347,6 +347,8 @@ declare module 'stripe' {
 
         oxxo_display_details?: NextAction.OxxoDisplayDetails;
 
+        paynow_display_qr_code?: NextAction.PaynowDisplayQrCode;
+
         redirect_to_url?: NextAction.RedirectToUrl;
 
         /**
@@ -530,6 +532,23 @@ declare module 'stripe' {
           number: string | null;
         }
 
+        interface PaynowDisplayQrCode {
+          /**
+           * The raw data string used to generate QR code, it should be used together with QR code library.
+           */
+          data: string;
+
+          /**
+           * The image_url_png string used to render QR code
+           */
+          image_url_png: string;
+
+          /**
+           * The image_url_svg string used to render QR code
+           */
+          image_url_svg: string;
+        }
+
         interface RedirectToUrl {
           /**
            * If the customer does not exit their browser while authenticating, they will be redirected to this specified URL after completion.
@@ -554,6 +573,15 @@ declare module 'stripe' {
            * The URL for the hosted verification page, which allows customers to verify their bank account.
            */
           hosted_verification_url: string;
+
+          /**
+           * The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
+           */
+          microdeposit_type?: VerifyWithMicrodeposits.MicrodepositType | null;
+        }
+
+        namespace VerifyWithMicrodeposits {
+          type MicrodepositType = 'amounts' | 'descriptor_code';
         }
 
         interface WechatPayDisplayQrCode {
@@ -662,9 +690,13 @@ declare module 'stripe' {
 
         p24?: PaymentMethodOptions.P24;
 
+        paynow?: PaymentMethodOptions.Paynow;
+
         sepa_debit?: PaymentMethodOptions.SepaDebit;
 
         sofort?: PaymentMethodOptions.Sofort;
+
+        us_bank_account?: PaymentMethodOptions.UsBankAccount;
 
         wechat_pay?: PaymentMethodOptions.WechatPay;
       }
@@ -723,6 +755,11 @@ declare module 'stripe' {
         }
 
         interface AfterpayClearpay {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           */
+          capture_method?: 'manual';
+
           /**
            * Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
            * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
@@ -827,6 +864,11 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           */
+          capture_method?: 'manual';
+
           /**
            * Installment details for this payment (Mexico only).
            *
@@ -1050,6 +1092,11 @@ declare module 'stripe' {
 
         interface Klarna {
           /**
+           * Controls when the funds will be captured from the customer's account.
+           */
+          capture_method?: 'manual';
+
+          /**
            * Preferred locale of the Klarna checkout page that the customer is redirected to.
            */
           preferred_locale: string | null;
@@ -1122,6 +1169,17 @@ declare module 'stripe' {
           setup_future_usage?: 'none';
         }
 
+        interface Paynow {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           */
+          setup_future_usage?: 'none';
+        }
+
         interface SepaDebit {
           mandate_options?: SepaDebit.MandateOptions;
 
@@ -1168,6 +1226,28 @@ declare module 'stripe' {
             | 'pl';
 
           type SetupFutureUsage = 'none' | 'off_session';
+        }
+
+        interface UsBankAccount {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           */
+          setup_future_usage?: UsBankAccount.SetupFutureUsage;
+
+          /**
+           * Bank account verification method.
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
 
         interface WechatPay {
@@ -1592,6 +1672,11 @@ declare module 'stripe' {
         p24?: PaymentMethodData.P24;
 
         /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
          * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
          */
         sepa_debit?: PaymentMethodData.SepaDebit;
@@ -1605,6 +1690,11 @@ declare module 'stripe' {
          * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
          */
         type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
 
         /**
          * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
@@ -1868,6 +1958,8 @@ declare module 'stripe' {
             | 'volkswagen_bank';
         }
 
+        interface Paynow {}
+
         interface SepaDebit {
           /**
            * IBAN of the bank account.
@@ -1903,9 +1995,39 @@ declare module 'stripe' {
           | 'konbini'
           | 'oxxo'
           | 'p24'
+          | 'paynow'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
 
         interface WechatPay {}
       }
@@ -2009,6 +2131,11 @@ declare module 'stripe' {
         p24?: Stripe.Emptyable<PaymentMethodOptions.P24>;
 
         /**
+         * If this is a `paynow` PaymentMethod, this sub-hash contains details about the PayNow payment method options.
+         */
+        paynow?: Stripe.Emptyable<PaymentMethodOptions.Paynow>;
+
+        /**
          * If this is a `sepa_debit` PaymentIntent, this sub-hash contains details about the SEPA Debit payment method options.
          */
         sepa_debit?: Stripe.Emptyable<PaymentMethodOptions.SepaDebit>;
@@ -2017,6 +2144,11 @@ declare module 'stripe' {
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
         sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+        /**
+         * If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
+         */
+        us_bank_account?: Stripe.Emptyable<PaymentMethodOptions.UsBankAccount>;
 
         /**
          * If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
@@ -2085,6 +2217,15 @@ declare module 'stripe' {
         }
 
         interface AfterpayClearpay {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
           /**
            * Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
            * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
@@ -2201,6 +2342,15 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
           /**
            * A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
            */
@@ -2428,6 +2578,15 @@ declare module 'stripe' {
 
         interface Klarna {
           /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
+          /**
            * Preferred language of the Klarna authorization page that the customer is redirected to
            */
           preferred_locale?: Klarna.PreferredLocale;
@@ -2545,6 +2704,19 @@ declare module 'stripe' {
           tos_shown_and_accepted?: boolean;
         }
 
+        interface Paynow {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: 'none';
+        }
+
         interface SepaDebit {
           /**
            * Additional fields for Mandate creation
@@ -2598,6 +2770,30 @@ declare module 'stripe' {
             | 'pl';
 
           type SetupFutureUsage = 'none' | 'off_session';
+        }
+
+        interface UsBankAccount {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: Stripe.Emptyable<UsBankAccount.SetupFutureUsage>;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
 
         interface WechatPay {
@@ -2901,6 +3097,11 @@ declare module 'stripe' {
         p24?: PaymentMethodData.P24;
 
         /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
          * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
          */
         sepa_debit?: PaymentMethodData.SepaDebit;
@@ -2914,6 +3115,11 @@ declare module 'stripe' {
          * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
          */
         type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
 
         /**
          * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
@@ -3177,6 +3383,8 @@ declare module 'stripe' {
             | 'volkswagen_bank';
         }
 
+        interface Paynow {}
+
         interface SepaDebit {
           /**
            * IBAN of the bank account.
@@ -3212,9 +3420,39 @@ declare module 'stripe' {
           | 'konbini'
           | 'oxxo'
           | 'p24'
+          | 'paynow'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
 
         interface WechatPay {}
       }
@@ -3318,6 +3556,11 @@ declare module 'stripe' {
         p24?: Stripe.Emptyable<PaymentMethodOptions.P24>;
 
         /**
+         * If this is a `paynow` PaymentMethod, this sub-hash contains details about the PayNow payment method options.
+         */
+        paynow?: Stripe.Emptyable<PaymentMethodOptions.Paynow>;
+
+        /**
          * If this is a `sepa_debit` PaymentIntent, this sub-hash contains details about the SEPA Debit payment method options.
          */
         sepa_debit?: Stripe.Emptyable<PaymentMethodOptions.SepaDebit>;
@@ -3326,6 +3569,11 @@ declare module 'stripe' {
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
         sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+        /**
+         * If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
+         */
+        us_bank_account?: Stripe.Emptyable<PaymentMethodOptions.UsBankAccount>;
 
         /**
          * If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
@@ -3394,6 +3642,15 @@ declare module 'stripe' {
         }
 
         interface AfterpayClearpay {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
           /**
            * Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
            * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
@@ -3510,6 +3767,15 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
           /**
            * A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
            */
@@ -3737,6 +4003,15 @@ declare module 'stripe' {
 
         interface Klarna {
           /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
+          /**
            * Preferred language of the Klarna authorization page that the customer is redirected to
            */
           preferred_locale?: Klarna.PreferredLocale;
@@ -3854,6 +4129,19 @@ declare module 'stripe' {
           tos_shown_and_accepted?: boolean;
         }
 
+        interface Paynow {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: 'none';
+        }
+
         interface SepaDebit {
           /**
            * Additional fields for Mandate creation
@@ -3907,6 +4195,30 @@ declare module 'stripe' {
             | 'pl';
 
           type SetupFutureUsage = 'none' | 'off_session';
+        }
+
+        interface UsBankAccount {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: Stripe.Emptyable<UsBankAccount.SetupFutureUsage>;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
 
         interface WechatPay {
@@ -4324,6 +4636,11 @@ declare module 'stripe' {
         p24?: PaymentMethodData.P24;
 
         /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
          * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
          */
         sepa_debit?: PaymentMethodData.SepaDebit;
@@ -4337,6 +4654,11 @@ declare module 'stripe' {
          * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
          */
         type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
 
         /**
          * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
@@ -4600,6 +4922,8 @@ declare module 'stripe' {
             | 'volkswagen_bank';
         }
 
+        interface Paynow {}
+
         interface SepaDebit {
           /**
            * IBAN of the bank account.
@@ -4635,9 +4959,39 @@ declare module 'stripe' {
           | 'konbini'
           | 'oxxo'
           | 'p24'
+          | 'paynow'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
 
         interface WechatPay {}
       }
@@ -4741,6 +5095,11 @@ declare module 'stripe' {
         p24?: Stripe.Emptyable<PaymentMethodOptions.P24>;
 
         /**
+         * If this is a `paynow` PaymentMethod, this sub-hash contains details about the PayNow payment method options.
+         */
+        paynow?: Stripe.Emptyable<PaymentMethodOptions.Paynow>;
+
+        /**
          * If this is a `sepa_debit` PaymentIntent, this sub-hash contains details about the SEPA Debit payment method options.
          */
         sepa_debit?: Stripe.Emptyable<PaymentMethodOptions.SepaDebit>;
@@ -4749,6 +5108,11 @@ declare module 'stripe' {
          * If this is a `sofort` PaymentMethod, this sub-hash contains details about the SOFORT payment method options.
          */
         sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+        /**
+         * If this is a `us_bank_account` PaymentMethod, this sub-hash contains details about the US bank account payment method options.
+         */
+        us_bank_account?: Stripe.Emptyable<PaymentMethodOptions.UsBankAccount>;
 
         /**
          * If this is a `wechat_pay` PaymentMethod, this sub-hash contains details about the WeChat Pay payment method options.
@@ -4817,6 +5181,15 @@ declare module 'stripe' {
         }
 
         interface AfterpayClearpay {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
           /**
            * Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
            * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
@@ -4933,6 +5306,15 @@ declare module 'stripe' {
         }
 
         interface Card {
+          /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
           /**
            * A single-use `cvc_update` Token that represents a card CVC value. When provided, the CVC value will be verified during the card payment attempt. This parameter can only be provided during confirmation.
            */
@@ -5160,6 +5542,15 @@ declare module 'stripe' {
 
         interface Klarna {
           /**
+           * Controls when the funds will be captured from the customer's account.
+           *
+           * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+           *
+           * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+           */
+          capture_method?: Stripe.Emptyable<'manual'>;
+
+          /**
            * Preferred language of the Klarna authorization page that the customer is redirected to
            */
           preferred_locale?: Klarna.PreferredLocale;
@@ -5277,6 +5668,19 @@ declare module 'stripe' {
           tos_shown_and_accepted?: boolean;
         }
 
+        interface Paynow {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: 'none';
+        }
+
         interface SepaDebit {
           /**
            * Additional fields for Mandate creation
@@ -5330,6 +5734,30 @@ declare module 'stripe' {
             | 'pl';
 
           type SetupFutureUsage = 'none' | 'off_session';
+        }
+
+        interface UsBankAccount {
+          /**
+           * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+           *
+           * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+           *
+           * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+           *
+           * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+           */
+          setup_future_usage?: Stripe.Emptyable<UsBankAccount.SetupFutureUsage>;
+
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
 
         interface WechatPay {
@@ -5401,6 +5829,11 @@ declare module 'stripe' {
        * Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
        */
       amounts?: Array<number>;
+
+      /**
+       * A six-character code starting with SM present in the microdeposit sent to the bank account.
+       */
+      descriptor_code?: string;
 
       /**
        * Specifies which fields in the response should be expanded.

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -76,6 +76,8 @@ declare module 'stripe' {
 
       p24?: PaymentMethod.P24;
 
+      paynow?: PaymentMethod.Paynow;
+
       sepa_debit?: PaymentMethod.SepaDebit;
 
       sofort?: PaymentMethod.Sofort;
@@ -84,6 +86,8 @@ declare module 'stripe' {
        * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
        */
       type: PaymentMethod.Type;
+
+      us_bank_account?: PaymentMethod.UsBankAccount;
 
       wechat_pay?: PaymentMethod.WechatPay;
     }
@@ -578,6 +582,8 @@ declare module 'stripe' {
           | 'volkswagen_bank';
       }
 
+      interface Paynow {}
+
       interface SepaDebit {
         /**
          * Bank code of bank associated with the bank account.
@@ -651,9 +657,49 @@ declare module 'stripe' {
         | 'konbini'
         | 'oxxo'
         | 'p24'
+        | 'paynow'
         | 'sepa_debit'
         | 'sofort'
+        | 'us_bank_account'
         | 'wechat_pay';
+
+      interface UsBankAccount {
+        /**
+         * Account holder type: individual or company.
+         */
+        account_holder_type: UsBankAccount.AccountHolderType | null;
+
+        /**
+         * Account type: checkings or savings. Defaults to checking if omitted.
+         */
+        account_type: UsBankAccount.AccountType | null;
+
+        /**
+         * The name of the bank.
+         */
+        bank_name: string | null;
+
+        /**
+         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+         */
+        fingerprint: string | null;
+
+        /**
+         * Last four digits of the bank account number.
+         */
+        last4: string | null;
+
+        /**
+         * Routing number of the bank account.
+         */
+        routing_number: string | null;
+      }
+
+      namespace UsBankAccount {
+        type AccountHolderType = 'company' | 'individual';
+
+        type AccountType = 'checking' | 'savings';
+      }
 
       interface WechatPay {}
     }
@@ -775,6 +821,11 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+       */
+      paynow?: PaymentMethodCreateParams.Paynow;
+
+      /**
        * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
        */
       sepa_debit?: PaymentMethodCreateParams.SepaDebit;
@@ -788,6 +839,11 @@ declare module 'stripe' {
        * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
        */
       type?: PaymentMethodCreateParams.Type;
+
+      /**
+       * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+       */
+      us_bank_account?: PaymentMethodCreateParams.UsBankAccount;
 
       /**
        * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
@@ -1077,6 +1133,8 @@ declare module 'stripe' {
           | 'volkswagen_bank';
       }
 
+      interface Paynow {}
+
       interface SepaDebit {
         /**
          * IBAN of the bank account.
@@ -1113,9 +1171,39 @@ declare module 'stripe' {
         | 'konbini'
         | 'oxxo'
         | 'p24'
+        | 'paynow'
         | 'sepa_debit'
         | 'sofort'
+        | 'us_bank_account'
         | 'wechat_pay';
+
+      interface UsBankAccount {
+        /**
+         * Account holder type: individual or company.
+         */
+        account_holder_type?: UsBankAccount.AccountHolderType;
+
+        /**
+         * Account number of the bank account.
+         */
+        account_number?: string;
+
+        /**
+         * Account type: checkings or savings. Defaults to checking if omitted.
+         */
+        account_type?: UsBankAccount.AccountType;
+
+        /**
+         * Routing number of the bank account.
+         */
+        routing_number?: string;
+      }
+
+      namespace UsBankAccount {
+        type AccountHolderType = 'company' | 'individual';
+
+        type AccountType = 'checking' | 'savings';
+      }
 
       interface WechatPay {}
     }
@@ -1167,6 +1255,11 @@ declare module 'stripe' {
        * This is a legacy parameter that will be removed in the future. It is a hash that does not accept any keys.
        */
       sepa_debit?: PaymentMethodUpdateParams.SepaDebit;
+
+      /**
+       * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+       */
+      us_bank_account?: PaymentMethodUpdateParams.UsBankAccount;
     }
 
     namespace PaymentMethodUpdateParams {
@@ -1217,6 +1310,17 @@ declare module 'stripe' {
       }
 
       interface SepaDebit {}
+
+      interface UsBankAccount {
+        /**
+         * Bank account type.
+         */
+        account_holder_type?: UsBankAccount.AccountHolderType;
+      }
+
+      namespace UsBankAccount {
+        type AccountHolderType = 'company' | 'individual';
+      }
     }
 
     interface PaymentMethodListParams extends PaginationParams {
@@ -1256,8 +1360,10 @@ declare module 'stripe' {
         | 'konbini'
         | 'oxxo'
         | 'p24'
+        | 'paynow'
         | 'sepa_debit'
         | 'sofort'
+        | 'us_bank_account'
         | 'wechat_pay';
     }
 

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -95,6 +95,8 @@ declare module 'stripe' {
          * The type of the payment method used in the SetupIntent (e.g., `card`). An additional hash is included on `payment_method_details` with a name matching this value. It contains confirmation-specific information for the payment method.
          */
         type: string;
+
+        us_bank_account?: PaymentMethodDetails.UsBankAccount;
       }
 
       namespace PaymentMethodDetails {
@@ -330,6 +332,8 @@ declare module 'stripe' {
         namespace Sofort {
           type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
         }
+
+        interface UsBankAccount {}
       }
 
       interface SetupError {

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -267,6 +267,15 @@ declare module 'stripe' {
            * The URL for the hosted verification page, which allows customers to verify their bank account.
            */
           hosted_verification_url: string;
+
+          /**
+           * The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
+           */
+          microdeposit_type?: VerifyWithMicrodeposits.MicrodepositType | null;
+        }
+
+        namespace VerifyWithMicrodeposits {
+          type MicrodepositType = 'amounts' | 'descriptor_code';
         }
       }
 
@@ -276,6 +285,8 @@ declare module 'stripe' {
         card?: PaymentMethodOptions.Card;
 
         sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+        us_bank_account?: PaymentMethodOptions.UsBankAccount;
       }
 
       namespace PaymentMethodOptions {
@@ -414,6 +425,17 @@ declare module 'stripe' {
 
         namespace SepaDebit {
           interface MandateOptions {}
+        }
+
+        interface UsBankAccount {
+          /**
+           * Bank account verification method.
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }
 
@@ -560,6 +582,11 @@ declare module 'stripe' {
          * If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
          */
         sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+        /**
+         * If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
+         */
+        us_bank_account?: PaymentMethodOptions.UsBankAccount;
       }
 
       namespace PaymentMethodOptions {
@@ -713,6 +740,17 @@ declare module 'stripe' {
 
         namespace SepaDebit {
           interface MandateOptions {}
+        }
+
+        interface UsBankAccount {
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }
 
@@ -798,6 +836,11 @@ declare module 'stripe' {
          * If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
          */
         sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+        /**
+         * If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
+         */
+        us_bank_account?: PaymentMethodOptions.UsBankAccount;
       }
 
       namespace PaymentMethodOptions {
@@ -951,6 +994,17 @@ declare module 'stripe' {
 
         namespace SepaDebit {
           interface MandateOptions {}
+        }
+
+        interface UsBankAccount {
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }
     }
@@ -1127,6 +1181,11 @@ declare module 'stripe' {
          * If this is a `sepa_debit` SetupIntent, this sub-hash contains details about the SEPA Debit payment method options.
          */
         sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+        /**
+         * If this is a `us_bank_account` SetupIntent, this sub-hash contains details about the US bank account payment method options.
+         */
+        us_bank_account?: PaymentMethodOptions.UsBankAccount;
       }
 
       namespace PaymentMethodOptions {
@@ -1281,6 +1340,17 @@ declare module 'stripe' {
         namespace SepaDebit {
           interface MandateOptions {}
         }
+
+        interface UsBankAccount {
+          /**
+           * Verification method for the intent
+           */
+          verification_method?: UsBankAccount.VerificationMethod;
+        }
+
+        namespace UsBankAccount {
+          type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+        }
       }
     }
 
@@ -1289,6 +1359,11 @@ declare module 'stripe' {
        * Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
        */
       amounts?: Array<number>;
+
+      /**
+       * A six-character code starting with SM present in the microdeposit sent to the bank account.
+       */
+      descriptor_code?: string;
 
       /**
        * Specifies which fields in the response should be expanded.

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -268,6 +268,11 @@ declare module 'stripe' {
            * This sub-hash contains details about the Konbini payment method options to pass to invoices created by the subscription.
            */
           konbini: PaymentMethodOptions.Konbini | null;
+
+          /**
+           * This sub-hash contains details about the ACH direct debit payment method options to pass to invoices created by the subscription.
+           */
+          us_bank_account?: PaymentMethodOptions.UsBankAccount | null;
         }
 
         namespace PaymentMethodOptions {
@@ -341,6 +346,17 @@ declare module 'stripe' {
           }
 
           interface Konbini {}
+
+          interface UsBankAccount {
+            /**
+             * Bank account verification method.
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
         }
 
         type PaymentMethodType =
@@ -357,9 +373,11 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'konbini'
+          | 'paynow'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
       }
 
@@ -798,6 +816,13 @@ declare module 'stripe' {
            * This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
            */
           konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
+
+          /**
+           * This sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          us_bank_account?: Stripe.Emptyable<
+            PaymentMethodOptions.UsBankAccount
+          >;
         }
 
         namespace PaymentMethodOptions {
@@ -877,6 +902,17 @@ declare module 'stripe' {
           }
 
           interface Konbini {}
+
+          interface UsBankAccount {
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
         }
 
         type PaymentMethodType =
@@ -893,9 +929,11 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'konbini'
+          | 'paynow'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
       }
 
@@ -1339,6 +1377,13 @@ declare module 'stripe' {
            * This sub-hash contains details about the Konbini payment method options to pass to the invoice's PaymentIntent.
            */
           konbini?: Stripe.Emptyable<PaymentMethodOptions.Konbini>;
+
+          /**
+           * This sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
+           */
+          us_bank_account?: Stripe.Emptyable<
+            PaymentMethodOptions.UsBankAccount
+          >;
         }
 
         namespace PaymentMethodOptions {
@@ -1418,6 +1463,17 @@ declare module 'stripe' {
           }
 
           interface Konbini {}
+
+          interface UsBankAccount {
+            /**
+             * Verification method for the intent
+             */
+            verification_method?: UsBankAccount.VerificationMethod;
+          }
+
+          namespace UsBankAccount {
+            type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
+          }
         }
 
         type PaymentMethodType =
@@ -1434,9 +1490,11 @@ declare module 'stripe' {
           | 'grabpay'
           | 'ideal'
           | 'konbini'
+          | 'paynow'
           | 'sepa_credit_transfer'
           | 'sepa_debit'
           | 'sofort'
+          | 'us_bank_account'
           | 'wechat_pay';
       }
 
@@ -1507,6 +1565,11 @@ declare module 'stripe' {
        * The status of the subscriptions to retrieve. Passing in a value of `canceled` will return all canceled subscriptions, including those belonging to deleted customers. Pass `ended` to find subscriptions that are canceled and subscriptions that are expired due to [incomplete payment](https://stripe.com/docs/billing/subscriptions/overview#subscription-statuses). Passing in a value of `all` will return subscriptions of all statuses. If no value is supplied, all subscriptions that have not been canceled are returned.
        */
       status?: SubscriptionListParams.Status;
+
+      /**
+       * Filter for subscriptions that are associated with the specified test clock. The response will not include subscriptions with test clocks if this and the customer parameter is not set.
+       */
+      test_clock?: string;
     }
 
     namespace SubscriptionListParams {

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -217,7 +217,8 @@ declare module 'stripe' {
     /**
      * API Errors
      */
-    errors: typeof Stripe.errors;
+    static errors: Stripe.Errors;
+    errors: Stripe.Errors;
 
     on(event: 'request', handler: (event: Stripe.RequestEvent) => void): void;
     on(event: 'response', handler: (event: Stripe.ResponseEvent) => void): void;

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -217,8 +217,7 @@ declare module 'stripe' {
     /**
      * API Errors
      */
-    static errors: Stripe.Errors;
-    errors: Stripe.Errors;
+    errors: typeof Stripe.errors;
 
     on(event: 'request', handler: (event: Stripe.RequestEvent) => void): void;
     on(event: 'response', handler: (event: Stripe.ResponseEvent) => void): void;


### PR DESCRIPTION
Codegen for openapi dc3ef48.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for PayNow and US Bank Accounts Debits payments
    * **Charge** ([API ref](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details))
        * Add support for `paynow` and `us_bank_account` on `Charge.payment_method_details`
    * **Customer** ([API ref](https://stripe.com/docs/api/payment_methods/customer_list#list_customer_payment_methods-type))
        * Add support for new values `paynow` and `us_bank_account` on enum `CustomerListPaymentMethodsParams.type`
    * **Payment Intent** ([API ref](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_options))
        * Add support for `paynow` and `us_bank_account` on `payment_method_options` on `PaymentIntent`, `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams` 
        * Add support for `paynow` and `us_bank_account` on `payment_method_data` on `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams`
        * Add support for `paynow_display_qr_code` on `PaymentIntent.next_action`
        * Add support for new values `paynow` and `us_bank_account` on enums `payment_method_data.type` on `PaymentIntentCreateParams`, and `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams`
    * **Setup Intent** ([API ref](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method_options))
        * Add support for `us_bank_account` on `payment_method_options` on `SetupIntent`, `SetupIntentCreateParams`, `SetupIntentUpdateParams`, and `SetupIntentConfirmParams`
    * **Setup Attempt** ([API ref](https://stripe.com/docs/api/setup_attempts/object#setup_attempt_object-payment_method_details))
        * Add support for `us_bank_account` on `SetupAttempt.payment_method_details`
    * **Payment Method** ([API ref](https://stripe.com/docs/api/payment_methods/object#payment_method_object-paynow))
        * Add support for `paynow` and `us_bank_account` on `PaymentMethod` and `PaymentMethodCreateParams`
        * Add support for `us_bank_account` on `PaymentMethodUpdateParams`
        * Add support for new values `paynow` and `us_bank_account` on enums `PaymentMethod.type`, `PaymentMethodCreateParams.type`. and `PaymentMethodListParams.type`
    * **Checkout Session** ([API ref](https://stripe.com/docs/api/checkout/sessions/create#create_checkout_session-payment_method_types))
        * Add support for `us_bank_account` on `payment_method_options` on `Checkout.Session` and `CheckoutSessionCreateParams`
        * Add support for new values `paynow` and `us_bank_account` on enum `CheckoutSessionCreateParams.payment_method_types[]`
    * **Invoice** ([API ref](https://stripe.com/docs/api/invoices/object#invoice_object-payment_settings-payment_method_types))
        * Add support for `us_bank_account` on `payment_settings.payment_method_options` on `Invoice`, `InvoiceCreateParams`, and `InvoiceUpdateParams`
        * Add support for new values `paynow` and `us_bank_account` on enums `payment_settings.payment_method_types[]` on `Invoice`, `InvoiceCreateParams`, and `InvoiceUpdateParams`
    * **Subscription** ([API ref](https://stripe.com/docs/api/subscriptions/object#subscription_object-payment_settings-payment_method_types))
        * Add support for `us_bank_account` on `Subscription.payment_settings.payment_method_options`, `SubscriptionCreateParams.payment_settings.payment_method_options`, and `SubscriptionUpdateParams.payment_settings.payment_method_options`
        * Add support for new values `paynow` and `us_bank_account` on enums `payment_settings.payment_method_types[]` on `Subscription`, `SubscriptionCreateParams`, and `SubscriptionUpdateParams`
    * **Account capabilities** ([API ref](https://stripe.com/docs/api/accounts/object#account_object-capabilities))
        * Add support for `paynow_payments` on `capabilities` on `Account`, `AccountCreateParams`, and `AccountUpdateParams`
* Add support for `failure_balance_transaction` on `Charge`
* Add support for `capture_method` on `afterpay_clearpay`, `card`, and `klarna` on `payment_method_options` on
`PaymentIntent`, `PaymentIntentCreateParams`, `PaymentIntentUpdateParams`, and `PaymentIntentConfirmParams` ([API ref](https://stripe.com/docs/api/payment_intents/object#payment_intent_object-payment_method_options-afterpay_clearpay-capture_method))
* Add additional support for verify microdeposits on Payment Intent and Setup Intent ([API ref](https://stripe.com/docs/api/payment_intents/verify_microdeposits))
    * Add support for `microdeposit_type` on `next_action.verify_with_microdeposits` on `PaymentIntent` and `SetupIntent`
    * Add support for `descriptor_code` on `PaymentIntentVerifyMicrodepositsParams` and `SetupIntentVerifyMicrodepositsParams`
* Add support for `test_clock` on `SubscriptionListParams` ([API ref](https://stripe.com/docs/api/subscriptions/list#list_subscriptions-test_clock))
