### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -1900,6 +1900,11 @@ declare module 'stripe' {
         political_exposure?: Individual.PoliticalExposure;
 
         /**
+         * The individual's registered address.
+         */
+        registered_address?: Individual.RegisteredAddress;
+
+        /**
          * The last four digits of the individual's Social Security Number (U.S. only).
          */
         ssn_last_4?: string;
@@ -1933,6 +1938,10 @@ declare module 'stripe' {
         }
 
         type PoliticalExposure = 'existing' | 'none';
+
+        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
 
         interface Verification {
           /**
@@ -2981,6 +2990,11 @@ declare module 'stripe' {
         political_exposure?: Individual.PoliticalExposure;
 
         /**
+         * The individual's registered address.
+         */
+        registered_address?: Individual.RegisteredAddress;
+
+        /**
          * The last four digits of the individual's Social Security Number (U.S. only).
          */
         ssn_last_4?: string;
@@ -3014,6 +3028,10 @@ declare module 'stripe' {
         }
 
         type PoliticalExposure = 'existing' | 'none';
+
+        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
 
         interface Verification {
           /**

--- a/types/2020-08-27/Issuing/Cardholders.d.ts
+++ b/types/2020-08-27/Issuing/Cardholders.d.ts
@@ -781,7 +781,7 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per interval.
+             * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
              */
             amount: number;
 

--- a/types/2020-08-27/Issuing/Cards.d.ts
+++ b/types/2020-08-27/Issuing/Cards.d.ts
@@ -787,7 +787,7 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per interval.
+             * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
              */
             amount: number;
 

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -225,7 +225,7 @@ declare module 'stripe' {
           /**
            * Portion of the amount that corresponds to a tip.
            */
-          amount: number | null;
+          amount?: number;
         }
       }
 

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -122,6 +122,8 @@ declare module 'stripe' {
        */
       political_exposure?: Person.PoliticalExposure;
 
+      registered_address?: Stripe.Address;
+
       relationship?: Person.Relationship;
 
       /**
@@ -690,6 +692,11 @@ declare module 'stripe' {
       political_exposure?: string;
 
       /**
+       * The person's registered address.
+       */
+      registered_address?: PersonCreateParams.RegisteredAddress;
+
+      /**
        * The relationship that this person has with the account's legal entity.
        */
       relationship?: PersonCreateParams.Relationship;
@@ -765,6 +772,10 @@ declare module 'stripe' {
            */
           files?: Array<string>;
         }
+      }
+
+      interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+        line1?: string;
       }
 
       interface Relationship {
@@ -957,6 +968,11 @@ declare module 'stripe' {
       political_exposure?: string;
 
       /**
+       * The person's registered address.
+       */
+      registered_address?: PersonUpdateParams.RegisteredAddress;
+
+      /**
        * The relationship that this person has with the account's legal entity.
        */
       relationship?: PersonUpdateParams.Relationship;
@@ -1032,6 +1048,10 @@ declare module 'stripe' {
            */
           files?: Array<string>;
         }
+      }
+
+      interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+        line1?: string;
       }
 
       interface Relationship {

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -492,6 +492,12 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method)
+       * value in the SetupIntent.
+       */
+      payment_method_data?: SetupIntentCreateParams.PaymentMethodData;
+
+      /**
        * Payment-method-specific configuration for this SetupIntent.
        */
       payment_method_options?: SetupIntentCreateParams.PaymentMethodOptions;
@@ -565,6 +571,471 @@ declare module 'stripe' {
 
           type Type = 'offline' | 'online';
         }
