### PR TITLE
Fix non-conforming changelog entries and port the Makefile fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# CHANGELOG
+# Changelog
 
 ## 9.8.0 - 2022-06-09
 * [#1448](https://github.com/stripe/stripe-node/pull/1448) Add types for extra request options
@@ -1527,7 +1527,7 @@ Pull requests included in this release (cf. [#606](https://github.com/stripe/str
 
 - [#619](https://github.com/stripe/stripe-node/pull/619) Move `generateTestHeaderString` to stripe.webhooks (fixes a bug in 6.33.0)
 
-## 6.33.0 - 2019-05-08 - UNRELEASED
+## 6.33.0 - 2019-05-08
 
 **Important**: This version is non-functional and has been yanked in favor of 6.32.0.
 
@@ -2082,7 +2082,7 @@ Pull requests included in this release (cf. [#606](https://github.com/stripe/str
 
 - [BUGFIX] Fix incorrect deleteDiscount method & related spec(s)
 
-### 2.2.1
+### 2.2.1 - 2013-12-01
 
 - [BUGFIX] Fix user-agent header issue (see issue #75)
 

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: codegen-format update-version
 update-version:
 	@echo "$(VERSION)" > VERSION
-	@perl -pi -e 's|"version": "[.\d\w-]+"|"version": "$(VERSION)"|' package.json
+	@perl -pi -e 's|"version": "[.\-\d\w]+"|"version": "$(VERSION)"|' package.json
 
 codegen-format:
 	yarn && yarn fix

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: codegen-format update-version
 update-version:
 	@echo "$(VERSION)" > VERSION
-	@perl -pi -e 's|"version": "[.\d]+"|"version": "$(VERSION)"|' package.json
+	@perl -pi -e 's|"version": "[.\d\w-]+"|"version": "$(VERSION)"|' package.json
 
 codegen-format:
 	yarn && yarn fix


### PR DESCRIPTION
While reviewing https://github.com/stripe/stripe-node/pull/1451 I've noticed that some entries were removed because they don't follow our changelog spec. Fix those and backport the https://github.com/stripe/stripe-node/pull/1445 to master.

r? @kamil-stripe 