### PR TITLE
New Orders API

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -30,7 +30,6 @@ module.exports = {
   Mandates: require('./resources/Mandates'),
   OAuth: require('./resources/OAuth'),
   Orders: require('./resources/Orders'),
-  OrderReturns: require('./resources/OrderReturns'),
   PaymentIntents: require('./resources/PaymentIntents'),
   PaymentLinks: require('./resources/PaymentLinks'),
   PaymentMethods: require('./resources/PaymentMethods'),

--- a/lib/resources/Orders.js
+++ b/lib/resources/Orders.js
@@ -29,13 +29,19 @@ module.exports = StripeResource.extend({
     methodType: 'list',
   }),
 
-  pay: stripeMethod({
+  cancel: stripeMethod({
     method: 'POST',
-    path: '/{id}/pay',
+    path: '/{id}/cancel',
   }),
 
-  returnOrder: stripeMethod({
+  listLineItems: stripeMethod({
+    method: 'GET',
+    path: '/{id}/line_items',
+    methodType: 'list',
+  }),
+
+  reopen: stripeMethod({
     method: 'POST',
-    path: '/{id}/returns',
+    path: '/{id}/reopen',
   }),
 });

--- a/lib/resources/Orders.js
+++ b/lib/resources/Orders.js
@@ -44,4 +44,9 @@ module.exports = StripeResource.extend({
     method: 'POST',
     path: '/{id}/reopen',
   }),
+
+  submit: stripeMethod({
+    method: 'POST',
+    path: '/{id}/submit',
+  }),
 });

--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -2068,3 +2068,46 @@ describe('Terminal.Configuration', function() {
     expect(deleted).not.to.be.null;
   });
 });
+
+describe('Order', function() {
+  it('create method', async function() {
+    const order = await stripe.orders.create({
+      description: 'description',
+      currency: 'usd',
+      line_items: [{description: 'my line item'}],
+    });
+    expect(order).not.to.be.null;
+  });
+
+  it('update method', async function() {
+    const order = await stripe.orders.update('order_xyz');
+    expect(order).not.to.be.null;
+  });
+
+  it('listLineItems method', async function() {
+    const lineItems = await stripe.orders.listLineItems('order_xyz');
+    expect(lineItems).not.to.be.null;
+  });
+
+  it('cancel method', async function() {
+    const order = await stripe.orders.cancel('order_xyz');
+    expect(order).not.to.be.null;
+  });
+
+  it('reopen method', async function() {
+    const order = await stripe.orders.reopen('order_xyz');
+    expect(order).not.to.be.null;
+  });
+
+  it('submit method', async function() {
+    const order = await stripe.orders.submit('order_xyz', {
+      expected_total: 100,
+    });
+    expect(order).not.to.be.null;
+  });
+
+  it('update method', async function() {
+    const order = await stripe.orders.update('order_xyz');
+    expect(order).not.to.be.null;
+  });
+});

--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -1848,65 +1848,6 @@ describe('Terminal.Reader', function() {
   });
 });
 