+      }
+
+      interface PaymentMethodData {
+        /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
+         * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
+         */
+        alipay?: PaymentMethodData.Alipay;
+
+        /**
+         * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+         */
+        au_becs_debit?: PaymentMethodData.AuBecsDebit;
+
+        /**
+         * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+         */
+        bacs_debit?: PaymentMethodData.BacsDebit;
+
+        /**
+         * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+         */
+        bancontact?: PaymentMethodData.Bancontact;
+
+        /**
+         * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+         */
+        billing_details?: PaymentMethodData.BillingDetails;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
+         * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+         */
+        customer_balance?: PaymentMethodData.CustomerBalance;
+
+        /**
+         * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+         */
+        eps?: PaymentMethodData.Eps;
+
+        /**
+         * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
+         */
+        fpx?: PaymentMethodData.Fpx;
+
+        /**
+         * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+         */
+        giropay?: PaymentMethodData.Giropay;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
+         */
+        grabpay?: PaymentMethodData.Grabpay;
+
+        /**
+         * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
+         */
+        ideal?: PaymentMethodData.Ideal;
+
+        /**
+         * If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
+         */
+        interac_present?: PaymentMethodData.InteracPresent;
+
+        /**
+         * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
+         */
+        klarna?: PaymentMethodData.Klarna;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.MetadataParam;
+
+        /**
+         * If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
+         */
+        oxxo?: PaymentMethodData.Oxxo;
+
+        /**
+         * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+         */
+        p24?: PaymentMethodData.P24;
+
+        /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
+         * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+         */
+        sepa_debit?: PaymentMethodData.SepaDebit;
+
+        /**
+         * If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
+         */
+        sofort?: PaymentMethodData.Sofort;
+
+        /**
+         * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+         */
+        type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
+      }
+
+      namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
+        interface AfterpayClearpay {}
+
+        interface Alipay {}
+
+        interface AuBecsDebit {
+          /**
+           * The account number for the bank account.
+           */
+          account_number: string;
+
+          /**
+           * Bank-State-Branch number of the bank account.
+           */
+          bsb_number: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Account number of the bank account that the funds will be debited from.
+           */
+          account_number?: string;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code?: string;
+        }
+
+        interface Bancontact {}
+
+        interface BillingDetails {
+          /**
+           * Billing address.
+           */
+          address?: Stripe.Emptyable<BillingDetails.Address>;
+
+          /**
+           * Email address.
+           */
+          email?: Stripe.Emptyable<string>;
+
+          /**
+           * Full name.
+           */
+          name?: string;
+
+          /**
+           * Billing phone number (including extension).
+           */
+          phone?: string;
+        }
+
+        namespace BillingDetails {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
+        }
+
+        interface Boleto {
+          /**
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
+           */
+          tax_id: string;
+        }
+
+        interface CustomerBalance {}
+
+        interface Eps {
+          /**
+           * The customer's bank.
+           */
+          bank?: Eps.Bank;
+        }
+
+        namespace Eps {
+          type Bank =
+            | 'arzte_und_apotheker_bank'
+            | 'austrian_anadi_bank_ag'
+            | 'bank_austria'
+            | 'bankhaus_carl_spangler'
+            | 'bankhaus_schelhammer_und_schattera_ag'
+            | 'bawag_psk_ag'
+            | 'bks_bank_ag'
+            | 'brull_kallmus_bank_ag'
+            | 'btv_vier_lander_bank'
+            | 'capital_bank_grawe_gruppe_ag'
+            | 'dolomitenbank'
+            | 'easybank_ag'
+            | 'erste_bank_und_sparkassen'
+            | 'hypo_alpeadriabank_international_ag'
+            | 'hypo_bank_burgenland_aktiengesellschaft'
+            | 'hypo_noe_lb_fur_niederosterreich_u_wien'
+            | 'hypo_oberosterreich_salzburg_steiermark'
+            | 'hypo_tirol_bank_ag'
+            | 'hypo_vorarlberg_bank_ag'
+            | 'marchfelder_bank'
+            | 'oberbank_ag'
+            | 'raiffeisen_bankengruppe_osterreich'
+            | 'schoellerbank_ag'
+            | 'sparda_bank_wien'
+            | 'volksbank_gruppe'
+            | 'volkskreditbank_ag'
+            | 'vr_bank_braunau';
+        }
+
+        interface Fpx {
+          /**
+           * Account holder type for FPX transaction
+           */
+          account_holder_type?: Fpx.AccountHolderType;
+
+          /**
+           * The customer's bank.
+           */
+          bank: Fpx.Bank;
+        }
+
+        namespace Fpx {
+          type AccountHolderType = 'company' | 'individual';
+
+          type Bank =
+            | 'affin_bank'
+            | 'agrobank'
+            | 'alliance_bank'
+            | 'ambank'
+            | 'bank_islam'
+            | 'bank_muamalat'
+            | 'bank_rakyat'
+            | 'bsn'
+            | 'cimb'
+            | 'deutsche_bank'
+            | 'hong_leong_bank'
+            | 'hsbc'
+            | 'kfh'
+            | 'maybank2e'
+            | 'maybank2u'
+            | 'ocbc'
+            | 'pb_enterprise'
+            | 'public_bank'
+            | 'rhb'
+            | 'standard_chartered'
+            | 'uob';
+        }
+
+        interface Giropay {}
+
+        interface Grabpay {}
+
+        interface Ideal {
+          /**
+           * The customer's bank.
+           */
+          bank?: Ideal.Bank;
+        }
+
+        namespace Ideal {
+          type Bank =
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'revolut'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+        }
+
+        interface InteracPresent {}
+
+        interface Klarna {
+          /**
+           * Customer's date of birth
+           */
+          dob?: Klarna.Dob;
+        }
+
+        namespace Klarna {
+          interface Dob {
+            /**
+             * The day of birth, between 1 and 31.
+             */
+            day: number;
+
+            /**
+             * The month of birth, between 1 and 12.
+             */
+            month: number;
+
+            /**
+             * The four-digit year of birth.
+             */
+            year: number;
+          }
+        }
+
+        interface Konbini {}
+
+        interface Oxxo {}
+
+        interface P24 {
+          /**
+           * The customer's bank.
+           */
+          bank?: P24.Bank;
+        }
+
+        namespace P24 {
+          type Bank =
+            | 'alior_bank'
+            | 'bank_millennium'
+            | 'bank_nowy_bfg_sa'
+            | 'bank_pekao_sa'
+            | 'banki_spbdzielcze'
+            | 'blik'
+            | 'bnp_paribas'
+            | 'boz'
+            | 'citi_handlowy'
+            | 'credit_agricole'
+            | 'envelobank'
+            | 'etransfer_pocztowy24'
+            | 'getin_bank'
+            | 'ideabank'
+            | 'ing'
+            | 'inteligo'
+            | 'mbank_mtransfer'
+            | 'nest_przelew'
+            | 'noble_pay'
+            | 'pbac_z_ipko'
+            | 'plus_bank'
+            | 'santander_przelew24'
+            | 'tmobile_usbugi_bankowe'
+            | 'toyota_bank'
+            | 'volkswagen_bank';
+        }
+
+        interface Paynow {}
+
+        interface SepaDebit {
+          /**
+           * IBAN of the bank account.
+           */
+          iban: string;
+        }
+
+        interface Sofort {
+          /**
+           * Two-letter ISO code representing the country the bank account is located in.
+           */
+          country: Sofort.Country;
+        }
+
+        namespace Sofort {
+          type Country = 'AT' | 'BE' | 'DE' | 'ES' | 'IT' | 'NL';
+        }
+
+        type Type =
+          | 'acss_debit'
+          | 'afterpay_clearpay'
+          | 'alipay'
+          | 'au_becs_debit'
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'boleto'
+          | 'customer_balance'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'grabpay'
+          | 'ideal'
+          | 'klarna'
+          | 'konbini'
+          | 'oxxo'
+          | 'p24'
+          | 'paynow'
+          | 'sepa_debit'
+          | 'sofort'
+          | 'us_bank_account'
+          | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {
@@ -810,6 +1281,12 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method)
+       * value in the SetupIntent.
+       */
+      payment_method_data?: SetupIntentUpdateParams.PaymentMethodData;
+
+      /**
        * Payment-method-specific configuration for this SetupIntent.
        */
       payment_method_options?: SetupIntentUpdateParams.PaymentMethodOptions;
