### PR TITLE
Narrower type for stripe.invoices.retrieveUpcoming()

### DIFF
--- a/types/Invoices.d.ts
+++ b/types/Invoices.d.ts
@@ -40,7 +40,7 @@ declare module 'stripe' {
       /**
        * Unique identifier for the object. This property is always present unless the invoice is an upcoming invoice. See [Retrieve an upcoming invoice](https://stripe.com/docs/api/invoices/upcoming) for more details.
        */
-      id?: string;
+      id: string;
 
       /**
        * String representing the object's type. Objects of the same type share the same value.

--- a/types/InvoicesResource.d.ts
+++ b/types/InvoicesResource.d.ts
@@ -2168,10 +2168,10 @@ declare module 'stripe' {
       retrieveUpcoming(
         params?: InvoiceRetrieveUpcomingParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Omit<Stripe.Invoice, 'id'>>>;
+      ): Promise<Stripe.Response<Stripe.UpcomingInvoice>>;
       retrieveUpcoming(
         options?: RequestOptions
-      ): Promise<Stripe.Response<Omit<Stripe.Invoice, 'id'>>>;
+      ): Promise<Stripe.Response<Stripe.UpcomingInvoice>>;
 
       /**
        * Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).

--- a/types/InvoicesResource.d.ts
+++ b/types/InvoicesResource.d.ts
@@ -2168,10 +2168,10 @@ declare module 'stripe' {
       retrieveUpcoming(
         params?: InvoiceRetrieveUpcomingParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.Invoice>>;
+      ): Promise<Stripe.Response<Omit<Stripe.Invoice, 'id'>>>;
       retrieveUpcoming(
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.Invoice>>;
+      ): Promise<Stripe.Response<Omit<Stripe.Invoice, 'id'>>>;
 
       /**
        * Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).

--- a/types/UpcomingInvoices.d.ts
+++ b/types/UpcomingInvoices.d.ts
@@ -1,0 +1,7 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    type UpcomingInvoice = Omit<Stripe.Invoice, 'id'>;
+  }
+}

--- a/types/UpcomingInvoices.d.ts
+++ b/types/UpcomingInvoices.d.ts
@@ -1,4 +1,3 @@
-
 declare module 'stripe' {
   namespace Stripe {
     type UpcomingInvoice = Omit<Stripe.Invoice, 'id'>;

--- a/types/UpcomingInvoices.d.ts
+++ b/types/UpcomingInvoices.d.ts
@@ -1,4 +1,3 @@
-// File generated from our OpenAPI spec
 
 declare module 'stripe' {
   namespace Stripe {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@
 ///<reference path='./Errors.d.ts' />
 ///<reference path='./OAuth.d.ts' />
 ///<reference path='./Webhooks.d.ts' />
+///<reference path='./UpcomingInvoices.d.ts' />
 ///<reference path='./AccountsResource.d.ts' />
 ///<reference path='./AccountLinksResource.d.ts' />
 ///<reference path='./ApplePayDomainsResource.d.ts' />

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -123,6 +123,10 @@ stripe = new Stripe('sk_test_123', {
       return undefined;
     });
 
+  // @ts-expect-error
+  (await stripe.invoices.retrieveUpcoming()).id;
+  (await stripe.invoices.retrieve('')).id;
+
   try {
     await stripe.paymentIntents.create({amount: 100, currency: 'USD'});
   } catch (err) {


### PR DESCRIPTION
Fixes https://github.com/stripe/stripe-node/issues/1500.

Makes `stripe.invoices.retrieveUpcoming` return `Omit<Invoice, 'id'>` instead of `Invoice`. This means that `Invoice.id` can now be required and should prevent some needless null checks.