### PR TITLE
Add named unions for all polymorphic types

### DIFF
--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -8,13 +8,13 @@ const expect = require('chai').expect;
 
 describe('Accounts', function() {
   it('listExternalAccounts method', async function() {
-    const externalAccount = await stripe.accounts.listExternalAccounts(
+    const externalAccounts = await stripe.accounts.listExternalAccounts(
       'acct_xxxxxxxxxxxxx',
       {
         limit: 3,
       }
     );
-    expect(externalAccount).not.to.be.null;
+    expect(externalAccounts).not.to.be.null;
   });
 
   it('list method', async function() {
@@ -93,6 +93,28 @@ describe('Accounts', function() {
     expect(capability).not.to.be.null;
   });
 
+  it('listExternalAccounts method', async function() {
+    const externalAccounts = await stripe.accounts.listExternalAccounts(
+      'acct_xxxxxxxxxxxxx',
+      {
+        object: 'bank_account',
+        limit: 3,
+      }
+    );
+    expect(externalAccounts).not.to.be.null;
+  });
+
+  it('listExternalAccounts method', async function() {
+    const externalAccounts = await stripe.accounts.listExternalAccounts(
+      'acct_xxxxxxxxxxxxx',
+      {
+        object: 'card',
+        limit: 3,
+      }
+    );
+    expect(externalAccounts).not.to.be.null;
+  });
+
   it('createExternalAccount method', async function() {
     const externalAccount = await stripe.accounts.createExternalAccount(
       'acct_xxxxxxxxxxxxx',
@@ -114,19 +136,19 @@ describe('Accounts', function() {
   });
 
   it('deleteExternalAccount method', async function() {
-    const deletedExternalAccount = await stripe.accounts.deleteExternalAccount(
+    const deleted = await stripe.accounts.deleteExternalAccount(
       'acct_xxxxxxxxxxxxx',
       'ba_xxxxxxxxxxxxx'
     );
-    expect(deletedExternalAccount).not.to.be.null;
+    expect(deleted).not.to.be.null;
   });
 
   it('deleteExternalAccount method', async function() {
-    const deletedExternalAccount = await stripe.accounts.deleteExternalAccount(
+    const deleted = await stripe.accounts.deleteExternalAccount(
       'acct_xxxxxxxxxxxxx',
       'card_xxxxxxxxxxxxx'
     );
-    expect(deletedExternalAccount).not.to.be.null;
+    expect(deleted).not.to.be.null;
   });
 
   it('retrieveExternalAccount method', async function() {
@@ -417,10 +439,14 @@ describe('Customers', function() {
   });
 
   it('updateSource method', async function() {
-    const card = await stripe.customers.updateSource('cus_123', 'card_123', {
-      account_holder_name: 'Kamil',
-    });
-    expect(card).not.to.be.null;
+    const customerSource = await stripe.customers.updateSource(
+      'cus_123',
+      'card_123',
+      {
+        account_holder_name: 'Kamil',
+      }
+    );
+    expect(customerSource).not.to.be.null;
   });
 
   it('list method', async function() {
@@ -517,81 +543,81 @@ describe('Customers', function() {
   });
 
   it('listSources method', async function() {
-    const paymentSource = await stripe.customers.listSources(
+    const customerSources = await stripe.customers.listSources(
       'cus_xxxxxxxxxxxxx',
       {
         object: 'bank_account',
         limit: 3,
       }
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSources).not.to.be.null;
   });
 
   it('listSources method', async function() {
-    const paymentSource = await stripe.customers.listSources(
+    const customerSources = await stripe.customers.listSources(
       'cus_xxxxxxxxxxxxx',
       {
         object: 'card',
         limit: 3,
       }
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSources).not.to.be.null;
   });
 
   it('createSource method', async function() {
-    const paymentSource = await stripe.customers.createSource(
+    const customerSource = await stripe.customers.createSource(
       'cus_xxxxxxxxxxxxx',
       {
         source: 'btok_xxxxxxxxxxxxx',
       }
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('createSource method', async function() {
-    const paymentSource = await stripe.customers.createSource(
+    const customerSource = await stripe.customers.createSource(
       'cus_xxxxxxxxxxxxx',
       {
         source: 'tok_xxxx',
       }
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('deleteSource method', async function() {
-    const paymentSource = await stripe.customers.deleteSource(
+    const customerSource = await stripe.customers.deleteSource(
       'cus_xxxxxxxxxxxxx',
       'ba_xxxxxxxxxxxxx'
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('deleteSource method', async function() {
-    const paymentSource = await stripe.customers.deleteSource(
+    const customerSource = await stripe.customers.deleteSource(
       'cus_xxxxxxxxxxxxx',
       'card_xxxxxxxxxxxxx'
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('retrieveSource method', async function() {
-    const paymentSource = await stripe.customers.retrieveSource(
+    const customerSource = await stripe.customers.retrieveSource(
       'cus_xxxxxxxxxxxxx',
       'ba_xxxxxxxxxxxxx'
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('retrieveSource method', async function() {
-    const paymentSource = await stripe.customers.retrieveSource(
+    const customerSource = await stripe.customers.retrieveSource(
       'cus_xxxxxxxxxxxxx',
       'card_xxxxxxxxxxxxx'
     );
-    expect(paymentSource).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('updateSource method', async function() {
-    const card = await stripe.customers.updateSource(
+    const customerSource = await stripe.customers.updateSource(
       'cus_xxxxxxxxxxxxx',
       'ba_xxxxxxxxxxxxx',
       {
@@ -600,18 +626,18 @@ describe('Customers', function() {
         },
       }
     );
-    expect(card).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('updateSource method', async function() {
-    const card = await stripe.customers.updateSource(
+    const customerSource = await stripe.customers.updateSource(
       'cus_xxxxxxxxxxxxx',
       'card_xxxxxxxxxxxxx',
       {
         name: 'Jenny Rosen',
       }
     );
-    expect(card).not.to.be.null;
+    expect(customerSource).not.to.be.null;
   });
 
   it('verifySource method', async function() {

--- a/types/Accounts.d.ts
+++ b/types/Accounts.d.ts
@@ -77,7 +77,7 @@ declare module 'stripe' {
       /**
        * External accounts (bank accounts and debit cards) currently attached to this account
        */
-      external_accounts?: ApiList<Stripe.BankAccount | Stripe.Card>;
+      external_accounts?: ApiList<Stripe.ExternalAccount>;
 
       future_requirements?: Account.FutureRequirements;
 

--- a/types/AccountsResource.d.ts
+++ b/types/AccountsResource.d.ts
@@ -3410,7 +3410,7 @@ declare module 'stripe' {
         id: string,
         params: ExternalAccountCreateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
+      ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
 
       /**
        * Creates a single-use login link for an Express account to access their Stripe dashboard.
@@ -3448,16 +3448,12 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountDeleteParams,
         options?: RequestOptions
-      ): Promise<
-        Stripe.Response<Stripe.DeletedBankAccount | Stripe.DeletedCard>
-      >;
+      ): Promise<Stripe.Response<Stripe.DeletedExternalAccount>>;
       deleteExternalAccount(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<
-        Stripe.Response<Stripe.DeletedBankAccount | Stripe.DeletedCard>
-      >;
+      ): Promise<Stripe.Response<Stripe.DeletedExternalAccount>>;
 
       /**
        * Deletes an existing person's relationship to the account's legal entity. Any person with a relationship for an account can be deleted through the API, except if the person is the account_opener. If your integration is using the executive parameter, you cannot delete the only verified executive on file.
@@ -3494,11 +3490,11 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountListParams,
         options?: RequestOptions
-      ): ApiListPromise<Stripe.BankAccount | Stripe.Card>;
+      ): ApiListPromise<Stripe.ExternalAccount>;
       listExternalAccounts(
         id: string,
         options?: RequestOptions
-      ): ApiListPromise<Stripe.BankAccount | Stripe.Card>;
+      ): ApiListPromise<Stripe.ExternalAccount>;
 
       /**
        * Returns a list of people associated with the account's legal entity. The people are returned sorted by creation date, with the most recent people appearing first.
@@ -3547,12 +3543,12 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountRetrieveParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
+      ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
       retrieveExternalAccount(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
+      ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
 
       /**
        * Retrieves an existing person.
@@ -3594,12 +3590,12 @@ declare module 'stripe' {
         id: string,
         params?: ExternalAccountUpdateParams,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
+      ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
       updateExternalAccount(
         accountId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.BankAccount | Stripe.Card>>;
+      ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
 
       /**
        * Updates an existing person.

--- a/types/BalanceTransactionSources.d.ts
+++ b/types/BalanceTransactionSources.d.ts
@@ -1,0 +1,24 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    type BalanceTransactionSource =
+      | ApplicationFee
+      | Charge
+      | ConnectCollectionTransfer
+      | CustomerCashBalanceTransaction
+      | Dispute
+      | FeeRefund
+      | Issuing.Authorization
+      | Issuing.Dispute
+      | Issuing.Transaction
+      | Payout
+      | PlatformTaxFee
+      | Refund
+      | ReserveTransaction
+      | TaxDeductedAtSource
+      | Topup
+      | Transfer
+      | TransferReversal;
+  }
+}

--- a/types/BalanceTransactions.d.ts
+++ b/types/BalanceTransactions.d.ts
@@ -72,26 +72,7 @@ declare module 'stripe' {
       /**
        * This transaction relates to the Stripe object.
        */
-      source:
-        | string
-        | Stripe.ApplicationFee
-        | Stripe.Charge
-        | Stripe.ConnectCollectionTransfer
-        | Stripe.CustomerCashBalanceTransaction
-        | Stripe.Dispute
-        | Stripe.FeeRefund
-        | Stripe.Issuing.Authorization
-        | Stripe.Issuing.Dispute
-        | Stripe.Issuing.Transaction
-        | Stripe.Payout
-        | Stripe.PlatformTaxFee
-        | Stripe.Refund
-        | Stripe.ReserveTransaction
-        | Stripe.TaxDeductedAtSource
-        | Stripe.Topup
-        | Stripe.Transfer
-        | Stripe.TransferReversal
-        | null;
+      source: string | Stripe.BalanceTransactionSource | null;
 
       /**
        * The transaction's net funds status in the Stripe balance, which are either `available` or `pending`.

--- a/types/CustomerSources.d.ts
+++ b/types/CustomerSources.d.ts
@@ -1,0 +1,9 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    type CustomerSource = Account | BankAccount | Card | Source;
+
+    type DeletedCustomerSource = DeletedBankAccount | DeletedCard;
+  }
+}

--- a/types/CustomersResource.d.ts
+++ b/types/CustomersResource.d.ts
@@ -1136,18 +1136,14 @@ declare module 'stripe' {
         params?: CustomerSourceDeleteParams,
         options?: RequestOptions
       ): Promise<
-        Stripe.Response<
-          Stripe.CustomerSource | Stripe.DeletedBankAccount | Stripe.DeletedCard
-        >
+        Stripe.Response<Stripe.CustomerSource | Stripe.DeletedCustomerSource>
       >;
       deleteSource(
         customerId: string,
         id: string,
         options?: RequestOptions
       ): Promise<
-        Stripe.Response<
-          Stripe.CustomerSource | Stripe.DeletedBankAccount | Stripe.DeletedCard
-        >
+        Stripe.Response<Stripe.CustomerSource | Stripe.DeletedCustomerSource>
       >;
 
       /**
@@ -1365,16 +1361,12 @@ declare module 'stripe' {
         id: string,
         params?: CustomerSourceUpdateParams,
         options?: RequestOptions
-      ): Promise<
-        Stripe.Response<Stripe.Card | Stripe.BankAccount | Stripe.Source>
-      >;
+      ): Promise<Stripe.Response<Stripe.CustomerSource>>;
       updateSource(
         customerId: string,
         id: string,
         options?: RequestOptions
-      ): Promise<
-        Stripe.Response<Stripe.Card | Stripe.BankAccount | Stripe.Source>
-      >;
+      ): Promise<Stripe.Response<Stripe.CustomerSource>>;
 
       /**
        * Verify a specified bank account for a given customer.

--- a/types/ExternalAccounts.d.ts
+++ b/types/ExternalAccounts.d.ts
@@ -1,0 +1,9 @@
+// File generated from our OpenAPI spec
+
+declare module 'stripe' {
+  namespace Stripe {
+    type DeletedExternalAccount = DeletedBankAccount | DeletedCard;
+
+    type ExternalAccount = BankAccount | Card;
+  }
+}

--- a/types/PaymentIntents.d.ts
+++ b/types/PaymentIntents.d.ts
@@ -198,8 +198,7 @@ declare module 'stripe' {
       source:
         | string
         | Stripe.CustomerSource
-        | Stripe.DeletedBankAccount
-        | Stripe.DeletedCard
+        | Stripe.DeletedCustomerSource
         | null;
 
       /**

--- a/types/Payouts.d.ts
+++ b/types/Payouts.d.ts
@@ -63,10 +63,8 @@ declare module 'stripe' {
        */
       destination:
         | string
-        | Stripe.BankAccount
-        | Stripe.DeletedBankAccount
-        | Stripe.Card
-        | Stripe.DeletedCard
+        | Stripe.ExternalAccount
+        | Stripe.DeletedExternalAccount
         | null;
 
       /**

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -112,6 +112,7 @@
 ///<reference path='./Applications.d.ts' />
 ///<reference path='./Apps/Secrets.d.ts' />
 ///<reference path='./Balance.d.ts' />
+///<reference path='./BalanceTransactionSources.d.ts' />
 ///<reference path='./BalanceTransactions.d.ts' />
 ///<reference path='./BankAccounts.d.ts' />
 ///<reference path='./BillingPortal/Configurations.d.ts' />
@@ -128,12 +129,14 @@
 ///<reference path='./CreditNotes.d.ts' />
 ///<reference path='./CustomerBalanceTransactions.d.ts' />
 ///<reference path='./CustomerCashBalanceTransactions.d.ts' />
+///<reference path='./CustomerSources.d.ts' />
 ///<reference path='./Customers.d.ts' />
 ///<reference path='./Discounts.d.ts' />
 ///<reference path='./Disputes.d.ts' />
 ///<reference path='./EphemeralKeys.d.ts' />
 ///<reference path='./Events.d.ts' />
 ///<reference path='./ExchangeRates.d.ts' />
+///<reference path='./ExternalAccounts.d.ts' />
 ///<reference path='./FeeRefunds.d.ts' />
 ///<reference path='./FileLinks.d.ts' />
 ///<reference path='./Files.d.ts' />

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -135,13 +135,9 @@ declare module 'stripe' {
 
     /**
      * The resulting source of [a Connect platform debiting a connected account](https://stripe.com/docs/connect/account-debits#charging-a-connected-account).
+     * @deprecated prefer Stripe.Account
      */
-    type AccountDebitSource = {
-      id: string;
-      object: 'account';
-    };
-
-    type CustomerSource = AccountDebitSource | BankAccount | Card | Source;
+    type AccountDebitSource = Account;
 
     interface RangeQueryParam {
       /**


### PR DESCRIPTION
We had a manually maintained `CustomerSource` union before but all other polymorphic types were expanded in-place.