### PR TITLE
Remove developer_message support

### DIFF
--- a/src/Error.ts
+++ b/src/Error.ts
@@ -50,7 +50,7 @@ export class StripeError extends Error {
   readonly source?: any;
 
   constructor(raw: StripeRawError = {}) {
-    super(raw.developer_message || raw.message);
+    super(raw.message);
     this.type = this.constructor.name;
 
     this.raw = raw;
@@ -63,7 +63,7 @@ export class StripeError extends Error {
     this.requestId = raw.requestId;
     this.statusCode = raw.statusCode;
     // @ts-ignore
-    this.message = raw.developer_message || raw.message;
+    this.message = raw.message;
 
     this.charge = raw.charge;
     this.decline_code = raw.decline_code;

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -176,7 +176,6 @@ export type RequestSender = {
 };
 export type StripeRawError = {
   message?: string;
-  developer_message?: string;
   type?: RawErrorType;
   headers?: {[header: string]: string};
   statusCode?: number;

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -515,22 +515,6 @@ describe('RequestSender', () => {
         });
       });
 
-      it('uses developer_message if it exists in error response', async () => {
-        const error = {
-          developer_message: 'Unacceptable',
-        };
-
-        nock(`https://${options.host}`)
-          .post('/v1/charges')
-          .reply(400, {
-            error,
-          });
-
-        await expect(
-          realStripe.rawRequest('POST', '/v1/charges')
-        ).to.be.rejectedWith(StripeError, /Unacceptable/);
-      });
-
       it('retries connection timeout errors', (done) => {
         let nRequestsReceived = 0;
         return getTestServerStripe(


### PR DESCRIPTION
Preview error messages now contain a `message` field.