### PR TITLE
Allow for deleting customer's email address in type defintions

### DIFF
--- a/types/CustomersResource.d.ts
+++ b/types/CustomersResource.d.ts
@@ -328,7 +328,7 @@ declare module 'stripe' {
       /**
        * Customer's email address. It's displayed alongside the customer in your dashboard and can be useful for searching and tracking. This may be up to *512 characters*.
        */
-      email?: string;
+      email?: string | null;
 
       /**
        * Specifies which fields in the response should be expanded.


### PR DESCRIPTION
You can delete a customer's email address via `stripe.customers.update(id, {email: null})`. However, this is currently causing a type error, since the type definitions don't allow the use of `null` here. But if you bypass the type check it works as expected. I wonder if other `CustomerUpdateParams` properties have the same issue?