-describe('Order', function() {
-  it('create method', async function() {
-    const order = await stripe.orders.create({
-      currency: 'usd',
-      email: 'jenny.rosen@example.com',
-      items: [{type: 'sku', parent: 'sku_xxxxxxxxxxxxx'}],
-      shipping: {
-        name: 'Jenny Rosen',
-        address: {
-          line1: '1234 Main Street',
-          city: 'San Francisco',
-          state: 'CA',
-          country: 'US',
-          postal_code: '94111',
-        },
-      },
-    });
-    expect(order).not.to.be.null;
-  });
-
-  it('retrieve method', async function() {
-    const order = await stripe.orders.retrieve('or_xxxxxxxxxxxxx');
-    expect(order).not.to.be.null;
-  });
-
-  it('update method', async function() {
-    const order = await stripe.orders.update('or_xxxxxxxxxxxxx', {
-      metadata: {order_id: '6735'},
-    });
-    expect(order).not.to.be.null;
-  });
-
-  it('pay method', async function() {
-    const order = await stripe.orders.pay('or_xxxxxxxxxxxxx', {
-      source: 'tok_xxxx',
-    });
-    expect(order).not.to.be.null;
-  });
-
-  it('list method', async function() {
-    const orders = await stripe.orders.list({limit: 3});
-    expect(orders).not.to.be.null;
-  });
-});
-
-describe('OrderReturn', function() {
-  it('retrieve method', async function() {
-    const orderReturn = await stripe.orderReturns.retrieve(
-      'orret_xxxxxxxxxxxxx'
-    );
-    expect(orderReturn).not.to.be.null;
-  });
-
-  it('list method', async function() {
-    const orderReturns = await stripe.orderReturns.list({limit: 3});
-    expect(orderReturns).not.to.be.null;
-  });
-});
-
 describe('Sku', function() {
   it('create method', async function() {
     const sku = await stripe.skus.create({

--- a/types/2020-08-27/Accounts.d.ts
+++ b/types/2020-08-27/Accounts.d.ts
@@ -1900,6 +1900,11 @@ declare module 'stripe' {
         political_exposure?: Individual.PoliticalExposure;
 
         /**
+         * The individual's registered address.
+         */
+        registered_address?: Individual.RegisteredAddress;
+
+        /**
          * The last four digits of the individual's Social Security Number (U.S. only).
          */
         ssn_last_4?: string;
@@ -1933,6 +1938,10 @@ declare module 'stripe' {
         }
 
         type PoliticalExposure = 'existing' | 'none';
+
+        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
 
         interface Verification {
           /**
@@ -2981,6 +2990,11 @@ declare module 'stripe' {
         political_exposure?: Individual.PoliticalExposure;
 
         /**
+         * The individual's registered address.
+         */
+        registered_address?: Individual.RegisteredAddress;
+
+        /**
          * The last four digits of the individual's Social Security Number (U.S. only).
          */
         ssn_last_4?: string;
@@ -3014,6 +3028,10 @@ declare module 'stripe' {
         }
 
         type PoliticalExposure = 'existing' | 'none';
+
+        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
 
         interface Verification {
           /**

--- a/types/2020-08-27/Charges.d.ts
+++ b/types/2020-08-27/Charges.d.ts
@@ -148,11 +148,6 @@ declare module 'stripe' {
       on_behalf_of: string | Stripe.Account | null;
 
       /**
-       * ID of the order this charge is for if one exists.
-       */
-      order: string | Stripe.Order | null;
-
-      /**
        * Details about whether the payment was accepted, and why. See [understanding declines](https://stripe.com/docs/declines) for details.
        */
       outcome: Charge.Outcome | null;
@@ -1723,7 +1718,7 @@ declare module 'stripe' {
         /**
          * Recipient name.
          */
-        name?: string | null;
+        name?: string;
 
         /**
          * Recipient phone (including extension).

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -566,7 +566,7 @@ declare module 'stripe' {
           /**
            * Recipient name.
            */
-          name?: string | null;
+          name?: string;
 
           /**
            * Recipient phone (including extension).

--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -185,7 +185,7 @@ declare module 'stripe' {
         /**
          * Recipient name.
          */
-        name?: string | null;
+        name?: string;
 
         /**
          * Recipient phone (including extension).

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -401,7 +401,7 @@ declare module 'stripe' {
         /**
          * Recipient name.
          */
-        name?: string | null;
+        name?: string;
 
         /**
          * Recipient phone (including extension).

--- a/types/2020-08-27/Issuing/Cardholders.d.ts
+++ b/types/2020-08-27/Issuing/Cardholders.d.ts
@@ -781,7 +781,7 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per interval.
+             * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
              */
             amount: number;
 

--- a/types/2020-08-27/Issuing/Cards.d.ts
+++ b/types/2020-08-27/Issuing/Cards.d.ts
@@ -787,7 +787,7 @@ declare module 'stripe' {
 
           interface SpendingLimit {
             /**
-             * Maximum amount allowed to spend per interval.
+             * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal).
              */
             amount: number;
 

--- a/types/2020-08-27/LineItems.d.ts
+++ b/types/2020-08-27/LineItems.d.ts
@@ -17,9 +17,19 @@ declare module 'stripe' {
       object: 'item';
 
       /**
+       * Total discount amount applied. If no discounts were applied, defaults to 0.
+       */
+      amount_discount?: number;
+
+      /**
        * Total before any discounts or taxes are applied.
        */
       amount_subtotal: number;
+
+      /**
+       * Total tax amount applied. If no tax was applied, defaults to 0.
+       */
+      amount_tax?: number;
 
       /**
        * Total after discounts and taxes.
@@ -45,6 +55,13 @@ declare module 'stripe' {
        * The price used to generate the line item.
        */
       price: Stripe.Price | null;
+
+      /**
+       * The ID of the product for this line item.
+       *
+       * This will always be the same as `price.product`.
+       */
+      product?: string | Stripe.Product | Stripe.DeletedProduct;
 
       /**
        * The quantity of products being purchased.

--- a/types/2020-08-27/Orders.d.ts
+++ b/types/2020-08-27/Orders.d.ts
@@ -17,29 +17,26 @@ declare module 'stripe' {
       object: 'order';
 
       /**
-       * A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the order.
+       * Order cost before any discounts or taxes are applied. A positive integer representing the subtotal of the order in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency).
        */
-      amount: number;
+      amount_subtotal: number;
 
       /**
-       * The total amount that was returned to the customer.
+       * Total order cost after discounts and taxes are applied. A positive integer representing the cost of the order in the [smallest currency unit](https://stripe.com/docs/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). To submit an order, the total must be either 0 or at least $0.50 USD or [equivalent in charge currency](https://stripe.com/docs/currencies#minimum-and-maximum-charge-amounts).
        */
-      amount_returned: number | null;
+      amount_total: number;
 
       /**
-       * ID of the Connect Application that created the order.
+       * ID of the Connect application that created the Order, if any.
        */
-      application: string | null;
+      application: string | Stripe.Application | null;
+
+      automatic_tax?: Order.AutomaticTax;
 
       /**
-       * A fee in cents that will be applied to the order and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the Stripe-Account header in order to take an application fee. For more information, see the application fees documentation.
+       * Customer billing details associated with the order.
        */
-      application_fee: number | null;
-
-      /**
-       * The ID of the payment used to pay for the order. Present if the order status is `paid`, `fulfilled`, or `refunded`.
-       */
-      charge: string | Stripe.Charge | null;
+      billing_details: Order.BillingDetails | null;
 
       /**
        * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -52,24 +49,29 @@ declare module 'stripe' {
       currency: string;
 
       /**
-       * The customer used for the order.
+       * The customer which this orders belongs to.
        */
       customer: string | Stripe.Customer | Stripe.DeletedCustomer | null;
 
       /**
-       * The email address of the customer placing the order.
+       * An arbitrary string attached to the object. Often useful for displaying to users.
        */
-      email: string | null;
+      description: string | null;
 
       /**
-       * External coupon code to load for this order.
+       * The discounts applied to the order. Use `expand[]=discounts` to expand each discount.
        */
-      external_coupon_code?: string;
+      discounts: Array<string | Stripe.Discount> | null;
 
       /**
-       * List of items constituting the order. An order can have up to 25 items.
+       * A recent IP address of the purchaser used for tax reporting and tax location inference.
        */
-      items: Array<Stripe.OrderItem>;
+      ip_address: string | null;
+
+      /**
+       * A list of line items the customer is ordering. Each line item includes information about the product, the quantity, and the resulting cost. There is a maximum of 100 line items.
+       */
+      line_items?: ApiList<Stripe.LineItem>;
 
       /**
        * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -81,143 +83,775 @@ declare module 'stripe' {
        */
       metadata: Stripe.Metadata | null;
 
-      /**
-       * A list of returns that have taken place for this order.
-       */
-      returns: ApiList<Stripe.OrderReturn> | null;
+      payment: Order.Payment;
 
       /**
-       * The shipping method that is currently selected for this order, if any. If present, it is equal to one of the `id`s of shipping methods in the `shipping_methods` array. At order creation time, if there are multiple shipping methods, Stripe will automatically selected the first method.
+       * The details of the customer cost of shipping, including the customer chosen ShippingRate.
        */
-      selected_shipping_method: string | null;
+      shipping_cost: Order.ShippingCost | null;
 
       /**
-       * The shipping address for the order. Present if the order is for goods to be shipped.
+       * Customer shipping information associated with the order.
        */
-      shipping: Order.Shipping | null;
+      shipping_details: Order.ShippingDetails | null;
 
       /**
-       * A list of supported shipping methods for this order. The desired shipping method can be specified either by updating the order, or when paying it.
+       * The overall status of the order.
        */
-      shipping_methods: Array<Order.ShippingMethod> | null;
+      status: Order.Status;
 
-      /**
-       * Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More details in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses).
-       */
-      status: string;
+      tax_details?: Order.TaxDetails;
 
-      /**
-       * The timestamps at which the order status was updated.
-       */
-      status_transitions: Order.StatusTransitions | null;
-
-      /**
-       * Time at which the object was last updated. Measured in seconds since the Unix epoch.
-       */
-      updated: number | null;
-
-      /**
-       * The user's order ID if it is different from the Stripe order ID.
-       */
-      upstream_id?: string;
+      total_details: Order.TotalDetails;
     }
 
     namespace Order {
-      interface Shipping {
-        address?: Stripe.Address;
+      interface AutomaticTax {
+        /**
+         * Whether Stripe automatically computes tax on this Order.
+         */
+        enabled: boolean;
 
         /**
-         * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
+         * The status of the most recent automated tax calculation for this Order.
          */
-        carrier?: string | null;
+        status: AutomaticTax.Status | null;
+      }
+
+      namespace AutomaticTax {
+        type Status = 'complete' | 'failed' | 'requires_location_inputs';
+      }
+
+      interface BillingDetails {
+        /**
+         * Billing address for the order.
+         */
+        address: Stripe.Address | null;
+
+        /**
+         * Email address for the order.
+         */
+        email: string | null;
+
+        /**
+         * Full name for the order.
+         */
+        name: string | null;
+
+        /**
+         * Billing phone number for the order (including extension).
+         */
+        phone: string | null;
+      }
+
+      interface Payment {
+        /**
+         * ID of the payment intent associated with this order. Null when the order is `open`.
+         */
+        payment_intent: string | Stripe.PaymentIntent | null;
+
+        /**
+         * Settings describing how the order should configure generated PaymentIntents.
+         */
+        settings: Payment.Settings | null;
+
+        /**
+         * The status of the underlying payment associated with this order, if any. Null when the order is `open`.
+         */
+        status: Payment.Status | null;
+      }
+
+      namespace Payment {
+        interface Settings {
+          /**
+           * The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
+           */
+          application_fee_amount: number | null;
+
+          /**
+           * PaymentMethod-specific configuration to provide to the order's PaymentIntent.
+           */
+          payment_method_options: Settings.PaymentMethodOptions | null;
+
+          /**
+           * The list of payment method types (e.g., card) to provide to the order's PaymentIntent.
+           */
+          payment_method_types: Array<Settings.PaymentMethodType> | null;
+
+          /**
+           * The URL to redirect the customer to after they authenticate their payment.
+           */
+          return_url: string | null;
+
+          /**
+           * For non-card charges, you can use this value as the complete description that appears on your customers' statements. Must contain at least one letter, maximum 22 characters.
+           */
+          statement_descriptor: string | null;
+
+          /**
+           * Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+           */
+          statement_descriptor_suffix: string | null;
+
+          /**
+           * Provides configuration for completing a transfer for the order after it is paid.
+           */
+          transfer_data: Settings.TransferData | null;
+        }
+
+        namespace Settings {
+          interface PaymentMethodOptions {
+            acss_debit?: PaymentMethodOptions.AcssDebit;
+
+            afterpay_clearpay?: PaymentMethodOptions.AfterpayClearpay;
+
+            alipay?: PaymentMethodOptions.Alipay;
+
+            bancontact?: PaymentMethodOptions.Bancontact;
+
+            card?: PaymentMethodOptions.Card;
+
+            customer_balance?: PaymentMethodOptions.CustomerBalance;
+
+            ideal?: PaymentMethodOptions.Ideal;
+
+            klarna?: PaymentMethodOptions.Klarna;
+
+            link?: PaymentMethodOptions.Link;
+
+            oxxo?: PaymentMethodOptions.Oxxo;
+
+            p24?: PaymentMethodOptions.P24;
+
+            paypal?: PaymentMethodOptions.Paypal;
+
+            sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+            sofort?: PaymentMethodOptions.Sofort;
+
+            wechat_pay?: PaymentMethodOptions.WechatPay;
+          }
+
+          namespace PaymentMethodOptions {
+            interface AcssDebit {
+              mandate_options?: AcssDebit.MandateOptions;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: AcssDebit.SetupFutureUsage;
+
+              /**
+               * Bank account verification method.
+               */
+              verification_method?: AcssDebit.VerificationMethod;
+            }
+
+            namespace AcssDebit {
+              interface MandateOptions {
+                /**
+                 * A URL for custom mandate text
+                 */
+                custom_mandate_url?: string;
+
+                /**
+                 * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
+                 */
+                interval_description: string | null;
+
+                /**
+                 * Payment schedule for the mandate.
+                 */
+                payment_schedule: MandateOptions.PaymentSchedule | null;
+
+                /**
+                 * Transaction type of the mandate.
+                 */
+                transaction_type: MandateOptions.TransactionType | null;
+              }
+
+              namespace MandateOptions {
+                type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+                type TransactionType = 'business' | 'personal';
+              }
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+              type VerificationMethod =
+                | 'automatic'
+                | 'instant'
+                | 'microdeposits';
+            }
+
+            interface AfterpayClearpay {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method?: AfterpayClearpay.CaptureMethod;
+
+              /**
+               * Order identifier shown to the user in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
+               */
+              reference: string | null;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace AfterpayClearpay {
+              type CaptureMethod = 'automatic' | 'manual';
+            }
+
+            interface Alipay {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: Alipay.SetupFutureUsage;
+            }
+
+            namespace Alipay {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Bancontact {
+              /**
+               * Preferred language of the Bancontact authorization page that the customer is redirected to.
+               */
+              preferred_language: Bancontact.PreferredLanguage;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: Bancontact.SetupFutureUsage;
+            }
+
+            namespace Bancontact {
+              type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Card {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method: Card.CaptureMethod;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: Card.SetupFutureUsage;
+            }
+
+            namespace Card {
+              type CaptureMethod = 'automatic' | 'manual';
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+            }
+
+            interface CustomerBalance {
+              bank_transfer?: CustomerBalance.BankTransfer;
+
+              /**
+               * The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+               */
+              funding_type: 'bank_transfer' | null;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace CustomerBalance {
+              interface BankTransfer {
+                /**
+                 * List of address types that should be returned in the financial_addresses response. If not specified, all valid types will be returned.
+                 *
+                 * Permitted values include: `zengin`.
+                 */
+                requested_address_types?: Array<'zengin'>;
+
+                /**
+                 * The bank transfer type that this PaymentIntent is allowed to use for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+                 */
+                type: BankTransfer.Type | null;
+              }
+
+              namespace BankTransfer {
+                type Type =
+                  | 'eu_bank_account'
+                  | 'eu_bank_transfer'
+                  | 'gb_bank_account'
+                  | 'gb_bank_transfer'
+                  | 'id_bank_account'
+                  | 'id_bank_transfer'
+                  | 'jp_bank_account'
+                  | 'jp_bank_transfer'
+                  | 'mx_bank_account'
+                  | 'mx_bank_transfer'
+                  | 'us_bank_account'
+                  | 'us_bank_transfer';
+              }
+            }
+
+            interface Ideal {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: Ideal.SetupFutureUsage;
+            }
+
+            namespace Ideal {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Klarna {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method?: 'manual';
+
+              /**
+               * Preferred locale of the Klarna checkout page that the customer is redirected to.
+               */
+              preferred_locale: string | null;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: 'none';
+            }
+
+            interface Link {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method?: 'manual';
+
+              /**
+               * Token used for persistent Link logins.
+               */
+              persistent_token: string | null;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: Link.SetupFutureUsage;
+            }
+
+            namespace Link {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Oxxo {
+              /**
+               * The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+               */
+              expires_after_days: number;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: 'none';
+            }
+
+            interface P24 {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: 'none';
+            }
+
+            interface Paypal {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method?: 'manual';
+
+              /**
+               * Preferred locale of the PayPal checkout page that the customer is redirected to.
+               */
+              preferred_locale: string | null;
+            }
+
+            interface SepaDebit {
+              mandate_options?: SepaDebit.MandateOptions;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: SepaDebit.SetupFutureUsage;
+            }
+
+            namespace SepaDebit {
+              interface MandateOptions {}
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+            }
+
+            interface Sofort {
+              /**
+               * Preferred language of the SOFORT authorization page that the customer is redirected to.
+               */
+              preferred_language: Sofort.PreferredLanguage | null;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: Sofort.SetupFutureUsage;
+            }
+
+            namespace Sofort {
+              type PreferredLanguage =
+                | 'de'
+                | 'en'
+                | 'es'
+                | 'fr'
+                | 'it'
+                | 'nl'
+                | 'pl';
+
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface WechatPay {
+              /**
+               * The app ID registered with WeChat Pay. Only required when client is ios or android.
+               */
+              app_id: string | null;
+
+              /**
+               * The client type that the end customer will pay from
+               */
+              client: WechatPay.Client | null;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace WechatPay {
+              type Client = 'android' | 'ios' | 'web';
+            }
+          }
+
+          type PaymentMethodType =
+            | 'acss_debit'
+            | 'afterpay_clearpay'
+            | 'alipay'
+            | 'au_becs_debit'
+            | 'bacs_debit'
+            | 'bancontact'
+            | 'card'
+            | 'customer_balance'
+            | 'eps'
+            | 'fpx'
+            | 'giropay'
+            | 'grabpay'
+            | 'ideal'
+            | 'klarna'
+            | 'link'
+            | 'oxxo'
+            | 'p24'
+            | 'paypal'
+            | 'sepa_debit'
+            | 'sofort'
+            | 'wechat_pay';
+
+          interface TransferData {
+            /**
+             * The amount that will be transferred automatically when the order is paid. If no amount is set, the full amount is transferred. There cannot be any line items with recurring prices when using this field.
+             */
+            amount: number | null;
+
+            /**
+             * ID of the Connected account receiving the transfer.
+             */
+            destination: string | Stripe.Account;
+          }
+        }
+
+        type Status =
+          | 'canceled'
+          | 'complete'
+          | 'not_required'
+          | 'processing'
+          | 'requires_action'
+          | 'requires_capture'
+          | 'requires_confirmation'
+          | 'requires_payment_method';
+      }
+
+      interface ShippingCost {
+        /**
+         * Total shipping cost before any discounts or taxes are applied.
+         */
+        amount_subtotal: number;
+
+        /**
+         * Total tax amount applied due to shipping costs. If no tax was applied, defaults to 0.
+         */
+        amount_tax: number;
+
+        /**
+         * Total shipping cost after discounts and taxes are applied.
+         */
+        amount_total: number;
+
+        /**
+         * The ID of the ShippingRate for this order.
+         */
+        shipping_rate: string | Stripe.ShippingRate | null;
+
+        /**
+         * The taxes applied to the shipping rate.
+         */
+        taxes?: Array<ShippingCost.Tax>;
+      }
+
+      namespace ShippingCost {
+        interface Tax {
+          /**
+           * Amount of tax applied for this rate.
+           */
+          amount: number;
+
+          /**
+           * Tax rates can be applied to [invoices](https://stripe.com/docs/billing/invoices/tax-rates), [subscriptions](https://stripe.com/docs/billing/subscriptions/taxes) and [Checkout Sessions](https://stripe.com/docs/payments/checkout/set-up-a-subscription#tax-rates) to collect tax.
+           *
+           * Related guide: [Tax Rates](https://stripe.com/docs/billing/taxes/tax-rates).
+           */
+          rate: Stripe.TaxRate;
+        }
+      }
+
+      interface ShippingDetails {
+        /**
+         * Recipient shipping address. Required if the order includes products that are shippable.
+         */
+        address: Stripe.Address | null;
 
         /**
          * Recipient name.
          */
-        name?: string | null;
+        name: string | null;
 
         /**
          * Recipient phone (including extension).
          */
-        phone?: string | null;
-
-        /**
-         * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
-         */
-        tracking_number?: string | null;
+        phone: string | null;
       }
 
-      interface ShippingMethod {
+      type Status =
+        | 'canceled'
+        | 'complete'
+        | 'open'
+        | 'processing'
+        | 'submitted';
+
+      interface TaxDetails {
         /**
-         * A positive integer in the smallest currency unit (that is, 100 cents for $1.00, or 1 for ¥1, Japanese Yen being a zero-decimal currency) representing the total amount for the line item.
+         * Describes the purchaser's tax exemption status. One of `none`, `exempt`, or `reverse`.
          */
-        amount: number;
+        tax_exempt: TaxDetails.TaxExempt;
 
         /**
-         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         * The purchaser's tax IDs to be used in calculation of tax for this Order.
          */
-        currency: string;
-
-        /**
-         * The estimated delivery date for the given shipping method. Can be either a specific date or a range.
-         */
-        delivery_estimate: ShippingMethod.DeliveryEstimate | null;
-
-        /**
-         * An arbitrary string attached to the object. Often useful for displaying to users.
-         */
-        description: string;
-
-        /**
-         * Unique identifier for the object.
-         */
-        id: string;
+        tax_ids: Array<TaxDetails.TaxId>;
       }
 
-      namespace ShippingMethod {
-        interface DeliveryEstimate {
+      namespace TaxDetails {
+        type TaxExempt = 'exempt' | 'none' | 'reverse';
+
+        interface TaxId {
           /**
-           * If `type` is `"exact"`, `date` will be the expected delivery date in the format YYYY-MM-DD.
+           * The type of the tax ID, one of `eu_vat`, `br_cnpj`, `br_cpf`, `eu_oss_vat`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `li_uid`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, or `unknown`
            */
-          date?: string;
+          type: TaxId.Type;
 
           /**
-           * If `type` is `"range"`, `earliest` will be be the earliest delivery date in the format YYYY-MM-DD.
+           * The value of the tax ID.
            */
-          earliest?: string;
+          value: string | null;
+        }
 
-          /**
-           * If `type` is `"range"`, `latest` will be the latest delivery date in the format YYYY-MM-DD.
-           */
-          latest?: string;
-
-          /**
-           * The type of estimate. Must be either `"range"` or `"exact"`.
-           */
-          type: string;
+        namespace TaxId {
+          type Type =
+            | 'ae_trn'
+            | 'au_abn'
+            | 'au_arn'
+            | 'bg_uic'
+            | 'br_cnpj'
+            | 'br_cpf'
+            | 'ca_bn'
+            | 'ca_gst_hst'
+            | 'ca_pst_bc'
+            | 'ca_pst_mb'
+            | 'ca_pst_sk'
+            | 'ca_qst'
+            | 'ch_vat'
+            | 'cl_tin'
+            | 'es_cif'
+            | 'eu_oss_vat'
+            | 'eu_vat'
+            | 'gb_vat'
+            | 'ge_vat'
+            | 'hk_br'
+            | 'hu_tin'
+            | 'id_npwp'
+            | 'il_vat'
+            | 'in_gst'
+            | 'is_vat'
+            | 'jp_cn'
+            | 'jp_rn'
+            | 'kr_brn'
+            | 'li_uid'
+            | 'mx_rfc'
+            | 'my_frp'
+            | 'my_itn'
+            | 'my_sst'
+            | 'no_vat'
+            | 'nz_gst'
+            | 'ru_inn'
+            | 'ru_kpp'
+            | 'sa_vat'
+            | 'sg_gst'
+            | 'sg_uen'
+            | 'si_tin'
+            | 'th_vat'
+            | 'tw_vat'
+            | 'ua_vat'
+            | 'unknown'
+            | 'us_ein'
+            | 'za_vat';
         }
       }
 
-      interface StatusTransitions {
+      interface TotalDetails {
         /**
-         * The time that the order was canceled.
+         * This is the sum of all the discounts.
          */
-        canceled: number | null;
+        amount_discount: number;
 
         /**
-         * The time that the order was fulfilled.
+         * This is the sum of all the shipping amounts.
          */
-        fulfiled: number | null;
+        amount_shipping: number | null;
 
         /**
-         * The time that the order was paid.
+         * This is the sum of all the tax amounts.
          */
-        paid: number | null;
+        amount_tax: number;
 
-        /**
-         * The time that the order was returned.
-         */
-        returned: number | null;
+        breakdown?: TotalDetails.Breakdown;
+      }
+
+      namespace TotalDetails {
+        interface Breakdown {
+          /**
+           * The aggregated discounts.
+           */
+          discounts: Array<Breakdown.Discount>;
+
+          /**
+           * The aggregated tax amounts by rate.
+           */
+          taxes: Array<Breakdown.Tax>;
+        }
+
+        namespace Breakdown {
+          interface Discount {
+            /**
+             * The amount discounted.
+             */
+            amount: number;
+
+            /**
+             * A discount represents the actual application of a coupon to a particular
+             * customer. It contains information about when the discount began and when it
+             * will end.
+             *
+             * Related guide: [Applying Discounts to Subscriptions](https://stripe.com/docs/billing/subscriptions/discounts).
+             */
+            discount: Stripe.Discount;
+          }
+
+          interface Tax {
+            /**
+             * Amount of tax applied for this rate.
+             */
+            amount: number;
+
+            /**
+             * Tax rates can be applied to [invoices](https://stripe.com/docs/billing/invoices/tax-rates), [subscriptions](https://stripe.com/docs/billing/subscriptions/taxes) and [Checkout Sessions](https://stripe.com/docs/payments/checkout/set-up-a-subscription#tax-rates) to collect tax.
+             *
+             * Related guide: [Tax Rates](https://stripe.com/docs/billing/taxes/tax-rates).
+             */
+            rate: Stripe.TaxRate;
+          }
+        }
       }
     }
 
@@ -228,19 +862,34 @@ declare module 'stripe' {
       currency: string;
 
       /**
-       * A coupon code that represents a discount to be applied to this order. Must be one-time duration and in same currency as the order. An order can have multiple coupons.
+       * A list of line items the customer is ordering. Each line item includes information about the product, the quantity, and the resulting cost.
        */
-      coupon?: string;
+      line_items: Array<OrderCreateParams.LineItem>;
 
       /**
-       * The ID of an existing customer to use for this order. If provided, the customer email and shipping address will be used to create the order. Subsequently, the customer will also be charged to pay the order. If `email` or `shipping` are also provided, they will override the values retrieved from the customer object.
+       * Settings for automatic tax calculation for this order.
+       */
+      automatic_tax?: OrderCreateParams.AutomaticTax;
+
+      /**
+       * Billing details for the customer. If a customer is provided, this will be automatically populated with values from that customer if override values are not provided.
+       */
+      billing_details?: Stripe.Emptyable<OrderCreateParams.BillingDetails>;
+
+      /**
+       * The customer associated with this order.
        */
       customer?: string;
 
       /**
-       * The email address of the customer placing the order.
+       * An arbitrary string attached to the object. Often useful for displaying to users.
        */
-      email?: string;
+      description?: string;
+
+      /**
+       * The coupons, promotion codes, and/or discounts to apply to the order.
+       */
+      discounts?: Stripe.Emptyable<Array<OrderCreateParams.Discount>>;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -248,9 +897,9 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
-       * List of items constituting the order. An order can have up to 25 items.
+       * The IP address of the purchaser for this order.
        */
-      items?: Array<OrderCreateParams.Item>;
+      ip_address?: string;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
@@ -258,56 +907,918 @@ declare module 'stripe' {
       metadata?: Stripe.MetadataParam;
 
       /**
-       * Shipping address for the order. Required if any of the SKUs are for products that have `shippable` set to true.
+       * Payment information associated with the order, including payment settings.
        */
-      shipping?: OrderCreateParams.Shipping;
+      payment?: OrderCreateParams.Payment;
+
+      /**
+       * Settings for the customer cost of shipping for this order.
+       */
+      shipping_cost?: Stripe.Emptyable<OrderCreateParams.ShippingCost>;
+
+      /**
+       * Shipping details for the order.
+       */
+      shipping_details?: Stripe.Emptyable<OrderCreateParams.ShippingDetails>;
+
+      /**
+       * Additional tax details about the purchaser to be used for this order.
+       */
+      tax_details?: OrderCreateParams.TaxDetails;
     }
 
     namespace OrderCreateParams {
-      interface Item {
-        amount?: number;
-
-        currency?: string;
-
-        description?: string;
-
+      interface AutomaticTax {
         /**
-         * The ID of the SKU being ordered.
+         * Enable automatic tax calculation which will automatically compute tax rates on this order.
          */
-        parent?: string;
-
-        /**
-         * The quantity of this order item. When type is `sku`, this is the number of instances of the SKU to be ordered.
-         */
-        quantity?: number;
-
-        type?: Item.Type;
+        enabled: boolean;
       }
 
-      namespace Item {
-        type Type = 'discount' | 'shipping' | 'sku' | 'tax';
-      }
-
-      interface Shipping {
+      interface BillingDetails {
         /**
-         * Customer shipping address.
+         * The billing address provided by the customer.
          */
-        address: Shipping.Address;
+        address?: BillingDetails.Address;
 
         /**
-         * Customer name.
+         * The billing email provided by the customer.
          */
-        name: string;
+        email?: string;
 
         /**
-         * Customer phone (including extension).
+         * The billing name provided by the customer.
+         */
+        name?: string;
+
+        /**
+         * The billing phone number provided by the customer.
          */
         phone?: string;
       }
 
-      namespace Shipping {
+      namespace BillingDetails {
         interface Address extends Omit<Stripe.AddressParam, 'line1'> {
           line1?: string;
+        }
+      }
+
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+
+        /**
+         * ID of the promotion code to create a new discount for.
+         */
+        promotion_code?: string;
+      }
+
+      interface LineItem {
+        /**
+         * The description for the line item. Will default to the name of the associated product.
+         */
+        description?: string;
+
+        /**
+         * The discounts applied to this line item.
+         */
+        discounts?: Stripe.Emptyable<Array<LineItem.Discount>>;
+
+        /**
+         * The ID of the price object. One of `product` (with default price) or `price` or `price_data` is required.
+         */
+        price?: string;
+
+        /**
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline. One of `product` (with default price) or `price` or `price_data` is required.
+         */
+        price_data?: LineItem.PriceData;
+
+        /**
+         * The product of the line item. The product must have a default price specified. One of `product` (with default price) or `price` or `price_data` is required.
+         */
+        product?: string;
+
+        /**
+         * The quantity of the line item.
+         */
+        quantity?: number;
+
+        /**
+         * The tax rates applied to this line item.
+         */
+        tax_rates?: Stripe.Emptyable<Array<string>>;
+      }
+
+      namespace LineItem {
+        interface Discount {
+          /**
+           * ID of the coupon to create a new discount for.
+           */
+          coupon?: string;
+
+          /**
+           * ID of an existing discount on the object (or one of its ancestors) to reuse.
+           */
+          discount?: string;
+        }
+
+        interface PriceData {
+          /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency?: string;
+
+          /**
+           * The ID of the product that this price will belong to.
+           */
+          product?: string;
+
+          /**
+           * Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed.
+           */
+          tax_behavior?: PriceData.TaxBehavior;
+
+          /**
+           * A positive integer in %s (or 0 for a free price) representing how much to charge.
+           */
+          unit_amount?: number;
+
+          /**
+           * Same as `unit_amount`, but accepts a decimal value in %s with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.
+           */
+          unit_amount_decimal?: string;
+        }
+
+        namespace PriceData {
+          type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';
+        }
+      }
+
+      interface Payment {
+        /**
+         * Settings describing how the order should configure generated PaymentIntents.
+         */
+        settings: Payment.Settings;
+      }
+
+      namespace Payment {
+        interface Settings {
+          /**
+           * The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
+           */
+          application_fee_amount?: number;
+
+          /**
+           * PaymentMethod-specific configuration to provide to the order's PaymentIntent.
+           */
+          payment_method_options?: Settings.PaymentMethodOptions;
+
+          /**
+           * The list of payment method types (e.g., card) to provide to the order's PaymentIntent.
+           */
+          payment_method_types?: Array<Settings.PaymentMethodType>;
+
+          /**
+           * The URL to redirect the customer to after they authenticate their payment.
+           */
+          return_url?: string;
+
+          /**
+           * For non-card charges, you can use this value as the complete description that appears on your customers' statements. Must contain at least one letter, maximum 22 characters.
+           */
+          statement_descriptor?: string;
+
+          /**
+           * Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+           */
+          statement_descriptor_suffix?: string;
+
+          /**
+           * Provides configuration for completing a transfer for the order after it is paid.
+           */
+          transfer_data?: Settings.TransferData;
+        }
+
+        namespace Settings {
+          interface PaymentMethodOptions {
+            /**
+             * If paying by `acss_debit`, this sub-hash contains details about the ACSS Debit payment method options to pass to the order's PaymentIntent.
+             */
+            acss_debit?: PaymentMethodOptions.AcssDebit;
+
+            /**
+             * If paying by `afterpay_clearpay`, this sub-hash contains details about the AfterpayClearpay payment method options to pass to the order's PaymentIntent.
+             */
+            afterpay_clearpay?: PaymentMethodOptions.AfterpayClearpay;
+
+            /**
+             * If paying by `alipay`, this sub-hash contains details about the Alipay payment method options to pass to the order's PaymentIntent.
+             */
+            alipay?: PaymentMethodOptions.Alipay;
+
+            /**
+             * If paying by `bancontact`, this sub-hash contains details about the Bancontact payment method options to pass to the order's PaymentIntent.
+             */
+            bancontact?: PaymentMethodOptions.Bancontact;
+
+            /**
+             * If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the order's PaymentIntent.
+             */
+            card?: PaymentMethodOptions.Card;
+
+            /**
+             * If paying by `customer_balance`, this sub-hash contains details about the Customer Balance payment method options to pass to the order's PaymentIntent.
+             */
+            customer_balance?: PaymentMethodOptions.CustomerBalance;
+
+            /**
+             * If paying by `ideal`, this sub-hash contains details about the iDEAL payment method options to pass to the order's PaymentIntent.
+             */
+            ideal?: PaymentMethodOptions.Ideal;
+
+            /**
+             * If paying by `klarna`, this sub-hash contains details about the Klarna payment method options to pass to the order's PaymentIntent.
+             */
+            klarna?: PaymentMethodOptions.Klarna;
+
+            /**
+             * If paying by `oxxo`, this sub-hash contains details about the OXXO payment method options to pass to the order's PaymentIntent.
+             */
+            oxxo?: PaymentMethodOptions.Oxxo;
+
+            /**
+             * If paying by `p24`, this sub-hash contains details about the P24 payment method options to pass to the order's PaymentIntent.
+             */
+            p24?: PaymentMethodOptions.P24;
+
+            /**
+             * If paying by `sepa_debit`, this sub-hash contains details about the SEPA Debit payment method options to pass to the order's PaymentIntent.
+             */
+            sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+            /**
+             * If paying by `sofort`, this sub-hash contains details about the Sofort payment method options to pass to the order's PaymentIntent.
+             */
+            sofort?: PaymentMethodOptions.Sofort;
+
+            /**
+             * If paying by `wechat_pay`, this sub-hash contains details about the WeChat Pay payment method options to pass to the order's PaymentIntent.
+             */
+            wechat_pay?: PaymentMethodOptions.WechatPay;
+          }
+
+          namespace PaymentMethodOptions {
+            interface AcssDebit {
+              /**
+               * Additional fields for Mandate creation
+               */
+              mandate_options?: AcssDebit.MandateOptions;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<AcssDebit.SetupFutureUsage>;
+
+              /**
+               * Verification method for the intent
+               */
+              verification_method?: AcssDebit.VerificationMethod;
+            }
+
+            namespace AcssDebit {
+              interface MandateOptions {
+                /**
+                 * A URL for custom mandate text to render during confirmation step.
+                 * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+                 * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+                 */
+                custom_mandate_url?: Stripe.Emptyable<string>;
+
+                /**
+                 * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+                 */
+                interval_description?: string;
+
+                /**
+                 * Payment schedule for the mandate.
+                 */
+                payment_schedule?: MandateOptions.PaymentSchedule;
+
+                /**
+                 * Transaction type of the mandate.
+                 */
+                transaction_type?: MandateOptions.TransactionType;
+              }
+
+              namespace MandateOptions {
+                type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+                type TransactionType = 'business' | 'personal';
+              }
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+              type VerificationMethod =
+                | 'automatic'
+                | 'instant'
+                | 'microdeposits';
+            }
+
+            interface AfterpayClearpay {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               *
+               * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+               *
+               * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+               */
+              capture_method?: AfterpayClearpay.CaptureMethod;
+
+              /**
+               * Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
+               * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
+               */
+              reference?: string;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace AfterpayClearpay {
+              type CaptureMethod = 'automatic' | 'manual';
+            }
+
+            interface Alipay {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<Alipay.SetupFutureUsage>;
+            }
+
+            namespace Alipay {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Bancontact {
+              /**
+               * Preferred language of the Bancontact authorization page that the customer is redirected to.
+               */
+              preferred_language?: Bancontact.PreferredLanguage;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<
+                Bancontact.SetupFutureUsage
+              >;
+            }
+
+            namespace Bancontact {
+              type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Card {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method?: Card.CaptureMethod;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Card.SetupFutureUsage;
+            }
+
+            namespace Card {
+              type CaptureMethod = 'automatic' | 'manual';
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+            }
+
+            interface CustomerBalance {
+              /**
+               * Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
+               */
+              bank_transfer?: CustomerBalance.BankTransfer;
+
+              /**
+               * The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+               */
+              funding_type?: 'bank_transfer';
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace CustomerBalance {
+              interface BankTransfer {
+                /**
+                 * List of address types that should be returned in the financial_addresses response. If not specified, all valid types will be returned.
+                 *
+                 * Permitted values include: `zengin`.
+                 */
+                requested_address_types?: Array<'zengin'>;
+
+                /**
+                 * The list of bank transfer types that this PaymentIntent is allowed to use for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+                 */
+                type: 'jp_bank_transfer';
+              }
+            }
+
+            interface Ideal {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<Ideal.SetupFutureUsage>;
+            }
+
+            namespace Ideal {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Klarna {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               *
+               * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+               *
+               * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+               */
+              capture_method?: Stripe.Emptyable<'manual'>;
+
+              /**
+               * Preferred language of the Klarna authorization page that the customer is redirected to
+               */
+              preferred_locale?: Klarna.PreferredLocale;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace Klarna {
+              type PreferredLocale =
+                | 'da-DK'
+                | 'de-AT'
+                | 'de-DE'
+                | 'en-AT'
+                | 'en-BE'
+                | 'en-DE'
+                | 'en-DK'
+                | 'en-ES'
+                | 'en-FI'
+                | 'en-FR'
+                | 'en-GB'
+                | 'en-IE'
+                | 'en-IT'
+                | 'en-NL'
+                | 'en-NO'
+                | 'en-SE'
+                | 'en-US'
+                | 'es-ES'
+                | 'es-US'
+                | 'fi-FI'
+                | 'fr-BE'
+                | 'fr-FR'
+                | 'it-IT'
+                | 'nb-NO'
+                | 'nl-BE'
+                | 'nl-NL'
+                | 'sv-FI'
+                | 'sv-SE';
+            }
+
+            interface Oxxo {
+              /**
+               * The number of calendar days before an OXXO voucher expires. For example, if you create an OXXO voucher on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+               */
+              expires_after_days?: number;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            interface P24 {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+
+              /**
+               * Confirm that the payer has accepted the P24 terms and conditions.
+               */
+              tos_shown_and_accepted?: boolean;
+            }
+
+            interface SepaDebit {
+              /**
+               * Additional fields for Mandate creation
+               */
+              mandate_options?: SepaDebit.MandateOptions;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<SepaDebit.SetupFutureUsage>;
+            }
+
+            namespace SepaDebit {
+              interface MandateOptions {}
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+            }
+
+            interface Sofort {
+              /**
+               * Language shown to the payer on redirect.
+               */
+              preferred_language?: Stripe.Emptyable<Sofort.PreferredLanguage>;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<Sofort.SetupFutureUsage>;
+            }
+
+            namespace Sofort {
+              type PreferredLanguage =
+                | 'de'
+                | 'en'
+                | 'es'
+                | 'fr'
+                | 'it'
+                | 'nl'
+                | 'pl';
+
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface WechatPay {
+              /**
+               * The app ID registered with WeChat Pay. Only required when client is ios or android.
+               */
+              app_id?: string;
+
+              /**
+               * The client type that the end customer will pay from
+               */
+              client: WechatPay.Client;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace WechatPay {
+              type Client = 'android' | 'ios' | 'web';
+            }
+          }
+
+          type PaymentMethodType =
+            | 'acss_debit'
+            | 'afterpay_clearpay'
+            | 'alipay'
+            | 'au_becs_debit'
+            | 'bacs_debit'
+            | 'bancontact'
+            | 'card'
+            | 'customer_balance'
+            | 'eps'
+            | 'fpx'
+            | 'giropay'
+            | 'grabpay'
+            | 'ideal'
+            | 'klarna'
+            | 'link'
+            | 'oxxo'
+            | 'p24'
+            | 'paypal'
+            | 'sepa_debit'
+            | 'sofort'
+            | 'wechat_pay';
+
+          interface TransferData {
+            /**
+             * The amount that will be transferred automatically when the order is paid. If no amount is set, the full amount is transferred. There cannot be any line items with recurring prices when using this field.
+             */
+            amount?: number;
+
+            /**
+             * ID of the Connected account receiving the transfer.
+             */
+            destination: string;
+          }
+        }
+      }
+
+      interface ShippingCost {
+        /**
+         * The ID of the shipping rate to use for this order.
+         */
+        shipping_rate?: string;
+
+        /**
+         * Parameters to create a new ad-hoc shipping rate for this order.
+         */
+        shipping_rate_data?: ShippingCost.ShippingRateData;
+      }
+
+      namespace ShippingCost {
+        interface ShippingRateData {
+          /**
+           * The estimated range for how long shipping will take, meant to be displayable to the customer. This will appear on CheckoutSessions.
+           */
+          delivery_estimate?: ShippingRateData.DeliveryEstimate;
+
+          /**
+           * The name of the shipping rate, meant to be displayable to the customer. This will appear on CheckoutSessions.
+           */
+          display_name: string;
+
+          /**
+           * Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
+           */
+          fixed_amount?: ShippingRateData.FixedAmount;
+
+          /**
+           * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+           */
+          metadata?: Stripe.MetadataParam;
+
+          /**
+           * Specifies whether the rate is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`.
+           */
+          tax_behavior?: ShippingRateData.TaxBehavior;
+
+          /**
+           * A [tax code](https://stripe.com/docs/tax/tax-categories) ID. The Shipping tax code is `txcd_92010001`.
+           */
+          tax_code?: string;
+
+          /**
+           * The type of calculation to use on the shipping rate. Can only be `fixed_amount` for now.
+           */
+          type?: 'fixed_amount';
+        }
+
+        namespace ShippingRateData {
+          interface DeliveryEstimate {
+            /**
+             * The upper bound of the estimated range. If empty, represents no upper bound i.e., infinite.
+             */
+            maximum?: DeliveryEstimate.Maximum;
+
+            /**
+             * The lower bound of the estimated range. If empty, represents no lower bound.
+             */
+            minimum?: DeliveryEstimate.Minimum;
+          }
+
+          namespace DeliveryEstimate {
+            interface Maximum {
+              /**
+               * A unit of time.
+               */
+              unit: Maximum.Unit;
+
+              /**
+               * Must be greater than 0.
+               */
+              value: number;
+            }
+
+            namespace Maximum {
+              type Unit = 'business_day' | 'day' | 'hour' | 'month' | 'week';
+            }
+
+            interface Minimum {
+              /**
+               * A unit of time.
+               */
+              unit: Minimum.Unit;
+
+              /**
+               * Must be greater than 0.
+               */
+              value: number;
+            }
+
+            namespace Minimum {
+              type Unit = 'business_day' | 'day' | 'hour' | 'month' | 'week';
+            }
+          }
+
+          interface FixedAmount {
+            /**
+             * A non-negative integer in cents representing how much to charge.
+             */
+            amount: number;
+
+            /**
+             * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+             */
+            currency: string;
+          }
+
+          type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';
+        }
+      }
+
+      interface ShippingDetails {
+        /**
+         * The shipping address for the order.
+         */
+        address: ShippingDetails.Address;
+
+        /**
+         * The name of the recipient of the order.
+         */
+        name: string;
+
+        /**
+         * The phone number (including extension) for the recipient of the order.
+         */
+        phone?: string;
+      }
+
+      namespace ShippingDetails {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
+      }
+
+      interface TaxDetails {
+        /**
+         * The purchaser's tax exemption status. One of `none`, `exempt`, or `reverse`.
+         */
+        tax_exempt?: Stripe.Emptyable<TaxDetails.TaxExempt>;
+
+        /**
+         * The purchaser's tax IDs to be used for this order.
+         */
+        tax_ids?: Array<TaxDetails.TaxId>;
+      }
+
+      namespace TaxDetails {
+        type TaxExempt = 'exempt' | 'none' | 'reverse';
+
+        interface TaxId {
+          /**
+           * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
+           */
+          type: TaxId.Type;
+
+          /**
+           * Value of the tax ID.
+           */
+          value: string;
+        }
+
+        namespace TaxId {
+          type Type =
+            | 'ae_trn'
+            | 'au_abn'
+            | 'au_arn'
+            | 'bg_uic'
+            | 'br_cnpj'
+            | 'br_cpf'
+            | 'ca_bn'
+            | 'ca_gst_hst'
+            | 'ca_pst_bc'
+            | 'ca_pst_mb'
+            | 'ca_pst_sk'
+            | 'ca_qst'
+            | 'ch_vat'
+            | 'cl_tin'
+            | 'es_cif'
+            | 'eu_oss_vat'
+            | 'eu_vat'
+            | 'gb_vat'
+            | 'ge_vat'
+            | 'hk_br'
+            | 'hu_tin'
+            | 'id_npwp'
+            | 'il_vat'
+            | 'in_gst'
+            | 'is_vat'
+            | 'jp_cn'
+            | 'jp_rn'
+            | 'kr_brn'
+            | 'li_uid'
+            | 'mx_rfc'
+            | 'my_frp'
+            | 'my_itn'
+            | 'my_sst'
+            | 'no_vat'
+            | 'nz_gst'
+            | 'ru_inn'
+            | 'ru_kpp'
+            | 'sa_vat'
+            | 'sg_gst'
+            | 'sg_uen'
+            | 'si_tin'
+            | 'th_vat'
+            | 'tw_vat'
+            | 'ua_vat'
+            | 'us_ein'
+            | 'za_vat';
         }
       }
     }
@@ -321,9 +1832,34 @@ declare module 'stripe' {
 
     interface OrderUpdateParams {
       /**
-       * A coupon code that represents a discount to be applied to this order. Must be one-time duration and in same currency as the order. An order can have multiple coupons.
+       * Settings for automatic tax calculation for this order.
        */
-      coupon?: string;
+      automatic_tax?: OrderUpdateParams.AutomaticTax;
+
+      /**
+       * Billing details for the customer. If a customer is provided, this will be automatically populated with values from that customer if override values are not provided.
+       */
+      billing_details?: Stripe.Emptyable<OrderUpdateParams.BillingDetails>;
+
+      /**
+       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+       */
+      currency?: string;
+
+      /**
+       * The customer associated with this order.
+       */
+      customer?: string;
+
+      /**
+       * An arbitrary string attached to the object. Often useful for displaying to users.
+       */
+      description?: string;
+
+      /**
+       * The coupons, promotion codes, and/or discounts to apply to the order. Pass the empty string `""` to unset this field.
+       */
+      discounts?: Stripe.Emptyable<Array<OrderUpdateParams.Discount>>;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -331,48 +1867,947 @@ declare module 'stripe' {
       expand?: Array<string>;
 
       /**
+       * The IP address of the purchaser for this order.
+       */
+      ip_address?: string;
+
+      /**
+       * A list of line items the customer is ordering. Each line item includes information about the product, the quantity, and the resulting cost.
+       */
+      line_items?: Array<OrderUpdateParams.LineItem>;
+
+      /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
        */
       metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
 
       /**
-       * The shipping method to select for fulfilling this order. If specified, must be one of the `id`s of a shipping method in the `shipping_methods` array. If specified, will overwrite the existing selected shipping method, updating `items` as necessary.
+       * Payment information associated with the order, including payment settings.
        */
-      selected_shipping_method?: string;
+      payment?: OrderUpdateParams.Payment;
 
       /**
-       * Tracking information once the order has been fulfilled.
+       * Settings for the customer cost of shipping for this order.
        */
-      shipping?: OrderUpdateParams.Shipping;
+      shipping_cost?: Stripe.Emptyable<OrderUpdateParams.ShippingCost>;
 
       /**
-       * Current order status. One of `created`, `paid`, `canceled`, `fulfilled`, or `returned`. More detail in the [Orders Guide](https://stripe.com/docs/orders/guide#understanding-order-statuses).
+       * Shipping details for the order.
        */
-      status?: OrderUpdateParams.Status;
+      shipping_details?: Stripe.Emptyable<OrderUpdateParams.ShippingDetails>;
+
+      /**
+       * Additional tax details about the purchaser to be used for this order.
+       */
+      tax_details?: OrderUpdateParams.TaxDetails;
     }
 
     namespace OrderUpdateParams {
-      interface Shipping {
+      interface AutomaticTax {
         /**
-         * The name of the carrier like `USPS`, `UPS`, or `FedEx`.
+         * Enable automatic tax calculation which will automatically compute tax rates on this order.
          */
-        carrier: string;
-
-        /**
-         * The tracking number provided by the carrier.
-         */
-        tracking_number: string;
+        enabled: boolean;
       }
 
-      type Status = 'canceled' | 'created' | 'fulfilled' | 'paid' | 'returned';
+      interface BillingDetails {
+        /**
+         * The billing address provided by the customer.
+         */
+        address?: BillingDetails.Address;
+
+        /**
+         * The billing email provided by the customer.
+         */
+        email?: string;
+
+        /**
+         * The billing name provided by the customer.
+         */
+        name?: string;
+
+        /**
+         * The billing phone number provided by the customer.
+         */
+        phone?: string;
+      }
+
+      namespace BillingDetails {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
+      }
+
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+
+        /**
+         * ID of the promotion code to create a new discount for.
+         */
+        promotion_code?: string;
+      }
+
+      interface LineItem {
+        /**
+         * The description for the line item. Will default to the name of the associated product.
+         */
+        description?: string;
+
+        /**
+         * The discounts applied to this line item.
+         */
+        discounts?: Stripe.Emptyable<Array<LineItem.Discount>>;
+
+        /**
+         * The ID of an existing line item on the order.
+         */
+        id?: string;
+
+        /**
+         * The ID of the price object. One of `product` (with default price) or `price` or `price_data` is required.
+         */
+        price?: string;
+
+        /**
+         * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline. One of `product` (with default price) or `price` or `price_data` is required.
+         */
+        price_data?: LineItem.PriceData;
+
+        /**
+         * The product of the line item. The product must have a default price specified. One of `product` (with default price) or `price` or `price_data` is required.
+         */
+        product?: string;
+
+        /**
+         * The quantity of the line item.
+         */
+        quantity?: number;
+
+        /**
+         * The tax rates applied to this line item.
+         */
+        tax_rates?: Stripe.Emptyable<Array<string>>;
+      }
+
+      namespace LineItem {
+        interface Discount {
+          /**
+           * ID of the coupon to create a new discount for.
+           */
+          coupon?: string;
+
+          /**
+           * ID of an existing discount on the object (or one of its ancestors) to reuse.
+           */
+          discount?: string;
+        }
+
+        interface PriceData {
+          /**
+           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+           */
+          currency?: string;
+
+          /**
+           * The ID of the product that this price will belong to.
+           */
+          product?: string;
+
+          /**
+           * Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed.
+           */
+          tax_behavior?: PriceData.TaxBehavior;
+
+          /**
+           * A positive integer in %s (or 0 for a free price) representing how much to charge.
+           */
+          unit_amount?: number;
+
+          /**
+           * Same as `unit_amount`, but accepts a decimal value in %s with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.
+           */
+          unit_amount_decimal?: string;
+        }
+
+        namespace PriceData {
+          type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';
+        }
+      }
+
+      interface Payment {
+        /**
+         * Settings describing how the order should configure generated PaymentIntents.
+         */
+        settings: Payment.Settings;
+      }
+
+      namespace Payment {
+        interface Settings {
+          /**
+           * The amount of the application fee (if any) that will be requested to be applied to the payment and transferred to the application owner's Stripe account.
+           */
+          application_fee_amount?: Stripe.Emptyable<number>;
+
+          /**
+           * PaymentMethod-specific configuration to provide to the order's PaymentIntent.
+           */
+          payment_method_options?: Settings.PaymentMethodOptions;
+
+          /**
+           * The list of payment method types (e.g., card) to provide to the order's PaymentIntent.
+           */
+          payment_method_types?: Array<Settings.PaymentMethodType>;
+
+          /**
+           * The URL to redirect the customer to after they authenticate their payment.
+           */
+          return_url?: Stripe.Emptyable<string>;
+
+          /**
+           * For non-card charges, you can use this value as the complete description that appears on your customers' statements. Must contain at least one letter, maximum 22 characters.
+           */
+          statement_descriptor?: string;
+
+          /**
+           * Provides information about a card payment that customers see on their statements. Concatenated with the prefix (shortened descriptor) or statement descriptor that's set on the account to form the complete statement descriptor. Maximum 22 characters for the concatenated descriptor.
+           */
+          statement_descriptor_suffix?: string;
+
+          /**
+           * Provides configuration for completing a transfer for the order after it is paid.
+           */
+          transfer_data?: Stripe.Emptyable<Settings.TransferData>;
+        }
+
+        namespace Settings {
+          interface PaymentMethodOptions {
+            /**
+             * If paying by `acss_debit`, this sub-hash contains details about the ACSS Debit payment method options to pass to the order's PaymentIntent.
+             */
+            acss_debit?: Stripe.Emptyable<PaymentMethodOptions.AcssDebit>;
+
+            /**
+             * If paying by `afterpay_clearpay`, this sub-hash contains details about the AfterpayClearpay payment method options to pass to the order's PaymentIntent.
+             */
+            afterpay_clearpay?: Stripe.Emptyable<
+              PaymentMethodOptions.AfterpayClearpay
+            >;
+
+            /**
+             * If paying by `alipay`, this sub-hash contains details about the Alipay payment method options to pass to the order's PaymentIntent.
+             */
+            alipay?: Stripe.Emptyable<PaymentMethodOptions.Alipay>;
+
+            /**
+             * If paying by `bancontact`, this sub-hash contains details about the Bancontact payment method options to pass to the order's PaymentIntent.
+             */
+            bancontact?: Stripe.Emptyable<PaymentMethodOptions.Bancontact>;
+
+            /**
+             * If paying by `card`, this sub-hash contains details about the Card payment method options to pass to the order's PaymentIntent.
+             */
+            card?: Stripe.Emptyable<PaymentMethodOptions.Card>;
+
+            /**
+             * If paying by `customer_balance`, this sub-hash contains details about the Customer Balance payment method options to pass to the order's PaymentIntent.
+             */
+            customer_balance?: Stripe.Emptyable<
+              PaymentMethodOptions.CustomerBalance
+            >;
+
+            /**
+             * If paying by `ideal`, this sub-hash contains details about the iDEAL payment method options to pass to the order's PaymentIntent.
+             */
+            ideal?: Stripe.Emptyable<PaymentMethodOptions.Ideal>;
+
+            /**
+             * If paying by `klarna`, this sub-hash contains details about the Klarna payment method options to pass to the order's PaymentIntent.
+             */
+            klarna?: Stripe.Emptyable<PaymentMethodOptions.Klarna>;
+
+            /**
+             * If paying by `oxxo`, this sub-hash contains details about the OXXO payment method options to pass to the order's PaymentIntent.
+             */
+            oxxo?: Stripe.Emptyable<PaymentMethodOptions.Oxxo>;
+
+            /**
+             * If paying by `p24`, this sub-hash contains details about the P24 payment method options to pass to the order's PaymentIntent.
+             */
+            p24?: Stripe.Emptyable<PaymentMethodOptions.P24>;
+
+            /**
+             * If paying by `sepa_debit`, this sub-hash contains details about the SEPA Debit payment method options to pass to the order's PaymentIntent.
+             */
+            sepa_debit?: Stripe.Emptyable<PaymentMethodOptions.SepaDebit>;
+
+            /**
+             * If paying by `sofort`, this sub-hash contains details about the Sofort payment method options to pass to the order's PaymentIntent.
+             */
+            sofort?: Stripe.Emptyable<PaymentMethodOptions.Sofort>;
+
+            /**
+             * If paying by `wechat_pay`, this sub-hash contains details about the WeChat Pay payment method options to pass to the order's PaymentIntent.
+             */
+            wechat_pay?: Stripe.Emptyable<PaymentMethodOptions.WechatPay>;
+          }
+
+          namespace PaymentMethodOptions {
+            interface AcssDebit {
+              /**
+               * Additional fields for Mandate creation
+               */
+              mandate_options?: AcssDebit.MandateOptions;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<AcssDebit.SetupFutureUsage>;
+
+              /**
+               * Verification method for the intent
+               */
+              verification_method?: AcssDebit.VerificationMethod;
+            }
+
+            namespace AcssDebit {
+              interface MandateOptions {
+                /**
+                 * A URL for custom mandate text to render during confirmation step.
+                 * The URL will be rendered with additional GET parameters `payment_intent` and `payment_intent_client_secret` when confirming a Payment Intent,
+                 * or `setup_intent` and `setup_intent_client_secret` when confirming a Setup Intent.
+                 */
+                custom_mandate_url?: Stripe.Emptyable<string>;
+
+                /**
+                 * Description of the mandate interval. Only required if 'payment_schedule' parameter is 'interval' or 'combined'.
+                 */
+                interval_description?: string;
+
+                /**
+                 * Payment schedule for the mandate.
+                 */
+                payment_schedule?: MandateOptions.PaymentSchedule;
+
+                /**
+                 * Transaction type of the mandate.
+                 */
+                transaction_type?: MandateOptions.TransactionType;
+              }
+
+              namespace MandateOptions {
+                type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
+
+                type TransactionType = 'business' | 'personal';
+              }
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+              type VerificationMethod =
+                | 'automatic'
+                | 'instant'
+                | 'microdeposits';
+            }
+
+            interface AfterpayClearpay {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               *
+               * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+               *
+               * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+               */
+              capture_method?: AfterpayClearpay.CaptureMethod;
+
+              /**
+               * Order identifier shown to the customer in Afterpay's online portal. We recommend using a value that helps you answer any questions a customer might have about
+               * the payment. The identifier is limited to 128 characters and may contain only letters, digits, underscores, backslashes and dashes.
+               */
+              reference?: string;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace AfterpayClearpay {
+              type CaptureMethod = 'automatic' | 'manual';
+            }
+
+            interface Alipay {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<Alipay.SetupFutureUsage>;
+            }
+
+            namespace Alipay {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Bancontact {
+              /**
+               * Preferred language of the Bancontact authorization page that the customer is redirected to.
+               */
+              preferred_language?: Bancontact.PreferredLanguage;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<
+                Bancontact.SetupFutureUsage
+              >;
+            }
+
+            namespace Bancontact {
+              type PreferredLanguage = 'de' | 'en' | 'fr' | 'nl';
+
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Card {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               */
+              capture_method?: Card.CaptureMethod;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Card.SetupFutureUsage;
+            }
+
+            namespace Card {
+              type CaptureMethod = 'automatic' | 'manual';
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+            }
+
+            interface CustomerBalance {
+              /**
+               * Configuration for the bank transfer funding type, if the `funding_type` is set to `bank_transfer`.
+               */
+              bank_transfer?: CustomerBalance.BankTransfer;
+
+              /**
+               * The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+               */
+              funding_type?: 'bank_transfer';
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace CustomerBalance {
+              interface BankTransfer {
+                /**
+                 * List of address types that should be returned in the financial_addresses response. If not specified, all valid types will be returned.
+                 *
+                 * Permitted values include: `zengin`.
+                 */
+                requested_address_types?: Array<'zengin'>;
+
+                /**
+                 * The list of bank transfer types that this PaymentIntent is allowed to use for funding. Permitted values include: `us_bank_account`, `eu_bank_account`, `id_bank_account`, `gb_bank_account`, `jp_bank_account`, `mx_bank_account`, `eu_bank_transfer`, `gb_bank_transfer`, `id_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
+                 */
+                type: 'jp_bank_transfer';
+              }
+            }
+
+            interface Ideal {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<Ideal.SetupFutureUsage>;
+            }
+
+            namespace Ideal {
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface Klarna {
+              /**
+               * Controls when the funds will be captured from the customer's account.
+               *
+               * If provided, this parameter will override the top-level `capture_method` when finalizing the payment with this payment method type.
+               *
+               * If `capture_method` is already set on the PaymentIntent, providing an empty value for this parameter will unset the stored value for this payment method type.
+               */
+              capture_method?: Stripe.Emptyable<'manual'>;
+
+              /**
+               * Preferred language of the Klarna authorization page that the customer is redirected to
+               */
+              preferred_locale?: Klarna.PreferredLocale;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace Klarna {
+              type PreferredLocale =
+                | 'da-DK'
+                | 'de-AT'
+                | 'de-DE'
+                | 'en-AT'
+                | 'en-BE'
+                | 'en-DE'
+                | 'en-DK'
+                | 'en-ES'
+                | 'en-FI'
+                | 'en-FR'
+                | 'en-GB'
+                | 'en-IE'
+                | 'en-IT'
+                | 'en-NL'
+                | 'en-NO'
+                | 'en-SE'
+                | 'en-US'
+                | 'es-ES'
+                | 'es-US'
+                | 'fi-FI'
+                | 'fr-BE'
+                | 'fr-FR'
+                | 'it-IT'
+                | 'nb-NO'
+                | 'nl-BE'
+                | 'nl-NL'
+                | 'sv-FI'
+                | 'sv-SE';
+            }
+
+            interface Oxxo {
+              /**
+               * The number of calendar days before an OXXO voucher expires. For example, if you create an OXXO voucher on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+               */
+              expires_after_days?: number;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            interface P24 {
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+
+              /**
+               * Confirm that the payer has accepted the P24 terms and conditions.
+               */
+              tos_shown_and_accepted?: boolean;
+            }
+
+            interface SepaDebit {
+              /**
+               * Additional fields for Mandate creation
+               */
+              mandate_options?: SepaDebit.MandateOptions;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<SepaDebit.SetupFutureUsage>;
+            }
+
+            namespace SepaDebit {
+              interface MandateOptions {}
+
+              type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+            }
+
+            interface Sofort {
+              /**
+               * Language shown to the payer on redirect.
+               */
+              preferred_language?: Stripe.Emptyable<Sofort.PreferredLanguage>;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: Stripe.Emptyable<Sofort.SetupFutureUsage>;
+            }
+
+            namespace Sofort {
+              type PreferredLanguage =
+                | 'de'
+                | 'en'
+                | 'es'
+                | 'fr'
+                | 'it'
+                | 'nl'
+                | 'pl';
+
+              type SetupFutureUsage = 'none' | 'off_session';
+            }
+
+            interface WechatPay {
+              /**
+               * The app ID registered with WeChat Pay. Only required when client is ios or android.
+               */
+              app_id?: string;
+
+              /**
+               * The client type that the end customer will pay from
+               */
+              client: WechatPay.Client;
+
+              /**
+               * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+               *
+               * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
+               *
+               * When processing card payments, Stripe also uses `setup_future_usage` to dynamically optimize your payment flow and comply with regional legislation and network rules, such as [SCA](https://stripe.com/docs/strong-customer-authentication).
+               *
+               * If `setup_future_usage` is already set and you are performing a request using a publishable key, you may only update the value from `on_session` to `off_session`.
+               */
+              setup_future_usage?: 'none';
+            }
+
+            namespace WechatPay {
+              type Client = 'android' | 'ios' | 'web';
+            }
+          }
+
+          type PaymentMethodType =
+            | 'acss_debit'
+            | 'afterpay_clearpay'
+            | 'alipay'
+            | 'au_becs_debit'
+            | 'bacs_debit'
+            | 'bancontact'
+            | 'card'
+            | 'customer_balance'
+            | 'eps'
+            | 'fpx'
+            | 'giropay'
+            | 'grabpay'
+            | 'ideal'
+            | 'klarna'
+            | 'link'
+            | 'oxxo'
+            | 'p24'
+            | 'paypal'
+            | 'sepa_debit'
+            | 'sofort'
+            | 'wechat_pay';
+
+          interface TransferData {
+            /**
+             * The amount that will be transferred automatically when the order is paid. If no amount is set, the full amount is transferred. There cannot be any line items with recurring prices when using this field.
+             */
+            amount?: number;
+
+            /**
+             * ID of the Connected account receiving the transfer.
+             */
+            destination: string;
+          }
+        }
+      }
+
+      interface ShippingCost {
+        /**
+         * The ID of the shipping rate to use for this order.
+         */
+        shipping_rate?: string;
+
+        /**
+         * Parameters to create a new ad-hoc shipping rate for this order.
+         */
+        shipping_rate_data?: ShippingCost.ShippingRateData;
+      }
+
+      namespace ShippingCost {
+        interface ShippingRateData {
+          /**
+           * The estimated range for how long shipping will take, meant to be displayable to the customer. This will appear on CheckoutSessions.
+           */
+          delivery_estimate?: ShippingRateData.DeliveryEstimate;
+
+          /**
+           * The name of the shipping rate, meant to be displayable to the customer. This will appear on CheckoutSessions.
+           */
+          display_name: string;
+
+          /**
+           * Describes a fixed amount to charge for shipping. Must be present if type is `fixed_amount`.
+           */
+          fixed_amount?: ShippingRateData.FixedAmount;
+
+          /**
+           * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+           */
+          metadata?: Stripe.MetadataParam;
+
+          /**
+           * Specifies whether the rate is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`.
+           */
+          tax_behavior?: ShippingRateData.TaxBehavior;
+
+          /**
+           * A [tax code](https://stripe.com/docs/tax/tax-categories) ID. The Shipping tax code is `txcd_92010001`.
+           */
+          tax_code?: string;
+
+          /**
+           * The type of calculation to use on the shipping rate. Can only be `fixed_amount` for now.
+           */
+          type?: 'fixed_amount';
+        }
+
+        namespace ShippingRateData {
+          interface DeliveryEstimate {
+            /**
+             * The upper bound of the estimated range. If empty, represents no upper bound i.e., infinite.
+             */
+            maximum?: DeliveryEstimate.Maximum;
+
+            /**
+             * The lower bound of the estimated range. If empty, represents no lower bound.
+             */
+            minimum?: DeliveryEstimate.Minimum;
+          }
+
+          namespace DeliveryEstimate {
+            interface Maximum {
+              /**
+               * A unit of time.
+               */
+              unit: Maximum.Unit;
+
+              /**
+               * Must be greater than 0.
+               */
+              value: number;
+            }
+
+            namespace Maximum {
+              type Unit = 'business_day' | 'day' | 'hour' | 'month' | 'week';
+            }
+
+            interface Minimum {
+              /**
+               * A unit of time.
+               */
+              unit: Minimum.Unit;
+
+              /**
+               * Must be greater than 0.
+               */
+              value: number;
+            }
+
+            namespace Minimum {
+              type Unit = 'business_day' | 'day' | 'hour' | 'month' | 'week';
+            }
+          }
+
+          interface FixedAmount {
+            /**
+             * A non-negative integer in cents representing how much to charge.
+             */
+            amount: number;
+
+            /**
+             * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+             */
+            currency: string;
+          }
+
+          type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';
+        }
+      }
+
+      interface ShippingDetails {
+        /**
+         * The shipping address for the order.
+         */
+        address: ShippingDetails.Address;
+
+        /**
+         * The name of the recipient of the order.
+         */
+        name: string;
+
+        /**
+         * The phone number (including extension) for the recipient of the order.
+         */
+        phone?: string;
+      }
+
+      namespace ShippingDetails {
+        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
+        }
+      }
+
+      interface TaxDetails {
+        /**
+         * The purchaser's tax exemption status. One of `none`, `exempt`, or `reverse`.
+         */
+        tax_exempt?: Stripe.Emptyable<TaxDetails.TaxExempt>;
+
+        /**
+         * The purchaser's tax IDs to be used for this order.
+         */
+        tax_ids?: Array<TaxDetails.TaxId>;
+      }
+
+      namespace TaxDetails {
+        type TaxExempt = 'exempt' | 'none' | 'reverse';
+
+        interface TaxId {
+          /**
+           * Type of the tax ID, one of `ae_trn`, `au_abn`, `au_arn`, `bg_uic`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `nz_gst`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `th_vat`, `tw_vat`, `ua_vat`, `us_ein`, or `za_vat`
+           */
+          type: TaxId.Type;
+
+          /**
+           * Value of the tax ID.
+           */
+          value: string;
+        }
+
+        namespace TaxId {
+          type Type =
+            | 'ae_trn'
+            | 'au_abn'
+            | 'au_arn'
+            | 'bg_uic'
+            | 'br_cnpj'
+            | 'br_cpf'
+            | 'ca_bn'
+            | 'ca_gst_hst'
+            | 'ca_pst_bc'
+            | 'ca_pst_mb'
+            | 'ca_pst_sk'
+            | 'ca_qst'
+            | 'ch_vat'
+            | 'cl_tin'
+            | 'es_cif'
+            | 'eu_oss_vat'
+            | 'eu_vat'
+            | 'gb_vat'
+            | 'ge_vat'
+            | 'hk_br'
+            | 'hu_tin'
+            | 'id_npwp'
+            | 'il_vat'
+            | 'in_gst'
+            | 'is_vat'
+            | 'jp_cn'
+            | 'jp_rn'
+            | 'kr_brn'
+            | 'li_uid'
+            | 'mx_rfc'
+            | 'my_frp'
+            | 'my_itn'
+            | 'my_sst'
+            | 'no_vat'
+            | 'nz_gst'
+            | 'ru_inn'
+            | 'ru_kpp'
+            | 'sa_vat'
+            | 'sg_gst'
+            | 'sg_uen'
+            | 'si_tin'
+            | 'th_vat'
+            | 'tw_vat'
+            | 'ua_vat'
+            | 'us_ein'
+            | 'za_vat';
+        }
+      }
     }
 
     interface OrderListParams extends PaginationParams {
-      /**
-       * Date this order was created.
-       */
-      created?: Stripe.RangeQueryParam | number;
-
       /**
        * Only return orders for the given customer.
        */
@@ -382,132 +2817,32 @@ declare module 'stripe' {
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
-
-      /**
-       * Only return orders with the given IDs.
-       */
-      ids?: Array<string>;
-
-      /**
-       * Only return orders that have the given status. One of `created`, `paid`, `fulfilled`, or `refunded`.
-       */
-      status?: string;
-
-      /**
-       * Filter orders based on when they were paid, fulfilled, canceled, or returned.
-       */
-      status_transitions?: OrderListParams.StatusTransitions;
-
-      /**
-       * Only return orders with the given upstream order IDs.
-       */
-      upstream_ids?: Array<string>;
     }
 
-    namespace OrderListParams {
-      interface StatusTransitions {
-        /**
-         * Date this order was canceled.
-         */
-        canceled?: Stripe.RangeQueryParam | number;
-
-        /**
-         * Date this order was fulfilled.
-         */
-        fulfilled?: Stripe.RangeQueryParam | number;
-
-        /**
-         * Date this order was paid.
-         */
-        paid?: Stripe.RangeQueryParam | number;
-
-        /**
-         * Date this order was returned.
-         */
-        returned?: Stripe.RangeQueryParam | number;
-      }
-    }
-
-    interface OrderPayParams {
-      /**
-       * A fee in %s that will be applied to the order and transferred to the application owner's Stripe account. The request must be made with an OAuth key or the `Stripe-Account` header in order to take an application fee. For more information, see the application fees [documentation](https://stripe.com/docs/connect/direct-charges#collecting-fees).
-       */
-      application_fee?: number;
-
-      /**
-       * The ID of an existing customer that will be charged for this order. If no customer was attached to the order at creation, either `source` or `customer` is required. Otherwise, the specified customer will be charged instead of the one attached to the order.
-       */
-      customer?: string;
-
-      /**
-       * The email address of the customer placing the order. Required if not previously specified for the order.
-       */
-      email?: string;
-
+    interface OrderCancelParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
-
-      /**
-       * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
-       */
-      metadata?: Stripe.MetadataParam;
-
-      /**
-       * A [Token](https://stripe.com/docs/api#tokens)'s or a [Source](https://stripe.com/docs/api#sources)'s ID, as returned by [Elements](https://stripe.com/docs/elements). If no customer was attached to the order at creation, either `source` or `customer` is required. Otherwise, the specified source will be charged intead of the customer attached to the order.
-       */
-      source?: string;
     }
 
-    interface OrderReturnOrderParams {
+    interface OrderListLineItemsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
-
-      /**
-       * List of items to return.
-       */
-      items?: Stripe.Emptyable<Array<OrderReturnOrderParams.Item>>;
     }
 
-    namespace OrderReturnOrderParams {
-      interface Item {
-        /**
-         * The amount (price) for this order item to return.
-         */
-        amount?: number;
-
-        /**
-         * If returning a `tax` item, use description to disambiguate which one to return.
-         */
-        description?: string;
-
-        /**
-         * The ID of the SKU, tax, or shipping item being returned.
-         */
-        parent?: string;
-
-        /**
-         * When type is `sku`, this is the number of instances of the SKU to be returned.
-         */
-        quantity?: number;
-
-        /**
-         * The type of this order item. Must be `sku`, `tax`, or `shipping`.
-         */
-        type?: Item.Type;
-      }
-
-      namespace Item {
-        type Type = 'discount' | 'shipping' | 'sku' | 'tax';
-      }
+    interface OrderReopenParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
     }
 
     class OrdersResource {
       /**
-       * Creates a new order object.
+       * Creates a new open order object.
        */
       create(
         params: OrderCreateParams,
@@ -546,30 +2881,43 @@ declare module 'stripe' {
       list(options?: RequestOptions): ApiListPromise<Stripe.Order>;
 
       /**
-       * Pay an order by providing a source to create a payment.
+       * Cancels the order as well as the payment intent if one is attached.
        */
-      pay(
+      cancel(
         id: string,
-        params?: OrderPayParams,
+        params?: OrderCancelParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Order>>;
-      pay(
+      cancel(
         id: string,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Order>>;
 
       /**
-       * Return all or part of an order. The order must have a status of paid or fulfilled before it can be returned. Once all items have been returned, the order will become canceled or returned depending on which status the order started in.
+       * When retrieving an order, there is an includable line_items property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of line items.
        */
-      returnOrder(
+      listLineItems(
         id: string,
-        params?: OrderReturnOrderParams,
+        params?: OrderListLineItemsParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.OrderReturn>>;
-      returnOrder(
+      ): ApiListPromise<Stripe.LineItem>;
+      listLineItems(
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.OrderReturn>>;
+      ): ApiListPromise<Stripe.LineItem>;
+
+      /**
+       * Reopens a processing order.
+       */
+      reopen(
+        id: string,
+        params?: OrderReopenParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Order>>;
+      reopen(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Order>>;
     }
   }
 }

--- a/types/2020-08-27/Orders.d.ts
+++ b/types/2020-08-27/Orders.d.ts
@@ -2840,6 +2840,18 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
+    interface OrderSubmitParams {
+      /**
+       * `expected_total` should always be set to the order's `amount_total` field. If they don't match, submitting the order will fail. This helps detect race conditions where something else concurrently modifies the order.
+       */
+      expected_total: number;
+
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
     class OrdersResource {
       /**
        * Creates a new open order object.
@@ -2916,6 +2928,15 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Order>>;
       reopen(
         id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Order>>;
+
+      /**
+       * Submitting an Order transitions the status to processing and creates a PaymentIntent object so the order can be paid. If the Order has an amount_total of 0, no PaymentIntent object will be created. Once the order is submitted, its contents cannot be changed, unless the [reopen](https://stripe.com/docs/api#reopen_order) method is called.
+       */
+      submit(
+        id: string,
+        params: OrderSubmitParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Order>>;
     }

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -225,7 +225,7 @@ declare module 'stripe' {
           /**
            * Portion of the amount that corresponds to a tip.
            */
-          amount: number | null;
+          amount?: number;
         }
       }
 
@@ -1453,7 +1453,7 @@ declare module 'stripe' {
         /**
          * Recipient name.
          */
-        name?: string | null;
+        name?: string;
 
         /**
          * Recipient phone (including extension).

--- a/types/2020-08-27/Persons.d.ts
+++ b/types/2020-08-27/Persons.d.ts
@@ -122,6 +122,8 @@ declare module 'stripe' {
        */
       political_exposure?: Person.PoliticalExposure;
 
+      registered_address?: Stripe.Address;
+
       relationship?: Person.Relationship;
 
       /**
@@ -690,6 +692,11 @@ declare module 'stripe' {
       political_exposure?: string;
 
       /**
+       * The person's registered address.
+       */
+      registered_address?: PersonCreateParams.RegisteredAddress;
+
+      /**
        * The relationship that this person has with the account's legal entity.
        */
       relationship?: PersonCreateParams.Relationship;
@@ -765,6 +772,10 @@ declare module 'stripe' {
            */
           files?: Array<string>;
         }
+      }
+
+      interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+        line1?: string;
       }
 
       interface Relationship {
@@ -957,6 +968,11 @@ declare module 'stripe' {
       political_exposure?: string;
 
       /**
+       * The person's registered address.
+       */
+      registered_address?: PersonUpdateParams.RegisteredAddress;
+
+      /**
        * The relationship that this person has with the account's legal entity.
        */
       relationship?: PersonUpdateParams.Relationship;
@@ -1032,6 +1048,10 @@ declare module 'stripe' {
            */
           files?: Array<string>;
         }
+      }
+
+      interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+        line1?: string;
       }
 
       interface Relationship {

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -492,6 +492,12 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method)
+       * value in the SetupIntent.
+       */
+      payment_method_data?: SetupIntentCreateParams.PaymentMethodData;
+
+      /**
        * Payment-method-specific configuration for this SetupIntent.
        */
       payment_method_options?: SetupIntentCreateParams.PaymentMethodOptions;
@@ -565,6 +571,471 @@ declare module 'stripe' {
 
           type Type = 'offline' | 'online';
         }
+      }
+
+      interface PaymentMethodData {
+        /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
+         * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
+         */
+        alipay?: PaymentMethodData.Alipay;
+
+        /**
+         * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+         */
+        au_becs_debit?: PaymentMethodData.AuBecsDebit;
+
+        /**
+         * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+         */
+        bacs_debit?: PaymentMethodData.BacsDebit;
+
+        /**
+         * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+         */
+        bancontact?: PaymentMethodData.Bancontact;
+
+        /**
+         * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+         */
+        billing_details?: PaymentMethodData.BillingDetails;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
+         * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+         */
+        customer_balance?: PaymentMethodData.CustomerBalance;
+
+        /**
+         * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+         */
+        eps?: PaymentMethodData.Eps;
+
+        /**
+         * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
+         */
+        fpx?: PaymentMethodData.Fpx;
+
+        /**
+         * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+         */
+        giropay?: PaymentMethodData.Giropay;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
+         */
+        grabpay?: PaymentMethodData.Grabpay;
+
+        /**
+         * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
+         */
+        ideal?: PaymentMethodData.Ideal;
+
+        /**
+         * If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
+         */
+        interac_present?: PaymentMethodData.InteracPresent;
+
+        /**
+         * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
+         */
+        klarna?: PaymentMethodData.Klarna;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.MetadataParam;
+
+        /**
+         * If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
+         */
+        oxxo?: PaymentMethodData.Oxxo;
+
+        /**
+         * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+         */
+        p24?: PaymentMethodData.P24;
+
+        /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
+         * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+         */
+        sepa_debit?: PaymentMethodData.SepaDebit;
+
+        /**
+         * If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
+         */
+        sofort?: PaymentMethodData.Sofort;
+
+        /**
+         * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+         */
+        type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
+      }
+
+      namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
+        interface AfterpayClearpay {}
+
+        interface Alipay {}
+
+        interface AuBecsDebit {
+          /**
+           * The account number for the bank account.
+           */
+          account_number: string;
+
+          /**
+           * Bank-State-Branch number of the bank account.
+           */
+          bsb_number: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Account number of the bank account that the funds will be debited from.
+           */
+          account_number?: string;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code?: string;
+        }
+
+        interface Bancontact {}
+
+        interface BillingDetails {
+          /**
+           * Billing address.
+           */
+          address?: Stripe.Emptyable<BillingDetails.Address>;
+
+          /**
+           * Email address.
+           */
+          email?: Stripe.Emptyable<string>;
+
+          /**
+           * Full name.
+           */
+          name?: string;
+
+          /**
+           * Billing phone number (including extension).
+           */
+          phone?: string;
+        }
+
+        namespace BillingDetails {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
+        }
+
+        interface Boleto {
+          /**
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
+           */
+          tax_id: string;
+        }
+
+        interface CustomerBalance {}
+
+        interface Eps {
+          /**
+           * The customer's bank.
+           */
+          bank?: Eps.Bank;
+        }
+
+        namespace Eps {
+          type Bank =
+            | 'arzte_und_apotheker_bank'
+            | 'austrian_anadi_bank_ag'
+            | 'bank_austria'
+            | 'bankhaus_carl_spangler'
+            | 'bankhaus_schelhammer_und_schattera_ag'
+            | 'bawag_psk_ag'
+            | 'bks_bank_ag'
+            | 'brull_kallmus_bank_ag'
+            | 'btv_vier_lander_bank'
+            | 'capital_bank_grawe_gruppe_ag'
+            | 'dolomitenbank'
+            | 'easybank_ag'
+            | 'erste_bank_und_sparkassen'
+            | 'hypo_alpeadriabank_international_ag'
+            | 'hypo_bank_burgenland_aktiengesellschaft'
+            | 'hypo_noe_lb_fur_niederosterreich_u_wien'
+            | 'hypo_oberosterreich_salzburg_steiermark'
+            | 'hypo_tirol_bank_ag'
+            | 'hypo_vorarlberg_bank_ag'
+            | 'marchfelder_bank'
+            | 'oberbank_ag'
+            | 'raiffeisen_bankengruppe_osterreich'
+            | 'schoellerbank_ag'
+            | 'sparda_bank_wien'
+            | 'volksbank_gruppe'
+            | 'volkskreditbank_ag'
+            | 'vr_bank_braunau';
+        }
+
+        interface Fpx {
+          /**
+           * Account holder type for FPX transaction
+           */
+          account_holder_type?: Fpx.AccountHolderType;
+
+          /**
+           * The customer's bank.
+           */
+          bank: Fpx.Bank;
+        }
+
+        namespace Fpx {
+          type AccountHolderType = 'company' | 'individual';
+
+          type Bank =
+            | 'affin_bank'
+            | 'agrobank'
+            | 'alliance_bank'
+            | 'ambank'
+            | 'bank_islam'
+            | 'bank_muamalat'
+            | 'bank_rakyat'
+            | 'bsn'
+            | 'cimb'
+            | 'deutsche_bank'
+            | 'hong_leong_bank'
+            | 'hsbc'
+            | 'kfh'
+            | 'maybank2e'
+            | 'maybank2u'
+            | 'ocbc'
+            | 'pb_enterprise'
+            | 'public_bank'
+            | 'rhb'
+            | 'standard_chartered'
+            | 'uob';
+        }
+
+        interface Giropay {}
+
+        interface Grabpay {}
+
+        interface Ideal {
+          /**
+           * The customer's bank.
+           */
+          bank?: Ideal.Bank;
+        }
+
+        namespace Ideal {
+          type Bank =
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'revolut'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+        }
+
+        interface InteracPresent {}
+
+        interface Klarna {
+          /**
+           * Customer's date of birth
+           */
+          dob?: Klarna.Dob;
+        }
+
+        namespace Klarna {
+          interface Dob {
+            /**
+             * The day of birth, between 1 and 31.
+             */
+            day: number;
+
+            /**
+             * The month of birth, between 1 and 12.
+             */
+            month: number;
+
+            /**
+             * The four-digit year of birth.
+             */
+            year: number;
+          }
+        }
+
+        interface Konbini {}
+
+        interface Oxxo {}
+
+        interface P24 {
+          /**
+           * The customer's bank.
+           */
+          bank?: P24.Bank;
+        }
+
+        namespace P24 {
+          type Bank =
+            | 'alior_bank'
+            | 'bank_millennium'
+            | 'bank_nowy_bfg_sa'
+            | 'bank_pekao_sa'
+            | 'banki_spbdzielcze'
+            | 'blik'
+            | 'bnp_paribas'
+            | 'boz'
+            | 'citi_handlowy'
+            | 'credit_agricole'
+            | 'envelobank'
+            | 'etransfer_pocztowy24'
+            | 'getin_bank'
+            | 'ideabank'
+            | 'ing'
+            | 'inteligo'
+            | 'mbank_mtransfer'
+            | 'nest_przelew'
+            | 'noble_pay'
+            | 'pbac_z_ipko'
+            | 'plus_bank'
+            | 'santander_przelew24'
+            | 'tmobile_usbugi_bankowe'
+            | 'toyota_bank'
+            | 'volkswagen_bank';
+        }
+
+        interface Paynow {}
+
+        interface SepaDebit {
+          /**
+           * IBAN of the bank account.
+           */
+          iban: string;
+        }
+
+        interface Sofort {
+          /**
+           * Two-letter ISO code representing the country the bank account is located in.
+           */
+          country: Sofort.Country;
+        }
+
+        namespace Sofort {
+          type Country = 'AT' | 'BE' | 'DE' | 'ES' | 'IT' | 'NL';
+        }
+
+        type Type =
+          | 'acss_debit'
+          | 'afterpay_clearpay'
+          | 'alipay'
+          | 'au_becs_debit'
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'boleto'
+          | 'customer_balance'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'grabpay'
+          | 'ideal'
+          | 'klarna'
+          | 'konbini'
+          | 'oxxo'
+          | 'p24'
+          | 'paynow'
+          | 'sepa_debit'
+          | 'sofort'
+          | 'us_bank_account'
+          | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {
@@ -810,6 +1281,12 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method)
+       * value in the SetupIntent.
+       */
+      payment_method_data?: SetupIntentUpdateParams.PaymentMethodData;
+
+      /**
        * Payment-method-specific configuration for this SetupIntent.
        */
       payment_method_options?: SetupIntentUpdateParams.PaymentMethodOptions;
@@ -821,6 +1298,471 @@ declare module 'stripe' {
     }
 
     namespace SetupIntentUpdateParams {
+      interface PaymentMethodData {
+        /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
+         * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
+         */
+        alipay?: PaymentMethodData.Alipay;
+
+        /**
+         * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+         */
+        au_becs_debit?: PaymentMethodData.AuBecsDebit;
+
+        /**
+         * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+         */
+        bacs_debit?: PaymentMethodData.BacsDebit;
+
+        /**
+         * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+         */
+        bancontact?: PaymentMethodData.Bancontact;
+
+        /**
+         * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+         */
+        billing_details?: PaymentMethodData.BillingDetails;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
+         * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+         */
+        customer_balance?: PaymentMethodData.CustomerBalance;
+
+        /**
+         * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+         */
+        eps?: PaymentMethodData.Eps;
+
+        /**
+         * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
+         */
+        fpx?: PaymentMethodData.Fpx;
+
+        /**
+         * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+         */
+        giropay?: PaymentMethodData.Giropay;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
+         */
+        grabpay?: PaymentMethodData.Grabpay;
+
+        /**
+         * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
+         */
+        ideal?: PaymentMethodData.Ideal;
+
+        /**
+         * If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
+         */
+        interac_present?: PaymentMethodData.InteracPresent;
+
+        /**
+         * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
+         */
+        klarna?: PaymentMethodData.Klarna;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.MetadataParam;
+
+        /**
+         * If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
+         */
+        oxxo?: PaymentMethodData.Oxxo;
+
+        /**
+         * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+         */
+        p24?: PaymentMethodData.P24;
+
+        /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
+         * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+         */
+        sepa_debit?: PaymentMethodData.SepaDebit;
+
+        /**
+         * If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
+         */
+        sofort?: PaymentMethodData.Sofort;
+
+        /**
+         * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+         */
+        type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
+      }
+
+      namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
+        interface AfterpayClearpay {}
+
+        interface Alipay {}
+
+        interface AuBecsDebit {
+          /**
+           * The account number for the bank account.
+           */
+          account_number: string;
+
+          /**
+           * Bank-State-Branch number of the bank account.
+           */
+          bsb_number: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Account number of the bank account that the funds will be debited from.
+           */
+          account_number?: string;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code?: string;
+        }
+
+        interface Bancontact {}
+
+        interface BillingDetails {
+          /**
+           * Billing address.
+           */
+          address?: Stripe.Emptyable<BillingDetails.Address>;
+
+          /**
+           * Email address.
+           */
+          email?: Stripe.Emptyable<string>;
+
+          /**
+           * Full name.
+           */
+          name?: string;
+
+          /**
+           * Billing phone number (including extension).
+           */
+          phone?: string;
+        }
+
+        namespace BillingDetails {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
+        }
+
+        interface Boleto {
+          /**
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
+           */
+          tax_id: string;
+        }
+
+        interface CustomerBalance {}
+
+        interface Eps {
+          /**
+           * The customer's bank.
+           */
+          bank?: Eps.Bank;
+        }
+
+        namespace Eps {
+          type Bank =
+            | 'arzte_und_apotheker_bank'
+            | 'austrian_anadi_bank_ag'
+            | 'bank_austria'
+            | 'bankhaus_carl_spangler'
+            | 'bankhaus_schelhammer_und_schattera_ag'
+            | 'bawag_psk_ag'
+            | 'bks_bank_ag'
+            | 'brull_kallmus_bank_ag'
+            | 'btv_vier_lander_bank'
+            | 'capital_bank_grawe_gruppe_ag'
+            | 'dolomitenbank'
+            | 'easybank_ag'
+            | 'erste_bank_und_sparkassen'
+            | 'hypo_alpeadriabank_international_ag'
+            | 'hypo_bank_burgenland_aktiengesellschaft'
+            | 'hypo_noe_lb_fur_niederosterreich_u_wien'
+            | 'hypo_oberosterreich_salzburg_steiermark'
+            | 'hypo_tirol_bank_ag'
+            | 'hypo_vorarlberg_bank_ag'
+            | 'marchfelder_bank'
+            | 'oberbank_ag'
+            | 'raiffeisen_bankengruppe_osterreich'
+            | 'schoellerbank_ag'
+            | 'sparda_bank_wien'
+            | 'volksbank_gruppe'
+            | 'volkskreditbank_ag'
+            | 'vr_bank_braunau';
+        }
+
+        interface Fpx {
+          /**
+           * Account holder type for FPX transaction
+           */
+          account_holder_type?: Fpx.AccountHolderType;
+
+          /**
+           * The customer's bank.
+           */
+          bank: Fpx.Bank;
+        }
+
+        namespace Fpx {
+          type AccountHolderType = 'company' | 'individual';
+
+          type Bank =
+            | 'affin_bank'
+            | 'agrobank'
+            | 'alliance_bank'
+            | 'ambank'
+            | 'bank_islam'
+            | 'bank_muamalat'
+            | 'bank_rakyat'
+            | 'bsn'
+            | 'cimb'
+            | 'deutsche_bank'
+            | 'hong_leong_bank'
+            | 'hsbc'
+            | 'kfh'
+            | 'maybank2e'
+            | 'maybank2u'
+            | 'ocbc'
+            | 'pb_enterprise'
+            | 'public_bank'
+            | 'rhb'
+            | 'standard_chartered'
+            | 'uob';
+        }
+
+        interface Giropay {}
+
+        interface Grabpay {}
+
+        interface Ideal {
+          /**
+           * The customer's bank.
+           */
+          bank?: Ideal.Bank;
+        }
+
+        namespace Ideal {
+          type Bank =
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'revolut'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+        }
+
+        interface InteracPresent {}
+
+        interface Klarna {
+          /**
+           * Customer's date of birth
+           */
+          dob?: Klarna.Dob;
+        }
+
+        namespace Klarna {
+          interface Dob {
+            /**
+             * The day of birth, between 1 and 31.
+             */
+            day: number;
+
+            /**
+             * The month of birth, between 1 and 12.
+             */
+            month: number;
+
+            /**
+             * The four-digit year of birth.
+             */
+            year: number;
+          }
+        }
+
+        interface Konbini {}
+
+        interface Oxxo {}
+
+        interface P24 {
+          /**
+           * The customer's bank.
+           */
+          bank?: P24.Bank;
+        }
+
+        namespace P24 {
+          type Bank =
+            | 'alior_bank'
+            | 'bank_millennium'
+            | 'bank_nowy_bfg_sa'
+            | 'bank_pekao_sa'
+            | 'banki_spbdzielcze'
+            | 'blik'
+            | 'bnp_paribas'
+            | 'boz'
+            | 'citi_handlowy'
+            | 'credit_agricole'
+            | 'envelobank'
+            | 'etransfer_pocztowy24'
+            | 'getin_bank'
+            | 'ideabank'
+            | 'ing'
+            | 'inteligo'
+            | 'mbank_mtransfer'
+            | 'nest_przelew'
+            | 'noble_pay'
+            | 'pbac_z_ipko'
+            | 'plus_bank'
+            | 'santander_przelew24'
+            | 'tmobile_usbugi_bankowe'
+            | 'toyota_bank'
+            | 'volkswagen_bank';
+        }
+
+        interface Paynow {}
+
+        interface SepaDebit {
+          /**
+           * IBAN of the bank account.
+           */
+          iban: string;
+        }
+
+        interface Sofort {
+          /**
+           * Two-letter ISO code representing the country the bank account is located in.
+           */
+          country: Sofort.Country;
+        }
+
+        namespace Sofort {
+          type Country = 'AT' | 'BE' | 'DE' | 'ES' | 'IT' | 'NL';
+        }
+
+        type Type =
+          | 'acss_debit'
+          | 'afterpay_clearpay'
+          | 'alipay'
+          | 'au_becs_debit'
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'boleto'
+          | 'customer_balance'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'grabpay'
+          | 'ideal'
+          | 'klarna'
+          | 'konbini'
+          | 'oxxo'
+          | 'p24'
+          | 'paynow'
+          | 'sepa_debit'
+          | 'sofort'
+          | 'us_bank_account'
+          | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
+
+        interface WechatPay {}
+      }
+
       interface PaymentMethodOptions {
         /**
          * If this is a `acss_debit` SetupIntent, this sub-hash contains details about the ACSS Debit payment method options.
@@ -1069,6 +2011,12 @@ declare module 'stripe' {
       payment_method?: string;
 
       /**
+       * When included, this hash creates a PaymentMethod that is set as the [`payment_method`](https://stripe.com/docs/api/setup_intents/object#setup_intent_object-payment_method)
+       * value in the SetupIntent.
+       */
+      payment_method_data?: SetupIntentConfirmParams.PaymentMethodData;
+
+      /**
        * Payment-method-specific configuration for this SetupIntent.
        */
       payment_method_options?: SetupIntentConfirmParams.PaymentMethodOptions;
@@ -1164,6 +2112,471 @@ declare module 'stripe' {
             user_agent?: string;
           }
         }
+      }
+
+      interface PaymentMethodData {
+        /**
+         * If this is an `acss_debit` PaymentMethod, this hash contains details about the ACSS Debit payment method.
+         */
+        acss_debit?: PaymentMethodData.AcssDebit;
+
+        /**
+         * If this is an `AfterpayClearpay` PaymentMethod, this hash contains details about the AfterpayClearpay payment method.
+         */
+        afterpay_clearpay?: PaymentMethodData.AfterpayClearpay;
+
+        /**
+         * If this is an `Alipay` PaymentMethod, this hash contains details about the Alipay payment method.
+         */
+        alipay?: PaymentMethodData.Alipay;
+
+        /**
+         * If this is an `au_becs_debit` PaymentMethod, this hash contains details about the bank account.
+         */
+        au_becs_debit?: PaymentMethodData.AuBecsDebit;
+
+        /**
+         * If this is a `bacs_debit` PaymentMethod, this hash contains details about the Bacs Direct Debit bank account.
+         */
+        bacs_debit?: PaymentMethodData.BacsDebit;
+
+        /**
+         * If this is a `bancontact` PaymentMethod, this hash contains details about the Bancontact payment method.
+         */
+        bancontact?: PaymentMethodData.Bancontact;
+
+        /**
+         * Billing information associated with the PaymentMethod that may be used or required by particular types of payment methods.
+         */
+        billing_details?: PaymentMethodData.BillingDetails;
+
+        /**
+         * If this is a `boleto` PaymentMethod, this hash contains details about the Boleto payment method.
+         */
+        boleto?: PaymentMethodData.Boleto;
+
+        /**
+         * If this is a `customer_balance` PaymentMethod, this hash contains details about the CustomerBalance payment method.
+         */
+        customer_balance?: PaymentMethodData.CustomerBalance;
+
+        /**
+         * If this is an `eps` PaymentMethod, this hash contains details about the EPS payment method.
+         */
+        eps?: PaymentMethodData.Eps;
+
+        /**
+         * If this is an `fpx` PaymentMethod, this hash contains details about the FPX payment method.
+         */
+        fpx?: PaymentMethodData.Fpx;
+
+        /**
+         * If this is a `giropay` PaymentMethod, this hash contains details about the Giropay payment method.
+         */
+        giropay?: PaymentMethodData.Giropay;
+
+        /**
+         * If this is a `grabpay` PaymentMethod, this hash contains details about the GrabPay payment method.
+         */
+        grabpay?: PaymentMethodData.Grabpay;
+
+        /**
+         * If this is an `ideal` PaymentMethod, this hash contains details about the iDEAL payment method.
+         */
+        ideal?: PaymentMethodData.Ideal;
+
+        /**
+         * If this is an `interac_present` PaymentMethod, this hash contains details about the Interac Present payment method.
+         */
+        interac_present?: PaymentMethodData.InteracPresent;
+
+        /**
+         * If this is a `klarna` PaymentMethod, this hash contains details about the Klarna payment method.
+         */
+        klarna?: PaymentMethodData.Klarna;
+
+        /**
+         * If this is a `konbini` PaymentMethod, this hash contains details about the Konbini payment method.
+         */
+        konbini?: PaymentMethodData.Konbini;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.MetadataParam;
+
+        /**
+         * If this is an `oxxo` PaymentMethod, this hash contains details about the OXXO payment method.
+         */
+        oxxo?: PaymentMethodData.Oxxo;
+
+        /**
+         * If this is a `p24` PaymentMethod, this hash contains details about the P24 payment method.
+         */
+        p24?: PaymentMethodData.P24;
+
+        /**
+         * If this is a `paynow` PaymentMethod, this hash contains details about the PayNow payment method.
+         */
+        paynow?: PaymentMethodData.Paynow;
+
+        /**
+         * If this is a `sepa_debit` PaymentMethod, this hash contains details about the SEPA debit bank account.
+         */
+        sepa_debit?: PaymentMethodData.SepaDebit;
+
+        /**
+         * If this is a `sofort` PaymentMethod, this hash contains details about the SOFORT payment method.
+         */
+        sofort?: PaymentMethodData.Sofort;
+
+        /**
+         * The type of the PaymentMethod. An additional hash is included on the PaymentMethod with a name matching this value. It contains additional information specific to the PaymentMethod type.
+         */
+        type: PaymentMethodData.Type;
+
+        /**
+         * If this is an `us_bank_account` PaymentMethod, this hash contains details about the US bank account payment method.
+         */
+        us_bank_account?: PaymentMethodData.UsBankAccount;
+
+        /**
+         * If this is an `wechat_pay` PaymentMethod, this hash contains details about the wechat_pay payment method.
+         */
+        wechat_pay?: PaymentMethodData.WechatPay;
+      }
+
+      namespace PaymentMethodData {
+        interface AcssDebit {
+          /**
+           * Customer's bank account number.
+           */
+          account_number: string;
+
+          /**
+           * Institution number of the customer's bank.
+           */
+          institution_number: string;
+
+          /**
+           * Transit number of the customer's bank.
+           */
+          transit_number: string;
+        }
+
+        interface AfterpayClearpay {}
+
+        interface Alipay {}
+
+        interface AuBecsDebit {
+          /**
+           * The account number for the bank account.
+           */
+          account_number: string;
+
+          /**
+           * Bank-State-Branch number of the bank account.
+           */
+          bsb_number: string;
+        }
+
+        interface BacsDebit {
+          /**
+           * Account number of the bank account that the funds will be debited from.
+           */
+          account_number?: string;
+
+          /**
+           * Sort code of the bank account. (e.g., `10-20-30`)
+           */
+          sort_code?: string;
+        }
+
+        interface Bancontact {}
+
+        interface BillingDetails {
+          /**
+           * Billing address.
+           */
+          address?: Stripe.Emptyable<BillingDetails.Address>;
+
+          /**
+           * Email address.
+           */
+          email?: Stripe.Emptyable<string>;
+
+          /**
+           * Full name.
+           */
+          name?: string;
+
+          /**
+           * Billing phone number (including extension).
+           */
+          phone?: string;
+        }
+
+        namespace BillingDetails {
+          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
+        }
+
+        interface Boleto {
+          /**
+           * The tax ID of the customer (CPF for individual consumers or CNPJ for businesses consumers)
+           */
+          tax_id: string;
+        }
+
+        interface CustomerBalance {}
+
+        interface Eps {
+          /**
+           * The customer's bank.
+           */
+          bank?: Eps.Bank;
+        }
+
+        namespace Eps {
+          type Bank =
+            | 'arzte_und_apotheker_bank'
+            | 'austrian_anadi_bank_ag'
+            | 'bank_austria'
+            | 'bankhaus_carl_spangler'
+            | 'bankhaus_schelhammer_und_schattera_ag'
+            | 'bawag_psk_ag'
+            | 'bks_bank_ag'
+            | 'brull_kallmus_bank_ag'
+            | 'btv_vier_lander_bank'
+            | 'capital_bank_grawe_gruppe_ag'
+            | 'dolomitenbank'
+            | 'easybank_ag'
+            | 'erste_bank_und_sparkassen'
+            | 'hypo_alpeadriabank_international_ag'
+            | 'hypo_bank_burgenland_aktiengesellschaft'
+            | 'hypo_noe_lb_fur_niederosterreich_u_wien'
+            | 'hypo_oberosterreich_salzburg_steiermark'
+            | 'hypo_tirol_bank_ag'
+            | 'hypo_vorarlberg_bank_ag'
+            | 'marchfelder_bank'
+            | 'oberbank_ag'
+            | 'raiffeisen_bankengruppe_osterreich'
+            | 'schoellerbank_ag'
+            | 'sparda_bank_wien'
+            | 'volksbank_gruppe'
+            | 'volkskreditbank_ag'
+            | 'vr_bank_braunau';
+        }
+
+        interface Fpx {
+          /**
+           * Account holder type for FPX transaction
+           */
+          account_holder_type?: Fpx.AccountHolderType;
+
+          /**
+           * The customer's bank.
+           */
+          bank: Fpx.Bank;
+        }
+
+        namespace Fpx {
+          type AccountHolderType = 'company' | 'individual';
+
+          type Bank =
+            | 'affin_bank'
+            | 'agrobank'
+            | 'alliance_bank'
+            | 'ambank'
+            | 'bank_islam'
+            | 'bank_muamalat'
+            | 'bank_rakyat'
+            | 'bsn'
+            | 'cimb'
+            | 'deutsche_bank'
+            | 'hong_leong_bank'
+            | 'hsbc'
+            | 'kfh'
+            | 'maybank2e'
+            | 'maybank2u'
+            | 'ocbc'
+            | 'pb_enterprise'
+            | 'public_bank'
+            | 'rhb'
+            | 'standard_chartered'
+            | 'uob';
+        }
+
+        interface Giropay {}
+
+        interface Grabpay {}
+
+        interface Ideal {
+          /**
+           * The customer's bank.
+           */
+          bank?: Ideal.Bank;
+        }
+
+        namespace Ideal {
+          type Bank =
+            | 'abn_amro'
+            | 'asn_bank'
+            | 'bunq'
+            | 'handelsbanken'
+            | 'ing'
+            | 'knab'
+            | 'moneyou'
+            | 'rabobank'
+            | 'regiobank'
+            | 'revolut'
+            | 'sns_bank'
+            | 'triodos_bank'
+            | 'van_lanschot';
+        }
+
+        interface InteracPresent {}
+
+        interface Klarna {
+          /**
+           * Customer's date of birth
+           */
+          dob?: Klarna.Dob;
+        }
+
+        namespace Klarna {
+          interface Dob {
+            /**
+             * The day of birth, between 1 and 31.
+             */
+            day: number;
+
+            /**
+             * The month of birth, between 1 and 12.
+             */
+            month: number;
+
+            /**
+             * The four-digit year of birth.
+             */
+            year: number;
+          }
+        }
+
+        interface Konbini {}
+
+        interface Oxxo {}
+
+        interface P24 {
+          /**
+           * The customer's bank.
+           */
+          bank?: P24.Bank;
+        }
+
+        namespace P24 {
+          type Bank =
+            | 'alior_bank'
+            | 'bank_millennium'
+            | 'bank_nowy_bfg_sa'
+            | 'bank_pekao_sa'
+            | 'banki_spbdzielcze'
+            | 'blik'
+            | 'bnp_paribas'
+            | 'boz'
+            | 'citi_handlowy'
+            | 'credit_agricole'
+            | 'envelobank'
+            | 'etransfer_pocztowy24'
+            | 'getin_bank'
+            | 'ideabank'
+            | 'ing'
+            | 'inteligo'
+            | 'mbank_mtransfer'
+            | 'nest_przelew'
+            | 'noble_pay'
+            | 'pbac_z_ipko'
+            | 'plus_bank'
+            | 'santander_przelew24'
+            | 'tmobile_usbugi_bankowe'
+            | 'toyota_bank'
+            | 'volkswagen_bank';
+        }
+
+        interface Paynow {}
+
+        interface SepaDebit {
+          /**
+           * IBAN of the bank account.
+           */
+          iban: string;
+        }
+
+        interface Sofort {
+          /**
+           * Two-letter ISO code representing the country the bank account is located in.
+           */
+          country: Sofort.Country;
+        }
+
+        namespace Sofort {
+          type Country = 'AT' | 'BE' | 'DE' | 'ES' | 'IT' | 'NL';
+        }
+
+        type Type =
+          | 'acss_debit'
+          | 'afterpay_clearpay'
+          | 'alipay'
+          | 'au_becs_debit'
+          | 'bacs_debit'
+          | 'bancontact'
+          | 'boleto'
+          | 'customer_balance'
+          | 'eps'
+          | 'fpx'
+          | 'giropay'
+          | 'grabpay'
+          | 'ideal'
+          | 'klarna'
+          | 'konbini'
+          | 'oxxo'
+          | 'p24'
+          | 'paynow'
+          | 'sepa_debit'
+          | 'sofort'
+          | 'us_bank_account'
+          | 'wechat_pay';
+
+        interface UsBankAccount {
+          /**
+           * Account holder type: individual or company.
+           */
+          account_holder_type?: UsBankAccount.AccountHolderType;
+
+          /**
+           * Account number of the bank account.
+           */
+          account_number?: string;
+
+          /**
+           * Account type: checkings or savings. Defaults to checking if omitted.
+           */
+          account_type?: UsBankAccount.AccountType;
+
+          /**
+           * Routing number of the bank account.
+           */
+          routing_number?: string;
+        }
+
+        namespace UsBankAccount {
+          type AccountHolderType = 'company' | 'individual';
+
+          type AccountType = 'checking' | 'savings';
+        }
+
+        interface WechatPay {}
       }
 
       interface PaymentMethodOptions {

--- a/types/2020-08-27/Sources.d.ts
+++ b/types/2020-08-27/Sources.d.ts
@@ -641,7 +641,7 @@ declare module 'stripe' {
           /**
            * Recipient name.
            */
-          name?: string | null;
+          name?: string;
 
           /**
            * Recipient phone (including extension).

--- a/types/2020-08-27/Tokens.d.ts
+++ b/types/2020-08-27/Tokens.d.ts
@@ -381,6 +381,11 @@ declare module 'stripe' {
           political_exposure?: Individual.PoliticalExposure;
 
           /**
+           * The individual's registered address.
+           */
+          registered_address?: Individual.RegisteredAddress;
+
+          /**
            * The last four digits of the individual's Social Security Number (U.S. only).
            */
           ssn_last_4?: string;
@@ -414,6 +419,11 @@ declare module 'stripe' {
           }
 
           type PoliticalExposure = 'existing' | 'none';
+
+          interface RegisteredAddress
+            extends Omit<Stripe.AddressParam, 'line1'> {
+            line1?: string;
+          }
 
           interface Verification {
             /**
@@ -633,6 +643,11 @@ declare module 'stripe' {
         political_exposure?: string;
 
         /**
+         * The person's registered address.
+         */
+        registered_address?: Person.RegisteredAddress;
+
+        /**
          * The relationship that this person has with the account's legal entity.
          */
         relationship?: Person.Relationship;
@@ -708,6 +723,10 @@ declare module 'stripe' {
              */
             files?: Array<string>;
           }
+        }
+
+        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
+          line1?: string;
         }
 
         interface Relationship {

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -58,8 +58,6 @@
 ///<reference path='./LineItems.d.ts' />
 ///<reference path='./LoginLinks.d.ts' />
 ///<reference path='./Mandates.d.ts' />
-///<reference path='./OrderItems.d.ts' />
-///<reference path='./OrderReturns.d.ts' />
 ///<reference path='./Orders.d.ts' />
 ///<reference path='./PaymentIntents.d.ts' />
 ///<reference path='./PaymentLinks.d.ts' />
@@ -149,7 +147,6 @@ declare module 'stripe' {
     issuerFraudRecords: Stripe.IssuerFraudRecordsResource;
     mandates: Stripe.MandatesResource;
     orders: Stripe.OrdersResource;
-    orderReturns: Stripe.OrderReturnsResource;
     paymentIntents: Stripe.PaymentIntentsResource;
     paymentLinks: Stripe.PaymentLinksResource;
     paymentMethods: Stripe.PaymentMethodsResource;


### PR DESCRIPTION
## Summary
* Introduces the revamped Orders API.
  * Substantial breaking changes to the type of `Order` and related methods.
  * Remove legacy resources `OrderItem` and `OrderReturn`, and legacy methods on `Order` `pay` and `return_order`.
  * Add new methods `cancel`, `list_line_items`, and `reopen` methods on resource `Order`
  * Remove support for `pay` and `return_order` methods on resource `Order`
  * Remove support for `order` on `Charge`




