### PR TITLE
chore: Update FetchHttpClient testing to use global fetch when available.

### DIFF
--- a/test/net/FetchHttpClient.spec.js
+++ b/test/net/FetchHttpClient.spec.js
@@ -1,23 +1,32 @@
 'use strict';
 
 const expect = require('chai').expect;
-const fetch = require('node-fetch');
+const nodeFetchPolyfill = require('node-fetch');
 const {Readable} = require('stream');
 const {FetchHttpClient} = require('../../lib/net/FetchHttpClient');
 
+const useGlobalFetch = typeof global.fetch !== 'undefined';
+
 const createFetchHttpClient = () => {
-  return new FetchHttpClient(fetch);
+  return new FetchHttpClient(useGlobalFetch ? undefined : nodeFetchPolyfill);
 };
 
 const {createHttpClientTestSuite, ArrayReadable} = require('./helpers');
 
-describe('FetchHttpClient', () => {
+describe(`FetchHttpClient (using global fetch? ${useGlobalFetch})`, () => {
   createHttpClientTestSuite(createFetchHttpClient, (setupNock, sendRequest) => {
     describe('raw stream', () => {
       it('getRawResponse()', async () => {
         setupNock().reply(200);
         const response = await sendRequest();
-        expect(response.getRawResponse()).to.be.an.instanceOf(fetch.Response);
+
+        if (useGlobalFetch) {
+          expect(response.getRawResponse()).to.be.an.instanceOf(fetch.Response);
+        } else {
+          expect(response.getRawResponse()).to.be.an.instanceOf(
+            nodeFetchPolyfill.Response
+          );
+        }
       });
 
       it('toStream returns the body as a stream', async () => {


### PR DESCRIPTION
## Summary

As of [Node 18](https://nodejs.org/en/blog/announcements/v18-release-announce/), `fetch` is globally available. 

This PR updates the tests for `FetchHttpClient` to rely on the global implementation when it's available instead of the `node-fetch` polyfill. The `FetchHttpClient` uses the global unless the user explicitly passes in a `fetch` function, so this is expected to mirror that behavior since `node-fetch` was only used for our testing when `fetch` wasn't available.