### PR TITLE
(next major) one network retry by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,7 +186,7 @@ const stripe = Stripe('sk_test_...', {
 | Option              | Default            | Description                                                                                                                                                                                                                                       |
 | ------------------- | ------------------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
 | `apiVersion`        | `null`             | Stripe API version to be used. If not set, stripe-node will use the latest version at the time of release.                                                                                                                                        |
-| `maxNetworkRetries` | 0                  | The amount of times a request should be [retried](#network-retries).                                                                                                                                                                              |
+| `maxNetworkRetries` | 1                  | The amount of times a request should be [retried](#network-retries).                                                                                                                                                                              |
 | `httpAgent`         | `null`             | [Proxy](#configuring-a-proxy) agent to be used by the library.                                                                                                                                                                                    |
 | `timeout`           | 80000              | [Maximum time each request can take in ms.](#configuring-timeout)                                                                                                                                                                                 |
 | `host`              | `'api.stripe.com'` | Host that requests are made to.                                                                                                                                                                                                                   |
@@ -253,10 +253,14 @@ if (process.env.http_proxy) {
 
 ### Network retries
 
-Automatic network retries can be enabled with the `maxNetworkRetries` config option.
-This will retry requests `n` times with exponential backoff if they fail due to an intermittent network problem.
-[Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
+As of [v13](https://github.com/stripe/stripe-node/releases/tag/v13.0.0) stripe-node will automatically do one reattempt for failed requests that are safe to retry. Automatic network retries can be disabled by setting the `maxNetworkRetries` config option to `0`. You can also set a higher number to reattempt multiple times, with exponential backoff. [Idempotency keys](https://stripe.com/docs/api/idempotent_requests) are added where appropriate to prevent duplication.
 
+```js
+const stripe = Stripe('sk_test_...', {
+  maxNetworkRetries: 0, // Disable retries
+});
+
+```
 ```js
 const stripe = Stripe('sk_test_...', {
   maxNetworkRetries: 2, // Retry a request twice before giving up

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -113,7 +113,7 @@ export function createStripe(
       maxNetworkRetries: validateInteger(
         'maxNetworkRetries',
         props.maxNetworkRetries,
-        0
+        1
       ),
       agent: agent,
       httpClient:

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -337,7 +337,9 @@ describe('RequestSender', () => {
 
   describe('Retry Network Requests', () => {
     // Use a real instance of stripe as we're mocking the http.request responses.
-    const realStripe = require('../src/stripe.cjs.node.js')('sk_test_xyz');
+    const realStripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
+      maxNetworkRetries: 0,
+    });
 
     // Override the sleep timer to speed up tests
     realStripe.charges._getSleepTimeInMS = () => 0;
@@ -374,7 +376,7 @@ describe('RequestSender', () => {
 
       it('throws an error on connection timeout', (done) => {
         return getTestServerStripe(
-          {timeout: 10},
+          {timeout: 10, maxNetworkRetries: 0},
           (req, res) => {
             // Do nothing. This will trigger a timeout.
           },

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -656,7 +656,6 @@ describe('RequestSender', () => {
       });
 
       it('should retry on a 409 error', (done) => {
-        global.debug = true;
         nock(`https://${options.host}`)
           .post(options.path, options.params)
           .reply(409, {
@@ -674,7 +673,6 @@ describe('RequestSender', () => {
         realStripe._setApiNumberField('maxNetworkRetries', 1);
 
         realStripe.charges.create(options.data, (err, charge) => {
-          global.debug = false;
           expect(charge.id).to.equal('ch_123');
           done(err);
         });

--- a/test/resources/Quotes.spec.js
+++ b/test/resources/Quotes.spec.js
@@ -169,7 +169,7 @@ describe('Quotes Resource', () => {
     });
 
     it('failure', (callback) => {
-      const handleRequest = (req, res) => {
+      const handleRequest = (req, res, nPreviousRequests) => {
         setTimeout(() => res.writeHead(500));
         setTimeout(
           () =>
@@ -179,6 +179,7 @@ describe('Quotes Resource', () => {
           10
         );
         setTimeout(() => res.end(), 20);
+        return {shouldStayOpen: nPreviousRequests < 1};
       };
 
       testUtils.getTestServerStripe(
@@ -191,7 +192,7 @@ describe('Quotes Resource', () => {
 
           return stripe.quotes.pdf(
             'foo_123',
-            {host: 'localhost'},
+            {host: 'localhost', maxNetworkRetries: 1},
             (err, res) => {
               closeServer();
               expect(err).to.exist;

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -586,12 +586,12 @@ describe('Stripe Module', function() {
     });
 
     describe('when passed in via the config object', () => {
-      it('should default to 0 if a non-integer is passed', () => {
+      it('should default to 1 if a non-integer is passed', () => {
         const newStripe = Stripe(FAKE_API_KEY, {
           maxNetworkRetries: 'foo',
         });
 
-        expect(newStripe.getMaxNetworkRetries()).to.equal(0);
+        expect(newStripe.getMaxNetworkRetries()).to.equal(1);
 
         expect(() => {
           Stripe(FAKE_API_KEY, {
@@ -613,7 +613,7 @@ describe('Stripe Module', function() {
       it('should use the default', () => {
         const newStripe = Stripe(FAKE_API_KEY);
 
-        expect(newStripe.getMaxNetworkRetries()).to.equal(0);
+        expect(newStripe.getMaxNetworkRetries()).to.equal(1);
       });
     });
   });

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -25,16 +25,19 @@ export const getTestServerStripe = (
   clientOptions: RequestSettings,
   handler: (
     req: http.IncomingMessage,
-    res: http.ServerResponse
-  ) => {shouldStayOpen?: true} | null,
+    res: http.ServerResponse,
+    nPreviousRequests: number
+  ) => {shouldStayOpen?: boolean} | null,
   callback: (
     err: Error | null,
     stripe: StripeClient,
     closeServer: () => void
   ) => void
 ): void => {
+  let nPreviousRequests = 0;
   const server = http.createServer((req, res) => {
-    const {shouldStayOpen} = handler(req, res) || {};
+    const {shouldStayOpen} = handler(req, res, nPreviousRequests) || {};
+    nPreviousRequests += 1;
     if (!shouldStayOpen) {
       res.on('close', () => {
         server.close();


### PR DESCRIPTION
## Summary
Changes the default behavior of stripe-node to perform 1 reattempt on retryable failures by default, instead of 0. Retrying is generally safe. This is the same behavior as in `stripe-go`.

This will improve the default experience in environments like AWS Lambda where broken connections are inevitable (fixes #1040)