### PR TITLE
Add a support section to the readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ See [video demonstrations][youtube-playlist] covering how to use the library.
 
 Node 8, 10 or higher.
 
+## Support
+
+New features and bug fixes are released on the latest major version of the stripe-node package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
+
 ## Installation
 
 Install the package with:

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ Node 8, 10 or higher.
 
 ## Support
 
-New features and bug fixes are released on the latest major version of the stripe-node package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
+New features and bug fixes are released on the latest major version of the `stripe` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
 
 ## Installation
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,10 @@ applications written in server-side JavaScript.
 
 For collecting customer and payment information in the browser, use [Stripe.js][stripe-js].
 
+## Support
+
+New features and bug fixes are released on the latest major version of the `stripe` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
+
 ## Documentation
 
 See the [`stripe-node` API docs](https://stripe.com/docs/api?lang=node) for Node.js.
@@ -19,10 +23,6 @@ See [video demonstrations][youtube-playlist] covering how to use the library.
 ## Requirements
 
 Node 8, 10 or higher.
-
-## Support
-
-New features and bug fixes are released on the latest major version of the `stripe` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.
 
 ## Installation
 


### PR DESCRIPTION
We have user feedback on the lack of clarity around whether or not we maintain and improve older major versions of the SDK. This PR adds a support section clarifying this