### PR TITLE
Remove deprecated events

### DIFF
--- a/types/Climate/Suppliers.d.ts
+++ b/types/Climate/Suppliers.d.ts
@@ -74,8 +74,7 @@ declare module 'stripe' {
         type RemovalPathway =
           | 'biomass_carbon_removal_and_storage'
           | 'direct_air_capture'
-          | 'enhanced_weathering'
-          | 'various';
+          | 'enhanced_weathering';
       }
     }
   }

--- a/types/EventTypes.d.ts
+++ b/types/EventTypes.d.ts
@@ -228,15 +228,7 @@ declare module 'stripe' {
       | TreasuryReceivedCreditCreatedEvent
       | TreasuryReceivedCreditFailedEvent
       | TreasuryReceivedCreditSucceededEvent
-      | TreasuryReceivedDebitCreatedEvent
-      | InvoiceitemUpdatedEvent
-      | OrderCreatedEvent
-      | RecipientCreatedEvent
-      | RecipientDeletedEvent
-      | RecipientUpdatedEvent
-      | SkuCreatedEvent
-      | SkuDeletedEvent
-      | SkuUpdatedEvent;
+      | TreasuryReceivedDebitCreatedEvent;
 
     /**
      * Occurs whenever a user authorizes an application. Sent to the related application only.
@@ -3858,102 +3850,6 @@ declare module 'stripe' {
 
         previous_attributes?: Partial<Stripe.Treasury.ReceivedDebit>;
       }
-    }
-
-    /**
-     * The "invoiceitem.updated" event is deprecated and will be removed in the next major version
-     */
-    interface InvoiceitemUpdatedEvent extends EventBase {
-      type: 'invoiceitem.updated';
-      data: InvoiceitemUpdatedEvent.Data;
-    }
-
-    namespace InvoiceitemUpdatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "order.created" event is deprecated and will be removed in the next major version
-     */
-    interface OrderCreatedEvent extends EventBase {
-      type: 'order.created';
-      data: OrderCreatedEvent.Data;
-    }
-
-    namespace OrderCreatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "recipient.created" event is deprecated and will be removed in the next major version
-     */
-    interface RecipientCreatedEvent extends EventBase {
-      type: 'recipient.created';
-      data: RecipientCreatedEvent.Data;
-    }
-
-    namespace RecipientCreatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "recipient.deleted" event is deprecated and will be removed in the next major version
-     */
-    interface RecipientDeletedEvent extends EventBase {
-      type: 'recipient.deleted';
-      data: RecipientDeletedEvent.Data;
-    }
-
-    namespace RecipientDeletedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "recipient.updated" event is deprecated and will be removed in the next major version
-     */
-    interface RecipientUpdatedEvent extends EventBase {
-      type: 'recipient.updated';
-      data: RecipientUpdatedEvent.Data;
-    }
-
-    namespace RecipientUpdatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "sku.created" event is deprecated and will be removed in the next major version
-     */
-    interface SkuCreatedEvent extends EventBase {
-      type: 'sku.created';
-      data: SkuCreatedEvent.Data;
-    }
-
-    namespace SkuCreatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "sku.deleted" event is deprecated and will be removed in the next major version
-     */
-    interface SkuDeletedEvent extends EventBase {
-      type: 'sku.deleted';
-      data: SkuDeletedEvent.Data;
-    }
-
-    namespace SkuDeletedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "sku.updated" event is deprecated and will be removed in the next major version
-     */
-    interface SkuUpdatedEvent extends EventBase {
-      type: 'sku.updated';
-      data: SkuUpdatedEvent.Data;
-    }
-
-    namespace SkuUpdatedEvent {
-      interface Data extends Stripe.Event.Data {}
     }
   }
 }

--- a/types/Events.d.ts
+++ b/types/Events.d.ts
@@ -259,15 +259,7 @@ declare module 'stripe' {
         | 'treasury.received_credit.created'
         | 'treasury.received_credit.failed'
         | 'treasury.received_credit.succeeded'
-        | 'treasury.received_debit.created'
-        | 'invoiceitem.updated'
-        | 'order.created'
-        | 'recipient.created'
-        | 'recipient.deleted'
-        | 'recipient.updated'
-        | 'sku.created'
-        | 'sku.deleted'
-        | 'sku.updated';
+        | 'treasury.received_debit.created';
     }
 
     /**

--- a/types/WebhookEndpointsResource.d.ts
+++ b/types/WebhookEndpointsResource.d.ts
@@ -369,15 +369,7 @@ declare module 'stripe' {
         | 'treasury.received_credit.created'
         | 'treasury.received_credit.failed'
         | 'treasury.received_credit.succeeded'
-        | 'treasury.received_debit.created'
-        | 'invoiceitem.updated'
-        | 'order.created'
-        | 'recipient.created'
-        | 'recipient.deleted'
-        | 'recipient.updated'
-        | 'sku.created'
-        | 'sku.deleted'
-        | 'sku.updated';
+        | 'treasury.received_debit.created';
     }
 
     interface WebhookEndpointRetrieveParams {
@@ -647,15 +639,7 @@ declare module 'stripe' {
         | 'treasury.received_credit.created'
         | 'treasury.received_credit.failed'
         | 'treasury.received_credit.succeeded'
-        | 'treasury.received_debit.created'
-        | 'invoiceitem.updated'
-        | 'order.created'
-        | 'recipient.created'
-        | 'recipient.deleted'
-        | 'recipient.updated'
-        | 'sku.created'
-        | 'sku.deleted'
-        | 'sku.updated';
+        | 'treasury.received_debit.created';
     }
 
     interface WebhookEndpointListParams extends PaginationParams {


### PR DESCRIPTION
Below Event types were removed from the API in the last year

[On Sept 22, 2023](https://docs.stripe.com/changelog#september-22,-2023)

> Remove support for values order.created, recipient.created, recipient.deleted, recipient.updated, sku.created, sku.deleted, and sku.updated from enum Event.type

[On Sept 4th, 2023](https://docs.stripe.com/changelog#september-4,-2023)

> Remove support for value invoiceitem.updated from enum Event.type

And the enum Climate.Supplier.removal_pathway was updated on [Dec 6th , 2023](https://docs.stripe.com/changelog#december-6,-2023)

> Remove support for value various from enum Climate.Supplier.removal_pathway

This PR removes the same from the SDKs

Related Jira: https://jira.corp.stripe.com/browse/DEVSDK-1740



