### PR TITLE
Standardize parameter interface names

### DIFF
--- a/src/resources/Accounts.ts
+++ b/src/resources/Accounts.ts
@@ -71,6 +71,7 @@ export const Accounts = StripeResource.extend({
     method: 'POST',
     fullPath: '/v1/accounts/{account}/reject',
   }),
+  retrieveCurrent: stripeMethod({method: 'GET', fullPath: '/v1/account'}),
   retrieveCapability: stripeMethod({
     method: 'GET',
     fullPath: '/v1/accounts/{account}/capabilities/{capability}',

--- a/src/resources/Customers.ts
+++ b/src/resources/Customers.ts
@@ -12,13 +12,13 @@ export const Customers = StripeResource.extend({
     methodType: 'list',
   }),
   del: stripeMethod({method: 'DELETE', fullPath: '/v1/customers/{customer}'}),
-  createFundingInstructions: stripeMethod({
-    method: 'POST',
-    fullPath: '/v1/customers/{customer}/funding_instructions',
-  }),
   createBalanceTransaction: stripeMethod({
     method: 'POST',
     fullPath: '/v1/customers/{customer}/balance_transactions',
+  }),
+  createFundingInstructions: stripeMethod({
+    method: 'POST',
+    fullPath: '/v1/customers/{customer}/funding_instructions',
   }),
   createSource: stripeMethod({
     method: 'POST',
@@ -40,11 +40,6 @@ export const Customers = StripeResource.extend({
     method: 'DELETE',
     fullPath: '/v1/customers/{customer}/tax_ids/{id}',
   }),
-  listPaymentMethods: stripeMethod({
-    method: 'GET',
-    fullPath: '/v1/customers/{customer}/payment_methods',
-    methodType: 'list',
-  }),
   listBalanceTransactions: stripeMethod({
     method: 'GET',
     fullPath: '/v1/customers/{customer}/balance_transactions',
@@ -53,6 +48,11 @@ export const Customers = StripeResource.extend({
   listCashBalanceTransactions: stripeMethod({
     method: 'GET',
     fullPath: '/v1/customers/{customer}/cash_balance_transactions',
+    methodType: 'list',
+  }),
+  listPaymentMethods: stripeMethod({
+    method: 'GET',
+    fullPath: '/v1/customers/{customer}/payment_methods',
     methodType: 'list',
   }),
   listSources: stripeMethod({
@@ -64,10 +64,6 @@ export const Customers = StripeResource.extend({
     method: 'GET',
     fullPath: '/v1/customers/{customer}/tax_ids',
     methodType: 'list',
-  }),
-  retrievePaymentMethod: stripeMethod({
-    method: 'GET',
-    fullPath: '/v1/customers/{customer}/payment_methods/{payment_method}',
   }),
   retrieveBalanceTransaction: stripeMethod({
     method: 'GET',
@@ -81,6 +77,10 @@ export const Customers = StripeResource.extend({
     method: 'GET',
     fullPath:
       '/v1/customers/{customer}/cash_balance_transactions/{transaction}',
+  }),
+  retrievePaymentMethod: stripeMethod({
+    method: 'GET',
+    fullPath: '/v1/customers/{customer}/payment_methods/{payment_method}',
   }),
   retrieveSource: stripeMethod({
     method: 'GET',

--- a/src/resources/Invoices.ts
+++ b/src/resources/Invoices.ts
@@ -44,6 +44,10 @@ export const Invoices = StripeResource.extend({
     method: 'POST',
     fullPath: '/v1/invoices/{invoice}/send',
   }),
+  updateLineItem: stripeMethod({
+    method: 'POST',
+    fullPath: '/v1/invoices/{invoice}/lines/{line_item_id}',
+  }),
   voidInvoice: stripeMethod({
     method: 'POST',
     fullPath: '/v1/invoices/{invoice}/void',

--- a/types/AccountsResource.d.ts
+++ b/types/AccountsResource.d.ts
@@ -2831,15 +2831,15 @@ declare module 'stripe' {
 
     interface AccountDeleteParams {}
 
-    interface ExternalAccountCreateParams {
+    interface AccountCreateExternalAccountParams {
       /**
        * Please refer to full [documentation](https://stripe.com/docs/api) instead.
        */
       external_account:
         | string
-        | ExternalAccountCreateParams.Card
-        | ExternalAccountCreateParams.BankAccount
-        | ExternalAccountCreateParams.CardToken;
+        | AccountCreateExternalAccountParams.Card
+        | AccountCreateExternalAccountParams.BankAccount
+        | AccountCreateExternalAccountParams.CardToken;
 
       /**
        * When set to true, or if this is the first external account added in this currency, this account becomes the default external account for its currency.
@@ -2857,7 +2857,7 @@ declare module 'stripe' {
       metadata?: Stripe.MetadataParam;
     }
 
-    namespace ExternalAccountCreateParams {
+    namespace AccountCreateExternalAccountParams {
       interface BankAccount {
         object: 'bank_account';
 
@@ -2938,18 +2938,18 @@ declare module 'stripe' {
       }
     }
 
-    interface LoginLinkCreateParams {
+    interface AccountCreateLoginLinkParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface PersonCreateParams {
+    interface AccountCreatePersonParams {
       /**
        * Details on the legal guardian's acceptance of the required Stripe agreements.
        */
-      additional_tos_acceptances?: PersonCreateParams.AdditionalTosAcceptances;
+      additional_tos_acceptances?: AccountCreatePersonParams.AdditionalTosAcceptances;
 
       /**
        * The person's address.
@@ -2969,12 +2969,12 @@ declare module 'stripe' {
       /**
        * The person's date of birth.
        */
-      dob?: Stripe.Emptyable<PersonCreateParams.Dob>;
+      dob?: Stripe.Emptyable<AccountCreatePersonParams.Dob>;
 
       /**
        * Documents that may be submitted to satisfy various informational requests.
        */
-      documents?: PersonCreateParams.Documents;
+      documents?: AccountCreatePersonParams.Documents;
 
       /**
        * The person's email address.
@@ -3074,7 +3074,7 @@ declare module 'stripe' {
       /**
        * The relationship that this person has with the account's legal entity.
        */
-      relationship?: PersonCreateParams.Relationship;
+      relationship?: AccountCreatePersonParams.Relationship;
 
       /**
        * The last four digits of the person's Social Security number (U.S. only).
@@ -3084,10 +3084,10 @@ declare module 'stripe' {
       /**
        * The person's verification status.
        */
-      verification?: PersonCreateParams.Verification;
+      verification?: AccountCreatePersonParams.Verification;
     }
 
-    namespace PersonCreateParams {
+    namespace AccountCreatePersonParams {
       interface AdditionalTosAcceptances {
         /**
          * Details on the legal guardian's acceptance of the main Stripe service agreement.
@@ -3247,18 +3247,18 @@ declare module 'stripe' {
       }
     }
 
-    interface ExternalAccountDeleteParams {}
+    interface AccountDeleteExternalAccountParams {}
 
-    interface PersonDeleteParams {}
+    interface AccountDeletePersonParams {}
 
-    interface CapabilityListParams {
+    interface AccountListCapabilitiesParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface ExternalAccountListParams extends PaginationParams {
+    interface AccountListExternalAccountsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -3267,14 +3267,14 @@ declare module 'stripe' {
       /**
        * Filter external accounts according to a particular object type.
        */
-      object?: ExternalAccountListParams.Object;
+      object?: AccountListExternalAccountsParams.Object;
     }
 
-    namespace ExternalAccountListParams {
+    namespace AccountListExternalAccountsParams {
       type Object = 'bank_account' | 'card';
     }
 
-    interface PersonListParams extends PaginationParams {
+    interface AccountListPersonsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -3283,10 +3283,10 @@ declare module 'stripe' {
       /**
        * Filters on the list of people returned based on the person's relationship to the account's company.
        */
-      relationship?: PersonListParams.Relationship;
+      relationship?: AccountListPersonsParams.Relationship;
     }
 
-    namespace PersonListParams {
+    namespace AccountListPersonsParams {
       interface Relationship {
         /**
          * A filter on the list of people returned based on whether these people are directors of the account's company.
@@ -3327,28 +3327,35 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface CapabilityRetrieveParams {
+    interface AccountRetrieveCurrentParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface ExternalAccountRetrieveParams {
+    interface AccountRetrieveCapabilityParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface PersonRetrieveParams {
+    interface AccountRetrieveExternalAccountParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface CapabilityUpdateParams {
+    interface AccountRetrievePersonParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    interface AccountUpdateCapabilityParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -3362,7 +3369,7 @@ declare module 'stripe' {
       requested?: boolean;
     }
 
-    interface ExternalAccountUpdateParams {
+    interface AccountUpdateExternalAccountParams {
       /**
        * The name of the person or business that owns the bank account.
        */
@@ -3372,13 +3379,13 @@ declare module 'stripe' {
        * The type of entity that holds the account. This can be either `individual` or `company`.
        */
       account_holder_type?: Stripe.Emptyable<
-        ExternalAccountUpdateParams.AccountHolderType
+        AccountUpdateExternalAccountParams.AccountHolderType
       >;
 
       /**
        * The bank account type. This can only be `checking` or `savings` in most countries. In Japan, this can only be `futsu` or `toza`.
        */
-      account_type?: ExternalAccountUpdateParams.AccountType;
+      account_type?: AccountUpdateExternalAccountParams.AccountType;
 
       /**
        * City/District/Suburb/Town/Village.
@@ -3418,7 +3425,7 @@ declare module 'stripe' {
       /**
        * Documents that may be submitted to satisfy various informational requests.
        */
-      documents?: ExternalAccountUpdateParams.Documents;
+      documents?: AccountUpdateExternalAccountParams.Documents;
 
       /**
        * Two digit number representing the card's expiration month.
@@ -3446,7 +3453,7 @@ declare module 'stripe' {
       name?: string;
     }
 
-    namespace ExternalAccountUpdateParams {
+    namespace AccountUpdateExternalAccountParams {
       type AccountHolderType = 'company' | 'individual';
 
       type AccountType = 'checking' | 'futsu' | 'savings' | 'toza';
@@ -3468,11 +3475,11 @@ declare module 'stripe' {
       }
     }
 
-    interface PersonUpdateParams {
+    interface AccountUpdatePersonParams {
       /**
        * Details on the legal guardian's acceptance of the required Stripe agreements.
        */
-      additional_tos_acceptances?: PersonUpdateParams.AdditionalTosAcceptances;
+      additional_tos_acceptances?: AccountUpdatePersonParams.AdditionalTosAcceptances;
 
       /**
        * The person's address.
@@ -3492,12 +3499,12 @@ declare module 'stripe' {
       /**
        * The person's date of birth.
        */
-      dob?: Stripe.Emptyable<PersonUpdateParams.Dob>;
+      dob?: Stripe.Emptyable<AccountUpdatePersonParams.Dob>;
 
       /**
        * Documents that may be submitted to satisfy various informational requests.
        */
-      documents?: PersonUpdateParams.Documents;
+      documents?: AccountUpdatePersonParams.Documents;
 
       /**
        * The person's email address.
@@ -3597,7 +3604,7 @@ declare module 'stripe' {
       /**
        * The relationship that this person has with the account's legal entity.
        */
-      relationship?: PersonUpdateParams.Relationship;
+      relationship?: AccountUpdatePersonParams.Relationship;
 
       /**
        * The last four digits of the person's Social Security number (U.S. only).
@@ -3607,10 +3614,10 @@ declare module 'stripe' {
       /**
        * The person's verification status.
        */
-      verification?: PersonUpdateParams.Verification;
+      verification?: AccountUpdatePersonParams.Verification;
     }
 
-    namespace PersonUpdateParams {
+    namespace AccountUpdatePersonParams {
       interface AdditionalTosAcceptances {
         /**
          * Details on the legal guardian's acceptance of the main Stripe service agreement.
@@ -3859,7 +3866,7 @@ declare module 'stripe' {
        */
       createExternalAccount(
         id: string,
-        params: ExternalAccountCreateParams,
+        params: AccountCreateExternalAccountParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
 
@@ -3870,7 +3877,7 @@ declare module 'stripe' {
        */
       createLoginLink(
         id: string,
-        params?: LoginLinkCreateParams,
+        params?: AccountCreateLoginLinkParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.LoginLink>>;
       createLoginLink(
@@ -3883,7 +3890,7 @@ declare module 'stripe' {
        */
       createPerson(
         id: string,
-        params?: PersonCreateParams,
+        params?: AccountCreatePersonParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Person>>;
       createPerson(
@@ -3897,7 +3904,7 @@ declare module 'stripe' {
       deleteExternalAccount(
         accountId: string,
         id: string,
-        params?: ExternalAccountDeleteParams,
+        params?: AccountDeleteExternalAccountParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.DeletedExternalAccount>>;
       deleteExternalAccount(
@@ -3912,7 +3919,7 @@ declare module 'stripe' {
       deletePerson(
         accountId: string,
         id: string,
-        params?: PersonDeleteParams,
+        params?: AccountDeletePersonParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.DeletedPerson>>;
       deletePerson(
@@ -3926,7 +3933,7 @@ declare module 'stripe' {
        */
       listCapabilities(
         id: string,
-        params?: CapabilityListParams,
+        params?: AccountListCapabilitiesParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.Capability>;
       listCapabilities(
@@ -3939,7 +3946,7 @@ declare module 'stripe' {
        */
       listExternalAccounts(
         id: string,
-        params?: ExternalAccountListParams,
+        params?: AccountListExternalAccountsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.ExternalAccount>;
       listExternalAccounts(
@@ -3952,7 +3959,7 @@ declare module 'stripe' {
        */
       listPersons(
         id: string,
-        params?: PersonListParams,
+        params?: AccountListPersonsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.Person>;
       listPersons(
@@ -3972,12 +3979,23 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.Account>>;
 
       /**
+       * Retrieves the details of an account.
+       */
+      retrieveCurrent(
+        params?: AccountRetrieveCurrentParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Account>>;
+      retrieveCurrent(
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.Account>>;
+
+      /**
        * Retrieves information about the specified Account Capability.
        */
       retrieveCapability(
         accountId: string,
         id: string,
-        params?: CapabilityRetrieveParams,
+        params?: AccountRetrieveCapabilityParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Capability>>;
       retrieveCapability(
@@ -3992,7 +4010,7 @@ declare module 'stripe' {
       retrieveExternalAccount(
         accountId: string,
         id: string,
-        params?: ExternalAccountRetrieveParams,
+        params?: AccountRetrieveExternalAccountParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
       retrieveExternalAccount(
@@ -4007,7 +4025,7 @@ declare module 'stripe' {
       retrievePerson(
         accountId: string,
         id: string,
-        params?: PersonRetrieveParams,
+        params?: AccountRetrievePersonParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Person>>;
       retrievePerson(
@@ -4022,7 +4040,7 @@ declare module 'stripe' {
       updateCapability(
         accountId: string,
         id: string,
-        params?: CapabilityUpdateParams,
+        params?: AccountUpdateCapabilityParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Capability>>;
       updateCapability(
@@ -4039,7 +4057,7 @@ declare module 'stripe' {
       updateExternalAccount(
         accountId: string,
         id: string,
-        params?: ExternalAccountUpdateParams,
+        params?: AccountUpdateExternalAccountParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.ExternalAccount>>;
       updateExternalAccount(
@@ -4054,7 +4072,7 @@ declare module 'stripe' {
       updatePerson(
         accountId: string,
         id: string,
-        params?: PersonUpdateParams,
+        params?: AccountUpdatePersonParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Person>>;
       updatePerson(

--- a/types/ApplicationFeesResource.d.ts
+++ b/types/ApplicationFeesResource.d.ts
@@ -23,7 +23,7 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface FeeRefundCreateParams {
+    interface ApplicationFeeCreateRefundParams {
       /**
        * A positive integer, in _cents (or local equivalent)_, representing how much of this fee to refund. Can refund only up to the remaining unrefunded amount of the fee.
        */
@@ -40,21 +40,21 @@ declare module 'stripe' {
       metadata?: Stripe.MetadataParam;
     }
 
-    interface FeeRefundListParams extends PaginationParams {
+    interface ApplicationFeeListRefundsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface FeeRefundRetrieveParams {
+    interface ApplicationFeeRetrieveRefundParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface FeeRefundUpdateParams {
+    interface ApplicationFeeUpdateRefundParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -102,7 +102,7 @@ declare module 'stripe' {
        */
       createRefund(
         id: string,
-        params?: FeeRefundCreateParams,
+        params?: ApplicationFeeCreateRefundParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.FeeRefund>>;
       createRefund(
@@ -115,7 +115,7 @@ declare module 'stripe' {
        */
       listRefunds(
         id: string,
-        params?: FeeRefundListParams,
+        params?: ApplicationFeeListRefundsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.FeeRefund>;
       listRefunds(
@@ -129,7 +129,7 @@ declare module 'stripe' {
       retrieveRefund(
         feeId: string,
         id: string,
-        params?: FeeRefundRetrieveParams,
+        params?: ApplicationFeeRetrieveRefundParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.FeeRefund>>;
       retrieveRefund(
@@ -146,7 +146,7 @@ declare module 'stripe' {
       updateRefund(
         feeId: string,
         id: string,
-        params?: FeeRefundUpdateParams,
+        params?: ApplicationFeeUpdateRefundParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.FeeRefund>>;
       updateRefund(

--- a/types/CreditNotesResource.d.ts
+++ b/types/CreditNotesResource.d.ts
@@ -193,7 +193,7 @@ declare module 'stripe' {
       invoice?: string;
     }
 
-    interface CreditNoteLineItemListParams extends PaginationParams {
+    interface CreditNoteListLineItemsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -565,7 +565,7 @@ declare module 'stripe' {
        */
       listLineItems(
         id: string,
-        params?: CreditNoteLineItemListParams,
+        params?: CreditNoteListLineItemsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.CreditNoteLineItem>;
       listLineItems(

--- a/types/CustomersResource.d.ts
+++ b/types/CustomersResource.d.ts
@@ -534,6 +534,33 @@ declare module 'stripe' {
 
     interface CustomerDeleteParams {}
 
+    interface CustomerCreateBalanceTransactionParams {
+      /**
+       * The integer amount in **cents (or local equivalent)** to apply to the customer's credit balance.
+       */
+      amount: number;
+
+      /**
+       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). Specifies the [`invoice_credit_balance`](https://stripe.com/docs/api/customers/object#customer_object-invoice_credit_balance) that this transaction will apply to. If the customer's `currency` is not set, it will be updated to this value.
+       */
+      currency: string;
+
+      /**
+       * An arbitrary string attached to the object. Often useful for displaying to users.
+       */
+      description?: string;
+
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+
+      /**
+       * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+       */
+      metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
+    }
+
     interface CustomerCreateFundingInstructionsParams {
       /**
        * Additional parameters for `bank_transfer` funding types
@@ -595,34 +622,7 @@ declare module 'stripe' {
       }
     }
 
-    interface CustomerBalanceTransactionCreateParams {
-      /**
-       * The integer amount in **cents (or local equivalent)** to apply to the customer's credit balance.
-       */
-      amount: number;
-
-      /**
-       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). Specifies the [`invoice_credit_balance`](https://stripe.com/docs/api/customers/object#customer_object-invoice_credit_balance) that this transaction will apply to. If the customer's `currency` is not set, it will be updated to this value.
-       */
-      currency: string;
-
-      /**
-       * An arbitrary string attached to the object. Often useful for displaying to users.
-       */
-      description?: string;
-
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-
-      /**
-       * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
-       */
-      metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
-    }
-
-    interface CustomerSourceCreateParams {
+    interface CustomerCreateSourceParams {
       /**
        * Please refer to full [documentation](https://stripe.com/docs/api) instead.
        */
@@ -641,11 +641,11 @@ declare module 'stripe' {
       validate?: boolean;
     }
 
-    interface TaxIdCreateParams {
+    interface CustomerCreateTaxIdParams {
       /**
        * Type of the tax ID, one of `ad_nrt`, `ae_trn`, `ar_cuit`, `au_abn`, `au_arn`, `bg_uic`, `bo_tin`, `br_cnpj`, `br_cpf`, `ca_bn`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `ca_qst`, `ch_vat`, `cl_tin`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eg_tin`, `es_cif`, `eu_oss_vat`, `eu_vat`, `gb_vat`, `ge_vat`, `hk_br`, `hu_tin`, `id_npwp`, `il_vat`, `in_gst`, `is_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `ke_pin`, `kr_brn`, `li_uid`, `mx_rfc`, `my_frp`, `my_itn`, `my_sst`, `no_vat`, `no_voec`, `nz_gst`, `pe_ruc`, `ph_tin`, `ro_tin`, `rs_pib`, `ru_inn`, `ru_kpp`, `sa_vat`, `sg_gst`, `sg_uen`, `si_tin`, `sv_nit`, `th_vat`, `tr_tin`, `tw_vat`, `ua_vat`, `us_ein`, `uy_ruc`, `ve_rif`, `vn_tin`, or `za_vat`
        */
-      type: TaxIdCreateParams.Type;
+      type: CustomerCreateTaxIdParams.Type;
 
       /**
        * Value of the tax ID.
@@ -658,7 +658,7 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    namespace TaxIdCreateParams {
+    namespace CustomerCreateTaxIdParams {
       type Type =
         | 'ad_nrt'
         | 'ae_trn'
@@ -731,14 +731,29 @@ declare module 'stripe' {
 
     interface CustomerDeleteDiscountParams {}
 
-    interface CustomerSourceDeleteParams {
+    interface CustomerDeleteSourceParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface TaxIdDeleteParams {}
+    interface CustomerDeleteTaxIdParams {}
+
+    interface CustomerListBalanceTransactionsParams extends PaginationParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    interface CustomerListCashBalanceTransactionsParams
+      extends PaginationParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
 
     interface CustomerListPaymentMethodsParams extends PaginationParams {
       /**
@@ -789,22 +804,7 @@ declare module 'stripe' {
         | 'zip';
     }
 
-    interface CustomerBalanceTransactionListParams extends PaginationParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
-    interface CustomerCashBalanceTransactionListParams
-      extends PaginationParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
-    interface CustomerSourceListParams extends PaginationParams {
+    interface CustomerListSourcesParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -816,7 +816,28 @@ declare module 'stripe' {
       object?: string;
     }
 
-    interface TaxIdListParams extends PaginationParams {
+    interface CustomerListTaxIdsParams extends PaginationParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    interface CustomerRetrieveBalanceTransactionParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    interface CustomerRetrieveCashBalanceParams {
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+    }
+
+    interface CustomerRetrieveCashBalanceTransactionParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -830,35 +851,14 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface CustomerBalanceTransactionRetrieveParams {
+    interface CustomerRetrieveSourceParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface CashBalanceRetrieveParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
-    interface CustomerCashBalanceTransactionRetrieveParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
-    interface CustomerSourceRetrieveParams {
-      /**
-       * Specifies which fields in the response should be expanded.
-       */
-      expand?: Array<string>;
-    }
-
-    interface TaxIdRetrieveParams {
+    interface CustomerRetrieveTaxIdParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -887,7 +887,7 @@ declare module 'stripe' {
       page?: string;
     }
 
-    interface CustomerBalanceTransactionUpdateParams {
+    interface CustomerUpdateBalanceTransactionParams {
       /**
        * An arbitrary string attached to the object. Often useful for displaying to users.
        */
@@ -904,7 +904,7 @@ declare module 'stripe' {
       metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
     }
 
-    interface CashBalanceUpdateParams {
+    interface CustomerUpdateCashBalanceParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -913,10 +913,10 @@ declare module 'stripe' {
       /**
        * A hash of settings for this cash balance.
        */
-      settings?: CashBalanceUpdateParams.Settings;
+      settings?: CustomerUpdateCashBalanceParams.Settings;
     }
 
-    namespace CashBalanceUpdateParams {
+    namespace CustomerUpdateCashBalanceParams {
       interface Settings {
         /**
          * Controls how funds transferred by the customer are applied to payment intents and invoices. Valid options are `automatic`, `manual`, or `merchant_default`. For more information about these reconciliation modes, see [Reconciliation](https://stripe.com/docs/payments/customer-balance/reconciliation).
@@ -929,7 +929,7 @@ declare module 'stripe' {
       }
     }
 
-    interface CustomerSourceUpdateParams {
+    interface CustomerUpdateSourceParams {
       /**
        * The name of the person or business that owns the bank account.
        */
@@ -938,7 +938,7 @@ declare module 'stripe' {
       /**
        * The type of entity that holds the account. This can be either `individual` or `company`.
        */
-      account_holder_type?: CustomerSourceUpdateParams.AccountHolderType;
+      account_holder_type?: CustomerUpdateSourceParams.AccountHolderType;
 
       /**
        * City/District/Suburb/Town/Village.
@@ -995,10 +995,10 @@ declare module 'stripe' {
        */
       name?: string;
 
-      owner?: CustomerSourceUpdateParams.Owner;
+      owner?: CustomerUpdateSourceParams.Owner;
     }
 
-    namespace CustomerSourceUpdateParams {
+    namespace CustomerUpdateSourceParams {
       type AccountHolderType = 'company' | 'individual';
 
       interface Owner {
@@ -1024,7 +1024,7 @@ declare module 'stripe' {
       }
     }
 
-    interface CustomerSourceVerifyParams {
+    interface CustomerVerifySourceParams {
       /**
        * Two positive integers, in *cents*, equal to the values of the microdeposits sent to the bank account.
        */
@@ -1095,6 +1095,15 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.DeletedCustomer>>;
 
       /**
+       * Creates an immutable transaction that updates the customer's credit [balance](https://stripe.com/docs/billing/customer/balance).
+       */
+      createBalanceTransaction(
+        id: string,
+        params: CustomerCreateBalanceTransactionParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
+
+      /**
        * Retrieve funding instructions for a customer cash balance. If funding instructions do not yet exist for the customer, new
        * funding instructions will be created. If funding instructions have already been created for a given customer, the same
        * funding instructions will be retrieved. In other words, we will return the same funding instructions each time.
@@ -1106,15 +1115,6 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.FundingInstructions>>;
 
       /**
-       * Creates an immutable transaction that updates the customer's credit [balance](https://stripe.com/docs/billing/customer/balance).
-       */
-      createBalanceTransaction(
-        id: string,
-        params: CustomerBalanceTransactionCreateParams,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
-
-      /**
        * When you create a new credit card, you must specify a customer or recipient on which to create it.
        *
        * If the card's owner has no default card, then the new card will become the default.
@@ -1123,7 +1123,7 @@ declare module 'stripe' {
        */
       createSource(
         id: string,
-        params: CustomerSourceCreateParams,
+        params: CustomerCreateSourceParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.CustomerSource>>;
 
@@ -1132,7 +1132,7 @@ declare module 'stripe' {
        */
       createTaxId(
         id: string,
-        params: TaxIdCreateParams,
+        params: CustomerCreateTaxIdParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.TaxId>>;
 
@@ -1155,7 +1155,7 @@ declare module 'stripe' {
       deleteSource(
         customerId: string,
         id: string,
-        params?: CustomerSourceDeleteParams,
+        params?: CustomerDeleteSourceParams,
         options?: RequestOptions
       ): Promise<
         Stripe.Response<Stripe.CustomerSource | Stripe.DeletedCustomerSource>
@@ -1174,7 +1174,7 @@ declare module 'stripe' {
       deleteTaxId(
         customerId: string,
         id: string,
-        params?: TaxIdDeleteParams,
+        params?: CustomerDeleteTaxIdParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.DeletedTaxId>>;
       deleteTaxId(
@@ -1182,6 +1182,32 @@ declare module 'stripe' {
         id: string,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.DeletedTaxId>>;
+
+      /**
+       * Returns a list of transactions that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
+       */
+      listBalanceTransactions(
+        id: string,
+        params?: CustomerListBalanceTransactionsParams,
+        options?: RequestOptions
+      ): ApiListPromise<Stripe.CustomerBalanceTransaction>;
+      listBalanceTransactions(
+        id: string,
+        options?: RequestOptions
+      ): ApiListPromise<Stripe.CustomerBalanceTransaction>;
+
+      /**
+       * Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
+       */
+      listCashBalanceTransactions(
+        id: string,
+        params?: CustomerListCashBalanceTransactionsParams,
+        options?: RequestOptions
+      ): ApiListPromise<Stripe.CustomerCashBalanceTransaction>;
+      listCashBalanceTransactions(
+        id: string,
+        options?: RequestOptions
+      ): ApiListPromise<Stripe.CustomerCashBalanceTransaction>;
 
       /**
        * Returns a list of PaymentMethods for a given Customer
@@ -1197,37 +1223,11 @@ declare module 'stripe' {
       ): ApiListPromise<Stripe.PaymentMethod>;
 
       /**
-       * Returns a list of transactions that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
-       */
-      listBalanceTransactions(
-        id: string,
-        params?: CustomerBalanceTransactionListParams,
-        options?: RequestOptions
-      ): ApiListPromise<Stripe.CustomerBalanceTransaction>;
-      listBalanceTransactions(
-        id: string,
-        options?: RequestOptions
-      ): ApiListPromise<Stripe.CustomerBalanceTransaction>;
-
-      /**
-       * Returns a list of transactions that modified the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
-       */
-      listCashBalanceTransactions(
-        id: string,
-        params?: CustomerCashBalanceTransactionListParams,
-        options?: RequestOptions
-      ): ApiListPromise<Stripe.CustomerCashBalanceTransaction>;
-      listCashBalanceTransactions(
-        id: string,
-        options?: RequestOptions
-      ): ApiListPromise<Stripe.CustomerCashBalanceTransaction>;
-
-      /**
        * List sources for a specified customer.
        */
       listSources(
         id: string,
-        params?: CustomerSourceListParams,
+        params?: CustomerListSourcesParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.CustomerSource>;
       listSources(
@@ -1240,13 +1240,56 @@ declare module 'stripe' {
        */
       listTaxIds(
         id: string,
-        params?: TaxIdListParams,
+        params?: CustomerListTaxIdsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.TaxId>;
       listTaxIds(
         id: string,
         options?: RequestOptions
       ): ApiListPromise<Stripe.TaxId>;
+
+      /**
+       * Retrieves a specific customer balance transaction that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
+       */
+      retrieveBalanceTransaction(
+        customerId: string,
+        id: string,
+        params?: CustomerRetrieveBalanceTransactionParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
+      retrieveBalanceTransaction(
+        customerId: string,
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
+
+      /**
+       * Retrieves a customer's cash balance.
+       */
+      retrieveCashBalance(
+        id: string,
+        params?: CustomerRetrieveCashBalanceParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CashBalance>>;
+      retrieveCashBalance(
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CashBalance>>;
+
+      /**
+       * Retrieves a specific cash balance transaction, which updated the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
+       */
+      retrieveCashBalanceTransaction(
+        customerId: string,
+        id: string,
+        params?: CustomerRetrieveCashBalanceTransactionParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CustomerCashBalanceTransaction>>;
+      retrieveCashBalanceTransaction(
+        customerId: string,
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.CustomerCashBalanceTransaction>>;
 
       /**
        * Retrieves a PaymentMethod object for a given Customer.
@@ -1264,55 +1307,12 @@ declare module 'stripe' {
       ): Promise<Stripe.Response<Stripe.PaymentMethod>>;
 
       /**
-       * Retrieves a specific customer balance transaction that updated the customer's [balances](https://stripe.com/docs/billing/customer/balance).
-       */
-      retrieveBalanceTransaction(
-        customerId: string,
-        id: string,
-        params?: CustomerBalanceTransactionRetrieveParams,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
-      retrieveBalanceTransaction(
-        customerId: string,
-        id: string,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
-
-      /**
-       * Retrieves a customer's cash balance.
-       */
-      retrieveCashBalance(
-        id: string,
-        params?: CashBalanceRetrieveParams,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CashBalance>>;
-      retrieveCashBalance(
-        id: string,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CashBalance>>;
-
-      /**
-       * Retrieves a specific cash balance transaction, which updated the customer's [cash balance](https://stripe.com/docs/payments/customer-balance).
-       */
-      retrieveCashBalanceTransaction(
-        customerId: string,
-        id: string,
-        params?: CustomerCashBalanceTransactionRetrieveParams,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CustomerCashBalanceTransaction>>;
-      retrieveCashBalanceTransaction(
-        customerId: string,
-        id: string,
-        options?: RequestOptions
-      ): Promise<Stripe.Response<Stripe.CustomerCashBalanceTransaction>>;
-
-      /**
        * Retrieve a specified source for a given customer.
        */
       retrieveSource(
         customerId: string,
         id: string,
-        params?: CustomerSourceRetrieveParams,
+        params?: CustomerRetrieveSourceParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.CustomerSource>>;
       retrieveSource(
@@ -1327,7 +1327,7 @@ declare module 'stripe' {
       retrieveTaxId(
         customerId: string,
         id: string,
-        params?: TaxIdRetrieveParams,
+        params?: CustomerRetrieveTaxIdParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.TaxId>>;
       retrieveTaxId(
@@ -1353,7 +1353,7 @@ declare module 'stripe' {
       updateBalanceTransaction(
         customerId: string,
         id: string,
-        params?: CustomerBalanceTransactionUpdateParams,
+        params?: CustomerUpdateBalanceTransactionParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.CustomerBalanceTransaction>>;
       updateBalanceTransaction(
@@ -1367,7 +1367,7 @@ declare module 'stripe' {
        */
       updateCashBalance(
         id: string,
-        params?: CashBalanceUpdateParams,
+        params?: CustomerUpdateCashBalanceParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.CashBalance>>;
       updateCashBalance(
@@ -1381,7 +1381,7 @@ declare module 'stripe' {
       updateSource(
         customerId: string,
         id: string,
-        params?: CustomerSourceUpdateParams,
+        params?: CustomerUpdateSourceParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.CustomerSource>>;
       updateSource(
@@ -1396,7 +1396,7 @@ declare module 'stripe' {
       verifySource(
         customerId: string,
         id: string,
-        params?: CustomerSourceVerifyParams,
+        params?: CustomerVerifySourceParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.BankAccount>>;
       verifySource(

--- a/types/Deprecations.d.ts
+++ b/types/Deprecations.d.ts
@@ -1,5 +1,6 @@
 declare module 'stripe' {
   namespace Stripe {
+    // TODO (MAJOR): go/j/DEVSDK-1812 remove the entire file
     /**
      * The resulting source of [a Connect platform debiting a connected account](https://stripe.com/docs/connect/account-debits#charging-a-connected-account).
      * @deprecated prefer Stripe.Account

--- a/types/Deprecations.d.ts
+++ b/types/Deprecations.d.ts
@@ -68,16 +68,6 @@ declare module 'stripe' {
     type CustomerCashBalanceTransactionRetrieveParams = CustomerRetrieveCashBalanceTransactionParams;
 
     /**
-     * @deprecated prefer {@link CustomerListPaymentMethodsParams}
-     **/
-    type CustomerListPaymentMethodsParams = CustomerListPaymentMethodsParams;
-
-    /**
-     * @deprecated prefer {@link CustomerRetrievePaymentMethodParams}
-     **/
-    type CustomerRetrievePaymentMethodParams = CustomerRetrievePaymentMethodParams;
-
-    /**
      * @deprecated prefer {@link CustomerCreateSourceParams}
      **/
     type CustomerSourceCreateParams = CustomerCreateSourceParams;

--- a/types/Deprecations.d.ts
+++ b/types/Deprecations.d.ts
@@ -1,0 +1,244 @@
+declare module 'stripe' {
+  namespace Stripe {
+    /**
+     * The resulting source of [a Connect platform debiting a connected account](https://stripe.com/docs/connect/account-debits#charging-a-connected-account).
+     * @deprecated prefer Stripe.Account
+     */
+    type AccountDebitSource = Account;
+
+    /**
+     * @deprecated prefer {@link AccountListCapabilitiesParams}
+     **/
+    type CapabilityListParams = AccountListCapabilitiesParams;
+
+    /**
+     * @deprecated prefer {@link AccountRetrieveCapabilityParams}
+     **/
+    type CapabilityRetrieveParams = AccountRetrieveCapabilityParams;
+
+    /**
+     * @deprecated prefer {@link AccountUpdateCapabilityParams}
+     **/
+    type CapabilityUpdateParams = AccountUpdateCapabilityParams;
+
+    /**
+     * @deprecated prefer {@link CustomerRetrieveCashBalanceParams}
+     **/
+    type CashBalanceRetrieveParams = CustomerRetrieveCashBalanceParams;
+
+    /**
+     * @deprecated prefer {@link CustomerUpdateCashBalanceParams}
+     **/
+    type CashBalanceUpdateParams = CustomerUpdateCashBalanceParams;
+
+    /**
+     * @deprecated prefer {@link CreditNoteListLineItemsParams}
+     **/
+    type CreditNoteLineItemListParams = CreditNoteListLineItemsParams;
+
+    /**
+     * @deprecated prefer {@link CustomerCreateBalanceTransactionParams}
+     **/
+    type CustomerBalanceTransactionCreateParams = CustomerCreateBalanceTransactionParams;
+
+    /**
+     * @deprecated prefer {@link CustomerListBalanceTransactionsParams}
+     **/
+    type CustomerBalanceTransactionListParams = CustomerListBalanceTransactionsParams;
+
+    /**
+     * @deprecated prefer {@link CustomerRetrieveBalanceTransactionParams}
+     **/
+    type CustomerBalanceTransactionRetrieveParams = CustomerRetrieveBalanceTransactionParams;
+
+    /**
+     * @deprecated prefer {@link CustomerUpdateBalanceTransactionParams}
+     **/
+    type CustomerBalanceTransactionUpdateParams = CustomerUpdateBalanceTransactionParams;
+
+    /**
+     * @deprecated prefer {@link CustomerListCashBalanceTransactionsParams}
+     **/
+    type CustomerCashBalanceTransactionListParams = CustomerListCashBalanceTransactionsParams;
+
+    /**
+     * @deprecated prefer {@link CustomerRetrieveCashBalanceTransactionParams}
+     **/
+    type CustomerCashBalanceTransactionRetrieveParams = CustomerRetrieveCashBalanceTransactionParams;
+
+    /**
+     * @deprecated prefer {@link CustomerListPaymentMethodsParams}
+     **/
+    type CustomerListPaymentMethodsParams = CustomerListPaymentMethodsParams;
+
+    /**
+     * @deprecated prefer {@link CustomerRetrievePaymentMethodParams}
+     **/
+    type CustomerRetrievePaymentMethodParams = CustomerRetrievePaymentMethodParams;
+
+    /**
+     * @deprecated prefer {@link CustomerCreateSourceParams}
+     **/
+    type CustomerSourceCreateParams = CustomerCreateSourceParams;
+
+    /**
+     * @deprecated prefer {@link CustomerDeleteSourceParams}
+     **/
+    type CustomerSourceDeleteParams = CustomerDeleteSourceParams;
+
+    /**
+     * @deprecated prefer {@link CustomerListSourcesParams}
+     **/
+    type CustomerSourceListParams = CustomerListSourcesParams;
+
+    /**
+     * @deprecated prefer {@link CustomerRetrieveSourceParams}
+     **/
+    type CustomerSourceRetrieveParams = CustomerRetrieveSourceParams;
+
+    /**
+     * @deprecated prefer {@link CustomerUpdateSourceParams}
+     **/
+    type CustomerSourceUpdateParams = CustomerUpdateSourceParams;
+
+    /**
+     * @deprecated prefer {@link CustomerVerifySourceParams}
+     **/
+    type CustomerSourceVerifyParams = CustomerVerifySourceParams;
+
+    /**
+     * @deprecated prefer {@link AccountCreateExternalAccountParams}
+     **/
+    type ExternalAccountCreateParams = AccountCreateExternalAccountParams;
+
+    /**
+     * @deprecated prefer {@link AccountDeleteExternalAccountParams}
+     **/
+    type ExternalAccountDeleteParams = AccountDeleteExternalAccountParams;
+
+    /**
+     * @deprecated prefer {@link AccountListExternalAccountsParams}
+     **/
+    type ExternalAccountListParams = AccountListExternalAccountsParams;
+
+    /**
+     * @deprecated prefer {@link AccountRetrieveExternalAccountParams}
+     **/
+    type ExternalAccountRetrieveParams = AccountRetrieveExternalAccountParams;
+
+    /**
+     * @deprecated prefer {@link AccountUpdateExternalAccountParams}
+     **/
+    type ExternalAccountUpdateParams = AccountUpdateExternalAccountParams;
+
+    /**
+     * @deprecated prefer {@link ApplicationFeeCreateRefundParams}
+     **/
+    type FeeRefundCreateParams = ApplicationFeeCreateRefundParams;
+
+    /**
+     * @deprecated prefer {@link ApplicationFeeListRefundsParams}
+     **/
+    type FeeRefundListParams = ApplicationFeeListRefundsParams;
+
+    /**
+     * @deprecated prefer {@link ApplicationFeeRetrieveRefundParams}
+     **/
+    type FeeRefundRetrieveParams = ApplicationFeeRetrieveRefundParams;
+
+    /**
+     * @deprecated prefer {@link ApplicationFeeUpdateRefundParams}
+     **/
+    type FeeRefundUpdateParams = ApplicationFeeUpdateRefundParams;
+
+    /**
+     * @deprecated prefer {@link InvoiceListLineItemsParams}
+     **/
+    type InvoiceLineItemListParams = InvoiceListLineItemsParams;
+
+    /**
+     * @deprecated prefer {@link InvoiceUpdateLineItemParams}
+     **/
+    type InvoiceLineItemUpdateParams = InvoiceUpdateLineItemParams;
+
+    /**
+     * @deprecated prefer {@link AccountCreateLoginLinkParams}
+     **/
+    type LoginLinkCreateParams = AccountCreateLoginLinkParams;
+
+    /**
+     * @deprecated prefer {@link AccountCreatePersonParams}
+     **/
+    type PersonCreateParams = AccountCreatePersonParams;
+
+    /**
+     * @deprecated prefer {@link AccountDeletePersonParams}
+     **/
+    type PersonDeleteParams = AccountDeletePersonParams;
+
+    /**
+     * @deprecated prefer {@link AccountListPersonsParams}
+     **/
+    type PersonListParams = AccountListPersonsParams;
+
+    /**
+     * @deprecated prefer {@link AccountRetrievePersonParams}
+     **/
+    type PersonRetrieveParams = AccountRetrievePersonParams;
+
+    /**
+     * @deprecated prefer {@link AccountUpdatePersonParams}
+     **/
+    type PersonUpdateParams = AccountUpdatePersonParams;
+
+    /**
+     * @deprecated prefer {@link CustomerCreateTaxIdParams}
+     **/
+    type TaxIdCreateParams = CustomerCreateTaxIdParams;
+
+    /**
+     * @deprecated prefer {@link CustomerDeleteTaxIdParams}
+     **/
+    type TaxIdDeleteParams = CustomerDeleteTaxIdParams;
+
+    /**
+     * @deprecated prefer {@link CustomerListTaxIdsParams}
+     **/
+    type TaxIdListParams = CustomerListTaxIdsParams;
+
+    /**
+     * @deprecated prefer {@link CustomerRetrieveTaxIdParams}
+     **/
+    type TaxIdRetrieveParams = CustomerRetrieveTaxIdParams;
+
+    /**
+     * @deprecated prefer {@link TransferCreateReversalParams}
+     **/
+    type TransferReversalCreateParams = TransferCreateReversalParams;
+
+    /**
+     * @deprecated prefer {@link TransferListReversalsParams}
+     **/
+    type TransferReversalListParams = TransferListReversalsParams;
+
+    /**
+     * @deprecated prefer {@link TransferRetrieveReversalParams}
+     **/
+    type TransferReversalRetrieveParams = TransferRetrieveReversalParams;
+
+    /**
+     * @deprecated prefer {@link TransferUpdateReversalParams}
+     **/
+    type TransferReversalUpdateParams = TransferUpdateReversalParams;
+
+    /**
+     * @deprecated prefer {@link SubscriptionItemCreateUsageRecordParams}
+     **/
+    type UsageRecordCreateParams = SubscriptionItemCreateUsageRecordParams;
+
+    /**
+     * @deprecated prefer {@link SubscriptionItemListUsageRecordSummariesParams}
+     **/
+    type UsageRecordSummaryListParams = SubscriptionItemListUsageRecordSummariesParams;
+  }
+}

--- a/types/InvoicesResource.d.ts
+++ b/types/InvoicesResource.d.ts
@@ -1438,7 +1438,7 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
-    interface InvoiceLineItemListParams extends PaginationParams {
+    interface InvoiceListLineItemsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -2718,6 +2718,239 @@ declare module 'stripe' {
       expand?: Array<string>;
     }
 
+    interface InvoiceUpdateLineItemParams {
+      /**
+       * The integer amount in cents (or local equivalent) of the charge to be applied to the upcoming invoice. If you want to apply a credit to the customer's account, pass a negative amount.
+       */
+      amount?: number;
+
+      /**
+       * An arbitrary string which you can attach to the invoice item. The description is displayed in the invoice for easy tracking.
+       */
+      description?: string;
+
+      /**
+       * Controls whether discounts apply to this line item. Defaults to false for prorations or negative line items, and true for all other line items. Cannot be set to true for prorations.
+       */
+      discountable?: boolean;
+
+      /**
+       * The coupons & existing discounts which apply to the line item. Item discounts are applied before invoice discounts. Pass an empty string to remove previously-defined discounts.
+       */
+      discounts?: Stripe.Emptyable<Array<InvoiceUpdateLineItemParams.Discount>>;
+
+      /**
+       * Specifies which fields in the response should be expanded.
+       */
+      expand?: Array<string>;
+
+      /**
+       * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+       */
+      metadata?: Stripe.Emptyable<Stripe.MetadataParam>;
+
+      /**
+       * The period associated with this invoice item. When set to different values, the period will be rendered on the invoice. If you have [Stripe Revenue Recognition](https://stripe.com/docs/revenue-recognition) enabled, the period will be used to recognize and defer revenue. See the [Revenue Recognition documentation](https://stripe.com/docs/revenue-recognition/methodology/subscriptions-and-invoicing) for details.
+       */
+      period?: InvoiceUpdateLineItemParams.Period;
+
+      /**
+       * The ID of the price object.
+       */
+      price?: string;
+
+      /**
+       * Data used to generate a new [Price](https://stripe.com/docs/api/prices) object inline.
+       */
+      price_data?: InvoiceUpdateLineItemParams.PriceData;
+
+      /**
+       * Non-negative integer. The quantity of units for the line item.
+       */
+      quantity?: number;
+
+      /**
+       * A list of up to 10 tax amounts for this line item. This can be useful if you calculate taxes on your own or use a third-party to calculate them. You cannot set tax amounts if any line item has [tax_rates](https://stripe.com/docs/api/invoices/line_item#invoice_line_item_object-tax_rates) or if the invoice has [default_tax_rates](https://stripe.com/docs/api/invoices/object#invoice_object-default_tax_rates) or uses [automatic tax](https://stripe.com/docs/tax/invoicing). Pass an empty string to remove previously defined tax amounts.
+       */
+      tax_amounts?: Stripe.Emptyable<
+        Array<InvoiceUpdateLineItemParams.TaxAmount>
+      >;
+
+      /**
+       * The tax rates which apply to the line item. When set, the `default_tax_rates` on the invoice do not apply to this line item. Pass an empty string to remove previously-defined tax rates.
+       */
+      tax_rates?: Stripe.Emptyable<Array<string>>;
+    }
+
+    namespace InvoiceUpdateLineItemParams {
+      interface Discount {
+        /**
+         * ID of the coupon to create a new discount for.
+         */
+        coupon?: string;
+
+        /**
+         * ID of an existing discount on the object (or one of its ancestors) to reuse.
+         */
+        discount?: string;
+      }
+
+      interface Period {
+        /**
+         * The end of the period, which must be greater than or equal to the start. This value is inclusive.
+         */
+        end: number;
+
+        /**
+         * The start of the period. This value is inclusive.
+         */
+        start: number;
+      }
+
+      interface PriceData {
+        /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        currency: string;
+
+        /**
+         * The ID of the product that this price will belong to. One of `product` or `product_data` is required.
+         */
+        product?: string;
+
+        /**
+         * Data used to generate a new product object inline. One of `product` or `product_data` is required.
+         */
+        product_data?: PriceData.ProductData;
+
+        /**
+         * Only required if a [default tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#setting-a-default-tax-behavior-(recommended)) was not provided in the Stripe Tax settings. Specifies whether the price is considered inclusive of taxes or exclusive of taxes. One of `inclusive`, `exclusive`, or `unspecified`. Once specified as either `inclusive` or `exclusive`, it cannot be changed.
+         */
+        tax_behavior?: PriceData.TaxBehavior;
+
+        /**
+         * A non-negative integer in cents (or local equivalent) representing how much to charge. One of `unit_amount` or `unit_amount_decimal` is required.
+         */
+        unit_amount?: number;
+
+        /**
+         * Same as `unit_amount`, but accepts a decimal value in cents (or local equivalent) with at most 12 decimal places. Only one of `unit_amount` and `unit_amount_decimal` can be set.
+         */
+        unit_amount_decimal?: string;
+      }
+
+      namespace PriceData {
+        interface ProductData {
+          /**
+           * The product's description, meant to be displayable to the customer. Use this field to optionally store a long form explanation of the product being sold for your own rendering purposes.
+           */
+          description?: string;
+
+          /**
+           * A list of up to 8 URLs of images for this product, meant to be displayable to the customer.
+           */
+          images?: Array<string>;
+
+          /**
+           * Set of [key-value pairs](https://stripe.com/docs/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format. Individual keys can be unset by posting an empty value to them. All keys can be unset by posting an empty value to `metadata`.
+           */
+          metadata?: Stripe.MetadataParam;
+
+          /**
+           * The product's name, meant to be displayable to the customer.
+           */
+          name: string;
+
+          /**
+           * A [tax code](https://stripe.com/docs/tax/tax-categories) ID.
+           */
+          tax_code?: string;
+        }
+
+        type TaxBehavior = 'exclusive' | 'inclusive' | 'unspecified';
+      }
+
+      interface TaxAmount {
+        /**
+         * The amount, in cents (or local equivalent), of the tax.
+         */
+        amount: number;
+
+        /**
+         * Data to find or create a TaxRate object.
+         *
+         * Stripe automatically creates or reuses a TaxRate object for each tax amount. If the `tax_rate_data` exactly matches a previous value, Stripe will reuse the TaxRate object. TaxRate objects created automatically by Stripe are immediately archived, do not appear in the line item's `tax_rates`, and cannot be directly added to invoices, payments, or line items.
+         */
+        tax_rate_data: TaxAmount.TaxRateData;
+
+        /**
+         * The amount on which tax is calculated, in cents (or local equivalent).
+         */
+        taxable_amount: number;
+      }
+
+      namespace TaxAmount {
+        interface TaxRateData {
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * An arbitrary string attached to the tax rate for your internal use only. It will not be visible to your customers.
+           */
+          description?: string;
+
+          /**
+           * The display name of the tax rate, which will be shown to users.
+           */
+          display_name: string;
+
+          /**
+           * This specifies if the tax rate is inclusive or exclusive.
+           */
+          inclusive: boolean;
+
+          /**
+           * The jurisdiction for the tax rate. You can use this label field for tax reporting purposes. It also appears on your customer's invoice.
+           */
+          jurisdiction?: string;
+
+          /**
+           * The statutory tax rate percent. This field accepts decimal values between 0 and 100 inclusive with at most 4 decimal places. To accommodate fixed-amount taxes, set the percentage to zero. Stripe will not display zero percentages on the invoice unless the `amount` of the tax is also zero.
+           */
+          percentage: number;
+
+          /**
+           * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2:US), without country prefix. For example, "NY" for New York, United States.
+           */
+          state?: string;
+
+          /**
+           * The high-level tax type, such as `vat` or `sales_tax`.
+           */
+          tax_type?: TaxRateData.TaxType;
+        }
+
+        namespace TaxRateData {
+          type TaxType =
+            | 'amusement_tax'
+            | 'communications_tax'
+            | 'gst'
+            | 'hst'
+            | 'igst'
+            | 'jct'
+            | 'lease_tax'
+            | 'pst'
+            | 'qst'
+            | 'rst'
+            | 'sales_tax'
+            | 'service_tax'
+            | 'vat';
+        }
+      }
+    }
+
     interface InvoiceVoidInvoiceParams {
       /**
        * Specifies which fields in the response should be expanded.
@@ -2804,7 +3037,7 @@ declare module 'stripe' {
        */
       listLineItems(
         id: string,
-        params?: InvoiceLineItemListParams,
+        params?: InvoiceListLineItemsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.InvoiceLineItem>;
       listLineItems(
@@ -2889,6 +3122,24 @@ declare module 'stripe' {
         id: string,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.Invoice>>;
+
+      /**
+       * Updates an invoice's line item. Some fields, such as tax_amounts, only live on the invoice line item,
+       * so they can only be updated through this endpoint. Other fields, such as amount, live on both the invoice
+       * item and the invoice line item, so updates on this endpoint will propagate to the invoice item as well.
+       * Updating an invoice's line item is only possible before the invoice is finalized.
+       */
+      updateLineItem(
+        invoiceId: string,
+        id: string,
+        params?: InvoiceUpdateLineItemParams,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.InvoiceLineItem>>;
+      updateLineItem(
+        invoiceId: string,
+        id: string,
+        options?: RequestOptions
+      ): Promise<Stripe.Response<Stripe.InvoiceLineItem>>;
 
       /**
        * Mark a finalized invoice as void. This cannot be undone. Voiding an invoice is similar to [deletion](https://stripe.com/docs/api#delete_invoice), however it only applies to finalized invoices and maintains a papertrail where the invoice can still be found.

--- a/types/SubscriptionItemsResource.d.ts
+++ b/types/SubscriptionItemsResource.d.ts
@@ -320,7 +320,7 @@ declare module 'stripe' {
       type ProrationBehavior = 'always_invoice' | 'create_prorations' | 'none';
     }
 
-    interface UsageRecordCreateParams {
+    interface SubscriptionItemCreateUsageRecordParams {
       /**
        * The usage quantity for the specified timestamp.
        */
@@ -329,7 +329,7 @@ declare module 'stripe' {
       /**
        * Valid values are `increment` (default) or `set`. When using `increment` the specified `quantity` will be added to the usage at the specified timestamp. The `set` action will overwrite the usage quantity at that timestamp. If the subscription has [billing thresholds](https://stripe.com/docs/api/subscriptions/object#subscription_object-billing_thresholds), `increment` is the only allowed value.
        */
-      action?: UsageRecordCreateParams.Action;
+      action?: SubscriptionItemCreateUsageRecordParams.Action;
 
       /**
        * Specifies which fields in the response should be expanded.
@@ -342,11 +342,12 @@ declare module 'stripe' {
       timestamp?: 'now' | number;
     }
 
-    namespace UsageRecordCreateParams {
+    namespace SubscriptionItemCreateUsageRecordParams {
       type Action = 'increment' | 'set';
     }
 
-    interface UsageRecordSummaryListParams extends PaginationParams {
+    interface SubscriptionItemListUsageRecordSummariesParams
+      extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -416,7 +417,7 @@ declare module 'stripe' {
        */
       createUsageRecord(
         id: string,
-        params: UsageRecordCreateParams,
+        params: SubscriptionItemCreateUsageRecordParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.UsageRecord>>;
 
@@ -427,7 +428,7 @@ declare module 'stripe' {
        */
       listUsageRecordSummaries(
         id: string,
-        params?: UsageRecordSummaryListParams,
+        params?: SubscriptionItemListUsageRecordSummariesParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.UsageRecordSummary>;
       listUsageRecordSummaries(

--- a/types/TransfersResource.d.ts
+++ b/types/TransfersResource.d.ts
@@ -96,7 +96,7 @@ declare module 'stripe' {
       transfer_group?: string;
     }
 
-    interface TransferReversalCreateParams {
+    interface TransferCreateReversalParams {
       /**
        * A positive integer in cents (or local equivalent) representing how much of this transfer to reverse. Can only reverse up to the unreversed amount remaining of the transfer. Partial transfer reversals are only allowed for transfers to Stripe Accounts. Defaults to the entire transfer amount.
        */
@@ -123,21 +123,21 @@ declare module 'stripe' {
       refund_application_fee?: boolean;
     }
 
-    interface TransferReversalListParams extends PaginationParams {
+    interface TransferListReversalsParams extends PaginationParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface TransferReversalRetrieveParams {
+    interface TransferRetrieveReversalParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
       expand?: Array<string>;
     }
 
-    interface TransferReversalUpdateParams {
+    interface TransferUpdateReversalParams {
       /**
        * Specifies which fields in the response should be expanded.
        */
@@ -200,7 +200,7 @@ declare module 'stripe' {
        */
       createReversal(
         id: string,
-        params?: TransferReversalCreateParams,
+        params?: TransferCreateReversalParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.TransferReversal>>;
       createReversal(
@@ -213,7 +213,7 @@ declare module 'stripe' {
        */
       listReversals(
         id: string,
-        params?: TransferReversalListParams,
+        params?: TransferListReversalsParams,
         options?: RequestOptions
       ): ApiListPromise<Stripe.TransferReversal>;
       listReversals(
@@ -227,7 +227,7 @@ declare module 'stripe' {
       retrieveReversal(
         transferId: string,
         id: string,
-        params?: TransferReversalRetrieveParams,
+        params?: TransferRetrieveReversalParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.TransferReversal>>;
       retrieveReversal(
@@ -244,7 +244,7 @@ declare module 'stripe' {
       updateReversal(
         transferId: string,
         id: string,
-        params?: TransferReversalUpdateParams,
+        params?: TransferUpdateReversalParams,
         options?: RequestOptions
       ): Promise<Stripe.Response<Stripe.TransferReversal>>;
       updateReversal(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -7,6 +7,7 @@
 ///<reference path='./Webhooks.d.ts' />
 ///<reference path='./EventTypes.d.ts' />
 ///<reference path='./UpcomingInvoices.d.ts' />
+///<reference path='./Deprecations.d.ts' />
 // Imports: The beginning of the section generated from our OpenAPI spec
 ///<reference path='./AccountLinksResource.d.ts' />
 ///<reference path='./AccountSessionsResource.d.ts' />

--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -133,12 +133,6 @@ declare module 'stripe' {
       town?: string;
     }
 
-    /**
-     * The resulting source of [a Connect platform debiting a connected account](https://stripe.com/docs/connect/account-debits#charging-a-connected-account).
-     * @deprecated prefer Stripe.Account
-     */
-    type AccountDebitSource = Account;
-
     interface RangeQueryParam {
       /**
        * Minimum value to filter by (exclusive)

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -6,7 +6,10 @@
  */
 
 ///<reference types=".." />
-import Stripe from 'stripe';
+import Stripe, {
+  UsageRecordCreateParams,
+  UsageRecordSummaryListParams,
+} from 'stripe';
 
 let stripe = new Stripe('sk_test_123', {
   apiVersion: '2023-10-16',
@@ -303,3 +306,6 @@ stripe.files.create({
   },
   file_link_data: {create: true},
 });
+
+// Test deprecated parameters still work
+const param: Stripe.UsageRecordSummaryListParams = {expand: []};

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -6,10 +6,7 @@
  */
 
 ///<reference types=".." />
-import Stripe, {
-  UsageRecordCreateParams,
-  UsageRecordSummaryListParams,
-} from 'stripe';
+import Stripe from 'stripe';
 
 let stripe = new Stripe('sk_test_123', {
   apiVersion: '2023-10-16',


### PR DESCRIPTION
Standardizes param class names to `<ResourceName><MethodName>Params`.

Adds type-forwards to preserve existing types.