### PR TITLE
API Updates

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -93,6 +93,7 @@ module.exports = {
     Readers: require('./resources/Terminal/Readers'),
   }),
   TestHelpers: resourceNamespace('testHelpers', {
+    Refunds: require('./resources/TestHelpers/Refunds'),
     TestClocks: require('./resources/TestHelpers/TestClocks'),
     Terminal: resourceNamespace('terminal', {
       Readers: require('./resources/TestHelpers/Terminal/Readers'),

--- a/lib/resources/TestHelpers/Refunds.js
+++ b/lib/resources/TestHelpers/Refunds.js
@@ -1,0 +1,15 @@
+// File generated from our OpenAPI spec
+
+'use strict';
+
+const StripeResource = require('../../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'test_helpers/refunds',
+
+  expire: stripeMethod({
+    method: 'POST',
+    path: '/{refund}/expire',
+  }),
+});

--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -441,6 +441,11 @@ describe('Refund', function() {
     const refunds = await stripe.refunds.list({limit: 3});
     expect(refunds).not.to.be.null;
   });
+
+  it('expire method', async function() {
+    const refund = await stripe.testHelpers.refunds.expire('re_123');
+    expect(refund).not.to.be.null;
+  });
 });
 
 describe('Token', function() {

--- a/types/2020-08-27/BillingPortal/Configurations.d.ts
+++ b/types/2020-08-27/BillingPortal/Configurations.d.ts
@@ -25,7 +25,7 @@ declare module 'stripe' {
         /**
          * ID of the Connect Application that created the configuration.
          */
-        application: string | null;
+        application: string | Stripe.Application | null;
 
         business_profile: Configuration.BusinessProfile;
 

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -979,7 +979,8 @@ declare module 'stripe' {
          * When a Customer is not created, you can still retrieve email, address, and other customer data entered in Checkout
          * with [customer_details](https://stripe.com/docs/api/checkout/sessions/object#checkout_session_object-customer_details).
          *
-         * Sessions that do not create Customers will instead create [Guest Customers](https://support.stripe.com/questions/guest-customer-faq) in the Dashboard.
+         * Sessions that don't create Customers instead create [Guest Customers](https://support.stripe.com/questions/guest-customer-faq)
+         * in the Dashboard. Promotion codes limited to first time customers will return invalid for these Sessions.
          *
          * Can only be set in `payment` and `setup` mode.
          */
@@ -1325,7 +1326,7 @@ declare module 'stripe' {
               name: string;
 
               /**
-               * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
+               * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
                */
               tax_code?: string;
             }
@@ -2009,7 +2010,7 @@ declare module 'stripe' {
             tax_behavior?: ShippingRateData.TaxBehavior;
 
             /**
-             * A [tax code](https://stripe.com/docs/tax/tax-codes) ID. The Shipping tax code is `txcd_92010001`.
+             * A [tax code](https://stripe.com/docs/tax/tax-categories) ID. The Shipping tax code is `txcd_92010001`.
              */
             tax_code?: string;
 

--- a/types/2020-08-27/Issuing/Disputes.d.ts
+++ b/types/2020-08-27/Issuing/Disputes.d.ts
@@ -320,11 +320,6 @@ declare module 'stripe' {
 
       interface DisputeCreateParams {
         /**
-         * The ID of the issuing transaction to create a dispute for.
-         */
-        transaction: string;
-
-        /**
          * Evidence provided for the dispute.
          */
         evidence?: DisputeCreateParams.Evidence;
@@ -338,6 +333,11 @@ declare module 'stripe' {
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
         metadata?: Stripe.MetadataParam;
+
+        /**
+         * The ID of the issuing transaction to create a dispute for. For transaction on Treasury FinancialAccounts, use `treasury.received_debit`.
+         */
+        transaction?: string;
       }
 
       namespace DisputeCreateParams {
@@ -973,7 +973,10 @@ declare module 'stripe' {
          * Creates an Issuing Dispute object. Individual pieces of evidence within the evidence object are optional at this point. Stripe only validates that required evidence is present during submission. Refer to [Dispute reasons and evidence](https://stripe.com/docs/issuing/purchases/disputes#dispute-reasons-and-evidence) for more details about evidence requirements.
          */
         create(
-          params: DisputeCreateParams,
+          params?: DisputeCreateParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
+        create(
           options?: RequestOptions
         ): Promise<Stripe.Response<Stripe.Issuing.Dispute>>;
 

--- a/types/2020-08-27/Plans.d.ts
+++ b/types/2020-08-27/Plans.d.ts
@@ -309,7 +309,7 @@ declare module 'stripe' {
         statement_descriptor?: string;
 
         /**
-         * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
+         * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
          */
         tax_code?: string;
 

--- a/types/2020-08-27/Prices.d.ts
+++ b/types/2020-08-27/Prices.d.ts
@@ -335,7 +335,7 @@ declare module 'stripe' {
         statement_descriptor?: string;
 
         /**
-         * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
+         * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
          */
         tax_code?: string;
 

--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -84,7 +84,7 @@ declare module 'stripe' {
       statement_descriptor: string | null;
 
       /**
-       * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
+       * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
        */
       tax_code: string | Stripe.TaxCode | null;
 
@@ -225,7 +225,7 @@ declare module 'stripe' {
       statement_descriptor?: string;
 
       /**
-       * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
+       * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
        */
       tax_code?: string;
 
@@ -345,7 +345,7 @@ declare module 'stripe' {
       statement_descriptor?: string;
 
       /**
-       * A [tax code](https://stripe.com/docs/tax/tax-codes) ID.
+       * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
        */
       tax_code?: Stripe.Emptyable<string>;
 

--- a/types/2020-08-27/ShippingRates.d.ts
+++ b/types/2020-08-27/ShippingRates.d.ts
@@ -54,7 +54,7 @@ declare module 'stripe' {
       tax_behavior: ShippingRate.TaxBehavior | null;
 
       /**
-       * A [tax code](https://stripe.com/docs/tax/tax-codes) ID. The Shipping tax code is `txcd_92010001`.
+       * A [tax code](https://stripe.com/docs/tax/tax-categories) ID. The Shipping tax code is `txcd_92010001`.
        */
       tax_code: string | Stripe.TaxCode | null;
 
@@ -158,7 +158,7 @@ declare module 'stripe' {
       tax_behavior?: ShippingRateCreateParams.TaxBehavior;
 
       /**
-       * A [tax code](https://stripe.com/docs/tax/tax-codes) ID. The Shipping tax code is `txcd_92010001`.
+       * A [tax code](https://stripe.com/docs/tax/tax-categories) ID. The Shipping tax code is `txcd_92010001`.
        */
       tax_code?: string;
 

--- a/types/2020-08-27/TaxCodes.d.ts
+++ b/types/2020-08-27/TaxCodes.d.ts
@@ -56,7 +56,7 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.TaxCode>>;
 
       /**
-       * A list of [all tax codes available](https://stripe.com/docs/tax/tax-codes) to add to Products in order to allow specific tax calculations.
+       * A list of [all tax codes available](https://stripe.com/docs/tax/tax-categories) to add to Products in order to allow specific tax calculations.
        */
       list(
         params?: TaxCodeListParams,

--- a/types/2020-08-27/TestHelpers/Refunds.d.ts
+++ b/types/2020-08-27/TestHelpers/Refunds.d.ts
@@ -1,0 +1,29 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    namespace TestHelpers {
+      interface RefundExpireParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      class RefundsResource {
+        /**
+         * Expire a refund with a status of requires_action.
+         */
+        expire(
+          id: string,
+          params?: RefundExpireParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Refund>>;
+        expire(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.Refund>>;
+      }
+    }
+  }
+}

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -99,6 +99,7 @@
 ///<reference path='./Terminal/ConnectionTokens.d.ts' />
 ///<reference path='./Terminal/Locations.d.ts' />
 ///<reference path='./Terminal/Readers.d.ts' />
+///<reference path='./TestHelpers/Refunds.d.ts' />
 ///<reference path='./TestHelpers/Terminal/Readers.d.ts' />
 ///<reference path='./TestHelpers/TestClocks.d.ts' />
 ///<reference path='./Tokens.d.ts' />
@@ -217,6 +218,7 @@ declare module 'stripe' {
     };
     testHelpers: {
       testClocks: Stripe.TestHelpers.TestClocksResource;
+      refunds: Stripe.TestHelpers.RefundsResource;
       terminal: {
         readers: Stripe.TestHelpers.Terminal.ReadersResource;
       };


### PR DESCRIPTION
Codegen for openapi e07f049.
r? @pakrym-stripe (test_helpers expertise)
cc @stripe/api-libraries

## Changelog
* Add support for `expire` test helper method on resource `Refund`
* Change type of `BillingPortal.Configuration.application` from `string` to `expandable($Application)`
* Change `IssuingDisputeCreateParams.transaction` to be optional

