### PR TITLE
Better CryptoProvider error

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -94,7 +94,7 @@ export function createWebhooks(
       } catch (e) {
         if (e instanceof CryptoProviderOnlySupportsAsyncError) {
           e.message +=
-            '\nUse `await constructEventAsync(...)` instead of `constructEvent(...).`';
+            '\nUse `await constructEventAsync(...)` instead of `constructEvent(...)`';
         }
         throw e;
       }

--- a/src/crypto/CryptoProvider.ts
+++ b/src/crypto/CryptoProvider.ts
@@ -30,3 +30,12 @@ export class CryptoProvider {
     throw new Error('computeHMACSignatureAsync not implemented.');
   }
 }
+
+/**
+ * If the crypto provider only supports asynchronous operations,
+ * throw CryptoProviderOnlySupportsAsyncError instead of
+ * a generic error so that the caller can choose to provide
+ * a more helpful error message to direct the user to use
+ * an asynchronous pathway.
+ */
+export class CryptoProviderOnlySupportsAsyncError extends Error {}

--- a/src/crypto/SubtleCryptoProvider.ts
+++ b/src/crypto/SubtleCryptoProvider.ts
@@ -1,4 +1,7 @@
-import {CryptoProvider} from './CryptoProvider.js';
+import {
+  CryptoProvider,
+  CryptoProviderOnlySupportsAsyncError,
+} from './CryptoProvider.js';
 
 /**
  * `CryptoProvider which uses the SubtleCrypto interface of the Web Crypto API.
@@ -19,7 +22,7 @@ export class SubtleCryptoProvider extends CryptoProvider {
 
   /** @override */
   computeHMACSignature(payload: string, secret: string): string {
-    throw new Error(
+    throw new CryptoProviderOnlySupportsAsyncError(
       'SubtleCryptoProvider cannot be used in a synchronous context.'
     );
   }

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -3,6 +3,7 @@
 import {expect} from 'chai';
 import {StripeSignatureVerificationError} from '../src/Error.js';
 import {FakeCryptoProvider, getSpyableStripe} from './testUtils.js';
+import {CryptoProviderOnlySupportsAsyncError} from '../src/crypto/CryptoProvider.js';
 const stripe = getSpyableStripe();
 
 const EVENT_PAYLOAD = {
@@ -152,13 +153,25 @@ describe('Webhooks', () => {
     };
   };
 
-  describe(
-    '.constructEvent',
+  describe('.constructEvent', () => {
     makeConstructEventTests(async (...args: any) => {
       const result = await stripe.webhooks.constructEvent(...args);
       return result;
-    })
-  );
+    })();
+    it('should provide helpful information when CryptoProviderOnlySupportsAsyncError is thrown', () => {
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload: 'payload',
+        secret: 'secret',
+      });
+      expect(() => {
+        stripe.webhooks.constructEvent('payload', header, 'secret', 0, {
+          computeHMACSignature() {
+            throw new CryptoProviderOnlySupportsAsyncError('foobar');
+          },
+        });
+      }).to.throw(/Use `await constructEventAsync/);
+    });
+  });
 
   describe(
     '.constructEventAsync',

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -169,7 +169,7 @@ describe('Webhooks', () => {
             throw new CryptoProviderOnlySupportsAsyncError('foobar');
           },
         });
-      }).to.throw(/Use `await constructEventAsync/);
+      }).to.throw(/foobar\nUse `await constructEventAsync/);
     });
   });
 


### PR DESCRIPTION
In response to #1827.

* I could have made a smaller change to just add the string to `SubtleCryptoProvider.computeHMACSignature` itself, but it felt wrong to me for `.computeHMACSignature` to make assumptions about how it was called, so instead I introduced a specialized error class for `constructEvent` can produce the message. Open to reversing this upon feedback.
* I didn't change the default implementation of `.computeHMACSignature` to throw this error. That means we're asking hypothetical implementors of additional async-only CryptoProviders will have to explicitly override `.computeHMACSignature` to throw this error instead of just only implementing `.computeHMACSignatureAsync`. This kind of is a bummer but I think it prevents misleading error messages in the hypothetical case where the implementer implements neither method. This almost certainly doesn't matter, but figured I'd mention.