### PR TITLE
Allow monkey patching http / https

### DIFF
--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -1,5 +1,15 @@
-import * as http from 'http';
-import * as https from 'https';
+// It's important to do a default import here, rather thane
+// `import * as http from 'http'` because the latter will
+// use a "Module Namespace Exotic Object" which is immune to
+// monkey-patching, whereas http.default (in an ES Module context)
+// will resolve to the same thing as require('http'), which is
+// monkey-patchable. We care about this because users in their test
+// suites might be using a library like "nock" which relies on the ability
+// to monkey-patch and intercept calls to http.request.
+
+// Get rid of this type error Module '"http"' has no default export.ts(1192)
+import * as http_ from 'http';
+import * as https_ from 'https';
 import {RequestHeaders, RequestData} from '../Types.js';
 import {
   HttpClient,
@@ -7,6 +17,9 @@ import {
   HttpClientResponseInterface,
 } from './HttpClient.js';
 
+const http = ((http_ as unknown) as {default: typeof http_}).default || http_;
+const https =
+  ((https_ as unknown) as {default: typeof https_}).default || https_;
 const defaultHttpAgent = new http.Agent({keepAlive: true});
 const defaultHttpsAgent = new https.Agent({keepAlive: true});
 
@@ -15,9 +28,9 @@ const defaultHttpsAgent = new https.Agent({keepAlive: true});
  * requests.`
  */
 export class NodeHttpClient extends HttpClient {
-  _agent?: http.Agent | https.Agent | undefined;
+  _agent?: http_.Agent | https_.Agent | undefined;
 
-  constructor(agent?: http.Agent | https.Agent) {
+  constructor(agent?: http_.Agent | https_.Agent) {
     super();
     this._agent = agent;
   }
@@ -93,19 +106,19 @@ export class NodeHttpClient extends HttpClient {
 
 export class NodeHttpClientResponse extends HttpClientResponse
   implements HttpClientResponseInterface {
-  _res: http.IncomingMessage;
+  _res: http_.IncomingMessage;
 
-  constructor(res: http.IncomingMessage) {
+  constructor(res: http_.IncomingMessage) {
     // @ts-ignore
     super(res.statusCode, res.headers || {});
     this._res = res;
   }
 
-  getRawResponse(): http.IncomingMessage {
+  getRawResponse(): http_.IncomingMessage {
     return this._res;
   }
 
-  toStream(streamCompleteCallback: () => void): http.IncomingMessage {
+  toStream(streamCompleteCallback: () => void): http_.IncomingMessage {
     // The raw response is itself the stream, so we just return that. To be
     // backwards compatible, we should invoke the streamCompleteCallback only
     // once the stream has been fully consumed.

--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -1,13 +1,3 @@
-// It's important to do a default import here, rather thane
-// `import * as http from 'http'` because the latter will
-// use a "Module Namespace Exotic Object" which is immune to
-// monkey-patching, whereas http.default (in an ES Module context)
-// will resolve to the same thing as require('http'), which is
-// monkey-patchable. We care about this because users in their test
-// suites might be using a library like "nock" which relies on the ability
-// to monkey-patch and intercept calls to http.request.
-
-// Get rid of this type error Module '"http"' has no default export.ts(1192)
 import * as http_ from 'http';
 import * as https_ from 'https';
 import {RequestHeaders, RequestData} from '../Types.js';
@@ -17,9 +7,16 @@ import {
   HttpClientResponseInterface,
 } from './HttpClient.js';
 
+// `import * as http_ from 'http'` creates a "Module Namespace Exotic Object"
+// which is immune to monkey-patching, whereas http_.default (in an ES Module context)
+// will resolve to the same thing as require('http'), which is
+// monkey-patchable. We care about this because users in their test
+// suites might be using a library like "nock" which relies on the ability
+// to monkey-patch and intercept calls to http.request.
 const http = ((http_ as unknown) as {default: typeof http_}).default || http_;
 const https =
   ((https_ as unknown) as {default: typeof https_}).default || https_;
+
 const defaultHttpAgent = new http.Agent({keepAlive: true});
 const defaultHttpsAgent = new https.Agent({keepAlive: true});
 

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -10,7 +10,7 @@
     "strict": true,
     "strictFunctionTypes": true,
     "types": [ "node" ],
-    "esModuleInterop": false
+    "esModuleInterop": false // This is a viral option, do not enable https://www.semver-ts.org/#module-interop
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/stripe.esm.node.ts", "./src/stripe.esm.worker.ts"],

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -9,7 +9,8 @@
     "noImplicitThis": true,
     "strict": true,
     "strictFunctionTypes": true,
-    "types": [ "node" ]
+    "types": [ "node" ],
+    "esModuleInterop": false
   },
   "include": ["./src/**/*"],
   "exclude": ["./src/stripe.esm.node.ts", "./src/stripe.esm.worker.ts"],


### PR DESCRIPTION
Achieves a similar affect as https://github.com/stripe/stripe-node/pull/1854 (but without turning on the `esModuleInterop` option) to enable monkey patching of the 'http' / 'https' modules when importing stripe as an ES module.

Also adds a test to prevent against future regressions, and makes `esModuleInterop: false` explicit.

Motivation: https://github.com/stripe/stripe-node/issues/1844 