### PR TITLE
Add generic type to createSource method

### DIFF
--- a/types/2020-08-27/Customers.d.ts
+++ b/types/2020-08-27/Customers.d.ts
@@ -1130,11 +1130,11 @@ declare module 'stripe' {
        * However, if the owner already has a default, then it will not change.
        * To change the default, you should [update the customer](https://stripe.com/docs/api#update_customer) to have a new default_source.
        */
-      createSource(
+      createSource<T = Stripe.CustomerSource>(
         id: string,
         params: CustomerSourceCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CustomerSource>>;
+      ): Promise<Stripe.Response<T>>;
 
       /**
        * Retrieve a specified source for a given customer.


### PR DESCRIPTION
When you know that it is card and you need to receive a card object - you can not pass Stripe.Card type to createSource method.

Unfortunately, I have to time to investigate and implement it to other methods.
Please approve.

Telegram: vvmspace