### PR TITLE
chore: esm supports top level await

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,13 +54,11 @@ Or using ES modules and `async`/`await`:
 import Stripe from 'stripe';
 const stripe = new Stripe('sk_test_...');
 
-(async () => {
-  const customer = await stripe.customers.create({
-    email: 'customer@example.com',
-  });
+const customer = await stripe.customers.create({
+  email: 'customer@example.com',
+});
 
-  console.log(customer.id);
-})();
+console.log(customer.id);
 ```
 
 ### Usage with TypeScript
@@ -377,7 +375,7 @@ const stripe = require('stripe')('sk_test_...', {
     name: 'MyAwesomePlugin',
     version: '1.2.34', // Optional
     url: 'https://myawesomeplugin.info', // Optional
-  }
+  },
 });
 ```
 
@@ -389,7 +387,7 @@ const stripe = new Stripe(apiKey, {
     name: 'MyAwesomePlugin',
     version: '1.2.34', // Optional
     url: 'https://myawesomeplugin.info', // Optional
-  }
+  },
 });
 ```
 


### PR DESCRIPTION
this pr changes readme esm example to use top level await