### PR TITLE
Adding error message for when signing secrets contain whitespace

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -358,7 +358,7 @@ export function createWebhooks(
             'Webhook payload must be provided as a string or a Buffer (https://nodejs.org/api/buffer.html) instance representing the _raw_ request body.' +
             'Payload was provided as a parsed JavaScript object instead. \n' +
             'Signature verification is impossible without access to the original signed material. \n' +
-            docsLocation +
+            docsLocation + '\n' +
             whitespaceMessage,
         });
       }
@@ -366,7 +366,7 @@ export function createWebhooks(
         message:
           'No signatures found matching the expected signature for payload.' +
           ' Are you passing the raw request body you received from Stripe? \n' +
-          docsLocation +
+          docsLocation + '\n' +
           whitespaceMessage,
       });
     }

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -358,7 +358,8 @@ export function createWebhooks(
             'Webhook payload must be provided as a string or a Buffer (https://nodejs.org/api/buffer.html) instance representing the _raw_ request body.' +
             'Payload was provided as a parsed JavaScript object instead. \n' +
             'Signature verification is impossible without access to the original signed material. \n' +
-            docsLocation + '\n' +
+            docsLocation +
+            '\n' +
             whitespaceMessage,
         });
       }
@@ -366,7 +367,8 @@ export function createWebhooks(
         message:
           'No signatures found matching the expected signature for payload.' +
           ' Are you passing the raw request body you received from Stripe? \n' +
-          docsLocation + '\n' +
+          docsLocation +
+          '\n' +
           whitespaceMessage,
       });
     }

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -370,6 +370,20 @@ describe('Webhooks', () => {
         );
       });
 
+      it('should raise a SignatureVerificationError when the signing secret contians whitespace', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        await expect(
+          verifyHeaderFn(EVENT_PAYLOAD_STRING, header, SECRET + ' ')
+        ).to.be.rejectedWith(
+          StripeSignatureVerificationError,
+          /The provided signing secret contains whitespace/
+        );
+      });
+
       describe('custom CryptoProvider', () => {
         const cryptoProvider = new FakeCryptoProvider();
 


### PR DESCRIPTION
Adding an error message that is surfaced when a signing secret that contains whitespace is used.