### PR TITLE
Remove circular reference in Stripe object

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -63,11 +63,6 @@ export function createStripe(
   Stripe.HttpClientResponse = HttpClientResponse;
   Stripe.CryptoProvider = CryptoProvider;
 
-  // For backwards compatibiblity after moving to separate CJS and ESM entrypoints.
-  // To be removed in the next major version.
-  Stripe.Stripe = Stripe;
-  Stripe.default = Stripe;
-
   function Stripe(
     this: StripeObject,
     key: string,

--- a/testProjects/mjs/index.js
+++ b/testProjects/mjs/index.js
@@ -41,9 +41,6 @@ assert(Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS);
 assert(Stripe.webhooks);
 assert(Stripe.resources);
 
-assert(Stripe.Stripe);
-assert(Stripe.default);
-
 const stripe = new Stripe(process.argv[2]);
 const defaultStripe = new DefaultStripe(process.argv[2]);
 


### PR DESCRIPTION
## Changelog
* ⚠️ Removed `Stripe` and `default` circular properties on the Stripe object. This was added to maintain backwards compatibility during the transition of stripe-node to a dual ES module / CommonJS package, and should not be functionally necessary.