### PR TITLE
docs: Update HttpClient documentation to remove experimental status.

### DIFF
--- a/lib/net/HttpClient.js
+++ b/lib/net/HttpClient.js
@@ -1,8 +1,13 @@
 'use strict';
 
 /**
- * Encapsulates the logic for issuing a request to the Stripe API. This is an
- * experimental interface and is not yet stable.
+ * Encapsulates the logic for issuing a request to the Stripe API.
+ *
+ * A custom HTTP client should should implement:
+ * 1. A response class which extends HttpClientResponse and wraps around their
+ *    own internal representation of a response.
+ * 2. A client class which extends HttpClient and implements all methods,
+ *    returning their own response class when making requests.
  */
 class HttpClient {
   /** The client name used for diagnostics. */


### PR DESCRIPTION
r? @kamil-stripe  

## Summary
Updates the documentation for HttpClient now that it is stable and used by both `NodeHttpClient` and `FetchHttpClient` in production. This is no longer experimental.