### PR TITLE
Add "plan" property of Subscription object to type definitions

### DIFF
--- a/types/Subscriptions.d.ts
+++ b/types/Subscriptions.d.ts
@@ -185,6 +185,11 @@ declare module 'stripe' {
       pending_update: Subscription.PendingUpdate | null;
 
       /**
+       * The [Plan](https://stripe.com/docs/api/plans) from the only subscription item. If there are none or multiple subscription items, or if the subscription item has a one-off price, this property is null.
+       */
+      plan: Stripe.Plan | null;
+
+      /**
        * The schedule attached to the subscription
        */
       schedule: string | Stripe.SubscriptionSchedule | null;

--- a/types/SubscriptionsResource.d.ts
+++ b/types/SubscriptionsResource.d.ts
@@ -143,6 +143,11 @@ declare module 'stripe' {
       >;
 
       /**
+       * The identifier of the plan to add to the subscription.
+       */
+      plan?: string;
+
+      /**
        * The API ID of a promotion code to apply to this subscription. A promotion code applied to a subscription will only affect invoices created for that particular subscription.
        */
       promotion_code?: string;
@@ -797,6 +802,11 @@ declare module 'stripe' {
       pending_invoice_item_interval?: Stripe.Emptyable<
         SubscriptionUpdateParams.PendingInvoiceItemInterval
       >;
+
+      /**
+       * The identifier of the new plan for this subscription.
+       */
+      plan?: string;
 
       /**
        * The promotion code to apply to this subscription. A promotion code applied to a subscription will only affect invoices created for that particular subscription.


### PR DESCRIPTION
It looks like the `Subscription` object's `plan` property despite still being present in the latest API version (2022-11-15) has been left out of the type definitions.