### PR TITLE
Update main entrypoint on package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   "engines": {
     "node": ">=12.*"
   },
-  "main": "lib/stripe.js",
+  "main": "lib/stripe.node.js",
   "types": "types/index.d.ts",
   "devDependencies": {
     "@types/chai": "^4.3.4",


### PR DESCRIPTION
Fix for the `main` entrypoint on package.json.
Noticed it when ESLint was complaining about not being able to find the module on path since `11.9.0`.