@@ -821,6 +1298,471 @@ declare module 'stripe' {
     }
 
     namespace SetupIntentUpdateParams {
+      interface PaymentMethodData {
+        /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
+         * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
+         */
+        alipay?: PaymentMethodData.Alipay;
+
+        /**
+         * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+         */
+        au_becs_debit?: PaymentMethodData.AuBecsDebit;
+
+        /**
+         * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+         */
+        bacs_debit?: PaymentMethodData.BacsDebit;
+
+        /**
+         * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+         */
+        bancontact?: PaymentMethodData.Bancontact;
+
+        /**
+         * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+         */
+        billing_details?: PaymentMethodData.BillingDetails;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
+         * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+         */
+        customer_balance?: PaymentMethodData.CustomerBalance;
+
+        /**
+         * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+         */
+        eps?: PaymentMethodData.Eps;
+
+        /**
+         * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
+         */
+        fpx?: PaymentMethodData.Fpx;
+
+        /**
+         * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+         */
+        giropay?: PaymentMethodData.Giropay;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
+         */
+        grabpay?: PaymentMethodData.Grabpay;
+
+        /**
+         * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
+         */
+        ideal?: PaymentMethodData.Ideal;
+
+        /**
+         * If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
+         */
+        interac_present?: PaymentMethodData.InteracPresent;
+
+        /**
+         * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
+         */
+        klarna?: PaymentMethodData.Klarna;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.MetadataParam;
+
+        /**
+         * If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
+         */
+        oxxo?: PaymentMethodData.Oxxo;
+
+        /**
+         * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+         */
+        p24?: PaymentMethodData.P24;
+
+        /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
+         * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+         */
+        sepa_debit?: PaymentMethodData.SepaDebit;
+
+        /**
+         * If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
+         */
+        sofort?: PaymentMethodData.Sofort;
+
+        /**
+         * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+         */
+        type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
+      }
+
+      namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
+        interface AfterpayClearpay {}
+
+        interface Alipay {}
+
+        interface AuBecsDebit {
+          /**
+           * The account number for the bank account.
+           */
+          account_number: string;
+
+          /**
+           * Bank-State-Branch number of the bank account.
+           */
+          bsb_number: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Account number of the bank account that the funds will be debited from.
+           */
+          account_number?: string;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code?: string;
+        }
+
+        interface Bancontact {}
+
+        interface BillingDetails {
+          /**
+           * Billing address.
+           */
+          address?: Stripe.Emptyable<BillingDetails.Address>;
+
+          /**
+           * Email address.
+           */
+          email?: Stripe.Emptyable<string>;
+
+          /**
+           * Full name.
+           */
+          name?: string;
+
+          /**
+           * Billing phone number (including extension).
+           */
+          phone?: string;
+        }
+
+        namespace BillingDetails {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
+        }
+
+        interface Boleto {
+          /**
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
+           */
+          tax_id: string;
+        }
+
+        interface CustomerBalance {}
+
+        interface Eps {
+          /**
+           * The customer's bank.
+           */
+          bank?: Eps.Bank;
+        }
+
+        namespace Eps {
+          type Bank =
+            | 'arzte_und_apotheker_bank'
+            | 'austrian_anadi_bank_ag'
+            | 'bank_austria'
+            | 'bankhaus_carl_spangler'
+            | 'bankhaus_schelhammer_und_schattera_ag'
+            | 'bawag_psk_ag'
+            | 'bks_bank_ag'
+            | 'brull_kallmus_bank_ag'
+            | 'btv_vier_lander_bank'
+            | 'capital_bank_grawe_gruppe_ag'
+            | 'dolomitenbank'
+            | 'easybank_ag'
+            | 'erste_bank_und_sparkassen'
+            | 'hypo_alpeadriabank_international_ag'
+            | 'hypo_bank_burgenland_aktiengesellschaft'
+            | 'hypo_noe_lb_fur_niederosterreich_u_wien'
+            | 'hypo_oberosterreich_salzburg_steiermark'
+            | 'hypo_tirol_bank_ag'
+            | 'hypo_vorarlberg_bank_ag'
+            | 'marchfelder_bank'
+            | 'oberbank_ag'
+            | 'raiffeisen_bankengruppe_osterreich'
+            | 'schoellerbank_ag'
+            | 'sparda_bank_wien'
+            | 'volksbank_gruppe'
+            | 'volkskreditbank_ag'
+            | 'vr_bank_braunau';
+        }
+
+        interface Fpx {
+          /**
+           * Account holder type for FPX transaction
+           */
+          account_holder_type?: Fpx.AccountHolderType;
+
+          /**
+           * The customer's bank.
+           */
+          bank: Fpx.Bank;
+        }
+
+        namespace Fpx {
+          type AccountHolderType = 'company' | 'individual';
+
+          type Bank =
+            | 'affin_bank'
+            | 'agrobank'
+            | 'alliance_bank'
+            | 'ambank'
+            | 'bank_islam'
+            | 'bank_muamalat'
+            | 'bank_rakyat'
+            | 'bsn'
+            | 'cimb'
+            | 'deutsche_bank'
+            | 'hong_leong_bank'
+            | 'hsbc'
+            | 'kfh'
+            | 'maybank2e'
+            | 'maybank2u'
+            | 'ocbc'
+            | 'pb_enterprise'
+            | 'public_bank'
+            | 'rhb'
+            | 'standard_chartered'
+            | 'uob';
+        }
+
+        interface Giropay {}
+
+        interface Grabpay {}
+
+        interface Ideal {
+          /**
+           * The customer's bank.
+           */
+          bank?: Ideal.Bank;
+        }
+
+        namespace Ideal {
+          type Bank =
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'revolut'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+        }
+
+        interface InteracPresent {}
+
+        interface Klarna {
+          /**
+           * Customer's date of birth
+           */
+          dob?: Klarna.Dob;
+        }
+
+        namespace Klarna {
+          interface Dob {
+            /**
+             * The day of birth, between 1 and 31.
+             */
+            day: number;
+
+            /**
+             * The month of birth, between 1 and 12.
+             */
+            month: number;
+
+            /**
+             * The four-digit year of birth.
+             */
+            year: number;
+          }
+        }
+
+        interface Konbini {}
+
+        interface Oxxo {}
+
+        interface P24 {
+          /**
+           * The customer's bank.
+           */
+          bank?: P24.Bank;
+        }
+
+        namespace P24 {
+          type Bank =
+            | 'alior_bank'
+            | 'bank_millennium'
+            | 'bank_nowy_bfg_sa'
+            | 'bank_pekao_sa'
+            | 'banki_spbdzielcze'
+            | 'blik'
+            | 'bnp_paribas'
+            | 'boz'
+            | 'citi_handlowy'
+            | 'credit_agricole'
+            | 'envelobank'
+            | 'etransfer_pocztowy24'
+            | 'getin_bank'
+            | 'ideabank'
+            | 'ing'
+            | 'inteligo'
+            | 'mbank_mtransfer'
+            | 'nest_przelew'
+            | 'noble_pay'
+            | 'pbac_z_ipko'
+            | 'plus_bank'
+            | 'santander_przelew24'
+            | 'tmobile_usbugi_bankowe'
+            | 'toyota_bank'
+            | 'volkswagen_bank';
+        }
+
+        interface Paynow {}
+
+        interface SepaDebit {
+          /**
+           * IBAN of the bank account.
+           */
+          iban: string;
+        }
+
+        interface Sofort {
+          /**
+           * Two-letter ISO code representing the country the bank account is located in.
+           */
+          country: Sofort.Country;
+        }
+
+        namespace Sofort {
+          type Country = 'AT' | 'BE' | 'DE' | 'ES' | 'IT' | 'NL';
+        }
+
+        type Type =
+          | 'acss_debit'
+          | 'afterpay_clearpay'
+          | 'alipay'
+          | 'au_becs_debit'
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'boleto'
+          | 'customer_balance'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'grabpay'
+          | 'ideal'
+          | 'klarna'
+          | 'konbini'
+          | 'oxxo'
+          | 'p24'
+          | 'paynow'
+          | 'sepa_debit'
+          | 'sofort'
+          | 'us_bank_account'
+          | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
+
+        interface WechatPay {}
+      }
+
       interface PaymentMethodOptions {
         /**
          * If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
@@ -1069,6 +2011,12 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method)
+       * value in the SetupIntent.
+       */
+      payment_method_data?: SetupIntentConfirmParams.PaymentMethodData;
+
+      /**
        * Payment-method-specific configuration for this SetupIntent.
        */
       payment_method_options?: SetupIntentConfirmParams.PaymentMethodOptions;
@@ -1164,6 +2112,471 @@ declare module 'stripe' {
             user_agent?: string;
           }
         }
