### PR TITLE
Remove https check for *.stripe.com

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1,18 +1,18 @@
 import * as _Error from './Error.js';
 import * as apiVersion from './apiVersion.js';
 import * as resources from './resources.js';
-import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
+import { HttpClient, HttpClientResponse } from './net/HttpClient.js';
 import {
   determineProcessUserAgentProperties,
   pascalToCamelCase,
   validateInteger,
 } from './utils.js';
-import {CryptoProvider} from './crypto/CryptoProvider.js';
-import {PlatformFunctions} from './platform/PlatformFunctions.js';
-import {RequestSender} from './RequestSender.js';
-import {StripeResource} from './StripeResource.js';
-import {WebhookObject, createWebhooks} from './Webhooks.js';
-import {StripeObject, AppInfo, UserProvidedConfig} from './Types.js';
+import { CryptoProvider } from './crypto/CryptoProvider.js';
+import { PlatformFunctions } from './platform/PlatformFunctions.js';
+import { RequestSender } from './RequestSender.js';
+import { StripeResource } from './StripeResource.js';
+import { WebhookObject, createWebhooks } from './Webhooks.js';
+import { StripeObject, AppInfo, UserProvidedConfig } from './Types.js';
 
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';
@@ -103,16 +103,6 @@ export function createStripe(
     this.on = this._emitter.on.bind(this._emitter);
     this.once = this._emitter.once.bind(this._emitter);
     this.off = this._emitter.removeListener.bind(this._emitter);
-
-    if (
-      props.protocol &&
-      props.protocol !== 'https' &&
-      (!props.host || /\.stripe\.com$/.test(props.host))
-    ) {
-      throw new Error(
-        'The `https` protocol must be used when sending requests to `*.stripe.com`'
-      );
-    }
 
     const agent = props.httpAgent || null;
 

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1,18 +1,18 @@
 import * as _Error from './Error.js';
 import * as apiVersion from './apiVersion.js';
 import * as resources from './resources.js';
-import { HttpClient, HttpClientResponse } from './net/HttpClient.js';
+import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
 import {
   determineProcessUserAgentProperties,
   pascalToCamelCase,
   validateInteger,
 } from './utils.js';
-import { CryptoProvider } from './crypto/CryptoProvider.js';
-import { PlatformFunctions } from './platform/PlatformFunctions.js';
-import { RequestSender } from './RequestSender.js';
-import { StripeResource } from './StripeResource.js';
-import { WebhookObject, createWebhooks } from './Webhooks.js';
-import { StripeObject, AppInfo, UserProvidedConfig } from './Types.js';
+import {CryptoProvider} from './crypto/CryptoProvider.js';
+import {PlatformFunctions} from './platform/PlatformFunctions.js';
+import {RequestSender} from './RequestSender.js';
+import {StripeResource} from './StripeResource.js';
+import {WebhookObject, createWebhooks} from './Webhooks.js';
+import {StripeObject, AppInfo, UserProvidedConfig} from './Types.js';
 
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -64,47 +64,6 @@ describe('Stripe Module', function() {
         });
       }).to.not.throw();
     });
-    it('should forbid sending http to *.stripe.com', () => {
-      expect(() => {
-        Stripe(FAKE_API_KEY, {
-          host: 'foo.stripe.com',
-          protocol: 'http',
-        });
-      }).to.throw(/The `https` protocol must be used/);
-
-      expect(() => {
-        Stripe(FAKE_API_KEY, {
-          protocol: 'http',
-        });
-      }).to.throw(/The `https` protocol must be used/);
-
-      expect(() => {
-        Stripe(FAKE_API_KEY, {
-          protocol: 'http',
-          host: 'api.stripe.com',
-        });
-      }).to.throw(/The `https` protocol must be used/);
-
-      expect(() => {
-        Stripe(FAKE_API_KEY, {
-          protocol: 'https',
-          host: 'api.stripe.com',
-        });
-      }).not.to.throw();
-
-      expect(() => {
-        Stripe(FAKE_API_KEY, {
-          host: 'api.stripe.com',
-        });
-      }).not.to.throw();
-
-      expect(() => {
-        Stripe(FAKE_API_KEY, {
-          protocol: 'http',
-          host: 'localhost',
-        });
-      }).not.to.throw();
-    });
 
     it('should perform a no-op if null, undefined or empty values are passed', () => {
       const cases = [null, undefined, '', {}];


### PR DESCRIPTION
As suggested in #2006.

## Summary
There is no analogous check in the other libraries (stripe-ruby, stripe-python), and the use case outlined in #2006 seems legitimate. Considering that setting the protocol to 'http' is something that users need to explicitly opt into anyway, throwing the exception here seems a little heavy-handed in the presence of legitimate use cases.

## Testing
The existing test that asserted that an exception was thrown in this case failed. Then I removed it.

## Changelog
* Stops throwing exceptions if `protocol: 'http'` is set for requests to `api.stripe.com`.
