### PR TITLE
Add support for updating the version of the repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: update-version codegen-format
+.PHONY: codegen-format update-version
 update-version:
 	@echo "$(VERSION)" > VERSION
 	@perl -pi -e 's|"version": "[.\d]+"|"version": "$(VERSION)"|' package.json

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,7 @@
+.PHONY: update-version codegen-format
+update-version:
+	@echo "$(VERSION)" > VERSION
+	@perl -pi -e 's|"version": "[.\d]+"|"version": "$(VERSION)"|' package.json
+
+codegen-format:
+	yarn && yarn fix


### PR DESCRIPTION
Encodes the logic for version updating as a Makefile. Simplifies what the generation tools needs to know about the repo.
The plan is to have the same interface across all the repos.

Sample usage:

```
make update-version VERSION=1.2.5
```

Also adds a target that codegen will use to format all our repos:

```
make codegen-format
```