+      }
+
+      interface PaymentMethodData {
+        /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
+         * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
+         */
+        alipay?: PaymentMethodData.Alipay;
+
+        /**
+         * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+         */
+        au_becs_debit?: PaymentMethodData.AuBecsDebit;
+
+        /**
+         * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+         */
+        bacs_debit?: PaymentMethodData.BacsDebit;
+
+        /**
+         * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+         */
+        bancontact?: PaymentMethodData.Bancontact;
+
+        /**
+         * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+         */
+        billing_details?: PaymentMethodData.BillingDetails;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
+         * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+         */
+        customer_balance?: PaymentMethodData.CustomerBalance;
+
+        /**
+         * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+         */
+        eps?: PaymentMethodData.Eps;
+
+        /**
+         * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
+         */
+        fpx?: PaymentMethodData.Fpx;
+
+        /**
+         * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+         */
+        giropay?: PaymentMethodData.Giropay;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
+         */
+        grabpay?: PaymentMethodData.Grabpay;
+
+        /**
+         * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
+         */
+        ideal?: PaymentMethodData.Ideal;
+
+        /**
+         * If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
+         */
+        interac_present?: PaymentMethodData.InteracPresent;
+
+        /**
+         * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
+         */
+        klarna?: PaymentMethodData.Klarna;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.MetadataParam;
+
+        /**
+         * If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
+         */
+        oxxo?: PaymentMethodData.Oxxo;
+
+        /**
+         * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+         */
+        p24?: PaymentMethodData.P24;
+
+        /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
+         * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+         */
+        sepa_debit?: PaymentMethodData.SepaDebit;
+
+        /**
+         * If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
+         */
+        sofort?: PaymentMethodData.Sofort;
+
+        /**
+         * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+         */
+        type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
+      }
+
+      namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
+        interface AfterpayClearpay {}
+
+        interface Alipay {}
+
+        interface AuBecsDebit {
+          /**
+           * The account number for the bank account.
+           */
+          account_number: string;
+
+          /**
+           * Bank-State-Branch number of the bank account.
+           */
+          bsb_number: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Account number of the bank account that the funds will be debited from.
+           */
+          account_number?: string;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code?: string;
+        }
+
+        interface Bancontact {}
+
+        interface BillingDetails {
+          /**
+           * Billing address.
+           */
+          address?: Stripe.Emptyable<BillingDetails.Address>;
+
+          /**
+           * Email address.
+           */
+          email?: Stripe.Emptyable<string>;
+
+          /**
+           * Full name.
+           */
+          name?: string;
+
+          /**
+           * Billing phone number (including extension).
+           */
+          phone?: string;
+        }
+
+        namespace BillingDetails {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
+        }
+
+        interface Boleto {
+          /**
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
+           */
+          tax_id: string;
+        }
+
+        interface CustomerBalance {}
+
+        interface Eps {
+          /**
+           * The customer's bank.
+           */
+          bank?: Eps.Bank;
+        }
+
+        namespace Eps {
+          type Bank =
+            | 'arzte_und_apotheker_bank'
+            | 'austrian_anadi_bank_ag'
+            | 'bank_austria'
+            | 'bankhaus_carl_spangler'
+            | 'bankhaus_schelhammer_und_schattera_ag'
+            | 'bawag_psk_ag'
+            | 'bks_bank_ag'
+            | 'brull_kallmus_bank_ag'
+            | 'btv_vier_lander_bank'
+            | 'capital_bank_grawe_gruppe_ag'
+            | 'dolomitenbank'
+            | 'easybank_ag'
+            | 'erste_bank_und_sparkassen'
+            | 'hypo_alpeadriabank_international_ag'
+            | 'hypo_bank_burgenland_aktiengesellschaft'
+            | 'hypo_noe_lb_fur_niederosterreich_u_wien'
+            | 'hypo_oberosterreich_salzburg_steiermark'
+            | 'hypo_tirol_bank_ag'
+            | 'hypo_vorarlberg_bank_ag'
+            | 'marchfelder_bank'
+            | 'oberbank_ag'
+            | 'raiffeisen_bankengruppe_osterreich'
+            | 'schoellerbank_ag'
+            | 'sparda_bank_wien'
+            | 'volksbank_gruppe'
+            | 'volkskreditbank_ag'
+            | 'vr_bank_braunau';
+        }
+
+        interface Fpx {
+          /**
+           * Account holder type for FPX transaction
+           */
+          account_holder_type?: Fpx.AccountHolderType;
+
+          /**
+           * The customer's bank.
+           */
+          bank: Fpx.Bank;
+        }
+
+        namespace Fpx {
+          type AccountHolderType = 'company' | 'individual';
+
+          type Bank =
+            | 'affin_bank'
+            | 'agrobank'
+            | 'alliance_bank'
+            | 'ambank'
+            | 'bank_islam'
+            | 'bank_muamalat'
+            | 'bank_rakyat'
+            | 'bsn'
+            | 'cimb'
+            | 'deutsche_bank'
+            | 'hong_leong_bank'
+            | 'hsbc'
+            | 'kfh'
+            | 'maybank2e'
+            | 'maybank2u'
+            | 'ocbc'
+            | 'pb_enterprise'
+            | 'public_bank'
+            | 'rhb'
+            | 'standard_chartered'
+            | 'uob';
+        }
+
+        interface Giropay {}
+
+        interface Grabpay {}
+
+        interface Ideal {
+          /**
+           * The customer's bank.
+           */
+          bank?: Ideal.Bank;
+        }
+
+        namespace Ideal {
+          type Bank =
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'revolut'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+        }
+
+        interface InteracPresent {}
+
+        interface Klarna {
+          /**
+           * Customer's date of birth
+           */
+          dob?: Klarna.Dob;
+        }
+
+        namespace Klarna {
+          interface Dob {
+            /**
+             * The day of birth, between 1 and 31.
+             */
+            day: number;
+
+            /**
+             * The month of birth, between 1 and 12.
+             */
+            month: number;
+
+            /**
+             * The four-digit year of birth.
+             */
+            year: number;
+          }
+        }
+
+        interface Konbini {}
+
+        interface Oxxo {}
+
+        interface P24 {
+          /**
+           * The customer's bank.
+           */
+          bank?: P24.Bank;
+        }
+
+        namespace P24 {
+          type Bank =
+            | 'alior_bank'
+            | 'bank_millennium'
+            | 'bank_nowy_bfg_sa'
+            | 'bank_pekao_sa'
+            | 'banki_spbdzielcze'
+            | 'blik'
+            | 'bnp_paribas'
+            | 'boz'
+            | 'citi_handlowy'
+            | 'credit_agricole'
+            | 'envelobank'
+            | 'etransfer_pocztowy24'
+            | 'getin_bank'
+            | 'ideabank'
+            | 'ing'
+            | 'inteligo'
+            | 'mbank_mtransfer'
+            | 'nest_przelew'
+            | 'noble_pay'
+            | 'pbac_z_ipko'
+            | 'plus_bank'
+            | 'santander_przelew24'
+            | 'tmobile_usbugi_bankowe'
+            | 'toyota_bank'
+            | 'volkswagen_bank';
+        }
+
+        interface Paynow {}
+
+        interface SepaDebit {
+          /**
+           * IBAN of the bank account.
+           */
+          iban: string;
+        }
+
+        interface Sofort {
+          /**
+           * Two-letter ISO code representing the country the bank account is located in.
+           */
+          country: Sofort.Country;
+        }
+
+        namespace Sofort {
+          type Country = 'AT' | 'BE' | 'DE' | 'ES' | 'IT' | 'NL';
+        }
+
+        type Type =
+          | 'acss_debit'
+          | 'afterpay_clearpay'
+          | 'alipay'
+          | 'au_becs_debit'
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'boleto'
+          | 'customer_balance'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'grabpay'
+          | 'ideal'
+          | 'klarna'
+          | 'konbini'
+          | 'oxxo'
+          | 'p24'
+          | 'paynow'
+          | 'sepa_debit'
+          | 'sofort'
+          | 'us_bank_account'
+          | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -381,6 +381,11 @@ declare module 'stripe' {
           political_exposure?: Individual.PoliticalExposure;
 
           /**
+           * The individual's registered address.
+           */
+          registered_address?: Individual.RegisteredAddress;
+
+          /**
            * The last four digits of the individual's Social Security Number (U.S. only).
            */
           ssn_last_4?: string;
@@ -414,6 +419,11 @@ declare module 'stripe' {
           }
 
           type PoliticalExposure = 'existing' | 'none';
+
+          interface RegisteredAddress
+            extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
 
           interface Verification {
             /**
@@ -633,6 +643,11 @@ declare module 'stripe' {
         political_exposure?: string;
 
         /**
+         * The person's registered address.
+         */
+        registered_address?: Person.RegisteredAddress;
+
+        /**
          * The relationship that this person has with the account's legal entity.
          */
         relationship?: Person.Relationship;
@@ -708,6 +723,10 @@ declare module 'stripe' {
              */
             files?: Array<string>;
           }
+        }
+
+        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
         }
 
         interface Relationship {


### PR DESCRIPTION
Codegen for openapi 158cf6c.
r? @kamil-stripe
cc @stripe/api-libraries

## Changelog
* Add support for `registered_address` on `AccountCreateParams.individual`, `AccountUpdateParams.individual`, `PersonCreateParams`, `PersonUpdateParams`, `Person`, `TokenCreateParams.account.individual`, and `TokenCreateParams.person`
* Change type of `PaymentIntent.amount_details.tip.amount` from `nullable(integer)` to `integer`
* Change `PaymentIntent.amount_details.tip.amount` to be optional
* Add support for `payment_method_data` on `SetupIntentConfirmParams`, `SetupIntentCreateParams`, and `SetupIntentUpdateParams`

