### PR TITLE
Don't deprecate relative `path`

### DIFF
--- a/lib/StripeMethod.js
+++ b/lib/StripeMethod.js
@@ -7,6 +7,8 @@ const makeAutoPaginationMethods = autoPagination.makeAutoPaginationMethods;
  * Create an API method from the declared spec.
  *
  * @param [spec.method='GET'] Request Method (POST, GET, DELETE, PUT)
+ * @param [spec.path=''] Path to be appended to the API BASE_PATH, joined with
+ *  the instance's path (e.g. 'charges' or 'customers')
  * @param [spec.fullPath=''] Fully qualified path to the method (eg. /v1/a/b/c).
  *  If this is specified, path should not be specified.
  * @param [spec.urlParams=[]] Array of required arguments in the order that they
@@ -18,17 +20,16 @@ const makeAutoPaginationMethods = autoPagination.makeAutoPaginationMethods;
  * @param [spec.host] Hostname for the request.
  */
 function stripeMethod(spec) {
-  if (spec.path !== undefined) {
+  if (spec.path !== undefined && spec.fullPath !== undefined) {
     throw new Error(
-      `Support for relative 'path' was removed in stripe-node v11.0.0. Please specify 'fullPath'`
+      `Method spec specified both a 'path' (${spec.path}) and a 'fullPath' (${spec.fullPath}).`
     );
-  }
-  if (!spec.fullPath) {
-    throw new Error(`'fullPath' must be provided when calling 'stripeMethod'`);
   }
   return function(...args) {
     const callback = typeof args[args.length - 1] == 'function' && args.pop();
-    spec.urlParams = utils.extractUrlParams(spec.fullPath);
+    spec.urlParams = utils.extractUrlParams(
+      spec.fullPath || this.createResourcePathWithSymbols(spec.path || '')
+    );
     const requestPromise = utils.callbackifyPromiseWithTimeout(
       makeRequest(this, args, spec, {}),
       callback

--- a/lib/StripeResource.js
+++ b/lib/StripeResource.js
@@ -26,19 +26,17 @@ function StripeResource(stripe, deprecatedUrlData) {
       'Support for curried url params was dropped in stripe-node v7.0.0. Instead, pass two ids.'
     );
   }
-  if (this.path) {
-    throw new Error(
-      'Support for StripeResource.path was dropped in stripe-node v11.0.0. Instead, you must fully specify "fullPath" on .stripeMethod({...})'
-    );
-  }
-  if (this.basePath) {
-    throw new Error(
-      'Support for StripeResource.basePath was dropped in stripe-node v11.0.0. Instead, you must fully specify "fullPath" on .stripeMethod({...})'
-    );
-  }
+  this.basePath = utils.makeURLInterpolator(
+    this.basePath || stripe.getApiField('basePath')
+  );
+  this.resourcePath = this.path;
+  this.path = utils.makeURLInterpolator(this.path);
   this.initialize(...arguments);
 }
 StripeResource.prototype = {
+  path: '',
+  // Methods that don't use the API's default '/v1' path can override it with this setting.
+  basePath: null,
   initialize() {},
   // Function to override the default data processor. This allows full control
   // over how a StripeResource's request data will get converted into an HTTP
@@ -48,20 +46,39 @@ StripeResource.prototype = {
   // Function to add a validation checks before sending the request, errors should
   // be thrown, and they will be passed to the callback/promise.
   validateRequest: null,
-  createFullPath(_commandPath, _urlData) {
-    throw new Error(
-      "Support for `createFullPath` was removed in stripe-node v11.0.0. Please specify 'fullPath' directly on .stripeMethod({})"
-    );
+  createFullPath(commandPath, urlData) {
+    const urlParts = [this.basePath(urlData), this.path(urlData)];
+    if (typeof commandPath === 'function') {
+      const computedCommandPath = commandPath(urlData);
+      // If we have no actual command path, we just omit it to avoid adding a
+      // trailing slash. This is important for top-level listing requests, which
+      // do not have a command path.
+      if (computedCommandPath) {
+        urlParts.push(computedCommandPath);
+      }
+    } else {
+      urlParts.push(commandPath);
+    }
+    return this._joinUrlParts(urlParts);
   },
-  createResourcePathWithSymbols(_pathWithSymbols) {
-    throw new Error(
-      "Support for `createResourcePathWithSymbols` was removed in stripe-node v11.0.0. Please specify 'fullPath' directly on .stripeMethod({})"
-    );
+  // Creates a relative resource path with symbols left in (unlike
+  // createFullPath which takes some data to replace them with). For example it
+  // might produce: /invoices/{id}
+  createResourcePathWithSymbols(pathWithSymbols) {
+    // If there is no path beyond the resource path, we want to produce just
+    // /<resource path> rather than /<resource path>/.
+    if (pathWithSymbols) {
+      return `/${this._joinUrlParts([this.resourcePath, pathWithSymbols])}`;
+    } else {
+      return `/${this.resourcePath}`;
+    }
   },
   _joinUrlParts(parts) {
-    throw new Error(
-      "Support for `_joinUrlParts` was removed in stripe-node v11.0.0. Please specify 'fullPath' directly on .stripeMethod({})"
-    );
+    // Replace any accidentally doubled up slashes. This previously used
+    // path.join, which would do this as well. Unfortunately we need to do this
+    // as the functions for creating paths are technically part of the public
+    // interface and so we need to preserve backwards compatibility.
+    return parts.join('/').replace(/\/{2,}/g, '/');
   },
   _timeoutHandler(timeout, req, callback) {
     return () => {

--- a/lib/makeRequest.js
+++ b/lib/makeRequest.js
@@ -5,8 +5,15 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   const requestMethod = (spec.method || 'GET').toUpperCase();
   const urlParams = spec.urlParams || [];
   const encode = spec.encode || ((data) => data);
-  const commandPath = utils.makeURLInterpolator(spec.fullPath || '');
-  const path = spec.fullPath;
+  const isUsingFullPath = !!spec.fullPath;
+  const commandPath = utils.makeURLInterpolator(
+    isUsingFullPath ? spec.fullPath : spec.path || ''
+  );
+  // When using fullPath, we ignore the resource path as it should already be
+  // fully qualified.
+  const path = isUsingFullPath
+    ? spec.fullPath
+    : self.createResourcePathWithSymbols(spec.path);
   // Don't mutate args externally.
   const args = [].slice.call(requestArgs);
   // Generate and validate url params.
@@ -32,7 +39,11 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
       `Stripe: Unknown arguments (${args}). Did you mean to pass an options object? See https://github.com/stripe/stripe-node/wiki/Passing-Options. (on API request to ${requestMethod} \`${path}\`)`
     );
   }
-  const requestPath = commandPath(urlData);
+  // When using full path, we can just invoke the URL interpolator directly
+  // as we don't need to use the resource to create a full path.
+  const requestPath = isUsingFullPath
+    ? commandPath(urlData)
+    : self.createFullPath(commandPath, urlData);
   const headers = Object.assign(options.headers, spec.headers);
   if (spec.validator) {
     spec.validator(data, {headers});

--- a/lib/resources/OAuth.js
+++ b/lib/resources/OAuth.js
@@ -4,6 +4,7 @@ const stripeMethod = StripeResource.method;
 const utils = require('../utils');
 const oAuthHost = 'connect.stripe.com';
 module.exports = StripeResource.extend({
+  basePath: '/',
   authorizeUrl(params, options) {
     params = params || {};
     options = options || {};
@@ -25,7 +26,7 @@ module.exports = StripeResource.extend({
   },
   token: stripeMethod({
     method: 'POST',
-    fullPath: '/oauth/token',
+    path: 'oauth/token',
     host: oAuthHost,
   }),
   deauthorize(spec) {
@@ -34,7 +35,7 @@ module.exports = StripeResource.extend({
     }
     return stripeMethod({
       method: 'POST',
-      fullPath: '/oauth/deauthorize',
+      path: 'oauth/deauthorize',
       host: oAuthHost,
     }).apply(this, arguments);
   },

--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -3,6 +3,7 @@ const _Error = require('./Error');
 const resources = require('./resources');
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';
+const DEFAULT_BASE_PATH = '/v1/';
 const DEFAULT_API_VERSION = null;
 const DEFAULT_TIMEOUT = 80000;
 Stripe.PACKAGE_VERSION = require('../package.json').version;
@@ -76,6 +77,7 @@ function Stripe(key, config = {}) {
     host: props.host || DEFAULT_HOST,
     port: props.port || DEFAULT_PORT,
     protocol: props.protocol || 'https',
+    basePath: DEFAULT_BASE_PATH,
     version: props.apiVersion || DEFAULT_API_VERSION,
     timeout: utils.validateInteger('timeout', props.timeout, DEFAULT_TIMEOUT),
     maxNetworkRetries: utils.validateInteger(
@@ -212,7 +214,7 @@ Stripe.prototype = {
       case 'DEFAULT_PORT':
         return DEFAULT_PORT;
       case 'DEFAULT_BASE_PATH':
-        throw new Error('DEFAULT_BASE_BATH was removed in v11.0.0');
+        return DEFAULT_BASE_PATH;
       case 'DEFAULT_API_VERSION':
         return DEFAULT_API_VERSION;
       case 'DEFAULT_TIMEOUT':

--- a/src/StripeMethod.ts
+++ b/src/StripeMethod.ts
@@ -4,14 +4,14 @@ import autoPagination = require('./autoPagination');
 const makeAutoPaginationMethods = autoPagination.makeAutoPaginationMethods;
 
 type StripeMethodSpec = {
-  method?: 'GET' | 'POST' | 'DELETE';
-  path: void; // removed in v11.0.0
-  fullPath: string;
-  urlParams?: Array<string>;
-  encode: any;
-  host?: string;
-  methodType?: 'list' | 'search';
-};
+  method?: 'GET' | 'POST' | 'DELETE',
+  path: void, // removed in v11.0.0
+  fullPath: string,
+  urlParams?: Array<string>,
+  encode: any // TODO
+  host?: string,
+  methodType?: 'list' | 'search'
+}
 /**
  * Create an API method from the declared spec.
  *
@@ -33,12 +33,16 @@ function stripeMethod(spec: StripeMethodSpec) {
     );
   }
   if (!spec.fullPath) {
-    throw new Error(`'fullPath' must be provided when calling 'stripeMethod'`);
+    throw new Error(
+      `'fullPath' must be provided when calling 'stripeMethod'`
+    );
   }
   return function(...args) {
     const callback = typeof args[args.length - 1] == 'function' && args.pop();
 
-    spec.urlParams = utils.extractUrlParams(spec.fullPath);
+    spec.urlParams = utils.extractUrlParams(
+      spec.fullPath
+    );
 
     const requestPromise = utils.callbackifyPromiseWithTimeout(
       makeRequest(this, args, spec, {}),

--- a/src/StripeMethod.ts
+++ b/src/StripeMethod.ts
@@ -3,19 +3,12 @@ import makeRequest = require('./makeRequest');
 import autoPagination = require('./autoPagination');
 const makeAutoPaginationMethods = autoPagination.makeAutoPaginationMethods;
 
-type StripeMethodSpec = {
-  method?: 'GET' | 'POST' | 'DELETE',
-  path: void, // removed in v11.0.0
-  fullPath: string,
-  urlParams?: Array<string>,
-  encode: any // TODO
-  host?: string,
-  methodType?: 'list' | 'search'
-}
 /**
  * Create an API method from the declared spec.
  *
  * @param [spec.method='GET'] Request Method (POST, GET, DELETE, PUT)
+ * @param [spec.path=''] Path to be appended to the API BASE_PATH, joined with
+ *  the instance's path (e.g. 'charges' or 'customers')
  * @param [spec.fullPath=''] Fully qualified path to the method (eg. /v1/a/b/c).
  *  If this is specified, path should not be specified.
  * @param [spec.urlParams=[]] Array of required arguments in the order that they
@@ -26,22 +19,17 @@ type StripeMethodSpec = {
  *  Usefully for applying transforms to data on a per-method basis.
  * @param [spec.host] Hostname for the request.
  */
-function stripeMethod(spec: StripeMethodSpec) {
-  if (spec.path !== undefined) {
+function stripeMethod(spec) {
+  if (spec.path !== undefined && spec.fullPath !== undefined) {
     throw new Error(
-      `Support for relative 'path' was removed in stripe-node v11.0.0. Please specify 'fullPath'`
-    );
-  }
-  if (!spec.fullPath) {
-    throw new Error(
-      `'fullPath' must be provided when calling 'stripeMethod'`
+      `Method spec specified both a 'path' (${spec.path}) and a 'fullPath' (${spec.fullPath}).`
     );
   }
   return function(...args) {
     const callback = typeof args[args.length - 1] == 'function' && args.pop();
 
     spec.urlParams = utils.extractUrlParams(
-      spec.fullPath
+      spec.fullPath || this.createResourcePathWithSymbols(spec.path || '')
     );
 
     const requestPromise = utils.callbackifyPromiseWithTimeout(

--- a/src/StripeResource.ts
+++ b/src/StripeResource.ts
@@ -45,13 +45,13 @@ function StripeResource(stripe, deprecatedUrlData) {
   if (this.path) {
     throw new Error(
       'Support for StripeResource.path was dropped in stripe-node v11.0.0. Instead, you must fully specify "fullPath" on .stripeMethod({...})'
-    );
+    )
   }
 
   if (this.basePath) {
     throw new Error(
       'Support for StripeResource.basePath was dropped in stripe-node v11.0.0. Instead, you must fully specify "fullPath" on .stripeMethod({...})'
-    );
+    )
   }
 
   this.initialize(...arguments);
@@ -71,21 +71,15 @@ StripeResource.prototype = {
   validateRequest: null,
 
   createFullPath(_commandPath, _urlData) {
-    throw new Error(
-      "Support for `createFullPath` was removed in stripe-node v11.0.0. Please specify 'fullPath' directly on .stripeMethod({})"
-    );
+    throw new Error('Support for `createFullPath` was removed in stripe-node v11.0.0. Please specify \'fullPath\' directly on .stripeMethod({})');
   },
 
   createResourcePathWithSymbols(_pathWithSymbols) {
-    throw new Error(
-      "Support for `createResourcePathWithSymbols` was removed in stripe-node v11.0.0. Please specify 'fullPath' directly on .stripeMethod({})"
-    );
+    throw new Error('Support for `createResourcePathWithSymbols` was removed in stripe-node v11.0.0. Please specify \'fullPath\' directly on .stripeMethod({})')
   },
 
   _joinUrlParts(parts) {
-    throw new Error(
-      "Support for `_joinUrlParts` was removed in stripe-node v11.0.0. Please specify 'fullPath' directly on .stripeMethod({})"
-    );
+    throw new Error('Support for `_joinUrlParts` was removed in stripe-node v11.0.0. Please specify \'fullPath\' directly on .stripeMethod({})')
   },
 
   _timeoutHandler(timeout, req, callback) {

--- a/src/StripeResource.ts
+++ b/src/StripeResource.ts
@@ -42,22 +42,21 @@ function StripeResource(stripe, deprecatedUrlData) {
     );
   }
 
-  if (this.path) {
-    throw new Error(
-      'Support for StripeResource.path was dropped in stripe-node v11.0.0. Instead, you must fully specify "fullPath" on .stripeMethod({...})'
-    )
-  }
-
-  if (this.basePath) {
-    throw new Error(
-      'Support for StripeResource.basePath was dropped in stripe-node v11.0.0. Instead, you must fully specify "fullPath" on .stripeMethod({...})'
-    )
-  }
+  this.basePath = utils.makeURLInterpolator(
+    this.basePath || stripe.getApiField('basePath')
+  );
+  this.resourcePath = this.path;
+  this.path = utils.makeURLInterpolator(this.path);
 
   this.initialize(...arguments);
 }
 
 StripeResource.prototype = {
+  path: '',
+
+  // Methods that don't use the API's default '/v1' path can override it with this setting.
+  basePath: null,
+
   initialize() {},
 
   // Function to override the default data processor. This allows full control
@@ -70,16 +69,43 @@ StripeResource.prototype = {
   // be thrown, and they will be passed to the callback/promise.
   validateRequest: null,
 
-  createFullPath(_commandPath, _urlData) {
-    throw new Error('Support for `createFullPath` was removed in stripe-node v11.0.0. Please specify \'fullPath\' directly on .stripeMethod({})');
+  createFullPath(commandPath, urlData) {
+    const urlParts = [this.basePath(urlData), this.path(urlData)];
+
+    if (typeof commandPath === 'function') {
+      const computedCommandPath = commandPath(urlData);
+      // If we have no actual command path, we just omit it to avoid adding a
+      // trailing slash. This is important for top-level listing requests, which
+      // do not have a command path.
+      if (computedCommandPath) {
+        urlParts.push(computedCommandPath);
+      }
+    } else {
+      urlParts.push(commandPath);
+    }
+
+    return this._joinUrlParts(urlParts);
   },
 
-  createResourcePathWithSymbols(_pathWithSymbols) {
-    throw new Error('Support for `createResourcePathWithSymbols` was removed in stripe-node v11.0.0. Please specify \'fullPath\' directly on .stripeMethod({})')
+  // Creates a relative resource path with symbols left in (unlike
+  // createFullPath which takes some data to replace them with). For example it
+  // might produce: /invoices/{id}
+  createResourcePathWithSymbols(pathWithSymbols) {
+    // If there is no path beyond the resource path, we want to produce just
+    // /<resource path> rather than /<resource path>/.
+    if (pathWithSymbols) {
+      return `/${this._joinUrlParts([this.resourcePath, pathWithSymbols])}`;
+    } else {
+      return `/${this.resourcePath}`;
+    }
   },
 
   _joinUrlParts(parts) {
-    throw new Error('Support for `_joinUrlParts` was removed in stripe-node v11.0.0. Please specify \'fullPath\' directly on .stripeMethod({})')
+    // Replace any accidentally doubled up slashes. This previously used
+    // path.join, which would do this as well. Unfortunately we need to do this
+    // as the functions for creating paths are technically part of the public
+    // interface and so we need to preserve backwards compatibility.
+    return parts.join('/').replace(/\/{2,}/g, '/');
   },
 
   _timeoutHandler(timeout, req, callback) {

--- a/src/makeRequest.ts
+++ b/src/makeRequest.ts
@@ -6,10 +6,15 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   const urlParams = spec.urlParams || [];
   const encode = spec.encode || ((data) => data);
 
+  const isUsingFullPath = !!spec.fullPath;
   const commandPath = utils.makeURLInterpolator(
-    spec.fullPath || ''
+    isUsingFullPath ? spec.fullPath : spec.path || ''
   );
-  const path = spec.fullPath
+  // When using fullPath, we ignore the resource path as it should already be
+  // fully qualified.
+  const path = isUsingFullPath
+    ? spec.fullPath
+    : self.createResourcePathWithSymbols(spec.path);
 
   // Don't mutate args externally.
   const args = [].slice.call(requestArgs);
@@ -40,7 +45,11 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
     );
   }
 
-  const requestPath = commandPath(urlData)
+  // When using full path, we can just invoke the URL interpolator directly
+  // as we don't need to use the resource to create a full path.
+  const requestPath = isUsingFullPath
+    ? commandPath(urlData)
+    : self.createFullPath(commandPath, urlData);
 
   const headers = Object.assign(options.headers, spec.headers);
 

--- a/src/makeRequest.ts
+++ b/src/makeRequest.ts
@@ -6,8 +6,10 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
   const urlParams = spec.urlParams || [];
   const encode = spec.encode || ((data) => data);
 
-  const commandPath = utils.makeURLInterpolator(spec.fullPath || '');
-  const path = spec.fullPath;
+  const commandPath = utils.makeURLInterpolator(
+    spec.fullPath || ''
+  );
+  const path = spec.fullPath
 
   // Don't mutate args externally.
   const args = [].slice.call(requestArgs);
@@ -38,7 +40,7 @@ function getRequestOpts(self, requestArgs, spec, overrideData) {
     );
   }
 
-  const requestPath = commandPath(urlData);
+  const requestPath = commandPath(urlData)
 
   const headers = Object.assign(options.headers, spec.headers);
 

--- a/src/resources/OAuth.js
+++ b/src/resources/OAuth.js
@@ -7,6 +7,8 @@ const utils = require('../utils');
 const oAuthHost = 'connect.stripe.com';
 
 module.exports = StripeResource.extend({
+  basePath: '/',
+
   authorizeUrl(params, options) {
     params = params || {};
     options = options || {};
@@ -35,7 +37,7 @@ module.exports = StripeResource.extend({
 
   token: stripeMethod({
     method: 'POST',
-    fullPath: '/oauth/token',
+    path: 'oauth/token',
     host: oAuthHost,
   }),
 
@@ -46,7 +48,7 @@ module.exports = StripeResource.extend({
 
     return stripeMethod({
       method: 'POST',
-      fullPath: '/oauth/deauthorize',
+      path: 'oauth/deauthorize',
       host: oAuthHost,
     }).apply(this, arguments);
   },

--- a/src/stripe.ts
+++ b/src/stripe.ts
@@ -4,6 +4,7 @@ const resources = require('./resources');
 
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';
+const DEFAULT_BASE_PATH = '/v1/';
 const DEFAULT_API_VERSION = null;
 
 const DEFAULT_TIMEOUT = 80000;
@@ -94,6 +95,7 @@ function Stripe(key, config = {}) {
     host: props.host || DEFAULT_HOST,
     port: props.port || DEFAULT_PORT,
     protocol: props.protocol || 'https',
+    basePath: DEFAULT_BASE_PATH,
     version: props.apiVersion || DEFAULT_API_VERSION,
     timeout: utils.validateInteger('timeout', props.timeout, DEFAULT_TIMEOUT),
     maxNetworkRetries: utils.validateInteger(
@@ -257,7 +259,7 @@ Stripe.prototype = {
       case 'DEFAULT_PORT':
         return DEFAULT_PORT;
       case 'DEFAULT_BASE_PATH':
-        throw new Error("DEFAULT_BASE_BATH was removed in v11.0.0")
+        return DEFAULT_BASE_PATH;
       case 'DEFAULT_API_VERSION':
         return DEFAULT_API_VERSION;
       case 'DEFAULT_TIMEOUT':

--- a/src/stripe.ts
+++ b/src/stripe.ts
@@ -257,7 +257,7 @@ Stripe.prototype = {
       case 'DEFAULT_PORT':
         return DEFAULT_PORT;
       case 'DEFAULT_BASE_PATH':
-        throw new Error('DEFAULT_BASE_BATH was removed in v11.0.0');
+        throw new Error("DEFAULT_BASE_BATH was removed in v11.0.0")
       case 'DEFAULT_API_VERSION':
         return DEFAULT_API_VERSION;
       case 'DEFAULT_TIMEOUT':

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -22,23 +22,33 @@ const {
 
 describe('StripeResource', () => {
   describe('createResourcePathWithSymbols', () => {
+    let testResource;
+    before(() => {
+      testResource = new (StripeResource.extend({
+        path: 'widgets',
+        create: stripeMethod({
+          method: 'POST',
+          path: '',
+        }),
+      }))(stripe);
+    });
     it('Generates a path when there is a symbol', () => {
-      stripe.invoices.create({});
-      const path = stripe.invoices.createResourcePathWithSymbols('{id}');
-      expect(path).to.equal('/invoices/{id}');
+      testResource.create({});
+      const path = testResource.createResourcePathWithSymbols('{id}');
+      expect(path).to.equal('/widgets/{id}');
     });
 
     it('Generates a path when there is nothing beyond the resource path', () => {
-      stripe.invoices.create({});
-      const path = stripe.invoices.createResourcePathWithSymbols('');
+      testResource.create({});
+      const path = testResource.createResourcePathWithSymbols('');
       // This explicitly shouldn't have a trailing slash.
-      expect(path).to.equal('/invoices');
+      expect(path).to.equal('/widgets');
     });
 
     it('Handles accidental double slashes', () => {
-      stripe.invoices.create({});
-      const path = stripe.invoices.createResourcePathWithSymbols('/{id}');
-      expect(path).to.equal('/invoices/{id}');
+      testResource.create({});
+      const path = testResource.createResourcePathWithSymbols('/{id}');
+      expect(path).to.equal('/widgets/{id}');
     });
   });
 

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -1030,7 +1030,7 @@ describe('StripeResource', () => {
     const makeResource = (stripe) => {
       return new (StripeResource.extend({
         testMethod: stripeMethod({
-          fullPath: '/v1/test',
+          fullPath: "/v1/test",
           method: 'GET',
           host: 'some.host.stripe.com',
         }),
@@ -1109,6 +1109,7 @@ describe('StripeResource', () => {
      */
     const makeResourceWithPDFMethod = (stripe) => {
       return new (StripeResource.extend({
+
         pdf: stripeMethod({
           method: 'GET',
           fullPath: '/v1/resourceWithPDF',

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -167,6 +167,10 @@ stripe = new Stripe('sk_test_123', {
 
 const Foo = Stripe.StripeResource.extend({
   includeBasic: ['retrieve'],
+  foo: Stripe.StripeResource.method({
+    method: 'create',
+    path: 'foo',
+  }),
   fooFullPath: Stripe.StripeResource.method({
     method: 'create',
     fullPath: '/v1/full/path',


### PR DESCRIPTION
* Reverts the [PR](https://github.com/stripe/stripe-node/pull/1604) that deprecated `path` on StripeResource and stripeMethod.
* Fixes the test suite not to depend on invoices defining `path`.