### PR TITLE
fix: Include trailing slash when passing empty query parameters.

### DIFF
--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -69,18 +69,34 @@ StripeResource.prototype = {
   validateRequest: null,
 
   createFullPath(commandPath, urlData) {
-    return this._joinUrlParts([
-      this.basePath(urlData),
-      this.path(urlData),
-      typeof commandPath == 'function' ? commandPath(urlData) : commandPath,
-    ]);
+    const urlParts = [this.basePath(urlData), this.path(urlData)];
+
+    if (typeof commandPath === 'function') {
+      const computedCommandPath = commandPath(urlData);
+      // If we have no actual command path, we just omit it to avoid adding a
+      // trailing slash. This is important for top-level listing requests, which
+      // do not have a command path.
+      if (computedCommandPath) {
+        urlParts.push(computedCommandPath);
+      }
+    } else {
+      urlParts.push(commandPath);
+    }
+
+    return this._joinUrlParts(urlParts);
   },
 
   // Creates a relative resource path with symbols left in (unlike
   // createFullPath which takes some data to replace them with). For example it
   // might produce: /invoices/{id}
   createResourcePathWithSymbols(pathWithSymbols) {
-    return `/${this._joinUrlParts([this.resourcePath, pathWithSymbols || ''])}`;
+    // If there is no path beyond the resource path, we want to produce just
+    // /<resource path> rather than /<resource path>/.
+    if (pathWithSymbols) {
+      return `/${this._joinUrlParts([this.resourcePath, pathWithSymbols])}`;
+    } else {
+      return `/${this.resourcePath}`;
+    }
   },
 
   _joinUrlParts(parts) {
@@ -88,11 +104,7 @@ StripeResource.prototype = {
     // path.join, which would do this as well. Unfortunately we need to do this
     // as the functions for creating paths are technically part of the public
     // interface and so we need to preserve backwards compatibility.
-    const path = parts.join('/').replace(/\/{2,}/g, '/');
-
-    // If the path ends with a /, we preserve the behavior of path.join and
-    // strip off the trailing / (eg. /v1/customers/ -> /v1/customers).
-    return path.endsWith('/') ? path.slice(0, -1) : path;
+    return parts.join('/').replace(/\/{2,}/g, '/');
   },
 
   // DEPRECATED: Here for backcompat in case users relied on this.

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -52,6 +52,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   const requestPath = isUsingFullPath
     ? commandPath(urlData)
     : self.createFullPath(commandPath, urlData);
+
   const headers = Object.assign(options.headers, spec.headers);
 
   if (spec.validator) {


### PR DESCRIPTION
r? @kamil-stripe 

## Summary

Fixes URL creation to include a trailing slash for endpoints which should have a query parameter (eg. `/v1/customers/{id}`) to avoid using `/v1/customers` as the endpoint instead of `/v1/customers/` when an empty ID parameter is passed.

The server interprets these differently based on whether the trailing slash is present.