### PR TITLE
API Updates

### DIFF
--- a/lib/resources/PaymentIntents.js
+++ b/lib/resources/PaymentIntents.js
@@ -49,6 +49,11 @@ module.exports = StripeResource.extend({
     path: '/{intent}/confirm',
   }),
 
+  incrementAuthorization: stripeMethod({
+    method: 'POST',
+    path: '/{intent}/increment_authorization',
+  }),
+
   search: stripeMethod({
     method: 'GET',
     path: '/search',

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -1007,6 +1007,11 @@ declare module 'stripe' {
           iin?: string | null;
 
           /**
+           * Whether this [PaymentIntent](https://stripe.com/docs/api/payment_intents) is eligible for incremental authorizations. Request support using [request_incremental_authorization_support] /docs/api/payment_intents/create#create_payment_intent-payment_method_options-card_present-request_incremental_authorization_support.
+           */
+          incremental_authorization_supported: boolean | null;
+
+          /**
            * The name of the card's issuing bank. (For internal use only and not typically available in standard API requests.)
            */
           issuer?: string | null;

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -529,7 +529,7 @@ declare module 'stripe' {
 
         /**
          * PaymentMethod objects represent your customer's payment instruments.
-         * They can be used with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or saved to
+         * You can use them with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or save them to
          * Customer objects to store instrument details for future payments.
          *
          * Related guides: [Payment Methods](https://stripe.com/docs/payments/payment-methods) and [More Payment Scenarios](https://stripe.com/docs/payments/more-payment-scenarios).

--- a/types/2020-08-27/SetupAttempts.d.ts
+++ b/types/2020-08-27/SetupAttempts.d.ts
@@ -384,7 +384,7 @@ declare module 'stripe' {
 
         /**
          * PaymentMethod objects represent your customer's payment instruments.
-         * They can be used with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or saved to
+         * You can use them with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or save them to
          * Customer objects to store instrument details for future payments.
          *
          * Related guides: [Payment Methods](https://stripe.com/docs/payments/payment-methods) and [More Payment Scenarios](https://stripe.com/docs/payments/more-payment-scenarios).

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -29,7 +29,7 @@ declare module 'stripe' {
       /**
        * The client secret of this SetupIntent. Used for client-side retrieval using a publishable key.
        *
-       * The client secret can be used to complete payment setup from your frontend. It should not be stored, logged, embedded in URLs, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
+       * The client secret can be used to complete payment setup from your frontend. It should not be stored, logged, or exposed to anyone other than the customer. Make sure that you have TLS enabled on any page that includes the client secret.
        */
       client_secret: string | null;
 
@@ -172,7 +172,7 @@ declare module 'stripe' {
 
         /**
          * PaymentMethod objects represent your customer's payment instruments.
-         * They can be used with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or saved to
+         * You can use them with [PaymentIntents](https://stripe.com/docs/payments/payment-intents) to collect payments or save them to
          * Customer objects to store instrument details for future payments.
          *
          * Related guides: [Payment Methods](https://stripe.com/docs/payments/payment-methods) and [More Payment Scenarios](https://stripe.com/docs/payments/more-payment-scenarios).


### PR DESCRIPTION
Codegen for openapi e0123a3.
r? @yejia-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `increment_authorization` method on resource `PaymentIntent`
* Add support for `incremental_authorization_supported` on `Charge.payment_method_details.card_present`
* Add support for `request_incremental_authorization_support` on `PaymentIntent.payment_method_options.card_present`, `PaymentIntentConfirmParams.payment_method_options.card_present`, `PaymentIntentCreateParams.payment_method_options.card_present`, and `PaymentIntentUpdateParams.payment_method_options.card_present`

