### PR TITLE
Move Webhooks instance to static field

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -45,7 +45,7 @@ type WebhookSignatureObject = {
     receivedAt: number
   ) => Promise<boolean>;
 };
-type WebhookObject = {
+export type WebhookObject = {
   DEFAULT_TOLERANCE: number;
   signature: WebhookSignatureObject;
   constructEvent: (

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -156,7 +156,10 @@ export function createStripe(
     this._setApiKey(key);
 
     this.errors = _Error;
-    this.webhooks = Stripe.webhooks;
+
+    // Once Stripe.webhooks looses the factory function signature in a future release
+    // then this should become this.webhooks = Stripe.webhooks
+    this.webhooks = createWebhooksDefault();
 
     this._prevRequestMetrics = [];
     this._enableTelemetry = props.telemetry !== false;

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -11,7 +11,7 @@ import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {PlatformFunctions} from './platform/PlatformFunctions.js';
 import {RequestSender} from './RequestSender.js';
 import {StripeResource} from './StripeResource.js';
-import {createWebhooks} from './Webhooks.js';
+import {WebhookObject, createWebhooks} from './Webhooks.js';
 import {StripeObject, AppInfo, UserProvidedConfig} from './Types.js';
 
 const DEFAULT_HOST = 'api.stripe.com';
@@ -63,6 +63,20 @@ export function createStripe(
   Stripe.HttpClient = HttpClient;
   Stripe.HttpClientResponse = HttpClientResponse;
   Stripe.CryptoProvider = CryptoProvider;
+
+  // Previously Stripe.webhooks was just the createWebhooks() factory function
+  // however going forward it will be a WebhookObject instance. To maintain
+  // backwards compatibility it is currently a factory function that also
+  // complies to the WebhookObject signature. The factory function signature
+  // will be removed as a breaking change in the next major release.
+  // See https://github.com/stripe/stripe-node/issues/1956
+  function createWebhooksDefault(fns = platformFunctions): WebhookObject {
+    return createWebhooks(fns);
+  }
+  Stripe.webhooks = Object.assign(
+    createWebhooksDefault,
+    createWebhooks(platformFunctions)
+  );
 
   function Stripe(
     this: StripeObject,
@@ -142,7 +156,7 @@ export function createStripe(
     this._setApiKey(key);
 
     this.errors = _Error;
-    this.webhooks = createWebhooks(platformFunctions);
+    this.webhooks = Stripe.webhooks;
 
     this._prevRequestMetrics = [];
     this._enableTelemetry = props.telemetry !== false;
@@ -155,7 +169,6 @@ export function createStripe(
   }
 
   Stripe.errors = _Error;
-  Stripe.webhooks = createWebhooks;
 
   Stripe.createNodeHttpClient = platformFunctions.createNodeHttpClient;
 

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -4,7 +4,6 @@ import {expect} from 'chai';
 import {StripeSignatureVerificationError} from '../src/Error.js';
 import {FakeCryptoProvider, getSpyableStripe} from './testUtils.js';
 import {CryptoProviderOnlySupportsAsyncError} from '../src/crypto/CryptoProvider.js';
-const stripe = getSpyableStripe();
 
 const EVENT_PAYLOAD = {
   id: 'evt_test_webhook',
@@ -13,7 +12,17 @@ const EVENT_PAYLOAD = {
 const EVENT_PAYLOAD_STRING = JSON.stringify(EVENT_PAYLOAD, null, 2);
 const SECRET = 'whsec_test_secret';
 
-describe('Webhooks', () => {
+describe('Webhooks on static Stripe factory', () => {
+  const Stripe = require('../src/stripe.cjs.node.js');
+  createWebhooksTestSuite(Stripe);
+});
+
+describe('Webhooks on Stripe instance', () => {
+  const stripe = getSpyableStripe();
+  createWebhooksTestSuite(stripe);
+});
+
+function createWebhooksTestSuite(stripe) {
   describe('.generateTestHeaderString', () => {
     it('should throw when no opts are passed', () => {
       expect(() => {
@@ -456,4 +465,4 @@ describe('Webhooks', () => {
       stripe.webhooks.signature.verifyHeaderAsync(...args)
     )
   );
-});
+}

--- a/testProjects/mjs/index.js
+++ b/testProjects/mjs/index.js
@@ -61,7 +61,6 @@ assert(stripe.VERSION);
 assert(stripe.errors);
 assert(stripe.webhookEndpoints);
 assert(stripe.webhooks);
-assert(stripe.webhooks === Stripe.webhooks);
 assert(stripe._emitter);
 assert(stripe.on);
 assert(stripe.off);

--- a/testProjects/mjs/index.js
+++ b/testProjects/mjs/index.js
@@ -61,6 +61,7 @@ assert(stripe.VERSION);
 assert(stripe.errors);
 assert(stripe.webhookEndpoints);
 assert(stripe.webhooks);
+assert(stripe.webhooks === Stripe.webhooks);
 assert(stripe._emitter);
 assert(stripe.on);
 assert(stripe.off);

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -233,6 +233,12 @@ declare module 'stripe' {
   export class Stripe {
     static Stripe: typeof Stripe;
 
+    // Actually has the signature `Stripe.Webhooks & ((platformFunctions?: PlatformFunctions) => Stripe.Webhooks)`
+    // However the factory function signature was never public in the typings and
+    // will be removed in the next major version so it is omitted
+    // See https://github.com/stripe/stripe-node/issues/1956
+    static webhooks: Stripe.Webhooks;
+
     constructor(apiKey: string, config?: Stripe.StripeConfig);
 
     StripeResource: Stripe.StripeResource;


### PR DESCRIPTION
See #1956 

`Stripe.webooks` has the following changes
- The `platformFunctions` parameter is now optional, defaulting to the `platformFunctions` instance used by the Stripe object
- It is now also confirms to the `Stripe.Webhooks` signature so that `Stripe.webhooks` can be used as a static reference to the webhook utilities

Furthermore, all `Stripe` instances share the same reference to the static `Stripe.webhooks` object/function.

The function signature will be removed as a breaking change in the next major release.