### PR TITLE
API Updates

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -93,5 +93,8 @@ module.exports = {
   }),
   TestHelpers: resourceNamespace('testHelpers', {
     TestClocks: require('./resources/TestHelpers/TestClocks'),
+    Terminal: resourceNamespace('terminal', {
+      Readers: require('./resources/TestHelpers/Terminal/Readers'),
+    }),
   }),
 };

--- a/lib/resources/Terminal/Readers.js
+++ b/lib/resources/Terminal/Readers.js
@@ -33,4 +33,24 @@ module.exports = StripeResource.extend({
     method: 'DELETE',
     path: '/{reader}',
   }),
+
+  cancelAction: stripeMethod({
+    method: 'POST',
+    path: '/{reader}/cancel_action',
+  }),
+
+  processPaymentIntent: stripeMethod({
+    method: 'POST',
+    path: '/{reader}/process_payment_intent',
+  }),
+
+  processSetupIntent: stripeMethod({
+    method: 'POST',
+    path: '/{reader}/process_setup_intent',
+  }),
+
+  setReaderDisplay: stripeMethod({
+    method: 'POST',
+    path: '/{reader}/set_reader_display',
+  }),
 });

--- a/lib/resources/TestHelpers/Terminal/Readers.js
+++ b/lib/resources/TestHelpers/Terminal/Readers.js
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+
+'use strict';
+
+const StripeResource = require('../../../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'test_helpers/terminal/readers',
+
+  presentPaymentMethod: stripeMethod({
+    method: 'POST',
+    path: '/{reader}/present_payment_method',
+  }),
+});

