### PR TITLE
Change httpProxy to httpAgent in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -237,7 +237,7 @@ if (process.env.http_proxy) {
   const ProxyAgent = require('https-proxy-agent');
 
   const stripe = Stripe('sk_test_...', {
-    httpProxy: new ProxyAgent(process.env.http_proxy),
+    httpAgent: new ProxyAgent(process.env.http_proxy),
   });
 }
 ```


### PR DESCRIPTION
This example never worked, the correct config property is `httpAgent`