### PR TITLE
API Updates

### DIFF
--- a/lib/resources.js
+++ b/lib/resources.js
@@ -63,6 +63,10 @@ module.exports = {
   Checkout: resourceNamespace('checkout', {
     Sessions: require('./resources/Checkout/Sessions'),
   }),
+  FinancialConnections: resourceNamespace('financialConnections', {
+    Accounts: require('./resources/FinancialConnections/Accounts'),
+    Sessions: require('./resources/FinancialConnections/Sessions'),
+  }),
   Identity: resourceNamespace('identity', {
     VerificationReports: require('./resources/Identity/VerificationReports'),
     VerificationSessions: require('./resources/Identity/VerificationSessions'),

--- a/lib/resources/FinancialConnections/Accounts.js
+++ b/lib/resources/FinancialConnections/Accounts.js
@@ -1,0 +1,25 @@
+// File generated from our OpenAPI spec
+
+'use strict';
+
+const StripeResource = require('../../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'financial_connections/accounts',
+
+  retrieve: stripeMethod({
+    method: 'GET',
+    path: '/{account}',
+  }),
+
+  disconnect: stripeMethod({
+    method: 'POST',
+    path: '/{account}/disconnect',
+  }),
+
+  refresh: stripeMethod({
+    method: 'POST',
+    path: '/{account}/refresh',
+  }),
+});

--- a/lib/resources/FinancialConnections/Sessions.js
+++ b/lib/resources/FinancialConnections/Sessions.js
@@ -1,0 +1,20 @@
+// File generated from our OpenAPI spec
+
+'use strict';
+
+const StripeResource = require('../../StripeResource');
+const stripeMethod = StripeResource.method;
+
+module.exports = StripeResource.extend({
+  path: 'financial_connections/sessions',
+
+  create: stripeMethod({
+    method: 'POST',
+    path: '',
+  }),
+
+  retrieve: stripeMethod({
+    method: 'GET',
+    path: '/{session}',
+  }),
+});

--- a/types/2020-08-27/Checkout/Sessions.d.ts
+++ b/types/2020-08-27/Checkout/Sessions.d.ts
@@ -535,6 +535,8 @@ declare module 'stripe' {
           }
 
           interface UsBankAccount {
+            financial_connections?: UsBankAccount.FinancialConnections;
+
             /**
              * Bank account verification method.
              */
@@ -542,6 +544,26 @@ declare module 'stripe' {
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. The `payment_method` permission must be included.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+
+              /**
+               * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+               */
+              return_url?: string;
+            }
+
+            namespace FinancialConnections {
+              type Permission =
+                | 'balances'
+                | 'ownership'
+                | 'payment_method'
+                | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant';
           }
         }
@@ -1659,12 +1681,32 @@ declare module 'stripe' {
 
           interface UsBankAccount {
             /**
+             * Additional fields for Financial Connections Session creation
+             */
+            financial_connections?: UsBankAccount.FinancialConnections;
+
+            /**
              * Verification method for the intent
              */
             verification_method?: UsBankAccount.VerificationMethod;
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission =
+                | 'balances'
+                | 'ownership'
+                | 'payment_method'
+                | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant';
           }
 

--- a/types/2020-08-27/FinancialConnections/Accounts.d.ts
+++ b/types/2020-08-27/FinancialConnections/Accounts.d.ts
@@ -1,0 +1,311 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    namespace FinancialConnections {
+      /**
+       * The Account object.
+       */
+      interface Account {
+        /**
+         * Unique identifier for the object.
+         */
+        id: string;
+
+        /**
+         * String representing the object's type. Objects of the same type share the same value.
+         */
+        object: 'financial_connections.account';
+
+        /**
+         * The account holder that this account belongs to.
+         */
+        account_holder: Account.AccountHolder | null;
+
+        /**
+         * The most recent information about the account's balance.
+         */
+        balance: Account.Balance | null;
+
+        /**
+         * The state of the most recent attempt to refresh the account balance.
+         */
+        balance_refresh: Account.BalanceRefresh | null;
+
+        /**
+         * The type of the account. Account category is further divided in `subcategory`.
+         */
+        category: Account.Category;
+
+        /**
+         * Time at which the object was created. Measured in seconds since the Unix epoch.
+         */
+        created: number;
+
+        /**
+         * A human-readable name that has been assigned to this account, either by the account holder or by the institution.
+         */
+        display_name: string | null;
+
+        /**
+         * The name of the institution that holds this account.
+         */
+        institution_name: string;
+
+        /**
+         * The last 4 digits of the account number. If present, this will be 4 numeric characters.
+         */
+        last4: string | null;
+
+        /**
+         * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+         */
+        livemode: boolean;
+
+        /**
+         * The most recent information about the account's owners.
+         */
+        ownership: string | Stripe.Ownership | null;
+
+        /**
+         * The state of the most recent attempt to refresh the account owners.
+         */
+        ownership_refresh: Account.OwnershipRefresh | null;
+
+        /**
+         * The list of permissions granted by this account.
+         */
+        permissions: Array<Account.Permission> | null;
+
+        /**
+         * The status of the link to the account.
+         */
+        status: Account.Status;
+
+        /**
+         * If `category` is `cash`, one of:
+         *
+         *  - `checking`
+         *  - `savings`
+         *  - `other`
+         *
+         * If `category` is `credit`, one of:
+         *
+         *  - `mortgage`
+         *  - `line_of_credit`
+         *  - `credit_card`
+         *  - `other`
+         *
+         * If `category` is `investment` or `other`, this will be `other`.
+         */
+        subcategory: Account.Subcategory;
+
+        /**
+         * The [PaymentMethod type](https://stripe.com/docs/api/payment_methods/object#payment_method_object-type)(s) that can be created from this account.
+         */
+        supported_payment_method_types: Array<
+          Account.SupportedPaymentMethodType
+        >;
+      }
+
+      namespace Account {
+        interface AccountHolder {
+          /**
+           * The ID of the Stripe account this account belongs to. Should only be present if `account_holder.type` is `account`.
+           */
+          account?: string | Stripe.Account;
+
+          /**
+           * ID of the Stripe customer this account belongs to. Present if and only if `account_holder.type` is `customer`.
+           */
+          customer?: string | Stripe.Customer;
+
+          /**
+           * Type of account holder that this account belongs to.
+           */
+          type: AccountHolder.Type;
+        }
+
+        namespace AccountHolder {
+          type Type = 'account' | 'customer';
+        }
+
+        interface Balance {
+          /**
+           * The time that the external institution calculated this balance. Measured in seconds since the Unix epoch.
+           */
+          as_of: number;
+
+          cash?: Balance.Cash;
+
+          credit?: Balance.Credit;
+
+          /**
+           * The balances owed to (or by) the account holder.
+           *
+           * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+           *
+           * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
+           */
+          current: {
+            [key: string]: number;
+          };
+
+          /**
+           * The `type` of the balance. An additional hash is included on the balance with a name matching this value.
+           */
+          type: Balance.Type;
+        }
+
+        namespace Balance {
+          interface Cash {
+            /**
+             * The funds available to the account holder. Typically this is the current balance less any holds.
+             *
+             * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+             *
+             * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
+             */
+            available: {
+              [key: string]: number;
+            } | null;
+          }
+
+          interface Credit {
+            /**
+             * The credit that has been used by the account holder.
+             *
+             * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+             *
+             * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
+             */
+            used: {
+              [key: string]: number;
+            } | null;
+          }
+
+          type Type = 'cash' | 'credit';
+        }
+
+        interface BalanceRefresh {
+          /**
+           * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
+           */
+          last_attempted_at: number;
+
+          /**
+           * The status of the last refresh attempt.
+           */
+          status: BalanceRefresh.Status;
+        }
+
+        namespace BalanceRefresh {
+          type Status = 'failed' | 'pending' | 'succeeded';
+        }
+
+        type Category = 'cash' | 'credit' | 'investment' | 'other';
+
+        interface OwnershipRefresh {
+          /**
+           * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
+           */
+          last_attempted_at: number;
+
+          /**
+           * The status of the last refresh attempt.
+           */
+          status: OwnershipRefresh.Status;
+        }
+
+        namespace OwnershipRefresh {
+          type Status = 'failed' | 'pending' | 'succeeded';
+        }
+
+        type Permission =
+          | 'balances'
+          | 'ownership'
+          | 'payment_method'
+          | 'transactions';
+
+        type Status = 'active' | 'disconnected' | 'inactive';
+
+        type Subcategory =
+          | 'checking'
+          | 'credit_card'
+          | 'line_of_credit'
+          | 'mortgage'
+          | 'other'
+          | 'savings';
+
+        type SupportedPaymentMethodType = 'link' | 'us_bank_account';
+      }
+
+      interface AccountRetrieveParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      interface AccountDisconnectParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      interface AccountRefreshParams {
+        /**
+         * The list of account features that you would like to refresh. Either: `balance` or `ownership`.
+         */
+        features: Array<AccountRefreshParams.Feature>;
+
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      namespace AccountRefreshParams {
+        type Feature = 'balance' | 'ownership';
+      }
+
+      class AccountsResource {
+        /**
+         * Retrieves the details of an Financial Connections Account.
+         */
+        retrieve(
+          id: string,
+          params?: AccountRetrieveParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Account>>;
+        retrieve(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Account>>;
+
+        /**
+         * Disables your access to a Financial Connections Account. You will no longer be able to access data associated with the account (e.g. balances, transactions).
+         */
+        disconnect(
+          id: string,
+          params?: AccountDisconnectParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Account>>;
+        disconnect(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Account>>;
+
+        /**
+         * Refreshes the data associated with a Financial Connections Account.
+         */
+        refresh(
+          id: string,
+          params: AccountRefreshParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Account>>;
+      }
+    }
+  }
+}

--- a/types/2020-08-27/FinancialConnections/Sessions.d.ts
+++ b/types/2020-08-27/FinancialConnections/Sessions.d.ts
@@ -1,0 +1,185 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    namespace FinancialConnections {
+      /**
+       * The Session object.
+       */
+      interface Session {
+        /**
+         * Unique identifier for the object.
+         */
+        id: string;
+
+        /**
+         * String representing the object's type. Objects of the same type share the same value.
+         */
+        object: 'financial_connections.session';
+
+        /**
+         * The account holder for whom accounts are collected in this session.
+         */
+        account_holder: Session.AccountHolder | null;
+
+        /**
+         * The accounts that were collected as part of this Session.
+         */
+        accounts: ApiList<Stripe.FinancialConnections.Account>;
+
+        /**
+         * A value that will be passed to the client to launch the authentication flow.
+         */
+        client_secret: string;
+
+        filters?: Session.Filters;
+
+        /**
+         * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
+         */
+        livemode: boolean;
+
+        /**
+         * Permissions requested for accounts collected during this session.
+         */
+        permissions: Array<Session.Permission>;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+         */
+        return_url?: string;
+      }
+
+      namespace Session {
+        interface AccountHolder {
+          /**
+           * The ID of the Stripe account this account belongs to. Should only be present if `account_holder.type` is `account`.
+           */
+          account?: string | Stripe.Account;
+
+          /**
+           * ID of the Stripe customer this account belongs to. Present if and only if `account_holder.type` is `customer`.
+           */
+          customer?: string | Stripe.Customer;
+
+          /**
+           * Type of account holder that this account belongs to.
+           */
+          type: AccountHolder.Type;
+        }
+
+        namespace AccountHolder {
+          type Type = 'account' | 'customer';
+        }
+
+        interface Filters {
+          /**
+           * List of countries from which to filter accounts.
+           */
+          countries: Array<string> | null;
+        }
+
+        type Permission =
+          | 'balances'
+          | 'ownership'
+          | 'payment_method'
+          | 'transactions';
+      }
+
+      interface SessionCreateParams {
+        /**
+         * The account holder to link accounts for.
+         */
+        account_holder: SessionCreateParams.AccountHolder;
+
+        /**
+         * List of data features that you would like to request access to.
+         *
+         * Possible values are `balances`, `transactions`, `ownership`, and `payment_method`.
+         */
+        permissions: Array<SessionCreateParams.Permission>;
+
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+
+        /**
+         * Filters to restrict the kinds of accounts to collect.
+         */
+        filters?: SessionCreateParams.Filters;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+         */
+        return_url?: string;
+      }
+
+      namespace SessionCreateParams {
+        interface AccountHolder {
+          /**
+           * The ID of the Stripe account whose accounts will be retrieved. Should only be present if `type` is `account`.
+           */
+          account?: string;
+
+          /**
+           * The ID of the Stripe customer whose accounts will be retrieved. Should only be present if `type` is `customer`.
+           */
+          customer?: string;
+
+          /**
+           * Type of account holder to collect accounts for.
+           */
+          type: AccountHolder.Type;
+        }
+
+        namespace AccountHolder {
+          type Type = 'account' | 'customer';
+        }
+
+        interface Filters {
+          /**
+           * List of countries from which to collect accounts.
+           */
+          countries: Array<string>;
+        }
+
+        type Permission =
+          | 'balances'
+          | 'ownership'
+          | 'payment_method'
+          | 'transactions';
+      }
+
+      interface SessionRetrieveParams {
+        /**
+         * Specifies which fields in the response should be expanded.
+         */
+        expand?: Array<string>;
+      }
+
+      class SessionsResource {
+        /**
+         * To launch the Financial Connections authorization flow, create a Session. The session's client_secret can be used to launch the flow using Stripe.js.
+         */
+        create(
+          params: SessionCreateParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Session>>;
+
+        /**
+         * Retrieves the details of a Financial Connections Session
+         */
+        retrieve(
+          id: string,
+          params?: SessionRetrieveParams,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Session>>;
+        retrieve(
+          id: string,
+          options?: RequestOptions
+        ): Promise<Stripe.Response<Stripe.FinancialConnections.Session>>;
+      }
+    }
+  }
+}

--- a/types/2020-08-27/Invoices.d.ts
+++ b/types/2020-08-27/Invoices.d.ts
@@ -706,6 +706,8 @@ declare module 'stripe' {
           interface Konbini {}
 
           interface UsBankAccount {
+            financial_connections?: UsBankAccount.FinancialConnections;
+
             /**
              * Bank account verification method.
              */
@@ -713,6 +715,17 @@ declare module 'stripe' {
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. The `payment_method` permission must be included.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission = 'balances' | 'payment_method' | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
         }
@@ -1135,12 +1148,32 @@ declare module 'stripe' {
 
           interface UsBankAccount {
             /**
+             * Additional fields for Financial Connections Session creation
+             */
+            financial_connections?: UsBankAccount.FinancialConnections;
+
+            /**
              * Verification method for the intent
              */
             verification_method?: UsBankAccount.VerificationMethod;
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission =
+                | 'balances'
+                | 'ownership'
+                | 'payment_method'
+                | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
         }
@@ -1455,12 +1488,32 @@ declare module 'stripe' {
 
           interface UsBankAccount {
             /**
+             * Additional fields for Financial Connections Session creation
+             */
+            financial_connections?: UsBankAccount.FinancialConnections;
+
+            /**
              * Verification method for the intent
              */
             verification_method?: UsBankAccount.VerificationMethod;
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission =
+                | 'balances'
+                | 'ownership'
+                | 'payment_method'
+                | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
         }

--- a/types/2020-08-27/PaymentIntents.d.ts
+++ b/types/2020-08-27/PaymentIntents.d.ts
@@ -1364,6 +1364,8 @@ declare module 'stripe' {
         }
 
         interface UsBankAccount {
+          financial_connections?: UsBankAccount.FinancialConnections;
+
           /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
            *
@@ -1380,6 +1382,26 @@ declare module 'stripe' {
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. The `payment_method` permission must be included.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
@@ -2161,6 +2183,11 @@ declare module 'stripe' {
           account_type?: UsBankAccount.AccountType;
 
           /**
+           * The ID of a Financial Connections Account to use as a payment method.
+           */
+          financial_connections_account?: string;
+
+          /**
            * Routing number of the bank account.
            */
           routing_number?: string;
@@ -2973,6 +3000,11 @@ declare module 'stripe' {
 
         interface UsBankAccount {
           /**
+           * Additional fields for Financial Connections Session creation
+           */
+          financial_connections?: UsBankAccount.FinancialConnections;
+
+          /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
            *
            * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
@@ -2990,6 +3022,26 @@ declare module 'stripe' {
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
@@ -3650,6 +3702,11 @@ declare module 'stripe' {
           account_type?: UsBankAccount.AccountType;
 
           /**
+           * The ID of a Financial Connections Account to use as a payment method.
+           */
+          financial_connections_account?: string;
+
+          /**
            * Routing number of the bank account.
            */
           routing_number?: string;
@@ -4462,6 +4519,11 @@ declare module 'stripe' {
 
         interface UsBankAccount {
           /**
+           * Additional fields for Financial Connections Session creation
+           */
+          financial_connections?: UsBankAccount.FinancialConnections;
+
+          /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
            *
            * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
@@ -4479,6 +4541,26 @@ declare module 'stripe' {
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
@@ -5276,6 +5358,11 @@ declare module 'stripe' {
           account_type?: UsBankAccount.AccountType;
 
           /**
+           * The ID of a Financial Connections Account to use as a payment method.
+           */
+          financial_connections_account?: string;
+
+          /**
            * Routing number of the bank account.
            */
           routing_number?: string;
@@ -6088,6 +6175,11 @@ declare module 'stripe' {
 
         interface UsBankAccount {
           /**
+           * Additional fields for Financial Connections Session creation
+           */
+          financial_connections?: UsBankAccount.FinancialConnections;
+
+          /**
            * Indicates that you intend to make future payments with this PaymentIntent's payment method.
            *
            * Providing this parameter will [attach the payment method](https://stripe.com/docs/payments/save-during-payment) to the PaymentIntent's Customer, if present, after the PaymentIntent is confirmed and any required actions from the user are complete. If no Customer was provided, the payment method can still be [attached](https://stripe.com/docs/api/payment_methods/attach) to a Customer after the transaction completes.
@@ -6105,6 +6197,26 @@ declare module 'stripe' {
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';

--- a/types/2020-08-27/PaymentMethods.d.ts
+++ b/types/2020-08-27/PaymentMethods.d.ts
@@ -685,6 +685,11 @@ declare module 'stripe' {
         bank_name: string | null;
 
         /**
+         * The ID of the Financial Connections Account used to create the payment method.
+         */
+        financial_connections_account?: string | null;
+
+        /**
          * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
          */
         fingerprint: string | null;
@@ -1205,6 +1210,11 @@ declare module 'stripe' {
          * Account type: checkings or savings. Defaults to checking if omitted.
          */
         account_type?: UsBankAccount.AccountType;
+
+        /**
+         * The ID of a Financial Connections Account to use as a payment method.
+         */
+        financial_connections_account?: string;
 
         /**
          * Routing number of the bank account.

--- a/types/2020-08-27/SetupIntents.d.ts
+++ b/types/2020-08-27/SetupIntents.d.ts
@@ -428,6 +428,8 @@ declare module 'stripe' {
         }
 
         interface UsBankAccount {
+          financial_connections?: UsBankAccount.FinancialConnections;
+
           /**
            * Bank account verification method.
            */
@@ -435,6 +437,26 @@ declare module 'stripe' {
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. The `payment_method` permission must be included.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }
@@ -1024,6 +1046,11 @@ declare module 'stripe' {
           account_type?: UsBankAccount.AccountType;
 
           /**
+           * The ID of a Financial Connections Account to use as a payment method.
+           */
+          financial_connections_account?: string;
+
+          /**
            * Routing number of the bank account.
            */
           routing_number?: string;
@@ -1215,12 +1242,37 @@ declare module 'stripe' {
 
         interface UsBankAccount {
           /**
+           * Additional fields for Financial Connections Session creation
+           */
+          financial_connections?: UsBankAccount.FinancialConnections;
+
+          /**
            * Verification method for the intent
            */
           verification_method?: UsBankAccount.VerificationMethod;
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }
@@ -1749,6 +1801,11 @@ declare module 'stripe' {
           account_type?: UsBankAccount.AccountType;
 
           /**
+           * The ID of a Financial Connections Account to use as a payment method.
+           */
+          financial_connections_account?: string;
+
+          /**
            * Routing number of the bank account.
            */
           routing_number?: string;
@@ -1940,12 +1997,37 @@ declare module 'stripe' {
 
         interface UsBankAccount {
           /**
+           * Additional fields for Financial Connections Session creation
+           */
+          financial_connections?: UsBankAccount.FinancialConnections;
+
+          /**
            * Verification method for the intent
            */
           verification_method?: UsBankAccount.VerificationMethod;
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }
@@ -2565,6 +2647,11 @@ declare module 'stripe' {
           account_type?: UsBankAccount.AccountType;
 
           /**
+           * The ID of a Financial Connections Account to use as a payment method.
+           */
+          financial_connections_account?: string;
+
+          /**
            * Routing number of the bank account.
            */
           routing_number?: string;
@@ -2756,12 +2843,37 @@ declare module 'stripe' {
 
         interface UsBankAccount {
           /**
+           * Additional fields for Financial Connections Session creation
+           */
+          financial_connections?: UsBankAccount.FinancialConnections;
+
+          /**
            * Verification method for the intent
            */
           verification_method?: UsBankAccount.VerificationMethod;
         }
 
         namespace UsBankAccount {
+          interface FinancialConnections {
+            /**
+             * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+             */
+            permissions?: Array<FinancialConnections.Permission>;
+
+            /**
+             * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+             */
+            return_url?: string;
+          }
+
+          namespace FinancialConnections {
+            type Permission =
+              | 'balances'
+              | 'ownership'
+              | 'payment_method'
+              | 'transactions';
+          }
+
           type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
         }
       }

--- a/types/2020-08-27/Subscriptions.d.ts
+++ b/types/2020-08-27/Subscriptions.d.ts
@@ -380,6 +380,8 @@ declare module 'stripe' {
           interface Konbini {}
 
           interface UsBankAccount {
+            financial_connections?: UsBankAccount.FinancialConnections;
+
             /**
              * Bank account verification method.
              */
@@ -387,6 +389,17 @@ declare module 'stripe' {
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. The `payment_method` permission must be included.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission = 'balances' | 'payment_method' | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
         }
@@ -966,12 +979,32 @@ declare module 'stripe' {
 
           interface UsBankAccount {
             /**
+             * Additional fields for Financial Connections Session creation
+             */
+            financial_connections?: UsBankAccount.FinancialConnections;
+
+            /**
              * Verification method for the intent
              */
             verification_method?: UsBankAccount.VerificationMethod;
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission =
+                | 'balances'
+                | 'ownership'
+                | 'payment_method'
+                | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
         }
@@ -1556,12 +1589,32 @@ declare module 'stripe' {
 
           interface UsBankAccount {
             /**
+             * Additional fields for Financial Connections Session creation
+             */
+            financial_connections?: UsBankAccount.FinancialConnections;
+
+            /**
              * Verification method for the intent
              */
             verification_method?: UsBankAccount.VerificationMethod;
           }
 
           namespace UsBankAccount {
+            interface FinancialConnections {
+              /**
+               * The list of permissions to request. If this parameter is passed, the `payment_method` permission must be included. Valid permissions include: `balances`, `payment_method`, and `transactions`.
+               */
+              permissions?: Array<FinancialConnections.Permission>;
+            }
+
+            namespace FinancialConnections {
+              type Permission =
+                | 'balances'
+                | 'ownership'
+                | 'payment_method'
+                | 'transactions';
+            }
+
             type VerificationMethod = 'automatic' | 'instant' | 'microdeposits';
           }
         }

--- a/types/2020-08-27/index.d.ts
+++ b/types/2020-08-27/index.d.ts
@@ -42,6 +42,8 @@
 ///<reference path='./FeeRefunds.d.ts' />
 ///<reference path='./FileLinks.d.ts' />
 ///<reference path='./Files.d.ts' />
+///<reference path='./FinancialConnections/Accounts.d.ts' />
+///<reference path='./FinancialConnections/Sessions.d.ts' />
 ///<reference path='./FundingInstructions.d.ts' />
 ///<reference path='./Identity/VerificationReports.d.ts' />
 ///<reference path='./Identity/VerificationSessions.d.ts' />
@@ -187,6 +189,10 @@ declare module 'stripe' {
     };
     checkout: {
       sessions: Stripe.Checkout.SessionsResource;
+    };
+    financialConnections: {
+      accounts: Stripe.FinancialConnections.AccountsResource;
+      sessions: Stripe.FinancialConnections.SessionsResource;
     };
     identity: {
       verificationReports: Stripe.Identity.VerificationReportsResource;


### PR DESCRIPTION
Codegen for openapi 42cbb18.
r? @kamil-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resources `FinancialConnections.AccountOwner`, `FinancialConnections.Account`, and `FinancialConnections.Session`
* Add support for `financial_connections` on `Checkout.Session.payment_method_options.us_bank_account`, `CheckoutSessionCreateParams.payment_method_options.us_bank_account`, `Invoice.payment_settings.payment_method_options.us_bank_account`, `InvoiceCreateParams.payment_settings.payment_method_options.us_bank_account`, `InvoiceUpdateParams.payment_settings.payment_method_options.us_bank_account`, `PaymentIntent.payment_method_options.us_bank_account`, `PaymentIntentConfirmParams.payment_method_options.us_bank_account`, `PaymentIntentCreateParams.payment_method_options.us_bank_account`, `PaymentIntentUpdateParams.payment_method_options.us_bank_account`, `SetupIntent.payment_method_options.us_bank_account`, `SetupIntentConfirmParams.payment_method_options.us_bank_account`, `SetupIntentCreateParams.payment_method_options.us_bank_account`, `SetupIntentUpdateParams.payment_method_options.us_bank_account`, `Subscription.payment_settings.payment_method_options.us_bank_account`, `SubscriptionCreateParams.payment_settings.payment_method_options.us_bank_account`, and `SubscriptionUpdateParams.payment_settings.payment_method_options.us_bank_account`
* Add support for `financial_connections_account` on `PaymentIntentConfirmParams.payment_method_data.us_bank_account`, `PaymentIntentCreateParams.payment_method_data.us_bank_account`, `PaymentIntentUpdateParams.payment_method_data.us_bank_account`, `PaymentMethod.us_bank_account`, `PaymentMethodCreateParams.us_bank_account`, `SetupIntentConfirmParams.payment_method_data.us_bank_account`, `SetupIntentCreateParams.payment_method_data.us_bank_account`, and `SetupIntentUpdateParams.payment_method_data.us_bank_account`