--- a/test/resources/Integration.spec.js
+++ b/test/resources/Integration.spec.js
@@ -44,7 +44,7 @@ describe('Charges Resource', () => {
 });
 
 describe('Reader Resource', () => {
-  describe('retrieve', () => {
+  describe('presentPaymentMethod', () => {
     it('Sends the correct request', async () => {
       const reader = await stripe.testHelpers.terminal.readers.presentPaymentMethod(
         'rdr_123'

--- a/test/resources/Integration.spec.js
+++ b/test/resources/Integration.spec.js
@@ -42,3 +42,14 @@ describe('Charges Resource', () => {
     });
   });
 });
+
+describe('Reader Resource', () => {
+  describe('retrieve', () => {
+    it('Sends the correct request', async () => {
+      const reader = await stripe.testHelpers.terminal.readers.presentPaymentMethod(
+        'rdr_123'
+      );
+      expect(reader).to.not.be.null;
+    });
+  });
+});

--- a/test/resources/TestHelpers/Terminal/Readers.spec.js
+++ b/test/resources/TestHelpers/Terminal/Readers.spec.js
@@ -1,0 +1,23 @@
+'use strict';
+
+const stripe = require('../../../../testUtils').getSpyableStripe();
+
+const expect = require('chai').expect;
+
+describe('Terminal', () => {
+  describe('Readers Resource', () => {
+    describe('update', () => {
+      it('Sends the correct request', () => {
+        stripe.testHelpers.terminal.readers.presentPaymentMethod('rdr_123');
+        expect(stripe.LAST_REQUEST).to.deep.equal({
+          method: 'POST',
+          url:
+            '/v1/test_helpers/terminal/readers/rdr_123/present_payment_method',
+          headers: {},
+          data: {},
+          settings: {},
+        });
+      });
+    });
+  });
+});

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -108,7 +108,7 @@ declare module 'stripe' {
       /**
        * ID of the balance transaction that describes the reversal of the balance on your account due to payment failure.
        */
-      failure_balance_transaction?: string | Stripe.BalanceTransaction | null;
+      failure_balance_transaction: string | Stripe.BalanceTransaction | null;
 
       /**
        * Error code explaining reason for charge failure if available (see [the errors section](https://stripe.com/docs/api#errors) for a list of codes).
@@ -2136,7 +2136,10 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Charge>>;
 
       /**
-       * Search for charges you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for charges you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: ChargeSearchParams,

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -1310,7 +1310,7 @@ declare module 'stripe' {
               metadata?: Stripe.MetadataParam;
 
               /**
-               * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+               * The product's name, meant to be displayable to the customer.
                */
               name: string;
 

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -827,7 +827,10 @@ declare module 'stripe' {
       ): ApiListPromise<Stripe.PaymentMethod>;
 
       /**
-       * Search for customers you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for customers you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: CustomerSearchParams,

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -620,7 +620,7 @@ declare module 'stripe' {
           /**
            * If paying by `us_bank_account`, this sub-hash contains details about the ACH direct debit payment method options to pass to the invoice's PaymentIntent.
            */
-          us_bank_account?: PaymentMethodOptions.UsBankAccount | null;
+          us_bank_account: PaymentMethodOptions.UsBankAccount | null;
         }
 
         namespace PaymentMethodOptions {
@@ -2163,7 +2163,10 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Invoice>>;
 
       /**
-       * Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: InvoiceSearchParams,

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -577,7 +577,7 @@ declare module 'stripe' {
           /**
            * The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
            */
-          microdeposit_type?: VerifyWithMicrodeposits.MicrodepositType | null;
+          microdeposit_type: VerifyWithMicrodeposits.MicrodepositType | null;
         }
 
         namespace VerifyWithMicrodeposits {
@@ -5994,7 +5994,10 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.PaymentIntent>>;
 
       /**
-       * Search for PaymentIntents you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for PaymentIntents you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: PaymentIntentSearchParams,

--- a/types/2020-08-27/Plans.d.ts
+++ b/types/2020-08-27/Plans.d.ts
@@ -297,7 +297,7 @@ declare module 'stripe' {
         metadata?: Stripe.MetadataParam;
 
         /**
-         * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+         * The product's name, meant to be displayable to the customer.
          */
         name: string;
 

--- a/types/2020-08-27/Prices.d.ts
+++ b/types/2020-08-27/Prices.d.ts
@@ -323,7 +323,7 @@ declare module 'stripe' {
         metadata?: Stripe.MetadataParam;
 
         /**
-         * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+         * The product's name, meant to be displayable to the customer.
          */
         name: string;
 
@@ -619,7 +619,10 @@ declare module 'stripe' {
       list(options?: RequestOptions): ApiListPromise<Stripe.Price>;
 
       /**
-       * Search for prices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for prices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: PriceSearchParams,

--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -64,7 +64,7 @@ declare module 'stripe' {
       metadata: Stripe.Metadata;
 
       /**
-       * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+       * The product's name, meant to be displayable to the customer.
        */
       name: string;
 
@@ -157,7 +157,7 @@ declare module 'stripe' {
 
     interface ProductCreateParams {
       /**
-       * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+       * The product's name, meant to be displayable to the customer.
        */
       name: string;
 
@@ -320,7 +320,7 @@ declare module 'stripe' {
       metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
 
       /**
-       * The product's name, meant to be displayable to the customer. Whenever this product is sold via a subscription, name will show up on associated invoice line item descriptions.
+       * The product's name, meant to be displayable to the customer.
        */
       name?: string;
 
@@ -503,7 +503,10 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.DeletedProduct>>;
 
       /**
-       * Search for products you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for products you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: ProductSearchParams,

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -271,7 +271,7 @@ declare module 'stripe' {
           /**
            * The type of the microdeposit sent to the customer. Used to distinguish between different verification methods.
            */
-          microdeposit_type?: VerifyWithMicrodeposits.MicrodepositType | null;
+          microdeposit_type: VerifyWithMicrodeposits.MicrodepositType | null;
         }
 
         namespace VerifyWithMicrodeposits {

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -272,7 +272,7 @@ declare module 'stripe' {
           /**
            * This sub-hash contains details about the ACH direct debit payment method options to pass to invoices created by the subscription.
            */
-          us_bank_account?: PaymentMethodOptions.UsBankAccount | null;
+          us_bank_account: PaymentMethodOptions.UsBankAccount | null;
         }
 
         namespace PaymentMethodOptions {
@@ -1705,7 +1705,10 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.DeletedDiscount>>;
 
       /**
-       * Search for subscriptions you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language)
+       * Search for subscriptions you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).
+       * Don't use search in read-after-write flows where strict consistency is necessary. Under normal operating
+       * conditions, data is searchable in less than a minute. Occasionally, propagation of new or updated data can be up
+       * to an hour behind during outages. Search functionality is not available to merchants in India.
        */
       search(
         params: SubscriptionSearchParams,

--- a/types/2020-08-27/TestHelpers/Terminal/Readers.d.ts
+++ b/types/2020-08-27/TestHelpers/Terminal/Readers.d.ts
@@ -1,0 +1,52 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    namespace TestHelpers {
+      namespace Terminal {
+        interface ReaderPresentPaymentMethodParams {
+          /**
+           * Simulated card present data
+           */
+          card_present?: ReaderPresentPaymentMethodParams.CardPresent;
+
+          /**
+           * Specifies which fields in the response should be expanded.
+           */
+          expand?: Array<string>;
+
+          /**
+           * Simulated payment type
+           */
+          type?: 'card_present';
+        }
+
+        namespace ReaderPresentPaymentMethodParams {
+          interface CardPresent {
+            /**
+             * Card Number
+             */
+            number?: string;
+          }
+        }
+      }
+
+      namespace Terminal {
+        class ReadersResource {
+          /**
+           * Presents a payment method on a simulated reader. Can be used to simulate accepting a payment, saving a card or refunding a transaction
+           */
+          presentPaymentMethod(
+            id: string,
+            params?: ReaderPresentPaymentMethodParams,
+            options?: RequestOptions
+          ): Promise<Stripe.Response<Stripe.Terminal.Reader>>;
+          presentPaymentMethod(
+            id: string,
+            options?: RequestOptions
+          ): Promise<Stripe.Response<Stripe.Terminal.Reader>>;
+        }
+      }
+    }
+  }
+}

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -97,6 +97,7 @@
 ///<reference path='./Terminal/ConnectionTokens.d.ts' />
 ///<reference path='./Terminal/Locations.d.ts' />
 ///<reference path='./Terminal/Readers.d.ts' />
+///<reference path='./TestHelpers/Terminal/Readers.d.ts' />
 ///<reference path='./TestHelpers/TestClocks.d.ts' />
 ///<reference path='./Tokens.d.ts' />
 ///<reference path='./Topups.d.ts' />
@@ -213,6 +214,9 @@ declare module 'stripe' {
     };
     testHelpers: {
       testClocks: Stripe.TestHelpers.TestClocksResource;
+      terminal: {
+        readers: Stripe.TestHelpers.Terminal.ReadersResource;
+      };
     };
     /**
      * API Errors


### PR DESCRIPTION
Codegen for openapi 1700e20.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `cancel_action`, `process_payment_intent`, `process_setup_intent`, and `set_reader_display` methods on resource `Terminal.Reader`
* Change `Charge.failure_balance_transaction`, `Invoice.payment_settings.payment_method_options.us_bank_account`, `PaymentIntent.next_action.verify_with_microdeposits.microdeposit_type`, `SetupIntent.next_action.verify_with_microdeposits.microdeposit_type`, and `Subscription.payment_settings.payment_method_options.us_bank_account` to be required
* Add support for `action` on `Terminal.Reader`

