### PR TITLE
Split StripeSignatureVerificationError detail field into header and payload

### DIFF
--- a/lib/Error.js
+++ b/lib/Error.js
@@ -93,7 +93,13 @@ class StripeConnectionError extends StripeError {}
  * SignatureVerificationError is raised when the signature verification for a
  * webhook fails
  */
-class StripeSignatureVerificationError extends StripeError {}
+class StripeSignatureVerificationError extends StripeError {
+  constructor(header, payload, raw = {}) {
+    super(raw);
+    this.header = header;
+    this.payload = payload;
+  }
+}
 /**
  * IdempotencyError is raised in cases where an idempotency key was used
  * improperly.

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -142,23 +142,14 @@ function parseEventDetails(encodedPayload, encodedHeader, expectedScheme) {
     : encodedHeader;
   const details = parseHeader(decodedHeader, expectedScheme);
   if (!details || details.timestamp === -1) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(decodedHeader, decodedPayload, {
       message: 'Unable to extract timestamp and signatures from header',
-      // @ts-expect-error Type '{ decodedHeader: any; decodedPayload: any; }' is not assignable to type 'string'.
-      detail: {
-        decodedHeader,
-        decodedPayload,
-      },
     });
   }
   if (!details.signatures.length) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(decodedHeader, decodedPayload, {
       message: 'No signatures found with expected scheme',
-      // @ts-expect-error Type '{ decodedHeader: any; decodedPayload: any; }' is not assignable to type 'string'.
-      detail: {
-        decodedHeader,
-        decodedPayload,
-      },
+      detail: decodedHeader,
     });
   }
   return {
@@ -178,27 +169,17 @@ function validateComputedSignature(
     utils.secureCompare.bind(utils, expectedSignature)
   ).length;
   if (!signatureFound) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(header, payload, {
       message:
         'No signatures found matching the expected signature for payload.' +
         ' Are you passing the raw request body you received from Stripe?' +
         ' https://github.com/stripe/stripe-node#webhook-signing',
-      // @ts-expect-error Type '{ header: any; payload: any; }' is not assignable to type 'string'.
-      detail: {
-        header,
-        payload,
-      },
     });
   }
   const timestampAge = Math.floor(Date.now() / 1000) - details.timestamp;
   if (tolerance > 0 && timestampAge > tolerance) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(header, payload, {
       message: 'Timestamp outside the tolerance zone',
-      // @ts-expect-error Type '{ header: any; payload: any; }' is not assignable to type 'string'.
-      detail: {
-        header,
-        payload,
-      },
     });
   }
   return true;

--- a/lib/Webhooks.js
+++ b/lib/Webhooks.js
@@ -149,7 +149,6 @@ function parseEventDetails(encodedPayload, encodedHeader, expectedScheme) {
   if (!details.signatures.length) {
     throw new StripeSignatureVerificationError(decodedHeader, decodedPayload, {
       message: 'No signatures found with expected scheme',
-      detail: decodedHeader,
     });
   }
   return {

--- a/src/Error.ts
+++ b/src/Error.ts
@@ -157,7 +157,16 @@ class StripeConnectionError extends StripeError {}
  * SignatureVerificationError is raised when the signature verification for a
  * webhook fails
  */
-class StripeSignatureVerificationError extends StripeError {}
+class StripeSignatureVerificationError extends StripeError {
+  header: string;
+  payload: string;
+
+  constructor(header: string, payload: string, raw: StripeRawError = {}) {
+    super(raw);
+    this.header = header;
+    this.payload = payload;
+  }
+}
 
 /**
  * IdempotencyError is raised in cases where an idempotency key was used

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -167,24 +167,14 @@ function parseEventDetails(encodedPayload, encodedHeader, expectedScheme) {
   const details = parseHeader(decodedHeader, expectedScheme);
 
   if (!details || details.timestamp === -1) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(decodedHeader, decodedPayload, {
       message: 'Unable to extract timestamp and signatures from header',
-      // @ts-expect-error Type '{ decodedHeader: any; decodedPayload: any; }' is not assignable to type 'string'.
-      detail: {
-        decodedHeader,
-        decodedPayload,
-      },
     });
   }
 
   if (!details.signatures.length) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(decodedHeader, decodedPayload, {
       message: 'No signatures found with expected scheme',
-      // @ts-expect-error Type '{ decodedHeader: any; decodedPayload: any; }' is not assignable to type 'string'.
-      detail: {
-        decodedHeader,
-        decodedPayload,
-      },
     });
   }
 
@@ -207,29 +197,19 @@ function validateComputedSignature(
   ).length;
 
   if (!signatureFound) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(header, payload, {
       message:
         'No signatures found matching the expected signature for payload.' +
         ' Are you passing the raw request body you received from Stripe?' +
         ' https://github.com/stripe/stripe-node#webhook-signing',
-      // @ts-expect-error Type '{ header: any; payload: any; }' is not assignable to type 'string'.
-      detail: {
-        header,
-        payload,
-      },
     });
   }
 
   const timestampAge = Math.floor(Date.now() / 1000) - details.timestamp;
 
   if (tolerance > 0 && timestampAge > tolerance) {
-    throw new StripeSignatureVerificationError({
+    throw new StripeSignatureVerificationError(header, payload, {
       message: 'Timestamp outside the tolerance zone',
-      // @ts-expect-error Type '{ header: any; payload: any; }' is not assignable to type 'string'.
-      detail: {
-        header,
-        payload,
-      },
     });
   }
 


### PR DESCRIPTION
(Duplicate of https://github.com/stripe/stripe-node/pull/1574)
r? @pakrym-stripe 
## Summary
Splits detail field in `Webhooks.ts` to match the [convention for the same error in stripe-php](https://github.com/stripe/stripe-php/blob/c7cfc8bdf68f063cdd835f1fa9d6faa44b5cc8c3/lib/Exception/SignatureVerificationException.php#L23).

## Motivation
Remove `ts-expect-error` because `detail` is of type string.