### PR TITLE
Add test coverage using Coveralls

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,6 +90,21 @@ jobs:
       - name: Test
         run: yarn && yarn test
 
+      - name: Coveralls
+        run: yarn report && yarn coveralls
+        env:
+          GITHUB_TOKEN: ${{ secrets.github_token }}
+          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
+          COVERALLS_PARALLEL: true
+          COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}
+
+  finish:
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+    - name: Coveralls Finished
+      run: curl "https://coveralls.io/webhook?repo_token=${{ secrets.GITHUB_TOKEN }}&repo_name=${{ github.repository }}" -d "payload[build_num]=${{ github.run_id }}&payload[status]=done"
+
   publish:
     name: Publish
     if: >-

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -96,6 +96,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
           COVERALLS_PARALLEL: true
+          COVERALLS_FLAG_NAME: node-${{ matrix.node }}
           COVERALLS_SERVICE_NUMBER: ${{ github.run_id }}
 
   finish:

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Version](https://img.shields.io/npm/v/stripe.svg)](https://www.npmjs.org/package/stripe)
 [![Build Status](https://github.com/stripe/stripe-node/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-node/actions?query=branch%3Amaster)
+[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-node/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-node?branch=master)
 [![Downloads](https://img.shields.io/npm/dm/stripe.svg)](https://www.npmjs.com/package/stripe)
 [![Try on RunKit](https://badge.runkitcdn.com/stripe.svg)](https://runkit.com/npm/stripe)
 

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "@typescript-eslint/parser": "^2.13.0",
     "chai": "~4.2.0",
     "chai-as-promised": "~7.1.1",
+    "coveralls": "^3.1.1",
     "eslint": "^6.8.0",
     "eslint-config-prettier": "^4.1.0",
     "eslint-plugin-chai-friendly": "^0.4.0",


### PR DESCRIPTION
### Summary
r? @kamil-stripe 

Add coveralls CI step. Test coverage data will be published to https://coveralls.io/github/stripe/stripe-node and displayed as a badge in the README.