### PR TITLE
Let user supply a timestamp when verifying webhooks

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -30,14 +30,16 @@ type WebhookSignatureObject = {
     encodedHeader: WebhookHeader,
     secret: string,
     tolerance: number,
-    cryptoProvider: CryptoProvider
+    cryptoProvider: CryptoProvider,
+    now: number
   ) => boolean;
   verifyHeaderAsync: (
     encodedPayload: WebhookPayload,
     encodedHeader: WebhookHeader,
     secret: string,
     tolerance: number,
-    cryptoProvider: CryptoProvider
+    cryptoProvider: CryptoProvider,
+    now: number
   ) => Promise<boolean>;
 };
 type WebhookObject = {
@@ -48,14 +50,16 @@ type WebhookObject = {
     header: WebhookHeader,
     secret: string,
     tolerance: null,
-    cryptoProvider: CryptoProvider
+    cryptoProvider: CryptoProvider,
+    now: number
   ) => WebhookEvent;
   constructEventAsync: (
     payload: WebhookPayload,
     header: WebhookHeader,
     secret: string,
     tolerance: number,
-    cryptoProvider: CryptoProvider
+    cryptoProvider: CryptoProvider,
+    now: number
   ) => Promise<WebhookEvent>;
   generateTestHeaderString: (opts: WebhookTestHeaderOptions) => string;
 };
