### PR TITLE
Simplify AddressParam definitions

### DIFF
--- a/types/2022-08-01/Accounts.d.ts
+++ b/types/2022-08-01/Accounts.d.ts
@@ -1237,7 +1237,7 @@ declare module 'stripe' {
         /**
          * A publicly available mailing address for sending support issues to.
          */
-        support_address?: BusinessProfile.SupportAddress;
+        support_address?: Stripe.AddressParam;
 
         /**
          * A publicly available email address for sending support issues to.
@@ -1258,12 +1258,6 @@ declare module 'stripe' {
          * The business's publicly available website.
          */
         url?: string;
-      }
-
-      namespace BusinessProfile {
-        interface SupportAddress extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       type BusinessType =
@@ -1676,7 +1670,7 @@ declare module 'stripe' {
         /**
          * The company's primary address.
          */
-        address?: Company.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The Kana variation of the company's primary address (Japan only).
@@ -1760,10 +1754,6 @@ declare module 'stripe' {
       }
 
       namespace Company {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface OwnershipDeclaration {
           /**
            * The Unix timestamp marking when the beneficial owner attestation was made.
@@ -1954,7 +1944,7 @@ declare module 'stripe' {
         /**
          * The individual's primary address.
          */
-        address?: Individual.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The Kana variation of the the individual's primary address (Japan only).
@@ -2049,7 +2039,7 @@ declare module 'stripe' {
         /**
          * The individual's registered address.
          */
-        registered_address?: Individual.RegisteredAddress;
+        registered_address?: Stripe.AddressParam;
 
         /**
          * The last four digits of the individual's Social Security Number (U.S. only).
@@ -2063,10 +2053,6 @@ declare module 'stripe' {
       }
 
       namespace Individual {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface Dob {
           /**
            * The day of birth, between 1 and 31.
@@ -2085,10 +2071,6 @@ declare module 'stripe' {
         }
 
         type PoliticalExposure = 'existing' | 'none';
-
-        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
 
         interface Verification {
           /**
@@ -2470,7 +2452,7 @@ declare module 'stripe' {
         /**
          * A publicly available mailing address for sending support issues to.
          */
-        support_address?: BusinessProfile.SupportAddress;
+        support_address?: Stripe.AddressParam;
 
         /**
          * A publicly available email address for sending support issues to.
@@ -2491,12 +2473,6 @@ declare module 'stripe' {
          * The business's publicly available website.
          */
         url?: string;
-      }
-
-      namespace BusinessProfile {
-        interface SupportAddress extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       type BusinessType =
@@ -2909,7 +2885,7 @@ declare module 'stripe' {
         /**
          * The company's primary address.
          */
-        address?: Company.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The Kana variation of the company's primary address (Japan only).
@@ -2993,10 +2969,6 @@ declare module 'stripe' {
       }
 
       namespace Company {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface OwnershipDeclaration {
           /**
            * The Unix timestamp marking when the beneficial owner attestation was made.
@@ -3150,7 +3122,7 @@ declare module 'stripe' {
         /**
          * The individual's primary address.
          */
-        address?: Individual.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The Kana variation of the the individual's primary address (Japan only).
@@ -3245,7 +3217,7 @@ declare module 'stripe' {
         /**
          * The individual's registered address.
          */
-        registered_address?: Individual.RegisteredAddress;
+        registered_address?: Stripe.AddressParam;
 
         /**
          * The last four digits of the individual's Social Security Number (U.S. only).
@@ -3259,10 +3231,6 @@ declare module 'stripe' {
       }
 
       namespace Individual {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface Dob {
           /**
            * The day of birth, between 1 and 31.
@@ -3281,10 +3249,6 @@ declare module 'stripe' {
         }
 
         type PoliticalExposure = 'existing' | 'none';
-
-        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
 
         interface Verification {
           /**

--- a/types/2022-08-01/Charges.d.ts
+++ b/types/2022-08-01/Charges.d.ts
@@ -1895,7 +1895,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -1916,12 +1916,6 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface TransferData {
@@ -2002,7 +1996,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -2023,12 +2017,6 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
     }
 

--- a/types/2022-08-01/Checkout/Sessions.d.ts
+++ b/types/2022-08-01/Checkout/Sessions.d.ts
@@ -1952,7 +1952,7 @@ declare module 'stripe' {
             /**
              * Shipping address.
              */
-            address: Stripe.AddressParam;
+            address: Stripe.ShippingAddressParam;
 
             /**
              * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.

--- a/types/2022-08-01/CustomerSources.d.ts
+++ b/types/2022-08-01/CustomerSources.d.ts
@@ -104,7 +104,7 @@ declare module 'stripe' {
         /**
          * Owner's address.
          */
-        address?: Owner.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * Owner's email address.
@@ -120,12 +120,6 @@ declare module 'stripe' {
          * Owner's phone number.
          */
         phone?: string;
-      }
-
-      namespace Owner {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
     }
 

--- a/types/2022-08-01/Customers.d.ts
+++ b/types/2022-08-01/Customers.d.ts
@@ -294,7 +294,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: Stripe.Emptyable<Stripe.AddressParam>;
+      address?: Stripe.Emptyable<Stripe.ShippingAddressParam>;
 
       /**
        * An integer amount in cents (or local equivalent) that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
@@ -470,7 +470,7 @@ declare module 'stripe' {
         /**
          * Customer shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * Customer name.
@@ -481,12 +481,6 @@ declare module 'stripe' {
          * Customer phone (including extension).
          */
         phone?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Tax {
@@ -572,7 +566,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: Stripe.Emptyable<Stripe.AddressParam>;
+      address?: Stripe.Emptyable<Stripe.ShippingAddressParam>;
 
       /**
        * An integer amount in cents (or local equivalent) that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
@@ -745,7 +739,7 @@ declare module 'stripe' {
         /**
          * Customer shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * Customer name.
@@ -756,12 +750,6 @@ declare module 'stripe' {
          * Customer phone (including extension).
          */
         phone?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Tax {

--- a/types/2022-08-01/Customers.d.ts
+++ b/types/2022-08-01/Customers.d.ts
@@ -294,7 +294,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: Stripe.Emptyable<Stripe.ShippingAddressParam>;
+      address?: Stripe.Emptyable<Stripe.AddressParam>;
 
       /**
        * An integer amount in cents (or local equivalent) that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.
@@ -566,7 +566,7 @@ declare module 'stripe' {
       /**
        * The customer's address.
        */
-      address?: Stripe.Emptyable<Stripe.ShippingAddressParam>;
+      address?: Stripe.Emptyable<Stripe.AddressParam>;
 
       /**
        * An integer amount in cents (or local equivalent) that represents the customer's current balance, which affect the customer's future invoices. A negative amount represents a credit that decreases the amount due on an invoice; a positive amount increases the amount due on an invoice.

--- a/types/2022-08-01/Invoices.d.ts
+++ b/types/2022-08-01/Invoices.d.ts
@@ -1950,7 +1950,7 @@ declare module 'stripe' {
         /**
          * The customer's address.
          */
-        address?: Stripe.Emptyable<CustomerDetails.Address>;
+        address?: Stripe.Emptyable<Stripe.AddressParam>;
 
         /**
          * The customer's shipping information. Appears on invoices emailed to this customer.
@@ -1974,15 +1974,11 @@ declare module 'stripe' {
       }
 
       namespace CustomerDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface Shipping {
           /**
            * Customer shipping address.
            */
-          address: Shipping.Address;
+          address: Stripe.AddressParam;
 
           /**
            * Customer name.
@@ -1993,12 +1989,6 @@ declare module 'stripe' {
            * Customer phone (including extension).
            */
           phone?: string;
-        }
-
-        namespace Shipping {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Tax {
@@ -2508,7 +2498,7 @@ declare module 'stripe' {
         /**
          * The customer's address.
          */
-        address?: Stripe.Emptyable<CustomerDetails.Address>;
+        address?: Stripe.Emptyable<Stripe.AddressParam>;
 
         /**
          * The customer's shipping information. Appears on invoices emailed to this customer.
@@ -2532,15 +2522,11 @@ declare module 'stripe' {
       }
 
       namespace CustomerDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface Shipping {
           /**
            * Customer shipping address.
            */
-          address: Shipping.Address;
+          address: Stripe.AddressParam;
 
           /**
            * Customer name.
@@ -2551,12 +2537,6 @@ declare module 'stripe' {
            * Customer phone (including extension).
            */
           phone?: string;
-        }
-
-        namespace Shipping {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Tax {

--- a/types/2022-08-01/Orders.d.ts
+++ b/types/2022-08-01/Orders.d.ts
@@ -977,7 +977,7 @@ declare module 'stripe' {
         /**
          * The billing address provided by the customer.
          */
-        address?: BillingDetails.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The billing email provided by the customer.
@@ -993,12 +993,6 @@ declare module 'stripe' {
          * The billing phone number provided by the customer.
          */
         phone?: string;
-      }
-
-      namespace BillingDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Discount {
@@ -1946,7 +1940,7 @@ declare module 'stripe' {
         /**
          * The shipping address for the order.
          */
-        address: ShippingDetails.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The name of the recipient of the order.
@@ -1957,12 +1951,6 @@ declare module 'stripe' {
          * The phone number (including extension) for the recipient of the order.
          */
         phone?: string;
-      }
-
-      namespace ShippingDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface TaxDetails {
@@ -2135,7 +2123,7 @@ declare module 'stripe' {
         /**
          * The billing address provided by the customer.
          */
-        address?: BillingDetails.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The billing email provided by the customer.
@@ -2151,12 +2139,6 @@ declare module 'stripe' {
          * The billing phone number provided by the customer.
          */
         phone?: string;
-      }
-
-      namespace BillingDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Discount {
@@ -3113,7 +3095,7 @@ declare module 'stripe' {
         /**
          * The shipping address for the order.
          */
-        address: ShippingDetails.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The name of the recipient of the order.
@@ -3124,12 +3106,6 @@ declare module 'stripe' {
          * The phone number (including extension) for the recipient of the order.
          */
         phone?: string;
-      }
-
-      namespace ShippingDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface TaxDetails {

--- a/types/2022-08-01/PaymentIntents.d.ts
+++ b/types/2022-08-01/PaymentIntents.d.ts
@@ -2171,7 +2171,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: Stripe.Emptyable<BillingDetails.Address>;
+          address?: Stripe.Emptyable<Stripe.AddressParam>;
 
           /**
            * Email address.
@@ -2187,12 +2187,6 @@ declare module 'stripe' {
            * Billing phone number (including extension).
            */
           phone?: string;
-        }
-
-        namespace BillingDetails {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Blik {}
@@ -3507,7 +3501,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -3528,12 +3522,6 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface TransferData {
@@ -3895,7 +3883,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: Stripe.Emptyable<BillingDetails.Address>;
+          address?: Stripe.Emptyable<Stripe.AddressParam>;
 
           /**
            * Email address.
@@ -3911,12 +3899,6 @@ declare module 'stripe' {
            * Billing phone number (including extension).
            */
           phone?: string;
-        }
-
-        namespace BillingDetails {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Blik {}
@@ -5224,7 +5206,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -5245,12 +5227,6 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface TransferData {
@@ -5754,7 +5730,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: Stripe.Emptyable<BillingDetails.Address>;
+          address?: Stripe.Emptyable<Stripe.AddressParam>;
 
           /**
            * Email address.
@@ -5770,12 +5746,6 @@ declare module 'stripe' {
            * Billing phone number (including extension).
            */
           phone?: string;
-        }
-
-        namespace BillingDetails {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Blik {}
@@ -7090,7 +7060,7 @@ declare module 'stripe' {
         /**
          * Shipping address.
          */
-        address: Shipping.Address;
+        address: Stripe.AddressParam;
 
         /**
          * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -7111,12 +7081,6 @@ declare module 'stripe' {
          * The tracking number for a physical product, obtained from the delivery service. If multiple tracking numbers were generated for this purchase, please separate them with commas.
          */
         tracking_number?: string;
-      }
-
-      namespace Shipping {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
     }
 

--- a/types/2022-08-01/PaymentMethods.d.ts
+++ b/types/2022-08-01/PaymentMethods.d.ts
@@ -1008,7 +1008,7 @@ declare module 'stripe' {
         /**
          * Billing address.
          */
-        address?: Stripe.Emptyable<BillingDetails.Address>;
+        address?: Stripe.Emptyable<Stripe.AddressParam>;
 
         /**
          * Email address.
@@ -1024,12 +1024,6 @@ declare module 'stripe' {
          * Billing phone number (including extension).
          */
         phone?: string;
-      }
-
-      namespace BillingDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Blik {}
@@ -1420,7 +1414,7 @@ declare module 'stripe' {
         /**
          * Billing address.
          */
-        address?: Stripe.Emptyable<BillingDetails.Address>;
+        address?: Stripe.Emptyable<Stripe.AddressParam>;
 
         /**
          * Email address.
@@ -1436,12 +1430,6 @@ declare module 'stripe' {
          * Billing phone number (including extension).
          */
         phone?: string;
-      }
-
-      namespace BillingDetails {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Blik {}

--- a/types/2022-08-01/Persons.d.ts
+++ b/types/2022-08-01/Persons.d.ts
@@ -591,7 +591,7 @@ declare module 'stripe' {
       /**
        * The person's address.
        */
-      address?: PersonCreateParams.Address;
+      address?: Stripe.AddressParam;
 
       /**
        * The Kana variation of the person's address (Japan only).
@@ -706,7 +706,7 @@ declare module 'stripe' {
       /**
        * The person's registered address.
        */
-      registered_address?: PersonCreateParams.RegisteredAddress;
+      registered_address?: Stripe.AddressParam;
 
       /**
        * The relationship that this person has with the account's legal entity.
@@ -725,10 +725,6 @@ declare module 'stripe' {
     }
 
     namespace PersonCreateParams {
-      interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-        line1?: string;
-      }
-
       interface Dob {
         /**
          * The day of birth, between 1 and 31.
@@ -784,10 +780,6 @@ declare module 'stripe' {
            */
           files?: Array<string>;
         }
-      }
-
-      interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
-        line1?: string;
       }
 
       interface Relationship {
@@ -872,7 +864,7 @@ declare module 'stripe' {
       /**
        * The person's address.
        */
-      address?: PersonUpdateParams.Address;
+      address?: Stripe.AddressParam;
 
       /**
        * The Kana variation of the person's address (Japan only).
@@ -987,7 +979,7 @@ declare module 'stripe' {
       /**
        * The person's registered address.
        */
-      registered_address?: PersonUpdateParams.RegisteredAddress;
+      registered_address?: Stripe.AddressParam;
 
       /**
        * The relationship that this person has with the account's legal entity.
@@ -1006,10 +998,6 @@ declare module 'stripe' {
     }
 
     namespace PersonUpdateParams {
-      interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-        line1?: string;
-      }
-
       interface Dob {
         /**
          * The day of birth, between 1 and 31.
@@ -1065,10 +1053,6 @@ declare module 'stripe' {
            */
           files?: Array<string>;
         }
-      }
-
-      interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
-        line1?: string;
       }
 
       interface Relationship {

--- a/types/2022-08-01/SetupIntents.d.ts
+++ b/types/2022-08-01/SetupIntents.d.ts
@@ -916,7 +916,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: Stripe.Emptyable<BillingDetails.Address>;
+          address?: Stripe.Emptyable<Stripe.AddressParam>;
 
           /**
            * Email address.
@@ -932,12 +932,6 @@ declare module 'stripe' {
            * Billing phone number (including extension).
            */
           phone?: string;
-        }
-
-        namespace BillingDetails {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Blik {}
@@ -1771,7 +1765,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: Stripe.Emptyable<BillingDetails.Address>;
+          address?: Stripe.Emptyable<Stripe.AddressParam>;
 
           /**
            * Email address.
@@ -1787,12 +1781,6 @@ declare module 'stripe' {
            * Billing phone number (including extension).
            */
           phone?: string;
-        }
-
-        namespace BillingDetails {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Blik {}
@@ -2708,7 +2696,7 @@ declare module 'stripe' {
           /**
            * Billing address.
            */
-          address?: Stripe.Emptyable<BillingDetails.Address>;
+          address?: Stripe.Emptyable<Stripe.AddressParam>;
 
           /**
            * Email address.
@@ -2724,12 +2712,6 @@ declare module 'stripe' {
            * Billing phone number (including extension).
            */
           phone?: string;
-        }
-
-        namespace BillingDetails {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
         }
 
         interface Blik {}

--- a/types/2022-08-01/Sources.d.ts
+++ b/types/2022-08-01/Sources.d.ts
@@ -915,7 +915,7 @@ declare module 'stripe' {
         /**
          * Owner's address.
          */
-        address?: Owner.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * Owner's email address.
@@ -931,12 +931,6 @@ declare module 'stripe' {
          * Owner's phone number.
          */
         phone?: string;
-      }
-
-      namespace Owner {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface Receiver {
@@ -998,7 +992,7 @@ declare module 'stripe' {
           /**
            * Shipping address.
            */
-          address: Stripe.AddressParam;
+          address: Stripe.ShippingAddressParam;
 
           /**
            * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.
@@ -1179,7 +1173,7 @@ declare module 'stripe' {
         /**
          * Owner's address.
          */
-        address?: Owner.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * Owner's email address.
@@ -1195,12 +1189,6 @@ declare module 'stripe' {
          * Owner's phone number.
          */
         phone?: string;
-      }
-
-      namespace Owner {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface SourceOrder {
@@ -1244,7 +1232,7 @@ declare module 'stripe' {
           /**
            * Shipping address.
            */
-          address: Stripe.AddressParam;
+          address: Stripe.ShippingAddressParam;
 
           /**
            * The delivery service that shipped a physical product, such as Fedex, UPS, USPS, etc.

--- a/types/2022-08-01/Terminal/Locations.d.ts
+++ b/types/2022-08-01/Terminal/Locations.d.ts
@@ -134,7 +134,7 @@ declare module 'stripe' {
         /**
          * The full address of the location.
          */
-        address?: LocationUpdateParams.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The ID of a configuration that will be used to customize all readers in this location.
@@ -155,12 +155,6 @@ declare module 'stripe' {
          * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
          */
         metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
-      }
-
-      namespace LocationUpdateParams {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
       }
 
       interface LocationListParams extends PaginationParams {

--- a/types/2022-08-01/Terminal/Readers.d.ts
+++ b/types/2022-08-01/Terminal/Readers.d.ts
@@ -114,6 +114,20 @@ declare module 'stripe' {
              * Most recent PaymentIntent processed by the reader.
              */
             payment_intent: string | Stripe.PaymentIntent;
+
+            /**
+             * Represents a per-transaction override of a reader configuration
+             */
+            process_config?: ProcessPaymentIntent.ProcessConfig;
+          }
+
+          namespace ProcessPaymentIntent {
+            interface ProcessConfig {
+              /**
+               * Override showing a tipping selection screen on this transaction.
+               */
+              skip_tipping?: boolean;
+            }
           }
 
           interface ProcessSetupIntent {

--- a/types/2022-08-01/Tokens.d.ts
+++ b/types/2022-08-01/Tokens.d.ts
@@ -135,7 +135,7 @@ declare module 'stripe' {
           /**
            * The company's primary address.
            */
-          address?: Company.Address;
+          address?: Stripe.AddressParam;
 
           /**
            * The Kana variation of the company's primary address (Japan only).
@@ -224,10 +224,6 @@ declare module 'stripe' {
         }
 
         namespace Company {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
-
           interface OwnershipDeclaration {
             /**
              * The Unix timestamp marking when the beneficial owner attestation was made.
@@ -293,7 +289,7 @@ declare module 'stripe' {
           /**
            * The individual's primary address.
            */
-          address?: Individual.Address;
+          address?: Stripe.AddressParam;
 
           /**
            * The Kana variation of the the individual's primary address (Japan only).
@@ -388,7 +384,7 @@ declare module 'stripe' {
           /**
            * The individual's registered address.
            */
-          registered_address?: Individual.RegisteredAddress;
+          registered_address?: Stripe.AddressParam;
 
           /**
            * The last four digits of the individual's Social Security Number (U.S. only).
@@ -402,10 +398,6 @@ declare module 'stripe' {
         }
 
         namespace Individual {
-          interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
-
           interface Dob {
             /**
              * The day of birth, between 1 and 31.
@@ -424,11 +416,6 @@ declare module 'stripe' {
           }
 
           type PoliticalExposure = 'existing' | 'none';
-
-          interface RegisteredAddress
-            extends Omit<Stripe.AddressParam, 'line1'> {
-            line1?: string;
-          }
 
           interface Verification {
             /**
@@ -550,7 +537,7 @@ declare module 'stripe' {
         /**
          * The person's address.
          */
-        address?: Person.Address;
+        address?: Stripe.AddressParam;
 
         /**
          * The Kana variation of the person's address (Japan only).
@@ -655,7 +642,7 @@ declare module 'stripe' {
         /**
          * The person's registered address.
          */
-        registered_address?: Person.RegisteredAddress;
+        registered_address?: Stripe.AddressParam;
 
         /**
          * The relationship that this person has with the account's legal entity.
@@ -674,10 +661,6 @@ declare module 'stripe' {
       }
 
       namespace Person {
-        interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
-        }
-
         interface Dob {
           /**
            * The day of birth, between 1 and 31.
@@ -733,10 +716,6 @@ declare module 'stripe' {
              */
             files?: Array<string>;
           }
-        }
-
-        interface RegisteredAddress extends Omit<Stripe.AddressParam, 'line1'> {
-          line1?: string;
         }
 
         interface Relationship {

--- a/types/2022-08-01/Treasury/OutboundPayments.d.ts
+++ b/types/2022-08-01/Treasury/OutboundPayments.d.ts
@@ -362,7 +362,7 @@ declare module 'stripe' {
             /**
              * Billing address.
              */
-            address?: Stripe.Emptyable<BillingDetails.Address>;
+            address?: Stripe.Emptyable<Stripe.AddressParam>;
 
             /**
              * Email address.
@@ -378,12 +378,6 @@ declare module 'stripe' {
              * Billing phone number (including extension).
              */
             phone?: string;
-          }
-
-          namespace BillingDetails {
-            interface Address extends Omit<Stripe.AddressParam, 'line1'> {
-              line1?: string;
-            }
           }
 
           type Type = 'financial_account' | 'us_bank_account';

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -87,7 +87,7 @@ declare module 'stripe' {
       town: string | null;
     }
 
-    interface AccountAddressParam {
+    interface AddressParam {
       /**
        * City, district, suburb, town, or village.
        */
@@ -119,7 +119,7 @@ declare module 'stripe' {
       state?: string;
     }
 
-    interface AddressParam extends AccountAddressParam {
+    interface ShippingAddressParam extends AddressParam {
       /**
        * Address line 1 (e.g., street, PO Box, or company name).
        */

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -89,7 +89,7 @@ declare module 'stripe' {
 
     interface AddressParam {
       /**
-       * City, district, suburb, town, or village.
+       * City, district, suburb, town, village, or ward.
        */
       city?: string;
 
@@ -99,7 +99,7 @@ declare module 'stripe' {
       country?: string;
 
       /**
-       * Address line 1 (e.g., street, PO Box, or company name).
+       * Address line 1 (e.g., street, block, PO Box, or company name).
        */
       line1?: string;
 
@@ -114,7 +114,7 @@ declare module 'stripe' {
       postal_code?: string;
 
       /**
-       * State, county, province, or region.
+       * State, county, province, prefecture, or region.
        */
       state?: string;
     }
@@ -126,37 +126,7 @@ declare module 'stripe' {
       line1: string;
     }
 
-    interface JapanAddressParam {
-      /**
-       * City or ward.
-       */
-      city?: string;
-
-      /**
-       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-       */
-      country?: string;
-
-      /**
-       * Block or building number.
-       */
-      line1?: string;
-
-      /**
-       * Building details.
-       */
-      line2?: string;
-
-      /**
-       * Postal code.
-       */
-      postal_code?: string;
-
-      /**
-       * Prefecture.
-       */
-      state?: string;
-
+    interface JapanAddressParam extends AddressParam {
       /**
        * Town or cho-me.
        */


### PR DESCRIPTION
r? @pakrym-stripe 
cc @stripe/api-libraries

## Summary
- Rename `AddressParam` to `ShippingAddressParam`: shipping address is the only address that requires `line1`
- Rename `AccountAddressParam` to `AddressParam`: `AccountAddressParam` was not referenced
- Change instances of `Address extends Omit<ShippingAddressParam, "line1"> {line1?: string}` to `AddressParam`, which is the same type, and more concise

## Changelog
- Rename `AddressParam` to `ShippingAddressParam`, and change type of `Source.source_order.shipping.address`, `SourceUpdateParams.SourceOrder.Shipping.address`, and `SessionCreateParams.PaymentIntentData.Shipping.address` to `ShippingAddressParam`
- Rename `AccountAddressParam` go `AddressParam`, and change type of `AccountCreateParams.BusinessProfile.support_address`, `AccountCreateParams.Company.address`, `AccountCreateParams.Individual.address `, `AccountCreateParams.Individual.registered_address`, `AccountUpdateParams.BusinessProfile.support_address`, `AccountUpdateParams.Company.address`, `AccountUpdateParams.Individual.address`, `AccountUpdateParams.Individual.registered_address`, `ChargeCreateParams.Shipping.address`, `ChargeUpdateParams.Shipping.address`, `CustomerCreateParams.Shipping.address`, `CustomerUpdateParams.Shipping.address`, `CustomerSourceUpdateParams.Owner.address`, `InvoiceListUpcomingLinesParams.CustomerDetails.Shipping.address`, `InvoiceRetrieveUpcomingParams.CustomerDetails.Shipping.address`, `OrderCreateParams.BillingDetails.address`, `OrderCreateParams.ShippingDetails.address`, `OrderUpdateParams.BillingDetails.address`, `OrderUpdateParams.ShippingDetails.address`, `PaymentIntentCreateParams.Shipping.address`, `PaymentIntentUpdateParams.Shipping.address`, `PaymentIntentConfirmParams.Shipping.address`, `PersonCreateParams.address`, `PersonCreateParams.registered_address`, `PersonUpdateParams.address`, `PersonUpdateParams.registered_address`, `SourceCreateParams.Owner.address`, `SourceUpdateParams.Owner.address`, `TokenCreateParams.Account.Company.address`, `TokenCreateParams.Account.Individual.address`, `TokenCreateParams.Account.Individual.registered_address`, `TokenCreateParams.Person.address`, `TokenCreateParams.Person.registered_address`, and `Terminal.LocationUpdateParams.address` to `AddressParam`