### PR TITLE
API Updates

### DIFF
--- a/types/2020-08-27/Products.d.ts
+++ b/types/2020-08-27/Products.d.ts
@@ -41,6 +41,11 @@ declare module 'stripe' {
        */
       deactivate_on?: Array<string>;
 
+      /**
+       * The ID of the [Price](https://stripe.com/docs/api/prices) object that is the default price for this product.
+       */
+      default_price?: string | Stripe.Price | null;
+
       deleted?: void;
 
       /**
@@ -182,6 +187,11 @@ declare module 'stripe' {
       deactivate_on?: Array<string>;
 
       /**
+       * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object. This Price will be set as the default price for this product.
+       */
+      default_price_data?: ProductCreateParams.DefaultPriceData;
+
+      /**
        * The product's description, meant to be displayable to the customer. Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
        */
       description?: string;
@@ -246,6 +256,53 @@ declare module 'stripe' {
     }
 
     namespace ProductCreateParams {
+      interface DefaultPriceData {
+        /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        currency: string;
+
+        /**
+         * The recurring components of a price such as `interval` and `interval_count`.
+         */
+        recurring?: DefaultPriceData.Recurring;
+
+        /**
+         * Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed.
+         */
+        tax_behavior?: DefaultPriceData.TaxBehavior;
+
+        /**
+         * A positive integer in %s (or 0 for a free price) representing how much to charge. One of `unit_amount` or `unit_amount_decimal` is required.
+         */
+        unit_amount?: number;
+
+        /**
+         * Same as `unit_amount`, but accepts a decimal value in %s with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.
+         */
+        unit_amount_decimal?: string;
+      }
+
+      namespace DefaultPriceData {
+        interface Recurring {
+          /**
+           * Specifies billing frequency. Either `day`, `week`, `month` or `year`.
+           */
+          interval: Recurring.Interval;
+
+          /**
+           * The number of intervals between subscription billings. For example, `interval=month` and `interval_count=3` bills every 3 months. Maximum of one year interval allowed (1 year, 12 months, or 52 weeks).
+           */
+          interval_count?: number;
+        }
+
+        namespace Recurring {
+          type Interval = 'day' | 'month' | 'week' | 'year';
+        }
+
+        type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';
+      }
+
       interface PackageDimensions {
         /**
          * Height, in inches. Maximum precision is 2 decimal places.
@@ -298,6 +355,11 @@ declare module 'stripe' {
        * An array of Connect application names or identifiers that should not be able to order the SKUs for this product. May only be set if `type=good`.
        */
       deactivate_on?: Array<string>;
+
+      /**
+       * The ID of the [Price](https://stripe.com/docs/api/prices) object that is the default price for this product.
+       */
+      default_price?: string;
 
       /**
        * The product's description, meant to be displayable to the customer. Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.

--- a/types/2020-08-27/Refunds.d.ts
+++ b/types/2020-08-27/Refunds.d.ts
@@ -57,6 +57,11 @@ declare module 'stripe' {
       failure_reason?: string;
 
       /**
+       * Email to which refund instructions, if required, are sent to.
+       */
+      instructions_email?: string;
+
+      /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
        */
       metadata: Stripe.Metadata | null;
@@ -148,6 +153,8 @@ declare module 'stripe' {
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
+
+      instructions_email?: string;
 
       /**
        * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.


### PR DESCRIPTION
Codegen for openapi dd21899.
r? @richardm-stripe
cc @stripe/api-libraries

## Changelog
* Add support for new resource `FinancialConnections.AccountOwnership`
* Change type of `FinancialConnections.Account.ownership` from `$Ownership` to `$FinancialConnections.AccountOwnership`
* Add support for `id` and `object` on `FinancialConnections.AccountOwner`
* Add support for `default_price_data` on `ProductCreateParams`
* Add support for `default_price` on `ProductUpdateParams` and `Product`
* Add support for `instructions_email` on `RefundCreateParams` and `Refund`

