### PR TITLE
Change default entrypoint to stripe.node

### DIFF
--- a/lib/stripe.js
+++ b/lib/stripe.js
@@ -1,2 +1,0 @@
-"use strict";
-module.exports = require('./stripe.node');

--- a/package.json
+++ b/package.json
@@ -74,6 +74,6 @@
     "types": "./types/index.d.ts",
     "browser": "./lib/stripe.worker.js",
     "worker": "./lib/stripe.worker.js",
-    "default": "./lib/stripe.js"
+    "default": "./lib/stripe.node.js"
   }
 }

--- a/src/stripe.ts
+++ b/src/stripe.ts
@@ -1,1 +1,0 @@
-export = require('./stripe.node');

--- a/test/RequestSender.spec.js
+++ b/test/RequestSender.spec.js
@@ -87,7 +87,7 @@ describe('RequestSender', () => {
 
   describe('Parameter encoding', () => {
     // Use a real instance of stripe as we're mocking the http.request responses.
-    const realStripe = require('../lib/stripe')(utils.getUserStripeKey());
+    const realStripe = require('../lib/stripe.node')(utils.getUserStripeKey());
 
     after(() => {
       nock.cleanAll();
@@ -334,7 +334,7 @@ describe('RequestSender', () => {
 
   describe('Retry Network Requests', () => {
     // Use a real instance of stripe as we're mocking the http.request responses.
-    const realStripe = require('../lib/stripe')(utils.getUserStripeKey());
+    const realStripe = require('../lib/stripe.node')(utils.getUserStripeKey());
 
     // Override the sleep timer to speed up tests
     realStripe.charges._getSleepTimeInMS = () => 0;

--- a/test/StripeResource.spec.js
+++ b/test/StripeResource.spec.js
@@ -107,7 +107,7 @@ describe('StripeResource', () => {
     };
 
     it('is not impacted by the global host', (done) => {
-      const stripe = require('../lib/stripe')('sk_test', {
+      const stripe = require('../lib/stripe.node')('sk_test', {
         host: 'bad.host.stripe.com',
       });
 
@@ -122,7 +122,7 @@ describe('StripeResource', () => {
     });
 
     it('still lets users override the host on a per-request basis', (done) => {
-      const stripe = require('../lib/stripe')('sk_test');
+      const stripe = require('../lib/stripe.node')('sk_test');
 
       const scope = nock('https://some.other.host.stripe.com')
         .get('/v1/resourceWithHost')

--- a/test/flows.spec.ts
+++ b/test/flows.spec.ts
@@ -2,7 +2,10 @@
 
 const testUtils = require('../testUtils');
 const chai = require('chai');
-const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), 'latest');
+const stripe = require('../lib/stripe.node')(
+  testUtils.getUserStripeKey(),
+  'latest'
+);
 const fs = require('fs');
 const path = require('path');
 const stream = require('stream');

--- a/test/net/NodeHttpClient.spec.js
+++ b/test/net/NodeHttpClient.spec.js
@@ -3,7 +3,7 @@
 const http = require('http');
 const expect = require('chai').expect;
 
-const {createNodeHttpClient} = require('../../lib/stripe');
+const {createNodeHttpClient} = require('../../lib/stripe.node');
 
 const {createHttpClientTestSuite, ArrayReadable} = require('./helpers');
 

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -7,8 +7,11 @@ import {NodeHttpClient} from '../lib/net/NodeHttpClient';
 import {getMockPlatformFunctions} from '../testUtils';
 
 const testUtils = require('../testUtils');
-const Stripe = require('../lib/stripe');
-const stripe = require('../lib/stripe')(testUtils.getUserStripeKey(), 'latest');
+const Stripe = require('../lib/stripe.node');
+const stripe = require('../lib/stripe.node')(
+  testUtils.getUserStripeKey(),
+  'latest'
+);
 const crypto = require('crypto');
 
 const expect = require('chai').expect;

--- a/test/telemetry.spec.js
+++ b/test/telemetry.spec.js
@@ -57,7 +57,7 @@ describe('Client Telemetry', () => {
         res.end('{}');
       },
       (host, port) => {
-        const stripe = require('../lib/stripe')(
+        const stripe = require('../lib/stripe.node')(
           'sk_test_FEiILxKZwnmmocJDUjUNO6pa',
           {
             telemetry: false,
@@ -107,7 +107,7 @@ describe('Client Telemetry', () => {
         res.end('{}');
       },
       (host, port) => {
-        const stripe = require('../lib/stripe')(
+        const stripe = require('../lib/stripe.node')(
           'sk_test_FEiILxKZwnmmocJDUjUNO6pa',
           {
             telemetry: true,
@@ -159,7 +159,7 @@ describe('Client Telemetry', () => {
         res.end('{}');
       },
       (host, port) => {
-        const stripe = require('../lib/stripe')(
+        const stripe = require('../lib/stripe.node')(
           'sk_test_FEiILxKZwnmmocJDUjUNO6pa',
           {
             telemetry: true,

--- a/testUtils/index.js
+++ b/testUtils/index.js
@@ -26,7 +26,7 @@ const utils = (module.exports = {
     });
     server.listen(0, () => {
       const {port} = server.address();
-      const stripe = require('../lib/stripe')(
+      const stripe = require('../lib/stripe.node')(
         module.exports.getUserStripeKey(),
         {
           host: 'localhost',
@@ -43,7 +43,7 @@ const utils = (module.exports = {
   },
 
   getStripeMockClient: () => {
-    const stripe = require('../lib/stripe');
+    const stripe = require('../lib/stripe.node');
 
     return stripe('sk_test_123', {
       host: process.env.STRIPE_MOCK_HOST || 'localhost',
@@ -97,7 +97,7 @@ const utils = (module.exports = {
 
     // Provide a testable stripe instance
     // That is, with mock-requests built in and hookable
-    const stripe = require('../lib/stripe');
+    const stripe = require('../lib/stripe.node');
     const stripeInstance = stripe('fakeAuthToken', config);
 
     stripeInstance._requestSender = new MockRequestSender(
@@ -165,7 +165,7 @@ const utils = (module.exports = {
 
     // Provide a testable stripe instance
     // That is, with mock-requests built in and hookable
-    const stripe = require('../lib/stripe');
+    const stripe = require('../lib/stripe.node');
     const stripeInstance = stripe('fakeAuthToken', config);
 
     stripeInstance.REQUESTS = [];
@@ -189,7 +189,7 @@ const utils = (module.exports = {
     function CleanupUtility(timeout) {
       const self = this;
       this._cleanupFns = [];
-      this._stripe = require('../lib/stripe')(
+      this._stripe = require('../lib/stripe.node')(
         utils.getUserStripeKey(),
         'latest'
       );


### PR DESCRIPTION
Removes unnecessary entrypoint file `stripe.js`. Updates default entrypoint to be `stripe.node.js` in package.json and test imports.