### PR TITLE
Stop sending Content-Length header for verbs which don't have bodies.

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -369,7 +369,6 @@ StripeResource.prototype = {
       Authorization: auth ? `Bearer ${auth}` : this._stripe.getApiField('auth'),
       Accept: 'application/json',
       'Content-Type': 'application/x-www-form-urlencoded',
-      'Content-Length': contentLength,
       'User-Agent': this._getUserAgentString(),
       'X-Stripe-Client-User-Agent': clientUserAgent,
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
@@ -380,6 +379,34 @@ StripeResource.prototype = {
         userSuppliedSettings
       ),
     };
+
+    // As per https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2:
+    //   A user agent SHOULD send a Content-Length in a request message when
+    //   no Transfer-Encoding is sent and the request method defines a meaning
+    //   for an enclosed payload body.  For example, a Content-Length header
+    //   field is normally sent in a POST request even when the value is 0
+    //   (indicating an empty payload body).  A user agent SHOULD NOT send a
+    //   Content-Length header field when the request message does not contain
+    //   a payload body and the method semantics do not anticipate such a
+    //   body.
+    //
+    // These method types are expected to have bodies and so we should always
+    // include a Content-Length.
+    const methodHasPayload =
+      method == 'POST' || method == 'PUT' || method == 'PATCH';
+
+    // If a content length was specified, we always include it regardless of
+    // whether the method semantics anticipate such a body. This keeps us
+    // consistent with historical behavior. We do however want to warn on this
+    // and fix these cases as they are semantically incorrect.
+    if (methodHasPayload || contentLength) {
+      if (!methodHasPayload) {
+        utils.emitWarning(
+          `${method} method had non-zero contentLength but no payload is expected for this verb`
+        );
+      }
+      defaultHeaders['Content-Length'] = contentLength;
+    }
 
     return Object.assign(
       utils.removeNullish(defaultHeaders),


### PR DESCRIPTION
r? @pakrym-stripe 

## Summary

Stops sending a `Content-Length` header for requests which:
1. Use a verb which doesn't anticipate a body (eg. `GET`, `DELETE`) and
2. Actually has no body.

For requests that don't anticipate a body but end up having one, we'll continue setting the header and emit a warning so that we can track and fix these cases as they are not following proper semantics.

`POST`, `PUT` and `PATCH` request are unchanged.

## Motivation

Fixes https://github.com/stripe/stripe-node/issues/1360