### PR TITLE
Remove deprecated types

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -118,31 +118,21 @@ declare module 'stripe' {
        * For Connect, we recommend using `stripeAccount` instead.
        */
       apiKey?: string;
-      /** @deprecated Please use apiKey instead. */
-      api_key?: string;
 
       /**
        * See the [idempotency key docs](https://stripe.com/docs/api/idempotent_requests).
        */
       idempotencyKey?: string;
-      /** @deprecated Please use idempotencyKey instead. */
-      idempotency_key?: string;
 
       /**
        * An account id on whose behalf you wish to make a request.
        */
       stripeAccount?: string;
-      /** @deprecated Please use stripeAccount instead. */
-      stripe_account?: string;
 
       /**
        * The [API Version](https://stripe.com/docs/upgrades) to use for a given request (e.g., '2020-03-02').
        */
       apiVersion?: string;
-      /** @deprecated Please use apiVersion instead. */
-      stripeVersion?: string;
-      /** @deprecated Please use stripeVersion instead. */
-      stripe_version?: string;
 
       /**
        * Specify the number of requests to retry in event of error.


### PR DESCRIPTION
(Merging into master this time)

These types should have been removed in v11.0.0 when we removed these deprecated option names ([Changelog](https://github.com/stripe/stripe-node/blob/v11.0.0/CHANGELOG.md#:~:text=Remove%20deprecated%20option%20names)).