@@ -72,14 +76,16 @@ export function createWebhooks(
       header: WebhookHeader,
       secret: string,
       tolerance: null,
-      cryptoProvider: CryptoProvider
+      cryptoProvider: CryptoProvider,
+      now: number
     ): WebhookEvent {
       this.signature.verifyHeader(
         payload,
         header,
         secret,
         tolerance || Webhook.DEFAULT_TOLERANCE,
-        cryptoProvider
+        cryptoProvider,
+        now
       );
 
       const jsonPayload =
@@ -94,14 +100,16 @@ export function createWebhooks(
       header: WebhookHeader,
       secret: string,
       tolerance: number,
-      cryptoProvider: CryptoProvider
+      cryptoProvider: CryptoProvider,
+      now: number
     ): Promise<WebhookEvent> {
       await this.signature.verifyHeaderAsync(
         payload,
         header,
         secret,
         tolerance || Webhook.DEFAULT_TOLERANCE,
-        cryptoProvider
+        cryptoProvider,
+        now
       );
 
       const jsonPayload =
@@ -159,7 +167,8 @@ export function createWebhooks(
       encodedHeader: WebhookHeader,
       secret: string,
       tolerance: number,
-      cryptoProvider: CryptoProvider
+      cryptoProvider: CryptoProvider,
+      now: number
     ): boolean {
       const {
         decodedHeader: header,
@@ -184,7 +193,8 @@ export function createWebhooks(
         details,
         expectedSignature,
         tolerance,
-        suspectPayloadType
+        suspectPayloadType,
+        now
       );
 
       return true;
@@ -195,7 +205,8 @@ export function createWebhooks(
       encodedHeader: WebhookHeader,
       secret: string,
       tolerance: number,
-      cryptoProvider: CryptoProvider
+      cryptoProvider: CryptoProvider,
+      now: number
     ): Promise<boolean> {
       const {
         decodedHeader: header,
@@ -221,7 +232,8 @@ export function createWebhooks(
         details,
         expectedSignature,
         tolerance,
-        suspectPayloadType
+        suspectPayloadType,
+        now
       );
     },
   };
@@ -319,7 +331,8 @@ export function createWebhooks(
     details: WebhookParsedHeader,
     expectedSignature: string,
     tolerance: number,
-    suspectPayloadType: boolean
+    suspectPayloadType: boolean,
+    now: number
   ): boolean {
     const signatureFound = !!details.signatures.filter(
       platformFunctions.secureCompare.bind(platformFunctions, expectedSignature)
@@ -345,7 +358,9 @@ export function createWebhooks(
       });
     }
 
-    const timestampAge = Math.floor(Date.now() / 1000) - details.timestamp;
+    const timestampAge =
+      Math.floor((typeof now === 'number' ? now : Date.now()) / 1000) -
+      details.timestamp;
 
     if (tolerance > 0 && timestampAge > tolerance) {
       // @ts-ignore

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -31,7 +31,7 @@ type WebhookSignatureObject = {
     secret: string,
     tolerance: number,
     cryptoProvider: CryptoProvider,
-    now: number
+    receivedAt: number
   ) => boolean;
   verifyHeaderAsync: (
     encodedPayload: WebhookPayload,
@@ -39,7 +39,7 @@ type WebhookSignatureObject = {
     secret: string,
     tolerance: number,
     cryptoProvider: CryptoProvider,
-    now: number
+    receivedAt: number
   ) => Promise<boolean>;
 };
 type WebhookObject = {
@@ -51,7 +51,7 @@ type WebhookObject = {
     secret: string,
     tolerance: null,
     cryptoProvider: CryptoProvider,
-    now: number
+    receivedAt: number
   ) => WebhookEvent;
   constructEventAsync: (
     payload: WebhookPayload,
@@ -59,7 +59,7 @@ type WebhookObject = {
     secret: string,
     tolerance: number,
     cryptoProvider: CryptoProvider,
-    now: number
+    receivedAt: number
   ) => Promise<WebhookEvent>;
   generateTestHeaderString: (opts: WebhookTestHeaderOptions) => string;
 };
@@ -77,7 +77,7 @@ export function createWebhooks(
       secret: string,
       tolerance: null,
       cryptoProvider: CryptoProvider,
-      now: number
+      receivedAt: number
     ): WebhookEvent {
       this.signature.verifyHeader(
         payload,
@@ -85,7 +85,7 @@ export function createWebhooks(
         secret,
         tolerance || Webhook.DEFAULT_TOLERANCE,
         cryptoProvider,
-        now
+        receivedAt
       );
 
       const jsonPayload =
@@ -101,7 +101,7 @@ export function createWebhooks(
       secret: string,
       tolerance: number,
       cryptoProvider: CryptoProvider,
-      now: number
+      receivedAt: number
     ): Promise<WebhookEvent> {
       await this.signature.verifyHeaderAsync(
         payload,
@@ -109,7 +109,7 @@ export function createWebhooks(
         secret,
         tolerance || Webhook.DEFAULT_TOLERANCE,
         cryptoProvider,
-        now
+        receivedAt
       );
 
       const jsonPayload =
@@ -168,7 +168,7 @@ export function createWebhooks(
       secret: string,
       tolerance: number,
       cryptoProvider: CryptoProvider,
-      now: number
+      receivedAt: number
     ): boolean {
       const {
         decodedHeader: header,
@@ -194,7 +194,7 @@ export function createWebhooks(
         expectedSignature,
         tolerance,
         suspectPayloadType,
-        now
+        receivedAt
       );
 
       return true;
@@ -206,7 +206,7 @@ export function createWebhooks(
       secret: string,
       tolerance: number,
       cryptoProvider: CryptoProvider,
-      now: number
+      receivedAt: number
     ): Promise<boolean> {
       const {
         decodedHeader: header,
@@ -233,7 +233,7 @@ export function createWebhooks(
         expectedSignature,
         tolerance,
         suspectPayloadType,
-        now
+        receivedAt
       );
     },
   };
@@ -332,7 +332,7 @@ export function createWebhooks(
     expectedSignature: string,
     tolerance: number,
     suspectPayloadType: boolean,
-    now: number
+    receivedAt: number
   ): boolean {
     const signatureFound = !!details.signatures.filter(
       platformFunctions.secureCompare.bind(platformFunctions, expectedSignature)
@@ -359,8 +359,9 @@ export function createWebhooks(
     }
 
     const timestampAge =
-      Math.floor((typeof now === 'number' ? now : Date.now()) / 1000) -
-      details.timestamp;
+      Math.floor(
+        (typeof receivedAt === 'number' ? receivedAt : Date.now()) / 1000
+      ) - details.timestamp;
 
     if (tolerance > 0 && timestampAge > tolerance) {
       // @ts-ignore

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -228,9 +228,9 @@ describe('Webhooks', () => {
       });
 
       it('should raise a SignatureVerificationError when the timestamp is not within the tolerance of the provided timestamp', async () => {
-        const someTime = 20000000;
+        const receivedAt = 20000000;
         const header = stripe.webhooks.generateTestHeaderString({
-          timestamp: someTime / 1000 - 15,
+          timestamp: receivedAt / 1000 - 15,
           payload: EVENT_PAYLOAD_STRING,
           secret: SECRET,
         });
@@ -242,7 +242,7 @@ describe('Webhooks', () => {
             SECRET,
             10,
             null,
-            someTime
+            receivedAt
           )
         ).to.be.rejectedWith(
           StripeSignatureVerificationError,
@@ -285,9 +285,9 @@ describe('Webhooks', () => {
         'should return true when the header contains a valid signature and ' +
           'the timestamp is within the tolerance of the provided timestamp',
         async () => {
-          const someTime = 20000000;
+          const receivedAt = 20000000;
           const header = stripe.webhooks.generateTestHeaderString({
-            timestamp: someTime / 1000 - 9,
+            timestamp: receivedAt / 1000 - 9,
             payload: EVENT_PAYLOAD_STRING,
             secret: SECRET,
           });
@@ -299,7 +299,7 @@ describe('Webhooks', () => {
               SECRET,
               10,
               null,
-              someTime
+              receivedAt
             )
           ).to.equal(true);
         }

--- a/types/Webhooks.d.ts
+++ b/types/Webhooks.d.ts
@@ -36,7 +36,12 @@ declare module 'stripe' {
         /**
          * Optional CryptoProvider to use for computing HMAC signatures.
          */
-        cryptoProvider?: CryptoProvider
+        cryptoProvider?: CryptoProvider,
+
+        /**
+         * Optional: timestamp to use when checking signature validity. Defaults to Date.now().
+         */
+        now?: number
       ): Stripe.Event;
 
       /**
@@ -73,7 +78,12 @@ declare module 'stripe' {
         /**
          * Optional CryptoProvider to use for computing HMAC signatures.
          */
-        cryptoProvider?: CryptoProvider
+        cryptoProvider?: CryptoProvider,
+
+        /**
+         * Optional: timestamp to use when checking signature validity. Defaults to Date.now().
+         */
+        now?: number
       ): Promise<Stripe.Event>;
 
       /**

--- a/types/Webhooks.d.ts
+++ b/types/Webhooks.d.ts
@@ -41,7 +41,7 @@ declare module 'stripe' {
         /**
          * Optional: timestamp to use when checking signature validity. Defaults to Date.now().
          */
-        now?: number
+        receivedAt?: number
       ): Stripe.Event;
 
       /**
@@ -83,7 +83,7 @@ declare module 'stripe' {
         /**
          * Optional: timestamp to use when checking signature validity. Defaults to Date.now().
          */
-        now?: number
+        receivedAt?: number
       ): Promise<Stripe.Event>;
 
       /**


### PR DESCRIPTION
## Summary

Lets you supply an optional timestamp to Webhook.constructEvent (and all intermediate functions) to use instead of `Date.now()` when verifying webhook signatures.
Fixes #1778