### PR TITLE
Do not run Coveralls if secret token is not available

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,7 @@ jobs:
 
       - name: Coveralls
         run: yarn report && yarn coveralls
-        if: matrix.node == '18'
+        if: env.COVERALLS_REPO_TOKEN && matrix.node == '18'
         env:
           GITHUB_TOKEN: ${{ secrets.github_token }}
           COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}


### PR DESCRIPTION
## Summary
Do not run Coveralls step if the secret token does not exist (for pushes triggered by outside collaborators).

## Motivation
https://github.com/stripe/stripe-php/pull/1379 - make this change consistent across all languages