### PR TITLE
Set the latest API version as the default

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,8 +97,7 @@ We therefore encourage [upgrading your API version][api-version-upgrading]
 if you would like to take advantage of Stripe's TypeScript definitions.
 
 If you are on an older API version (e.g., `2019-10-17`) and not able to upgrade,
-you may pass another version or `apiVersion: null` to use your account's default API version,
-and use a comment like `// @ts-ignore stripe-version-2019-10-17` to silence type errors here
+you may pass another version and use a comment like `// @ts-ignore stripe-version-2019-10-17` to silence type errors here
 and anywhere the types differ between your API version and the latest.
 When you upgrade, you should remove these comments.
 
@@ -176,7 +175,7 @@ const stripe = Stripe('sk_test_...', {
 
 | Option              | Default            | Description                                                                                                                                                                                                                                       |
 | ------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `apiVersion`        | `null`             | Stripe API version to be used. If not set the account's default version will be used.                                                                                                                                                             |
+| `apiVersion`        | `null`             | Stripe API version to be used. If not set, stripe-node will use the latest version at the time of release.                                                                                                                                        |
 | `maxNetworkRetries` | 0                  | The amount of times a request should be [retried](#network-retries).                                                                                                                                                                              |
 | `httpAgent`         | `null`             | [Proxy](#configuring-a-proxy) agent to be used by the library.                                                                                                                                                                                    |
 | `timeout`           | 80000              | [Maximum time each request can take in ms.](#configuring-timeout)                                                                                                                                                                                 |

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1,4 +1,5 @@
 import * as _Error from './Error.js';
+import * as apiVersion from './apiVersion.js';
 import * as resources from './resources.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
 import {
@@ -16,7 +17,7 @@ import {StripeObject, AppInfo, UserProvidedConfig} from './Types.js';
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';
 const DEFAULT_BASE_PATH = '/v1/';
-const DEFAULT_API_VERSION = (null as unknown) as string;
+const DEFAULT_API_VERSION = apiVersion.ApiVersion;
 
 const DEFAULT_TIMEOUT = 80000;
 

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -6,6 +6,7 @@ import {FetchHttpClient} from '../cjs/net/FetchHttpClient.js';
 import {NodeHttpClient} from '../cjs/net/NodeHttpClient.js';
 import {createStripe} from '../cjs/stripe.core.js';
 import {getMockPlatformFunctions} from './testUtils.js';
+import {ApiVersion} from '../cjs/apiVersion.js';
 
 const testUtils = require('./testUtils.js');
 const Stripe = require('../cjs/stripe.cjs.node.js');
@@ -119,7 +120,7 @@ describe('Stripe Module', function() {
 
       cases.forEach((item) => {
         const newStripe = Stripe(testUtils.getUserStripeKey(), item);
-        expect(newStripe.getApiField('version')).to.equal(null);
+        expect(newStripe.getApiField('version')).to.equal(ApiVersion);
       });
     });
 


### PR DESCRIPTION
## Summary
**⚠️ ACTION REQUIRED: the breaking change in this release likely affects you ⚠️**

In this release, Stripe API Version `2022-11-15` (the latest at time of release) will be sent by default on all requests. 
The previous default was to use your [Stripe account's default API version](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version).

To successfully upgrade to stripe-node v12, you must either

1. **(Recommended) Upgrade your integration to be compatible with API Version `2022-11-15`.**
  
   Please read the API Changelog carefully for each API Version from `2022-11-15` back to your [Stripe account's default API version](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version). Determine if you are using any of the APIs that have changed in a breaking way, and adjust your integration accordingly. Carefully test your changes with Stripe [Test Mode](https://stripe.com/docs/keys#test-live-modes) before deploying them to production.
   
   You can read the [v12 migration guide](...) for more detailed instructions.
2. **(Alternative option) Specify a version other than `2022-11-15` when initializing `stripe-node`.** 

   If you were previously initializing stripe-node without an explicit API Version, you can postpone modifying your integration by specifying a version equal to your [Stripe account's default API version](https://stripe.com/docs/development/dashboard/request-logs#view-your-default-api-version). For example:
  
   ```diff
   - const stripe = require('stripe')('sk_test_...'); 
   + const stripe = require('stripe')('sk_test_...', {
   +   apiVersion: 'YYYY-MM-DD' // Determine your default version from https://dashboard.stripe.com/developers
   + })
   ```

   If you were already initializing stripe-node with an explicit API Version, upgrading to v12 will not affect your integration.

   Read the [v12 migration guide](...) for more details.

Going forward, each major release of this library will be *pinned* by default to the latest Stripe API Version at the time of release. 
That is, instead of upgrading stripe-node and separately upgrading your Stripe API Version through the Stripe Dashboard. whenever you upgrade major versions of stripe-node, you should also upgrade your integration to be compatible with the latest Stripe API version.