### PR TITLE
Refactor src/autoPagination.ts

### DIFF
--- a/src/StripeMethod.ts
+++ b/src/StripeMethod.ts
@@ -40,17 +40,10 @@ export function stripeMethod(
       callback
     );
 
-    // Please note `spec.methodType === 'search'` is beta functionality and this
-    // interface is subject to change/removal at any time.
-    if (spec.methodType === 'list' || spec.methodType === 'search') {
-      const autoPaginationMethods = makeAutoPaginationMethods(
-        this,
-        args,
-        spec,
-        requestPromise
-      );
-      Object.assign(requestPromise, autoPaginationMethods);
-    }
+    Object.assign(
+      requestPromise,
+      makeAutoPaginationMethods(this, args, spec, requestPromise)
+    );
 
     return requestPromise;
   };

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -63,9 +63,7 @@ class StripeIterator<T> implements IStripeIterator<T> {
     this.stripeResource = stripeResource;
   }
 
-  async iterate(
-    pageResult: PageResult<T>
-  ): Promise<IterationResult<T>> {
+  async iterate(pageResult: PageResult<T>): Promise<IterationResult<T>> {
     if (
       !(
         pageResult &&
@@ -92,7 +90,7 @@ class StripeIterator<T> implements IStripeIterator<T> {
       this.index = 0;
       this.pagePromise = this.getNextPage(pageResult);
       const nextPageResult = await this.pagePromise;
-      return this.iterate(nextPageResult)
+      return this.iterate(nextPageResult);
     }
     // TODO (next major) stop returning explicit undefined
     return {value: undefined, done: true};
@@ -103,8 +101,8 @@ class StripeIterator<T> implements IStripeIterator<T> {
   }
 
   private async _next() {
-    return this.iterate(await this.pagePromise)
-  };
+    return this.iterate(await this.pagePromise);
+  }
 
   next(): Promise<IterationResult<T>> {
     /**
@@ -116,7 +114,9 @@ class StripeIterator<T> implements IStripeIterator<T> {
       return this.promiseCache.currentPromise;
     }
 
-    const nextPromise = this._next().then((x) => (this.promiseCache.currentPromise = null, x))
+    const nextPromise = this._next().then(
+      (x) => ((this.promiseCache.currentPromise = null), x)
+    );
     this.promiseCache.currentPromise = nextPromise;
 
     return nextPromise;

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -63,9 +63,9 @@ class StripeIterator<T> implements IStripeIterator<T> {
     this.stripeResource = stripeResource;
   }
 
-  iterate(
+  async iterate(
     pageResult: PageResult<T>
-  ): IterationResult<T> | Promise<IterationResult<T>> {
+  ): Promise<IterationResult<T>> {
     if (
       !(
         pageResult &&
@@ -91,8 +91,10 @@ class StripeIterator<T> implements IStripeIterator<T> {
       // Reset counter, request next page, and recurse.
       this.i = 0;
       this.pagePromise = this.getNextPage(pageResult);
-      return this.pagePromise.then((pageResult) => this.iterate(pageResult));
+      const nextPageResult = await this.pagePromise;
+      return this.iterate(nextPageResult)
     }
+    // TODO (next major) stop returning explicit undefined
     return {value: undefined, done: true};
   }
 

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -43,7 +43,7 @@ type PageResult<T> = {
   next_page: string | null;
 };
 class StripeIterator<T> implements IStripeIterator<T> {
-  private i: number;
+  private index: number;
   private pagePromise: Promise<PageResult<T>>;
   private promiseCache: PromiseCache;
   protected requestArgs: RequestArgs;
@@ -55,7 +55,7 @@ class StripeIterator<T> implements IStripeIterator<T> {
     spec: MethodSpec,
     stripeResource: StripeResourceObject
   ) {
-    this.i = 0;
+    this.index = 0;
     this.pagePromise = firstPagePromise;
     this.promiseCache = {currentPromise: null};
     this.requestArgs = requestArgs;
@@ -79,17 +79,17 @@ class StripeIterator<T> implements IStripeIterator<T> {
     }
 
     const reverseIteration = isReverseIteration(this.requestArgs);
-    if (this.i < pageResult.data.length) {
+    if (this.index < pageResult.data.length) {
       const idx = reverseIteration
-        ? pageResult.data.length - 1 - this.i
-        : this.i;
+        ? pageResult.data.length - 1 - this.index
+        : this.index;
       const value = pageResult.data[idx];
-      this.i += 1;
+      this.index += 1;
 
       return {value, done: false};
     } else if (pageResult.has_more) {
       // Reset counter, request next page, and recurse.
-      this.i = 0;
+      this.index = 0;
       this.pagePromise = this.getNextPage(pageResult);
       const nextPageResult = await this.pagePromise;
       return this.iterate(nextPageResult)

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -4,82 +4,68 @@ import {callbackifyPromiseWithTimeout, getDataFromArgs} from './utils.js';
 type PromiseCache = {
   currentPromise: Promise<any> | undefined | null;
 };
-type IterationResult = {
-  done: boolean;
-  value?: any;
-};
+type IterationResult<T> =
+  | {
+      done: false;
+      value: T;
+    }
+  | {done: true; value?: undefined};
 type IterationDoneCallback = () => void;
-type IterationItemCallback = (
-  item: any,
+type IterationItemCallback<T> = (
+  item: T,
   next: any
 ) => void | boolean | Promise<void | boolean>;
-type ListResult = {
-  data: Array<any>;
-  // eslint-disable-next-line camelcase
-  has_more: boolean;
-};
-type AutoPagingEach = (
-  onItem: IterationItemCallback,
+type AutoPagingEach<T> = (
+  onItem: IterationItemCallback<T>,
   onDone?: IterationDoneCallback
 ) => Promise<void>;
 
 type AutoPagingToArrayOptions = {
   limit?: number;
 };
-type AutoPagingToArray = (
+type AutoPagingToArray<T> = (
   opts: AutoPagingToArrayOptions,
   onDone: IterationDoneCallback
-) => Promise<Array<any>>;
+) => Promise<Array<T>>;
 
-type AutoPaginationMethods = {
-  autoPagingEach: AutoPagingEach;
-  autoPagingToArray: AutoPagingToArray;
-  next: () => Promise<void>;
+type AutoPaginationMethods<T> = {
+  autoPagingEach: AutoPagingEach<T>;
+  autoPagingToArray: AutoPagingToArray<T>;
+  next: () => Promise<IterationResult<T>>;
   return: () => void;
 };
-
-export function makeAutoPaginationMethods(
-  self: StripeResourceObject,
-  requestArgs: RequestArgs,
-  spec: MethodSpec,
-  firstPagePromise: Promise<any>
-): AutoPaginationMethods {
-  const promiseCache: PromiseCache = {currentPromise: null};
-  const reverseIteration = isReverseIteration(requestArgs);
-  let pagePromise = firstPagePromise;
-  let i = 0;
-
-  // Search and List methods iterate differently.
-  // Search relies on a `next_page` token and can only iterate in one direction.
-  // List relies on either an `ending_before` or `starting_after` field with
-  // an item ID to paginate and is bi-directional.
-  //
-  // Please note: spec.methodType === 'search' is beta functionality and is
-  // subject to change/removal at any time.
-  let getNextPagePromise: (pageResult: any) => Promise<any>;
-  if (spec.methodType === 'search') {
-    getNextPagePromise = (pageResult): Promise<any> => {
-      if (!pageResult.next_page) {
-        throw Error(
-          'Unexpected: Stripe API response does not have a well-formed `next_page` field, but `has_more` was true.'
-        );
-      }
-      return self._makeRequest(requestArgs, spec, {
-        page: pageResult.next_page,
-      });
-    };
-  } else {
-    getNextPagePromise = (pageResult): Promise<any> => {
-      const lastId = getLastId(pageResult, reverseIteration);
-      return self._makeRequest(requestArgs, spec, {
-        [reverseIteration ? 'ending_before' : 'starting_after']: lastId,
-      });
-    };
+interface IStripeIterator<T> {
+  next: () => Promise<IterationResult<T>>;
+}
+type PageResult<T> = {
+  data: Array<T>;
+  has_more: boolean;
+  next_page: string | null;
+};
+class StripeIterator<T> implements IStripeIterator<T> {
+  private i: number;
+  private pagePromise: Promise<PageResult<T>>;
+  private promiseCache: PromiseCache;
+  protected requestArgs: RequestArgs;
+  protected spec: MethodSpec;
+  protected stripeResource: StripeResourceObject;
+  constructor(
+    firstPagePromise: Promise<PageResult<T>>,
+    requestArgs: RequestArgs,
+    spec: MethodSpec,
+    stripeResource: StripeResourceObject
+  ) {
+    this.i = 0;
+    this.pagePromise = firstPagePromise;
+    this.promiseCache = {currentPromise: null};
+    this.requestArgs = requestArgs;
+    this.spec = spec;
+    this.stripeResource = stripeResource;
   }
 
-  function iterate(
-    pageResult: ListResult
-  ): IterationResult | Promise<IterationResult> {
+  iterate(
+    pageResult: PageResult<T>
+  ): IterationResult<T> | Promise<IterationResult<T>> {
     if (
       !(
         pageResult &&
@@ -92,39 +78,97 @@ export function makeAutoPaginationMethods(
       );
     }
 
-    if (i < pageResult.data.length) {
-      const idx = reverseIteration ? pageResult.data.length - 1 - i : i;
+    const reverseIteration = isReverseIteration(this.requestArgs);
+    if (this.i < pageResult.data.length) {
+      const idx = reverseIteration
+        ? pageResult.data.length - 1 - this.i
+        : this.i;
       const value = pageResult.data[idx];
-      i += 1;
+      this.i += 1;
 
       return {value, done: false};
     } else if (pageResult.has_more) {
       // Reset counter, request next page, and recurse.
-      i = 0;
-      pagePromise = getNextPagePromise(pageResult);
-      return pagePromise.then(iterate);
+      this.i = 0;
+      this.pagePromise = this.getNextPage(pageResult);
+      return this.pagePromise.then((pageResult) => this.iterate(pageResult));
     }
     return {value: undefined, done: true};
   }
 
-  function asyncIteratorNext(): Promise<any> {
-    return memoizedPromise(promiseCache, (resolve, reject) => {
-      return pagePromise
-        .then(iterate)
+  getNextPage(_pageResult: PageResult<T>): Promise<PageResult<T>> {
+    throw new Error('Unimplemented');
+  }
+
+  next(): Promise<IterationResult<T>> {
+    return memoizedPromise(this.promiseCache, (resolve, reject) => {
+      return this.pagePromise
+        .then((pageResult) => this.iterate(pageResult))
         .then(resolve)
         .catch(reject);
     });
   }
+}
 
-  const autoPagingEach = makeAutoPagingEach(asyncIteratorNext);
+class ListIterator<T extends {id: string}> extends StripeIterator<T> {
+  getNextPage(pageResult: PageResult<T>): Promise<PageResult<T>> {
+    const reverseIteration = isReverseIteration(this.requestArgs);
+    const lastId = getLastId(pageResult, reverseIteration);
+    return this.stripeResource._makeRequest(this.requestArgs, this.spec, {
+      [reverseIteration ? 'ending_before' : 'starting_after']: lastId,
+    });
+  }
+}
+
+class SearchIterator<T> extends StripeIterator<T> {
+  getNextPage(pageResult: PageResult<T>): Promise<PageResult<T>> {
+    if (!pageResult.next_page) {
+      throw Error(
+        'Unexpected: Stripe API response does not have a well-formed `next_page` field, but `has_more` was true.'
+      );
+    }
+    return this.stripeResource._makeRequest(this.requestArgs, this.spec, {
+      page: pageResult.next_page,
+    });
+  }
+}
+
+export const makeAutoPaginationMethods = <
+  TMethodSpec extends MethodSpec,
+  TItem extends {id: string}
+>(
+  stripeResource: StripeResourceObject,
+  requestArgs: RequestArgs,
+  spec: TMethodSpec,
+  firstPagePromise: Promise<PageResult<TItem>>
+): AutoPaginationMethods<TItem> | null => {
+  if (spec.methodType === 'search') {
+    return makeAutoPaginationMethodsFromIterator(
+      new SearchIterator(firstPagePromise, requestArgs, spec, stripeResource)
+    );
+  }
+  if (spec.methodType === 'list') {
+    return makeAutoPaginationMethodsFromIterator(
+      new ListIterator(firstPagePromise, requestArgs, spec, stripeResource)
+    );
+  }
+  return null;
+};
+
+const makeAutoPaginationMethodsFromIterator = <T>(
+  iterator: IStripeIterator<T>
+): AutoPaginationMethods<T> => {
+  const autoPagingEach = makeAutoPagingEach((...args) =>
+    iterator.next(...args)
+  );
   const autoPagingToArray = makeAutoPagingToArray(autoPagingEach);
 
-  const autoPaginationMethods: AutoPaginationMethods = {
+  const autoPaginationMethods: AutoPaginationMethods<T> = {
     autoPagingEach,
     autoPagingToArray,
 
     // Async iterator functions:
-    next: asyncIteratorNext,
+    next: () => iterator.next(),
     return: (): any => {
       // This is required for `break`.
       return {};
@@ -134,7 +178,7 @@ export function makeAutoPaginationMethods(
     },
   };
   return autoPaginationMethods;
-}
+};
 
 /**
  * ----------------
@@ -174,7 +218,9 @@ function getDoneCallback(args: Array<any>): IterationDoneCallback | null {
  * In addition to standard validation, this helper
  * coalesces the former forms into the latter form.
  */
-function getItemCallback(args: Array<any>): IterationItemCallback | undefined {
+function getItemCallback<T>(
+  args: Array<any>
+): IterationItemCallback<T> | undefined {
   if (args.length === 0) {
     return undefined;
   }
@@ -206,7 +252,10 @@ function getItemCallback(args: Array<any>): IterationItemCallback | undefined {
   };
 }
 
-function getLastId(listResult: ListResult, reverseIteration: boolean): string {
+function getLastId<T extends {id: string}>(
+  listResult: PageResult<T>,
+  reverseIteration: boolean
+): string {
   const lastIdx = reverseIteration ? 0 : listResult.data.length - 1;
   const lastItem = listResult.data[lastIdx];
   const lastId = lastItem && lastItem.id;
@@ -237,9 +286,9 @@ function memoizedPromise<T>(
   return promiseCache.currentPromise;
 }
 
-function makeAutoPagingEach(
-  asyncIteratorNext: () => Promise<IterationResult>
-): AutoPagingEach {
+function makeAutoPagingEach<T>(
+  asyncIteratorNext: () => Promise<IterationResult<T>>
+): AutoPagingEach<T> {
   return function autoPagingEach(/* onItem?, onDone? */): Promise<void> {
     const args = [].slice.call(arguments);
     const onItem = getItemCallback(args);
@@ -254,12 +303,12 @@ function makeAutoPagingEach(
       onItem
     );
     return callbackifyPromiseWithTimeout(autoPagePromise, onDone);
-  } as AutoPagingEach;
+  } as AutoPagingEach<T>;
 }
 
-function makeAutoPagingToArray(
-  autoPagingEach: AutoPagingEach
-): AutoPagingToArray {
+function makeAutoPagingToArray<T>(
+  autoPagingEach: AutoPagingEach<T>
+): AutoPagingToArray<T> {
   return function autoPagingToArray(
     opts,
     onDone: IterationDoneCallback
@@ -293,12 +342,14 @@ function makeAutoPagingToArray(
   };
 }
 
-function wrapAsyncIteratorWithCallback(
-  asyncIteratorNext: () => Promise<IterationResult>,
-  onItem: IterationItemCallback
+function wrapAsyncIteratorWithCallback<T>(
+  asyncIteratorNext: () => Promise<IterationResult<T>>,
+  onItem: IterationItemCallback<T>
 ): Promise<void> {
   return new Promise<void>((resolve, reject) => {
-    function handleIteration(iterResult: IterationResult): Promise<any> | void {
+    function handleIteration(
+      iterResult: IterationResult<T>
+    ): Promise<any> | void {
       if (iterResult.done) {
         resolve();
         return;

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -121,6 +121,7 @@ class StripeIterator<T> implements IStripeIterator<T> {
       this.promiseCache.currentPromise = null;
       return ret;
     })();
+
     this.promiseCache.currentPromise = nextPromise;
 
     return nextPromise;

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -92,15 +92,17 @@ class StripeIterator<T> implements IStripeIterator<T> {
       const nextPageResult = await this.pagePromise;
       return this.iterate(nextPageResult);
     }
+    // eslint-disable-next-line no-warning-comments
     // TODO (next major) stop returning explicit undefined
     return {value: undefined, done: true};
   }
 
+  /** @abstract */
   getNextPage(_pageResult: PageResult<T>): Promise<PageResult<T>> {
     throw new Error('Unimplemented');
   }
 
-  private async _next() {
+  private async _next(): Promise<IterationResult<T>> {
     return this.iterate(await this.pagePromise);
   }
 
@@ -114,9 +116,11 @@ class StripeIterator<T> implements IStripeIterator<T> {
       return this.promiseCache.currentPromise;
     }
 
-    const nextPromise = this._next().then(
-      (x) => ((this.promiseCache.currentPromise = null), x)
-    );
+    const nextPromise = (async (): Promise<IterationResult<T>> => {
+      const ret = await this._next();
+      this.promiseCache.currentPromise = null;
+      return ret;
+    })();
     this.promiseCache.currentPromise = nextPromise;
 
     return nextPromise;

--- a/test/autoPagination.spec.js
+++ b/test/autoPagination.spec.js
@@ -9,11 +9,14 @@ const {makeAutoPaginationMethods} = require('../cjs/autoPagination.js');
 
 const expect = require('chai').expect;
 
-describe('auto pagination', function() {
-  const testCase = (
-    mockPaginationFn,
-    {pages, limit, expectedIds, expectedParamsLog, initialArgs}
-  ) => {
+describe('auto pagination', () => {
+  const testCase = (mockPaginationFn) => ({
+    pages,
+    limit,
+    expectedIds,
+    expectedParamsLog,
+    initialArgs,
+  }) => {
     const {paginator, paramsLog} = mockPaginationFn(pages, initialArgs);
 
     return expect(
@@ -28,14 +31,15 @@ describe('auto pagination', function() {
       paramsLog: expectedParamsLog,
     });
   };
-
-  describe('pagination logic using a mock paginator', () => {
-    const mockPagination = (pages, initialArgs) => {
+  describe('V1 list response pagination', () => {
+    const mockPaginationV1List = (pages, initialArgs) => {
       let i = 1;
       const paramsLog = [];
       const spec = {
         method: 'GET',
         fullPath: '/v1/items',
+        methodType: 'list',
+        apiMode: 'v1',
       };
 
       const mockStripe = testUtils.getMockStripe(
@@ -65,6 +69,7 @@ describe('auto pagination', function() {
       );
       return {paginator, paramsLog};
     };
+    const testCaseV1List = testCase(mockPaginationV1List);
 
     const ID_PAGES = [
       ['cus_1', 'cus_2', 'cus_3'],
@@ -83,7 +88,7 @@ describe('auto pagination', function() {
 
     describe('callbacks', () => {
       it('lets you call `next()` to iterate and `next(false)` to break', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -111,7 +116,7 @@ describe('auto pagination', function() {
       });
 
       it('lets you ignore the second arg and `return false` to break', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -138,7 +143,7 @@ describe('auto pagination', function() {
       });
 
       it('lets you ignore the second arg and return a Promise which returns `false` to break', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -166,7 +171,7 @@ describe('auto pagination', function() {
       });
 
       it('can use a promise instead of a callback for onDone', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -187,7 +192,7 @@ describe('auto pagination', function() {
       });
 
       it('handles the end of a list properly when the last page is full', () => {
-        const {paginator} = mockPagination(
+        const {paginator} = mockPaginationV1List(
           [
             ['cus_1', 'cus_2'],
             ['cus_3', 'cus_4'],
@@ -213,7 +218,7 @@ describe('auto pagination', function() {
       });
 
       it('handles the end of a list properly when the last page is not full', () => {
-        const {paginator} = mockPagination(
+        const {paginator} = mockPaginationV1List(
           [
             ['cus_1', 'cus_2', 'cus_3'],
             ['cus_4', 'cus_5', 'cus_6'],
@@ -237,7 +242,7 @@ describe('auto pagination', function() {
       });
 
       it('handles a list which is shorter than the page size properly', () => {
-        const {paginator} = mockPagination([OBJECT_IDS], {
+        const {paginator} = mockPaginationV1List([OBJECT_IDS], {
           limit: TOTAL_OBJECTS + 2,
         });
 
@@ -257,7 +262,7 @@ describe('auto pagination', function() {
       });
 
       it('handles errors after the first page correctly (callback)', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -280,7 +285,7 @@ describe('auto pagination', function() {
       });
 
       it('handles errors after the first page correctly (promise)', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -339,7 +344,7 @@ describe('auto pagination', function() {
       }
 
       it('works with `for await` when that feature exists (user break)', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -353,7 +358,7 @@ describe('auto pagination', function() {
       });
 
       it('works with `for await` when that feature exists (end of list)', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -367,7 +372,7 @@ describe('auto pagination', function() {
       });
 
       it('works with `await` and a while loop when await exists', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -381,7 +386,7 @@ describe('auto pagination', function() {
       });
 
       it('returns an empty object from .return() so that `break;` works in for-await', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -403,7 +408,7 @@ describe('auto pagination', function() {
       });
 
       it('works when you call it sequentially', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -426,7 +431,7 @@ describe('auto pagination', function() {
       });
 
       it('gives you the same result each time when you call it multiple times in parallel', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         expect(
           new Promise((resolve, reject) => {
@@ -476,7 +481,7 @@ describe('auto pagination', function() {
 
     describe('autoPagingToArray', () => {
       it('can go to the end', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -490,7 +495,7 @@ describe('auto pagination', function() {
       });
 
       it('returns a promise of an array', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -504,7 +509,7 @@ describe('auto pagination', function() {
       });
 
       it('accepts an onDone callback, passing an array', () => {
-        const {paginator} = mockPagination(ID_PAGES, {});
+        const {paginator} = mockPaginationV1List(ID_PAGES, {});
 
         return expect(
           new Promise((resolve, reject) => {
@@ -524,7 +529,7 @@ describe('auto pagination', function() {
 
     describe('foward pagination', () => {
       it('paginates forwards through a page', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [
             [1, 2],
             [3, 4],
@@ -536,7 +541,7 @@ describe('auto pagination', function() {
       });
 
       it('paginates forwards through un-even sized pages', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [[1, 2], [3, 4], [5]],
           limit: 10,
           expectedIds: [1, 2, 3, 4, 5],
@@ -545,7 +550,7 @@ describe('auto pagination', function() {
       });
 
       it('respects limit even when paginating', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [
             [1, 2],
             [3, 4],
@@ -558,7 +563,7 @@ describe('auto pagination', function() {
       });
 
       it('paginates through multiple full pages', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [
             [1, 2],
             [3, 4],
@@ -580,7 +585,7 @@ describe('auto pagination', function() {
 
     describe('backwards pagination', () => {
       it('paginates forwards through a page', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [
             [-2, -1],
             [-4, -3],
@@ -593,7 +598,7 @@ describe('auto pagination', function() {
       });
 
       it('paginates backwards through un-even sized pages ', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [[-2, -1], [-4, -3], [-5]],
           limit: 5,
           expectedIds: [-1, -2, -3, -4, -5],
@@ -603,7 +608,7 @@ describe('auto pagination', function() {
       });
 
       it('respects limit', () => {
-        return testCase(mockPagination, {
+        return testCaseV1List({
           pages: [
             [-2, -1],
             [-4, -3],
@@ -618,13 +623,14 @@ describe('auto pagination', function() {
     });
   });
 
-  describe('pagination logic using a mock search paginator', () => {
-    const mockPagination = (pages, initialArgs) => {
+  describe('V1 search result pagination', () => {
+    const mockPaginationV1Search = (pages, initialArgs) => {
       let i = 1;
       const paramsLog = [];
       const spec = {
         method: 'GET',
         methodType: 'search',
+        apiMode: 'v1',
       };
 
       const addNextPage = (props) => {
@@ -668,9 +674,9 @@ describe('auto pagination', function() {
       );
       return {paginator, paramsLog};
     };
-
+    const testCaseV1Search = testCase(mockPaginationV1Search);
     it('paginates forwards through a page', () => {
-      return testCase(mockPagination, {
+      return testCaseV1Search({
         pages: [
           [1, 2],
           [3, 4],
@@ -682,7 +688,7 @@ describe('auto pagination', function() {
     });
 
     it('paginates forwards through uneven-sized pages', () => {
-      return testCase(mockPagination, {
+      return testCaseV1Search({
         pages: [[1, 2], [3, 4], [5]],
         limit: 10,
         expectedIds: [1, 2, 3, 4, 5],
@@ -691,7 +697,7 @@ describe('auto pagination', function() {
     });
 
     it('respects limit even when paginating', () => {
-      return testCase(mockPagination, {
+      return testCaseV1Search({
         pages: [
           [1, 2],
           [3, 4],
@@ -704,7 +710,7 @@ describe('auto pagination', function() {
     });
 
     it('paginates through multiple full pages', () => {
-      return testCase(mockPagination, {
+      return testCaseV1Search({
         pages: [
           [1, 2],
           [3, 4],


### PR DESCRIPTION
## Summary
Refactors src/autoPagination.ts to create a clearer division between "define a .next() style iterator" step and "given an implementation of a .next()-style iterator, produce .autoPagingEach and .autoPagingToArray methods" step.

To me this makes this file more readable and easier to extend.