### PR TITLE
API Updates

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -87,6 +87,7 @@ module.exports = {
     ScheduledQueryRuns: require('./resources/Sigma/ScheduledQueryRuns'),
   }),
   Terminal: resourceNamespace('terminal', {
+    Configurations: require('./resources/Terminal/Configurations'),
     ConnectionTokens: require('./resources/Terminal/ConnectionTokens'),
     Locations: require('./resources/Terminal/Locations'),
     Readers: require('./resources/Terminal/Readers'),

--- a/lib/resources/Customers.js
+++ b/lib/resources/Customers.js
@@ -34,6 +34,11 @@ module.exports = StripeResource.extend({
     path: '/{customer}',
   }),
 
+  createFundingInstructions: stripeMethod({
+    method: 'POST',
+    path: '/{customer}/funding_instructions',
+  }),
+
   deleteDiscount: stripeMethod({
     method: 'DELETE',
     path: '/{customer}/discount',

--- a/lib/resources/Terminal/Configurations.js
+++ b/lib/resources/Terminal/Configurations.js
@@ -1,0 +1,36 @@
+// File generated from our OpenAPI spec
+
+'use strict';
+
+const StripeResource = require('../../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'terminal/configurations',
+
+  create: stripeMethod({
+    method: 'POST',
+    path: '',
+  }),
+
+  retrieve: stripeMethod({
+    method: 'GET',
+    path: '/{configuration}',
+  }),
+
+  update: stripeMethod({
+    method: 'POST',
+    path: '/{configuration}',
+  }),
+
+  list: stripeMethod({
+    method: 'GET',
+    path: '',
+    methodType: 'list',
+  }),
+
+  del: stripeMethod({
+    method: 'DELETE',
+    path: '/{configuration}',
+  }),
+});

--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -47,6 +47,21 @@ describe('Customer', function() {
     );
     expect(paymentMethods).not.to.be.null;
   });
+
+  it('createFundingInstructions method', async function() {
+    const fundingInstructions = await stripe.customers.createFundingInstructions(
+      'cus_123',
+      {
+        bank_transfer: {
+          requested_address_types: ['zengin'],
+          type: 'jp_bank_transfer',
+        },
+        currency: 'usd',
+        funding_type: 'bank_transfer',
+      }
+    );
+    expect(fundingInstructions).not.to.be.null;
+  });
 });
 
 describe('BalanceTransaction', function() {
@@ -2073,5 +2088,37 @@ describe('TestHelpers.TestClock', function() {
       frozen_time: 142,
     });
     expect(testClock).not.to.be.null;
+  });
+});
+
+describe('Terminal.Configuration', function() {
+  it('list method', async function() {
+    const configurations = await stripe.terminal.configurations.list();
+    expect(configurations).not.to.be.null;
+  });
+
+  it('retrieve method', async function() {
+    const configuration = await stripe.terminal.configurations.retrieve(
+      'uc_123'
+    );
+    expect(configuration).not.to.be.null;
+  });
+
+  it('create method', async function() {
+    const configuration = await stripe.terminal.configurations.create();
+    expect(configuration).not.to.be.null;
+  });
+
+  it('update method', async function() {
+    const configuration = await stripe.terminal.configurations.update(
+      'uc_123',
+      {tipping: {usd: {fixed_amounts: [10]}}}
+    );
+    expect(configuration).not.to.be.null;
+  });
+
+  it('del method', async function() {
+    const deleted = await stripe.terminal.configurations.del('uc_123');
+    expect(deleted).not.to.be.null;
   });
 });

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -409,6 +409,8 @@ declare module 'stripe' {
 
         card_present?: PaymentMethodDetails.CardPresent;
 
+        customer_balance?: PaymentMethodDetails.CustomerBalance;
+
         eps?: PaymentMethodDetails.Eps;
 
         fpx?: PaymentMethodDetails.Fpx;
@@ -1007,7 +1009,7 @@ declare module 'stripe' {
           iin?: string | null;
 
           /**
-           * Whether this [PaymentIntent](https://stripe.com/docs/api/payment_intents) is eligible for incremental authorizations. Request support using [request_incremental_authorization_support] /docs/api/payment_intents/create#create_payment_intent-payment_method_options-card_present-request_incremental_authorization_support.
+           * Whether this [PaymentIntent](https://stripe.com/docs/api/payment_intents) is eligible for incremental authorizations. Request support using [request_incremental_authorization_support](https://stripe.com/docs/api/payment_intents/create#create_payment_intent-payment_method_options-card_present-request_incremental_authorization_support).
            */
           incremental_authorization_supported: boolean | null;
 
@@ -1101,6 +1103,8 @@ declare module 'stripe' {
             type AccountType = 'checking' | 'credit' | 'prepaid' | 'unknown';
           }
         }
+
+        interface CustomerBalance {}
 
         interface Eps {
           /**

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -277,6 +277,11 @@ declare module 'stripe' {
        */
       balance?: number;
 
+      /**
+       * Balance information and default balance settings for this customer.
+       */
+      cash_balance?: CustomerCreateParams.CashBalance;
+
       coupon?: string;
 
       /**
@@ -365,6 +370,34 @@ declare module 'stripe' {
     }
 
     namespace CustomerCreateParams {
+      interface CashBalance {
+        /**
+         * Settings controlling the behavior of the customer's cash balance,
+         * such as reconciliation of funds received.
+         */
+        settings?: CashBalance.Settings;
+      }
+
+      namespace CashBalance {
+        interface Settings {
+          /**
+           * Method for using the customer balance to pay outstanding
+           * `customer_balance` PaymentIntents. If set to `automatic`, all available
+           * funds will automatically be used to pay any outstanding PaymentIntent.
+           * If set to `manual`, only customer balance funds from bank transfers
+           * with a reference code matching
+           * `payment_intent.next_action.display_bank_transfer_intructions.reference_code` will
+           * automatically be used to pay the corresponding outstanding
+           * PaymentIntent.
+           */
+          reconciliation_mode?: Settings.ReconciliationMode;
+        }
+
+        namespace Settings {
+          type ReconciliationMode = 'automatic' | 'manual';
+        }
+      }
+
       interface InvoiceSettings {
         /**
          * Default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
@@ -508,6 +541,11 @@ declare module 'stripe' {
        */
       balance?: number;
 
+      /**
+       * Balance information and default balance settings for this customer.
+       */
+      cash_balance?: CustomerUpdateParams.CashBalance;
+
       coupon?: string;
 
       /**
@@ -598,6 +636,34 @@ declare module 'stripe' {
     }
 
     namespace CustomerUpdateParams {
+      interface CashBalance {
+        /**
+         * Settings controlling the behavior of the customer's cash balance,
+         * such as reconciliation of funds received.
+         */
+        settings?: CashBalance.Settings;
+      }
+
+      namespace CashBalance {
+        interface Settings {
+          /**
+           * Method for using the customer balance to pay outstanding
+           * `customer_balance` PaymentIntents. If set to `automatic`, all available
+           * funds will automatically be used to pay any outstanding PaymentIntent.
+           * If set to `manual`, only customer balance funds from bank transfers
+           * with a reference code matching
+           * `payment_intent.next_action.display_bank_transfer_intructions.reference_code` will
+           * automatically be used to pay the corresponding outstanding
+           * PaymentIntent.
+           */
+          reconciliation_mode?: Settings.ReconciliationMode;
+        }
+
+        namespace Settings {
+          type ReconciliationMode = 'automatic' | 'manual';
+        }
+      }
+
       interface InvoiceSettings {
         /**
          * Default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
@@ -683,6 +749,44 @@ declare module 'stripe' {
 
     interface CustomerDeleteParams {}
 
+    interface CustomerCreateFundingInstructionsParams {
+      /**
+       * Additional parameters for `bank_transfer` funding types
+       */
+      bank_transfer: CustomerCreateFundingInstructionsParams.BankTransfer;
+
+      /**
+       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+       */
+      currency: string;
+
+      /**
+       * The `funding_type` to get the instructions for.
+       */
+      funding_type: 'bank_transfer';
+
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    namespace CustomerCreateFundingInstructionsParams {
+      interface BankTransfer {
+        /**
+         * List of address types that should be returned in the financial_addresses response. If not specified, all valid types will be returned.
+         *
+         * Permitted values include: `zengin`.
+         */
+        requested_address_types?: Array<'zengin'>;
+
+        /**
+         * The type of the `bank_transfer`
+         */
+        type: 'jp_bank_transfer';
+      }
+    }
+
     interface CustomerDeleteDiscountParams {}
 
     interface CustomerListPaymentMethodsParams extends PaginationParams {
@@ -708,6 +812,7 @@ declare module 'stripe' {
         | 'boleto'
         | 'card'
         | 'card_present'
+        | 'customer_balance'
         | 'eps'
         | 'fpx'
         | 'giropay'
@@ -803,6 +908,17 @@ declare module 'stripe' {
         id: string,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.DeletedCustomer>>;
+
+      /**
+       * Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
+       * funding instructions will be created. If funding instructions have already been created for a given customer, the same
+       * funding instructions will be retrieved. In other words, we will return the same funding instructions each time.
+       */
+      createFundingInstructions(
+        id: string,
+        params: CustomerCreateFundingInstructionsParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.FundingInstructions>>;
 
       /**
        * Removes the currently applied discount on a customer.

--- a/types/2020-08-27/FundingInstructions.d.ts
+++ b/types/2020-08-27/FundingInstructions.d.ts
@@ -1,0 +1,80 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    /**
+     * The FundingInstructions object.
+     */
+    interface FundingInstructions {
+      /**
+       * String representing the object's type. Objects of the same type share the same value.
+       */
+      object: 'funding_instructions';
+
+      bank_transfer: FundingInstructions.BankTransfer;
+
+      /**
+       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+       */
+      currency: string;
+
+      /**
+       * The `funding_type` of the returned instructions
+       */
+      funding_type: 'bank_transfer';
+
+      /**
+       * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+       */
+      livemode: boolean;
+    }
+
+    namespace FundingInstructions {
+      interface BankTransfer {
+        /**
+         * The country of the bank account to fund
+         */
+        country: string;
+
+        /**
+         * A list of financial addresses that can be used to fund a particular balance
+         */
+        financial_addresses: Array<BankTransfer.FinancialAddress>;
+
+        /**
+         * The bank_transfer type
+         */
+        type: BankTransfer.Type;
+      }
+
+      namespace BankTransfer {
+        interface FinancialAddress {
+          /**
+           * The payment networks supported by this FinancialAddress
+           */
+          supported_networks?: Array<FinancialAddress.SupportedNetwork>;
+
+          /**
+           * The type of financial address
+           */
+          type: FinancialAddress.Type;
+
+          /**
+           * Zengin Records contain Japan bank account details per the Zengin format.
+           */
+          zengin?: FinancialAddress.Zengin;
+        }
+
+        namespace FinancialAddress {
+          type SupportedNetwork = 'sepa' | 'zengin';
+
+          type Type = 'iban' | 'zengin';
+
+          interface Zengin {}
+        }
+
+        type Type = 'eu_bank_transfer' | 'jp_bank_transfer';
+      }
+    }
+  }
+}

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -46,6 +46,8 @@ declare module 'stripe' {
        */
       customer: string | Stripe.Customer | null;
 
+      customer_balance?: PaymentMethod.CustomerBalance;
+
       eps?: PaymentMethod.Eps;
 
       fpx?: PaymentMethod.Fpx;
@@ -389,6 +391,8 @@ declare module 'stripe' {
 
       interface CardPresent {}
 
+      interface CustomerBalance {}
+
       interface Eps {
         /**
          * The customer's bank. Should be one of `arzte_und_apotheker_bank`, `austrian_anadi_bank_ag`, `bank_austria`, `bankhaus_carl_spangler`, `bankhaus_schelhammer_und_schattera_ag`, `bawag_psk_ag`, `bks_bank_ag`, `brull_kallmus_bank_ag`, `btv_vier_lander_bank`, `capital_bank_grawe_gruppe_ag`, `dolomitenbank`, `easybank_ag`, `erste_bank_und_sparkassen`, `hypo_alpeadriabank_international_ag`, `hypo_noe_lb_fur_niederosterreich_u_wien`, `hypo_oberosterreich_salzburg_steiermark`, `hypo_tirol_bank_ag`, `hypo_vorarlberg_bank_ag`, `hypo_bank_burgenland_aktiengesellschaft`, `marchfelder_bank`, `oberbank_ag`, `raiffeisen_bankengruppe_osterreich`, `schoellerbank_ag`, `sparda_bank_wien`, `volksbank_gruppe`, `volkskreditbank_ag`, or `vr_bank_braunau`.
@@ -647,6 +651,7 @@ declare module 'stripe' {
         | 'boleto'
         | 'card'
         | 'card_present'
+        | 'customer_balance'
         | 'eps'
         | 'fpx'
         | 'giropay'
@@ -754,6 +759,11 @@ declare module 'stripe' {
        * The `Customer` to whom the original PaymentMethod is attached.
        */
       customer?: string;
+
+      /**
+       * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+       */
+      customer_balance?: PaymentMethodCreateParams.CustomerBalance;
 
       /**
        * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
@@ -960,6 +970,8 @@ declare module 'stripe' {
         token: string;
       }
 
+      interface CustomerBalance {}
+
       interface Eps {
         /**
          * The customer's bank.
@@ -1162,6 +1174,7 @@ declare module 'stripe' {
         | 'bancontact'
         | 'boleto'
         | 'card'
+        | 'customer_balance'
         | 'eps'
         | 'fpx'
         | 'giropay'
@@ -1351,6 +1364,7 @@ declare module 'stripe' {
         | 'boleto'
         | 'card'
         | 'card_present'
+        | 'customer_balance'
         | 'eps'
         | 'fpx'
         | 'giropay'

--- a/types/2020-08-27/Terminal/Configurations.d.ts
+++ b/types/2020-08-27/Terminal/Configurations.d.ts
@@ -1,0 +1,1075 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    namespace Terminal {
+      /**
+       * The Configuration object.
+       */
+      interface Configuration {
+        /**
+         * Unique identifier for the object.
+         */
+        id: string;
+
+        /**
+         * String representing the object's type. Objects of the same type share the same value.
+         */
+        object: 'terminal.configuration';
+
+        bbpos_wisepos_e?: Configuration.BbposWiseposE;
+
+        deleted?: void;
+
+        /**
+         * Whether this Configuration is the default for your account
+         */
+        is_account_default: boolean | null;
+
+        /**
+         * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+         */
+        livemode: boolean;
+
+        tipping?: Configuration.Tipping;
+
+        verifone_p400?: Configuration.VerifoneP400;
+      }
+
+      namespace Configuration {
+        interface BbposWiseposE {
+          /**
+           * A File ID representing an image you would like displayed on the reader.
+           */
+          splashscreen?: string | Stripe.File;
+        }
+
+        interface Tipping {
+          aud?: Tipping.Aud;
+
+          cad?: Tipping.Cad;
+
+          chf?: Tipping.Chf;
+
+          dkk?: Tipping.Dkk;
+
+          eur?: Tipping.Eur;
+
+          gbp?: Tipping.Gbp;
+
+          hkd?: Tipping.Hkd;
+
+          myr?: Tipping.Myr;
+
+          nok?: Tipping.Nok;
+
+          nzd?: Tipping.Nzd;
+
+          sek?: Tipping.Sek;
+
+          sgd?: Tipping.Sgd;
+
+          usd?: Tipping.Usd;
+        }
+
+        namespace Tipping {
+          interface Aud {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Cad {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Chf {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Dkk {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Eur {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Gbp {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Hkd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Myr {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Nok {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Nzd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Sek {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Sgd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Usd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts: Array<number> | null;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages: Array<number> | null;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+        }
+
+        interface VerifoneP400 {
+          /**
+           * A File ID representing an image you would like displayed on the reader.
+           */
+          splashscreen?: string | Stripe.File;
+        }
+      }
+
+      /**
+       * The DeletedConfiguration object.
+       */
+      interface DeletedConfiguration {
+        /**
+         * Unique identifier for the object.
+         */
+        id: string;
+
+        /**
+         * String representing the object's type. Objects of the same type share the same value.
+         */
+        object: 'terminal.configuration';
+
+        /**
+         * Always true for a deleted object
+         */
+        deleted: true;
+      }
+
+      interface ConfigurationCreateParams {
+        /**
+         * An object containing device type specific settings for BBPOS WisePOS E readers
+         */
+        bbpos_wisepos_e?: ConfigurationCreateParams.BbposWiseposE;
+
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+
+        /**
+         * Tipping configurations for readers supporting on-reader tips
+         */
+        tipping?: Stripe.Emptyable<ConfigurationCreateParams.Tipping>;
+
+        /**
+         * An object containing device type specific settings for Verifone P400 readers
+         */
+        verifone_p400?: ConfigurationCreateParams.VerifoneP400;
+      }
+
+      namespace ConfigurationCreateParams {
+        interface BbposWiseposE {
+          /**
+           * A File ID representing an image you would like displayed on the reader.
+           */
+          splashscreen?: Stripe.Emptyable<string>;
+        }
+
+        interface Tipping {
+          /**
+           * Tipping configuration for AUD
+           */
+          aud?: Tipping.Aud;
+
+          /**
+           * Tipping configuration for CAD
+           */
+          cad?: Tipping.Cad;
+
+          /**
+           * Tipping configuration for CHF
+           */
+          chf?: Tipping.Chf;
+
+          /**
+           * Tipping configuration for DKK
+           */
+          dkk?: Tipping.Dkk;
+
+          /**
+           * Tipping configuration for EUR
+           */
+          eur?: Tipping.Eur;
+
+          /**
+           * Tipping configuration for GBP
+           */
+          gbp?: Tipping.Gbp;
+
+          /**
+           * Tipping configuration for HKD
+           */
+          hkd?: Tipping.Hkd;
+
+          /**
+           * Tipping configuration for MYR
+           */
+          myr?: Tipping.Myr;
+
+          /**
+           * Tipping configuration for NOK
+           */
+          nok?: Tipping.Nok;
+
+          /**
+           * Tipping configuration for NZD
+           */
+          nzd?: Tipping.Nzd;
+
+          /**
+           * Tipping configuration for SEK
+           */
+          sek?: Tipping.Sek;
+
+          /**
+           * Tipping configuration for SGD
+           */
+          sgd?: Tipping.Sgd;
+
+          /**
+           * Tipping configuration for USD
+           */
+          usd?: Tipping.Usd;
+        }
+
+        namespace Tipping {
+          interface Aud {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Cad {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Chf {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Dkk {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Eur {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Gbp {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Hkd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Myr {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Nok {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Nzd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Sek {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Sgd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Usd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+        }
+
+        interface VerifoneP400 {
+          /**
+           * A File ID representing an image you would like displayed on the reader.
+           */
+          splashscreen?: Stripe.Emptyable<string>;
+        }
+      }
+
+      interface ConfigurationRetrieveParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      interface ConfigurationUpdateParams {
+        /**
+         * An object containing device type specific settings for BBPOS WisePOS E readers
+         */
+        bbpos_wisepos_e?: Stripe.Emptyable<
+          ConfigurationUpdateParams.BbposWiseposE
+        >;
+
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+
+        /**
+         * Tipping configurations for readers supporting on-reader tips
+         */
+        tipping?: Stripe.Emptyable<ConfigurationUpdateParams.Tipping>;
+
+        /**
+         * An object containing device type specific settings for Verifone P400 readers
+         */
+        verifone_p400?: Stripe.Emptyable<
+          ConfigurationUpdateParams.VerifoneP400
+        >;
+      }
+
+      namespace ConfigurationUpdateParams {
+        interface BbposWiseposE {
+          /**
+           * A File ID representing an image you would like displayed on the reader.
+           */
+          splashscreen?: Stripe.Emptyable<string>;
+        }
+
+        interface Tipping {
+          /**
+           * Tipping configuration for AUD
+           */
+          aud?: Tipping.Aud;
+
+          /**
+           * Tipping configuration for CAD
+           */
+          cad?: Tipping.Cad;
+
+          /**
+           * Tipping configuration for CHF
+           */
+          chf?: Tipping.Chf;
+
+          /**
+           * Tipping configuration for DKK
+           */
+          dkk?: Tipping.Dkk;
+
+          /**
+           * Tipping configuration for EUR
+           */
+          eur?: Tipping.Eur;
+
+          /**
+           * Tipping configuration for GBP
+           */
+          gbp?: Tipping.Gbp;
+
+          /**
+           * Tipping configuration for HKD
+           */
+          hkd?: Tipping.Hkd;
+
+          /**
+           * Tipping configuration for MYR
+           */
+          myr?: Tipping.Myr;
+
+          /**
+           * Tipping configuration for NOK
+           */
+          nok?: Tipping.Nok;
+
+          /**
+           * Tipping configuration for NZD
+           */
+          nzd?: Tipping.Nzd;
+
+          /**
+           * Tipping configuration for SEK
+           */
+          sek?: Tipping.Sek;
+
+          /**
+           * Tipping configuration for SGD
+           */
+          sgd?: Tipping.Sgd;
+
+          /**
+           * Tipping configuration for USD
+           */
+          usd?: Tipping.Usd;
+        }
+
+        namespace Tipping {
+          interface Aud {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Cad {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Chf {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Dkk {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Eur {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Gbp {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Hkd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Myr {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Nok {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Nzd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Sek {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Sgd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+
+          interface Usd {
+            /**
+             * Fixed amounts displayed when collecting a tip
+             */
+            fixed_amounts?: Array<number>;
+
+            /**
+             * Percentages displayed when collecting a tip
+             */
+            percentages?: Array<number>;
+
+            /**
+             * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+             */
+            smart_tip_threshold?: number;
+          }
+        }
+
+        interface VerifoneP400 {
+          /**
+           * A File ID representing an image you would like displayed on the reader.
+           */
+          splashscreen?: Stripe.Emptyable<string>;
+        }
+      }
+
+      interface ConfigurationListParams extends PaginationParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+
+        /**
+         * if present, only return the account default or non-default configurations.
+         */
+        is_account_default?: boolean;
+      }
+
+      interface ConfigurationDeleteParams {}
+
+      class ConfigurationsResource {
+        /**
+         * Creates a new Configuration object.
+         */
+        create(
+          params?: ConfigurationCreateParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Terminal.Configuration>>;
+        create(
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Terminal.Configuration>>;
+
+        /**
+         * Retrieves a Configuration object.
+         */
+        retrieve(
+          id: string,
+          params?: ConfigurationRetrieveParams,
+          options?: RequestOptions
+        ): Promise<
+          Stripe.Response<
+            Stripe.Terminal.Configuration | Stripe.Terminal.DeletedConfiguration
+          >
+        >;
+        retrieve(
+          id: string,
+          options?: RequestOptions
+        ): Promise<
+          Stripe.Response<
+            Stripe.Terminal.Configuration | Stripe.Terminal.DeletedConfiguration
+          >
+        >;
+
+        /**
+         * Updates a new Configuration object.
+         */
+        update(
+          id: string,
+          params?: ConfigurationUpdateParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Terminal.Configuration>>;
+
+        /**
+         * Returns a list of Configuration objects.
+         */
+        list(
+          params?: ConfigurationListParams,
+          options?: RequestOptions
+        ): ApiListPromise<Stripe.Terminal.Configuration>;
+        list(
+          options?: RequestOptions
+        ): ApiListPromise<Stripe.Terminal.Configuration>;
+
+        /**
+         * Deletes a Configuration object.
+         */
+        del(
+          id: string,
+          params?: ConfigurationDeleteParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Terminal.DeletedConfiguration>>;
+        del(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Terminal.DeletedConfiguration>>;
+      }
+    }
+  }
+}

--- a/types/2020-08-27/Terminal/Locations.d.ts
+++ b/types/2020-08-27/Terminal/Locations.d.ts
@@ -19,6 +19,11 @@ declare module 'stripe' {
 
         address: Stripe.Address;
 
+        /**
+         * The ID of a configuration that will be used to customize all readers in this location.
+         */
+        configuration_overrides?: string;
+
         deleted?: void;
 
         /**
@@ -67,6 +72,11 @@ declare module 'stripe' {
          * A name for the location.
          */
         display_name: string;
+
+        /**
+         * The ID of a configuration that will be used to customize all readers in this location.
+         */
+        configuration_overrides?: string;
 
         /**
          * Specifies which fields in the response should be expanded.
@@ -125,6 +135,11 @@ declare module 'stripe' {
          * The full address of the location.
          */
         address?: LocationUpdateParams.Address;
+
+        /**
+         * The ID of a configuration that will be used to customize all readers in this location.
+         */
+        configuration_overrides?: string;
 
         /**
          * A name for the location.

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -41,6 +41,7 @@
 ///<reference path='./FeeRefunds.d.ts' />
 ///<reference path='./FileLinks.d.ts' />
 ///<reference path='./Files.d.ts' />
+///<reference path='./FundingInstructions.d.ts' />
 ///<reference path='./Identity/VerificationReports.d.ts' />
 ///<reference path='./Identity/VerificationSessions.d.ts' />
 ///<reference path='./InvoiceItems.d.ts' />
@@ -94,6 +95,7 @@
 ///<reference path='./TaxDeductedAtSources.d.ts' />
 ///<reference path='./TaxIds.d.ts' />
 ///<reference path='./TaxRates.d.ts' />
+///<reference path='./Terminal/Configurations.d.ts' />
 ///<reference path='./Terminal/ConnectionTokens.d.ts' />
 ///<reference path='./Terminal/Locations.d.ts' />
 ///<reference path='./Terminal/Readers.d.ts' />
@@ -208,6 +210,7 @@ declare module 'stripe' {
       scheduledQueryRuns: Stripe.Sigma.ScheduledQueryRunsResource;
     };
     terminal: {
+      configurations: Stripe.Terminal.ConfigurationsResource;
       connectionTokens: Stripe.Terminal.ConnectionTokensResource;
       locations: Stripe.Terminal.LocationsResource;
       readers: Stripe.Terminal.ReadersResource;


### PR DESCRIPTION
Codegen for openapi a8928d0.
r? @dcr-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resources `FundingInstructions` and `Terminal.Configuration`
* Add support for `create_funding_instructions` method on resource `Customer`
* Add support for `customer_balance` on `Charge.payment_method_details`, `PaymentIntent.payment_method_options`, `PaymentIntentConfirmParams.payment_method_data`, `PaymentIntentConfirmParams.payment_method_options`, `PaymentIntentCreateParams.payment_method_data`, `PaymentIntentCreateParams.payment_method_options`, `PaymentIntentUpdateParams.payment_method_data`, `PaymentIntentUpdateParams.payment_method_options`, `PaymentMethodCreateParams`, and `PaymentMethod`
* Add support for `cash_balance` on `CustomerCreateParams` and `CustomerUpdateParams`
* Add support for new value `customer_balance` on enums `CustomerListPaymentMethodsParams.type` and `PaymentMethodListParams.type`
* Add support for new value `customer_balance` on enums `PaymentIntentConfirmParams.payment_method_data.type`, `PaymentIntentCreateParams.payment_method_data.type`, and `PaymentIntentUpdateParams.payment_method_data.type`
* Add support for `amount_details` on `PaymentIntent`
* Add support for `display_bank_transfer_instructions` on `PaymentIntent.next_action`
* Add support for new value `customer_balance` on enum `PaymentMethodCreateParams.type`
* Add support for new value `customer_balance` on enum `PaymentMethod.type`
* Add support for `configuration_overrides` on `Terminal.Location`, `TerminalLocationCreateParams`, and `TerminalLocationUpdateParams`

