### PR TITLE
fix: added support for TypeScript "NodeNext" module resolution

### DIFF
--- a/package.json
+++ b/package.json
@@ -71,6 +71,7 @@
     "coveralls": "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
   },
   "exports": {
+    "types": "./types/index.d.ts",
     "browser": "./lib/stripe.worker.js",
     "worker": "./lib/stripe.worker.js",
     "default": "./lib/stripe.js"


### PR DESCRIPTION
Hey there!

Small fix for people using `{ "moduleResolution": "NodeNext" }` in their tsconfig