### PR TITLE
Fix: add dashboard fields

### DIFF
--- a/types/2022-08-01/Accounts.d.ts
+++ b/types/2022-08-01/Accounts.d.ts
@@ -3551,7 +3551,7 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface AccountDeleteParams { }
+    interface AccountDeleteParams {}
 
     interface AccountRejectParams {
       /**

--- a/types/2022-08-01/Accounts.d.ts
+++ b/types/2022-08-01/Accounts.d.ts
@@ -53,6 +53,16 @@ declare module 'stripe' {
       created?: number;
 
       /**
+       * Time at which the account was connected. Measured in seconds since the Unix epoch.
+       */
+      dashboard_account_status?: string;
+
+      /**
+       * Time at which the account was connected. Measured in seconds since the Unix epoch.
+       */
+      dashboard_type?: string;
+
+      /**
        * Three-letter ISO currency code representing the default currency for the account. This must be a currency that [Stripe supports in the account's country](https://stripe.com/docs/payouts).
        */
       default_currency?: string;
@@ -3541,7 +3551,7 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface AccountDeleteParams {}
+    interface AccountDeleteParams { }
 
     interface AccountRejectParams {
       /**

--- a/types/2022-08-01/Accounts.d.ts
+++ b/types/2022-08-01/Accounts.d.ts
@@ -53,12 +53,12 @@ declare module 'stripe' {
       created?: number;
 
       /**
-       * Time at which the account was connected. Measured in seconds since the Unix epoch.
+       * The account dashboard status.
        */
       dashboard_account_status?: string;
 
       /**
-       * Time at which the account was connected. Measured in seconds since the Unix epoch.
+       * The account dashboard type.
        */
       dashboard_type?: string;
 


### PR DESCRIPTION
### Changes made
Adds **dashboard_account_status** and **dashboard_type** on account types.

### Purpose of changes

This is also much safer than monkey patching the https.request or tls.secureContext functions to inject additional options.

Sample Usage
const stripe = stripe.accounts.retrieve('acct_xxxxxxxxxxxxx');


Response
```

{
    "id": "xxxx",
    "object": "account",
    "capabilities": {
        "boleto_payments": "active",
        "card_payments": "active",
        "platform_payments": "active"
    },
    "dashboard_account_status": "complete",
    "dashboard_type": "full",
...
}

```













