### PR TITLE
Update readme to include a note on beta packages

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,20 @@ npm install stripe --save
 yarn add stripe
 ```
 
+### Beta version
+
+Stripe has features in the beta phase that can be accessed via the beta version of this package.
+We would love for you to try these and share feedback with us before these features reach the stable phase.
+The beta versions can be installed in one of two ways 
+- To install the latest beta version, run the command `npm install stripe@beta – save`  
+- To install a specific beta version, replace the term "beta" in the above command with the version number like `npm install stripe@1.2.3-beta.1 --save` 
+
+> Note: There can be breaking changes between beta packages. Therefore we recommend pinning the beta version in your package.json file so that you can install the same version each time without breaking changes unless you are intentionally looking for the latest beta package. 
+
+We highly recommend keeping an eye on when the beta feature you are interested in goes from beta to stable so that you can move from using a beta version of the SDK to the stable version.  
+
+The versions tab on the [stripe page on npm](https://www.npmjs.com/package/stripe) lists the current tags in use. The `beta` tag here corresponds to the the latest beta version of the package.
+
 ## Usage
 
 The package needs to be configured with your account's secret key, which is


### PR DESCRIPTION
We now have beta versions of the packages that need to be pinned when using and users should move off of it to the stable package ASAP. This PR attempts to add such a note to the readme.

