### PR TITLE
Don't auto update api version in samples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,6 @@
 update-version:
 	@echo "$(VERSION)" > VERSION
 	@perl -pi -e 's|"version": "[.\-\d\w]+"|"version": "$(VERSION)"|' package.json
-	@find . -name 'package.json' -exec perl -pi -e 's|"stripe": "[\^\d\w.]*?"|"stripe": "^$(VERSION)"|' {} +
 
 codegen-format:
 	yarn && yarn fix && yarn build

--- a/scripts/updateAPIVersion.js
+++ b/scripts/updateAPIVersion.js
@@ -30,10 +30,7 @@ const main = () => {
 
   replaceAPIVersion('README.md', 'apiVersion: [\'"]API_VERSION[\'"]');
   replaceAPIVersion('package.json', '"types": "types/API_VERSION/index.d.ts');
-  replaceAPIVersion(
-    'examples/webhook-signing/typescript-node-express/express-ts.ts',
-    'apiVersion: [\'"]API_VERSION[\'"]'
-  );
+
   replaceAPIVersion(
     'types/lib.d.ts',
     'export type LatestApiVersion = [\'"]API_VERSION[\'"]'


### PR DESCRIPTION
This fails because we re-arranged samples but we shouldn't update them automatically as they reference the package not the local code.

The misalignment will be caught by TS compiler when we update the package version used in tests.