### PR TITLE
Revert "import * as http -> import http from 'http'"

### DIFF
--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -1,15 +1,5 @@
-// It's important to do a default import here, rather thane
-// `import * as http from 'http'` because the latter will
-// use a "Module Namespace Exotic Object" which is immune to
-// monkey-patching, whereas http.default (in an ES Module context)
-// will resolve to the same thing as require('http'), which is
-// monkey-patchable. We care about this because users in their test
-// suites might be using a library like "nock" which relies on the ability
-// to monkey-patch and intercept calls to http.request.
-// In order to get this to play nicely with commonJS, in our TSConfig we have
-// esModuleInterop set to true.
-import http from 'http';
-import https from 'https';
+import * as http from 'http';
+import * as https from 'https';
 import {RequestHeaders, RequestData} from '../Types.js';
 import {
   HttpClient,

--- a/test/StripeResource.spec.ts
+++ b/test/StripeResource.spec.ts
@@ -1,6 +1,6 @@
 // @ts-nocheck
 import {expect} from 'chai';
-import nock from 'nock';
+import * as nock from 'nock';
 import {StripeResource} from '../src/StripeResource.js';
 import {getSpyableStripe, getTestServerStripe} from './testUtils.js';
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -9,8 +9,7 @@
     "noImplicitThis": true,
     "strict": true,
     "strictFunctionTypes": true,
-    "types": [ "node" ],
-    "esModuleInterop": true
+    "types": [ "node" ]
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/stripe.esm.node.ts", "./src/stripe.esm.worker.ts"],


### PR DESCRIPTION
Reverts stripe/stripe-node#1854

We should not use `esModuleInterop` because this is a breaking change

> Accordingly, library authors should set both allowSyntheticDefaultImports and esModuleInterop to false. This allows consumers to opt into these semantics, but does not require them to do so. Consumers can always safely use alternative import syntaxes (including falling back to require() and import()), or can enable these flags and opt into this behavior themselves.

https://www.semver-ts.org/#module-interop

Thank you for catching this @anniel-stripe!