### PR TITLE
Check if stripe-signature header exists

### DIFF
--- a/examples/webhook-signing/typescript-node-express/express-ts.ts
+++ b/examples/webhook-signing/typescript-node-express/express-ts.ts
@@ -32,6 +32,11 @@ app.post(
   // Stripe requires the raw body to construct the event
   express.raw({type: 'application/json'}),
   (req: express.Request, res: express.Response): void => {
+    if (!req.headers['stripe-signature']) {
+      console.log('❌ Error message: missing stripe-signature header');
+      return;
+    }
+
     const sig = req.headers['stripe-signature'];
 
     let event: Stripe.Event;


### PR DESCRIPTION
Since stripe-signature could be undefined, we check it first

"Argument of type 'string | string[] | undefined' is not assignable to parameter of type 'string | string[] | Buffer'.\n  Type 'undefined' is not assignable to type 'string | string[] | Buffer'.",