### PR TITLE
Generate FileCreateParams

### DIFF
--- a/types/FilesResource.d.ts
+++ b/types/FilesResource.d.ts
@@ -2,7 +2,58 @@
 
 declare module 'stripe' {
   namespace Stripe {
-    interface FileCreateParams {}
+    interface FileCreateParams {
+      /**
+       * A file to upload. The file should follow the specifications of RFC 2388 (which defines file transfers for the `multipart/form-data` protocol).
+       */
+      file: FileData;
+
+      /**
+       * The [purpose](https://stripe.com/docs/file-upload#uploading-a-file) of the uploaded file.
+       */
+      purpose: FileCreateParams.Purpose;
+
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+
+      /**
+       * Optional parameters to automatically create a [file link](https://stripe.com/docs/api#file_links) for the newly created file.
+       */
+      file_link_data?: FileCreateParams.FileLinkData;
+    }
+
+    namespace FileCreateParams {
+      interface FileLinkData {
+        /**
+         * Set this to `true` to create a file link for the newly created file. Creating a link is only possible when the file's `purpose` is one of the following: `business_icon`, `business_logo`, `customer_signature`, `dispute_evidence`, `pci_document`, `tax_document_user_upload`, or `terminal_reader_splashscreen`.
+         */
+        create: boolean;
+
+        /**
+         * A future timestamp after which the link will no longer be usable.
+         */
+        expires_at?: number;
+
+        /**
+         * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+         */
+        metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
+      }
+
+      type Purpose =
+        | 'account_requirement'
+        | 'additional_verification'
+        | 'business_icon'
+        | 'business_logo'
+        | 'customer_signature'
+        | 'dispute_evidence'
+        | 'identity_document'
+        | 'pci_document'
+        | 'tax_document_user_upload'
+        | 'terminal_reader_splashscreen';
+    }
 
     interface FileRetrieveParams {
       /**
@@ -51,10 +102,9 @@ declare module 'stripe' {
        * All of Stripe's officially supported Client libraries should have support for sending multipart/form-data.
        */
       create(
-        params?: FileCreateParams,
+        params: FileCreateParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.File>>;
-      create(options?: RequestOptions): Promise<Stripe.Response<Stripe.File>>;
 
       /**
        * Retrieves the details of an existing file object. Supply the unique file ID from a file, and Stripe will return the corresponding file object. To access file contents, see the [File Upload Guide](https://stripe.com/docs/file-upload#download-file-contents).

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -289,5 +289,11 @@ declare module 'stripe' {
       url?: string;
       version?: string;
     }
+
+    export interface FileData {
+      data: string | Buffer | Uint8Array;
+      name?: string;
+      type?: string;
+    }
   }
 }

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -284,3 +284,12 @@ Stripe.errors.StripeError.generate({
 stripe.accounts.retrieve('123', {
   host: 'my_host',
 });
+stripe.files.create({
+  purpose: 'dispute_evidence',
+  file: {
+    data: Buffer.from('File'),
+    name: 'minimal.pdf',
+    type: 'application/octet-stream',
+  },
+  file_link_data: {create: true},
+});


### PR DESCRIPTION
Adds type definition to `files.create()` method params.