### PR TITLE
use native UUID method if available

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -369,6 +369,11 @@ const utils = {
    * https://stackoverflow.com/a/2117523
    */
   uuid4: () => {
+    // available in: v14.17.x+
+    if (crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+    // legacy behavior if native UUIDs aren't available
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
       const r = (Math.random() * 16) | 0;
       const v = c === 'x' ? r : (r & 0x3) | 0x8;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -428,6 +428,12 @@ const utils = {
    * https://stackoverflow.com/a/2117523
    */
   uuid4: () => {
+    // available in: v14.17.x+
+    if (crypto.randomUUID) {
+      return crypto.randomUUID();
+    }
+
+    // legacy behavior if native UUIDs aren't available
     return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
       const r = (Math.random() * 16) | 0;
       const v = c === 'x' ? r : (r & 0x3) | 0x8;

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -616,19 +616,27 @@ describe('utils', () => {
       let randomUUID$;
       let called;
       beforeEach(() => {
-        called = false;
-        randomUUID$ = crypto.randomUUID;
-        crypto.randomUUID = () => {
-          called = true;
-          return 'no, YOU you id';
-        };
+        // if it's available, mock it and ensure it's called
+        // otherwise, skip this whole operation
+        if (crypto.randomUUID) {
+          called = false;
+          randomUUID$ = crypto.randomUUID;
+          crypto.randomUUID = () => {
+            called = true;
+            return 'no, YOU you id';
+          };
+        }
       });
       afterEach(() => {
-        crypto.randomUUID = randomUUID$;
+        if (randomUUID$) {
+          crypto.randomUUID = randomUUID$;
+        }
       });
       it('is called if available', () => {
-        expect(utils.uuid4()).to.equal('no, YOU you id');
-        expect(called).to.equal(true);
+        if (randomUUID$) {
+          expect(utils.uuid4()).to.equal('no, YOU you id');
+          expect(called).to.equal(true);
+        }
       });
     });
     it('should return a well-formatted v4 UUID', () => {

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -611,6 +611,26 @@ describe('utils', () => {
   });
 
   describe('uuid', () => {
+    describe('crypto.randomUUID', () => {
+      const crypto = require('crypto');
+      let randomUUID$;
+      let called;
+      beforeEach(() => {
+        called = false;
+        randomUUID$ = crypto.randomUUID;
+        crypto.randomUUID = () => {
+          called = true;
+          return 'no, YOU you id';
+        };
+      });
+      afterEach(() => {
+        crypto.randomUUID = randomUUID$;
+      });
+      it('is called if available', () => {
+        expect(utils.uuid4()).to.equal('no, YOU you id');
+        expect(called).to.equal(true);
+      });
+    });
     it('should return a well-formatted v4 UUID', () => {
       expect(utils.uuid4()).to.match(
         // regex from https://createuuid.com/validator/, specifically for v4

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -609,6 +609,17 @@ describe('utils', () => {
       }).to.throw();
     });
   });
+
+  describe('uuid', () => {
+    it('should return a well-formatted v4 UUID', () => {
+      expect(utils.uuid4()).to.match(
+        // regex from https://createuuid.com/validator/, specifically for v4
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+      // further test: could spy on crypto.randomUUID to ensure it's being used, if available
+      // whether that's useful is a race between using jest/sinon for these tests and dropping support for node < 14
+    });
+  });
 });
 
 function handleWarnings(doWithShimmedConsoleWarn, onWarn) {


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-node/issues/1101 by using the native UUID implementation, if available. Added a (very) basic test as a starter.