### PR TITLE
Restore lib after generating

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,4 +4,4 @@ update-version:
 	@perl -pi -e 's|"version": "[.\-\d\w]+"|"version": "$(VERSION)"|' package.json
 
 codegen-format:
-	yarn && yarn fix
+	yarn && yarn fix && yarn build


### PR DESCRIPTION
### Summary
r? @pakrym-stripe 

Add yarn build call at the end of codegen-format to restore lib/ after generating files.