### PR TITLE
Update docstrings to indicate removal of deprecated event types

### DIFF
--- a/types/EventTypes.d.ts
+++ b/types/EventTypes.d.ts
@@ -3393,8 +3393,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "invoiceitem.updated" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-invoiceitem.updated for details.
+     * The "invoiceitem.updated" event is deprecated and will be removed in the next major version
      */
     interface InvoiceitemUpdatedEvent extends EventBase {
       type: 'invoiceitem.updated';
@@ -3406,8 +3405,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "order.created" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-order.created for details.
+     * The "order.created" event is deprecated and will be removed in the next major version
      */
     interface OrderCreatedEvent extends EventBase {
       type: 'order.created';
@@ -3419,8 +3417,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "recipient.created" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-recipient.created for details.
+     * The "recipient.created" event is deprecated and will be removed in the next major version
      */
     interface RecipientCreatedEvent extends EventBase {
       type: 'recipient.created';
@@ -3432,8 +3429,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "recipient.deleted" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-recipient.deleted for details.
+     * The "recipient.deleted" event is deprecated and will be removed in the next major version
      */
     interface RecipientDeletedEvent extends EventBase {
       type: 'recipient.deleted';
@@ -3445,8 +3441,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "recipient.updated" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-recipient.updated for details.
+     * The "recipient.updated" event is deprecated and will be removed in the next major version
      */
     interface RecipientUpdatedEvent extends EventBase {
       type: 'recipient.updated';
@@ -3458,8 +3453,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "sku.created" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-sku.created for details.
+     * The "sku.created" event is deprecated and will be removed in the next major version
      */
     interface SkuCreatedEvent extends EventBase {
       type: 'sku.created';
@@ -3471,8 +3465,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "sku.deleted" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-sku.deleted for details.
+     * The "sku.deleted" event is deprecated and will be removed in the next major version
      */
     interface SkuDeletedEvent extends EventBase {
       type: 'sku.deleted';
@@ -3484,8 +3477,7 @@ declare module 'stripe' {
     }
 
     /**
-     * The "sku.updated" event type.
-     * See https://stripe.com/docs/api/events/types#event_types-sku.updated for details.
+     * The "sku.updated" event is deprecated and will be removed in the next major version
      */
     interface SkuUpdatedEvent extends EventBase {
       type: 'sku.updated';


### PR DESCRIPTION
These events will be removed in an upcoming major version.

Motivation: https://github.com/stripe/stripe-node/issues/1984