### PR TITLE
Remove wrong signature overload for stripe.invoice.retrieveUpcoming

### DIFF
--- a/types/InvoicesResource.d.ts
+++ b/types/InvoicesResource.d.ts
@@ -2566,9 +2566,6 @@ declare module 'stripe' {
         params?: InvoiceRetrieveUpcomingParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.UpcomingInvoice>>;
-      retrieveUpcoming(
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.UpcomingInvoice>>;
 
       /**
        * Search for invoices you've previously created using Stripe's [Search Query Language](https://stripe.com/docs/search#search-query-language).


### PR DESCRIPTION
When calling `stripe.invoice.retrieveUpcoming` with a single argument, it is expected to be of the type `InvoiceRetrieveUpcomingParams`. This is already supported by the first signature, as the second argument is optional. However, the second overlaoded signature is picked up which incorrectly expects a `RequestOptions` object as first/only argument.