### PR TITLE
fix: Update FetchHttpClient to send empty string for empty POST/PUT/PATCH requests.

### DIFF
--- a/lib/net/FetchHttpClient.js
+++ b/lib/net/FetchHttpClient.js
@@ -39,11 +39,19 @@ class FetchHttpClient extends HttpClient {
     );
     url.port = port;
 
+    // For methods which expect payloads, we should always pass a body value
+    // even when it is empty. Without this, some JS runtimes (eg. Deno) will
+    // inject a second Content-Length header. See https://github.com/stripe/stripe-node/issues/1519
+    // for more details.
+    const methodHasPayload =
+      method == 'POST' || method == 'PUT' || method == 'PATCH';
+    const body = requestData || (methodHasPayload ? '' : undefined);
+
     const fetchFn = this._fetchFn || fetch;
     const fetchPromise = fetchFn(url.toString(), {
       method,
       headers,
-      body: requestData || undefined,
+      body,
     });
 
     // The Fetch API does not support passing in a timeout natively, so a


### PR DESCRIPTION
r? @kamil-stripe 

## Summary

Updates the FetchHttpClient to explicitly send an empty string for methods which expect a payload but have no request data. 

## Motivation

https://github.com/stripe/stripe-node/issues/1519

Deno injects a second `Content-Length` header when we don't specify body explicitly (ie. pass a concrete value other than undefined), causing Stripe POST requests without bodies to fail. By passing an explicit body, this will no longer happen.

## Release plan

Publish this as a beta to validate the fix and then, if all looks good, roll it out to stable.