### PR TITLE
vscode settings: true -> "explicit"

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -10,6 +10,6 @@
   "eslint.packageManager": "yarn",
   "npm.packageManager": "yarn",
   "editor.codeActionsOnSave": {
-    "source.fixAll.eslint": true
+    "source.fixAll.eslint": "explicit"
   }
 }


### PR DESCRIPTION
As of [VSCode v1.85](https://code.visualstudio.com/updates/v1_85#_code-actions-on-save-and-auto):
> the previous boolean values to be deprecated in favor of the string equivalent.

Discovered from https://stackoverflow.com/questions/77637621/vscode-workspace-settings-change-on-its-own because .vscode/settings kept changing on me