### PR TITLE
Split CI into two stages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,12 +76,12 @@ jobs:
       - name: Start stripe-mock
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
-      - name: Install dependencies (8)
-        if: ${{ matrix.node_version == "8" }}
+      - name: Install dependencies (Node.js 8)
+        if: ${{ matrix.node_version == '8' }}
         run: yarn install --ignore-engines
 
       - name: Install dependencies
-        if: ${{ matrix.node_version != "8" }}
+        if: ${{ matrix.node_version != '8' }}
         run: yarn install
 
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,5 +1,3 @@
-# This is a basic workflow to help you get started with Actions
-
 name: CI
 
 on:
@@ -13,17 +11,50 @@ on:
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [ '10', '12', '14', '16' ]
 
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup node
         uses: actions/setup-node@v2
+
+      - name: Get yarn cache directory path
+        id: yarn-cache-dir-path
+        run: echo "::set-output name=dir::$(yarn cache dir)"
+
+      - uses: actions/cache@v2
+        id: yarn-cache
         with:
-          node-version: ${{ matrix.node }}
+          path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-yarn-
+
+      - name: Node check
+        run: find . -name "*.js" -type f -not -path "./node_modules/*" -not -path "./\.*" -exec node --check {} \;
+
+      - name: Lint
+        run: yarn && yarn lint
+
+  test:
+    needs: [build]
+    strategy:
+      matrix:
+        os:
+          - "ubuntu-latest"
+        node:
+          - "16"
+          - "14"
+          - "12"
+          - "10"
+          - "8"
+    name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Setup node
+        uses: actions/setup-node@v2
 
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,11 +77,11 @@ jobs:
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
       - name: Install dependencies (8)
-        if: ${{ matrix.node_version == 8 }}
+        if: ${{ matrix.node_version == "8" }}
         run: yarn install --ignore-engines
 
       - name: Install dependencies
-        if: ${{ matrix.node_version != 8 }}
+        if: ${{ matrix.node_version != "8" }}
         run: yarn install
 
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,6 +55,8 @@ jobs:
 
       - name: Setup node
         uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node }}
 
       - name: Print Node.js version
         run: node -v

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,11 +77,11 @@ jobs:
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
       - name: Install dependencies (Node.js 8)
-        if: ${{ matrix.node_version == '8' }}
+        if: ${{ matrix.node == '8' }}
         run: yarn install --ignore-engines
 
       - name: Install dependencies
-        if: ${{ matrix.node_version != '8' }}
+        if: ${{ matrix.node != '8' }}
         run: yarn install
 
       - name: Test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,11 +43,11 @@ jobs:
         os:
           - "ubuntu-latest"
         node:
+          - "18"
           - "16"
           - "14"
           - "12"
           - "10"
-          - "8"
     name: Node.js ${{ matrix.node }} on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     steps:
@@ -76,13 +76,5 @@ jobs:
       - name: Start stripe-mock
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
-      - name: Install dependencies (Node.js 8)
-        if: ${{ matrix.node == '8' }}
-        run: yarn install --ignore-engines
-
-      - name: Install dependencies
-        if: ${{ matrix.node != '8' }}
-        run: yarn install
-
       - name: Test
-        run: yarn test
+        run: yarn && yarn test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,5 +76,13 @@ jobs:
       - name: Start stripe-mock
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
+      - name: Install dependencies (8)
+        if: ${{ matrix.node_version == 8 }}
+        run: yarn install --ignore-engines
+
+      - name: Install dependencies
+        if: ${{ matrix.node_version != 8 }}
+        run: yarn install
+
       - name: Test
-        run: yarn install --production --ignore-engines && yarn test
+        run: yarn test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -71,5 +71,5 @@ jobs:
       - name: Start stripe-mock
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
-      - name: Lint, typecheck, and test
+      - name: Test
         run: yarn && yarn test

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -56,6 +56,9 @@ jobs:
       - name: Setup node
         uses: actions/setup-node@v2
 
+      - name: Print Node.js version
+        run: node -v
+
       - name: Get yarn cache directory path
         id: yarn-cache-dir-path
         run: echo "::set-output name=dir::$(yarn cache dir)"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -77,4 +77,4 @@ jobs:
         run: docker run -d -p 12111-12112:12111-12112 stripe/stripe-mock && sleep 5
 
       - name: Test
-        run: yarn && yarn test
+        run: yarn install --production --ignore-engines && yarn test

--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "clean": "rm -rf ./.nyc_output ./node_modules/.cache ./coverage",
     "mocha": "nyc mocha --config=test/.mocharc.js",
     "mocha-only": "mocha --config=test/.mocharc.js",
-    "test": "yarn lint && yarn test-typescript && yarn mocha",
+    "test": "yarn test-typescript && yarn mocha",
     "test-typescript": "tsc --build types/test",
     "lint": "eslint --ext .js,.jsx,.ts .",
     "fix": "yarn lint --fix && ./scripts/updateAPIVersion.js",


### PR DESCRIPTION
Split CI into build stage that builds and lints on the latest Node.js and test stage that tests on each Node.js version that is supported by us. 