### PR TITLE
Do not require passing apiVersion

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,9 +70,7 @@ and instantiate it as `new Stripe()` with the latest API version.
 
 ```ts
 import Stripe from 'stripe';
-const stripe = new Stripe('sk_test_...', {
-  apiVersion: '2023-10-16',
-});
+const stripe = new Stripe('sk_test_...');
 
 const createCustomer = async () => {
   const params: Stripe.CustomerCreateParams = {
@@ -158,11 +156,13 @@ stripe.customers
       });
   });
 ```
+
 ### Usage with Deno
 
 As of 11.16.0, stripe-node provides a `deno` export target. In your Deno project, import stripe-node using an npm specifier:
 
 Import using npm specifiers:
+
 ```js
 import Stripe from 'npm:stripe';
 ```
@@ -179,7 +179,6 @@ The package can be initialized with several options:
 import ProxyAgent from 'https-proxy-agent';
 
 const stripe = Stripe('sk_test_...', {
-  apiVersion: '2019-08-08',
   maxNetworkRetries: 1,
   httpAgent: new ProxyAgent(process.env.http_proxy),
   timeout: 1000,
@@ -265,8 +264,8 @@ As of [v13](https://github.com/stripe/stripe-node/releases/tag/v13.0.0) stripe-n
 const stripe = Stripe('sk_test_...', {
   maxNetworkRetries: 0, // Disable retries
 });
-
 ```
+
 ```js
 const stripe = Stripe('sk_test_...', {
   maxNetworkRetries: 2, // Retry a request twice before giving up
@@ -394,7 +393,7 @@ const stripe = require('stripe')('sk_test_...', {
     name: 'MyAwesomePlugin',
     version: '1.2.34', // Optional
     url: 'https://myawesomeplugin.info', // Optional
-  }
+  },
 });
 ```
 
@@ -406,7 +405,7 @@ const stripe = new Stripe(apiKey, {
     name: 'MyAwesomePlugin',
     version: '1.2.34', // Optional
     url: 'https://myawesomeplugin.info', // Optional
-  }
+  },
 });
 ```
 
@@ -496,6 +495,7 @@ const stripe = new Stripe('sk_test_...', {
 Stripe has features in the beta phase that can be accessed via the beta version of this package.
 We would love for you to try these and share feedback with us before these features reach the stable phase.
 The beta versions can be installed in one of two ways
+
 - To install the latest beta version, run the command `npm install stripe@beta --save`
 - To install a specific beta version, replace the term "beta" in the above command with the version number like `npm install stripe@1.2.3-beta.1 --save`
 

--- a/examples/webhook-signing/express/main.ts
+++ b/examples/webhook-signing/express/main.ts
@@ -7,9 +7,7 @@ import {AddressInfo} from 'net';
 
 env.config();
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-08-16',
-});
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 const webhookSecret: string = process.env.STRIPE_WEBHOOK_SECRET;
 

--- a/examples/webhook-signing/koa/main.ts
+++ b/examples/webhook-signing/koa/main.ts
@@ -11,9 +11,7 @@ const app = new Koa();
 env.config();
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-08-16',
-});
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 const handleWebhook = async (ctx: Koa.ParameterizedContext, next: Koa.Next) => {
   const sig = ctx.request.headers['stripe-signature'];

--- a/examples/webhook-signing/nestjs/app.controller.ts
+++ b/examples/webhook-signing/nestjs/app.controller.ts
@@ -20,7 +20,6 @@ export class AppController {
   private readonly client: Stripe;
   constructor(@Inject(ConfigService) private readonly config: ConfigService) {
     this.client = new Stripe(this.config.get('Stripe.secret_key'), {
-      apiVersion: '2022-11-15',
       typescript: true,
     });
   }

--- a/examples/webhook-signing/nextjs/pages/api/webhooks.ts
+++ b/examples/webhook-signing/nextjs/pages/api/webhooks.ts
@@ -5,9 +5,7 @@ const handler = async (
   req: NextApiRequest,
   res: NextApiResponse
 ): Promise<void> => {
-  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-    apiVersion: '2023-08-16',
-  });
+  const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
   const webhookSecret: string = process.env.STRIPE_WEBHOOK_SECRET;
 

--- a/examples/webhook-signing/test/main.ts
+++ b/examples/webhook-signing/test/main.ts
@@ -41,9 +41,7 @@ env.config({
 });
 
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
-const stripe = new Stripe(process.env.STRIPE_SECRET_KEY, {
-  apiVersion: '2023-08-16',
-});
+const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 const payload = Buffer.from(
   JSON.stringify(

--- a/scripts/updateAPIVersion.js
+++ b/scripts/updateAPIVersion.js
@@ -51,10 +51,6 @@ const main = () => {
     'types/test/typescriptTest.ts',
     'apiVersion: [\'"]API_VERSION[\'"]'
   );
-  replaceAPIVersion(
-    'testProjects/mjs-ts/index.ts',
-    'apiVersion: [\'"]API_VERSION[\'"]'
-  );
 };
 
 if (require.main === module) {

--- a/testProjects/cloudflare-pages/functions/index.js
+++ b/testProjects/cloudflare-pages/functions/index.js
@@ -5,7 +5,6 @@ export async function onRequestPost({env, request}) {
   const body = await request.text();
 
   const stripe = new Stripe(env.STRIPE_API_KEY, {
-    apiVersion: '2023-08-16',
     httpClient: Stripe.createFetchHttpClient(),
   });
   const webCrypto = Stripe.createSubtleCryptoProvider();

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -231,7 +231,7 @@ declare module 'stripe' {
   export class Stripe {
     static Stripe: typeof Stripe;
 
-    constructor(apiKey: string, config: Stripe.StripeConfig);
+    constructor(apiKey: string, config?: Stripe.StripeConfig);
 
     StripeResource: Stripe.StripeResource;
 

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -44,7 +44,7 @@ declare module 'stripe' {
        *
        * @docs https://stripe.com/docs/api/versioning
        */
-      apiVersion: LatestApiVersion;
+      apiVersion?: LatestApiVersion;
 
       /**
        * Optionally indicate that you are using TypeScript.

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -12,7 +12,6 @@ let stripe = new Stripe('sk_test_123', {
   apiVersion: '2023-10-16',
 });
 
-// @ts-ignore lazily ignore apiVersion requirement.
 stripe = new Stripe('sk_test_123');
 
 stripe = new Stripe('sk_test_123', {


### PR DESCRIPTION
Now that the library is pinned to the latest API version we can remove the requirement to pass the explicit version.