### PR TITLE
Remove parts of the API that is no longer publicly documented

### DIFF
--- a/types/BalanceTransactions.d.ts
+++ b/types/BalanceTransactions.d.ts
@@ -153,11 +153,7 @@ declare module 'stripe' {
         | 'transfer'
         | 'transfer_cancel'
         | 'transfer_failure'
-        | 'transfer_refund'
-        | 'obligation_inbound'
-        | 'obligation_payout'
-        | 'obligation_payout_failure'
-        | 'obligation_reversal_outbound';
+        | 'transfer_refund';
     }
   }
 }

--- a/types/Climate/Suppliers.d.ts
+++ b/types/Climate/Suppliers.d.ts
@@ -74,8 +74,7 @@ declare module 'stripe' {
         type RemovalPathway =
           | 'biomass_carbon_removal_and_storage'
           | 'direct_air_capture'
-          | 'enhanced_weathering'
-          | 'various';
+          | 'enhanced_weathering';
       }
     }
   }

--- a/types/EventTypes.d.ts
+++ b/types/EventTypes.d.ts
@@ -228,15 +228,7 @@ declare module 'stripe' {
       | TreasuryReceivedCreditCreatedEvent
       | TreasuryReceivedCreditFailedEvent
       | TreasuryReceivedCreditSucceededEvent
-      | TreasuryReceivedDebitCreatedEvent
-      | InvoiceitemUpdatedEvent
-      | OrderCreatedEvent
-      | RecipientCreatedEvent
-      | RecipientDeletedEvent
-      | RecipientUpdatedEvent
-      | SkuCreatedEvent
-      | SkuDeletedEvent
-      | SkuUpdatedEvent;
+      | TreasuryReceivedDebitCreatedEvent;
 
     /**
      * Occurs whenever a user authorizes an application. Sent to the related application only.
@@ -3858,102 +3850,6 @@ declare module 'stripe' {
 
         previous_attributes?: Partial<Stripe.Treasury.ReceivedDebit>;
       }
-    }
-
-    /**
-     * The "invoiceitem.updated" event is deprecated and will be removed in the next major version
-     */
-    interface InvoiceitemUpdatedEvent extends EventBase {
-      type: 'invoiceitem.updated';
-      data: InvoiceitemUpdatedEvent.Data;
-    }
-
-    namespace InvoiceitemUpdatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "order.created" event is deprecated and will be removed in the next major version
-     */
-    interface OrderCreatedEvent extends EventBase {
-      type: 'order.created';
-      data: OrderCreatedEvent.Data;
-    }
-
-    namespace OrderCreatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "recipient.created" event is deprecated and will be removed in the next major version
-     */
-    interface RecipientCreatedEvent extends EventBase {
-      type: 'recipient.created';
-      data: RecipientCreatedEvent.Data;
-    }
-
-    namespace RecipientCreatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "recipient.deleted" event is deprecated and will be removed in the next major version
-     */
-    interface RecipientDeletedEvent extends EventBase {
-      type: 'recipient.deleted';
-      data: RecipientDeletedEvent.Data;
-    }
-
-    namespace RecipientDeletedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "recipient.updated" event is deprecated and will be removed in the next major version
-     */
-    interface RecipientUpdatedEvent extends EventBase {
-      type: 'recipient.updated';
-      data: RecipientUpdatedEvent.Data;
-    }
-
-    namespace RecipientUpdatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "sku.created" event is deprecated and will be removed in the next major version
-     */
-    interface SkuCreatedEvent extends EventBase {
-      type: 'sku.created';
-      data: SkuCreatedEvent.Data;
-    }
-
-    namespace SkuCreatedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "sku.deleted" event is deprecated and will be removed in the next major version
-     */
-    interface SkuDeletedEvent extends EventBase {
-      type: 'sku.deleted';
-      data: SkuDeletedEvent.Data;
-    }
-
-    namespace SkuDeletedEvent {
-      interface Data extends Stripe.Event.Data {}
-    }
-
-    /**
-     * The "sku.updated" event is deprecated and will be removed in the next major version
-     */
-    interface SkuUpdatedEvent extends EventBase {
-      type: 'sku.updated';
-      data: SkuUpdatedEvent.Data;
-    }
-
-    namespace SkuUpdatedEvent {
-      interface Data extends Stripe.Event.Data {}
     }
   }
 }

--- a/types/Events.d.ts
+++ b/types/Events.d.ts
@@ -259,15 +259,7 @@ declare module 'stripe' {
         | 'treasury.received_credit.created'
         | 'treasury.received_credit.failed'
         | 'treasury.received_credit.succeeded'
-        | 'treasury.received_debit.created'
-        | 'invoiceitem.updated'
-        | 'order.created'
-        | 'recipient.created'
-        | 'recipient.deleted'
-        | 'recipient.updated'
-        | 'sku.created'
-        | 'sku.deleted'
-        | 'sku.updated';
+        | 'treasury.received_debit.created';
     }
 
     /**

--- a/types/InvoicesResource.d.ts
+++ b/types/InvoicesResource.d.ts
@@ -509,10 +509,7 @@ declare module 'stripe' {
           | 'wechat_pay';
       }
 
-      type PendingInvoiceItemsBehavior =
-        | 'exclude'
-        | 'include'
-        | 'include_and_require';
+      type PendingInvoiceItemsBehavior = 'exclude' | 'include';
 
       interface Rendering {
         /**
@@ -2972,8 +2969,7 @@ declare module 'stripe' {
             | 'qst'
             | 'rst'
             | 'sales_tax'
-            | 'vat'
-            | 'service_tax';
+            | 'vat';
         }
       }
     }

--- a/types/PaymentIntentsResource.d.ts
+++ b/types/PaymentIntentsResource.d.ts
@@ -1557,15 +1557,6 @@ declare module 'stripe' {
            * Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
            */
           request_incremental_authorization_support?: boolean;
-
-          /**
-           * This field was released by mistake and will be removed in the next major version
-           */
-          request_incremental_authorization?: CardPresent.RequestIncrementalAuthorization;
-        }
-
-        namespace CardPresent {
-          type RequestIncrementalAuthorization = 'if_available' | 'never';
         }
 
         interface Cashapp {
@@ -3755,15 +3746,6 @@ declare module 'stripe' {
            * Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
            */
           request_incremental_authorization_support?: boolean;
-
-          /**
-           * This field was released by mistake and will be removed in the next major version
-           */
-          request_incremental_authorization?: CardPresent.RequestIncrementalAuthorization;
-        }
-
-        namespace CardPresent {
-          type RequestIncrementalAuthorization = 'if_available' | 'never';
         }
 
         interface Cashapp {
@@ -6098,15 +6080,6 @@ declare module 'stripe' {
            * Request ability to [increment](https://stripe.com/docs/terminal/features/incremental-authorizations) this PaymentIntent if the combination of MCC and card brand is eligible. Check [incremental_authorization_supported](https://stripe.com/docs/api/charges/object#charge_object-payment_method_details-card_present-incremental_authorization_supported) in the [Confirm](https://stripe.com/docs/api/payment_intents/confirm) response to verify support.
            */
           request_incremental_authorization_support?: boolean;
-
-          /**
-           * This field was released by mistake and will be removed in the next major version
-           */
-          request_incremental_authorization?: CardPresent.RequestIncrementalAuthorization;
-        }
-
-        namespace CardPresent {
-          type RequestIncrementalAuthorization = 'if_available' | 'never';
         }
 
         interface Cashapp {

--- a/types/PaymentMethodConfigurations.d.ts
+++ b/types/PaymentMethodConfigurations.d.ts
@@ -77,8 +77,6 @@ declare module 'stripe' {
 
       grabpay?: PaymentMethodConfiguration.Grabpay;
 
-      id_bank_transfer?: PaymentMethodConfiguration.IdBankTransfer;
-
       ideal?: PaymentMethodConfiguration.Ideal;
 
       /**
@@ -99,14 +97,10 @@ declare module 'stripe' {
        */
       livemode: boolean;
 
-      multibanco?: PaymentMethodConfiguration.Multibanco;
-
       /**
        * The configuration's name.
        */
       name: string;
-
-      netbanking?: PaymentMethodConfiguration.Netbanking;
 
       oxxo?: PaymentMethodConfiguration.Oxxo;
 
@@ -116,8 +110,6 @@ declare module 'stripe' {
        * For child configs, the configuration's parent configuration.
        */
       parent: string | null;
-
-      pay_by_bank?: PaymentMethodConfiguration.PayByBank;
 
       paynow?: PaymentMethodConfiguration.Paynow;
 
@@ -130,8 +122,6 @@ declare module 'stripe' {
       sepa_debit?: PaymentMethodConfiguration.SepaDebit;
 
       sofort?: PaymentMethodConfiguration.Sofort;
-
-      upi?: PaymentMethodConfiguration.Upi;
 
       us_bank_account?: PaymentMethodConfiguration.UsBankAccount;
 
@@ -785,40 +775,6 @@ declare module 'stripe' {
         }
       }
 
-      interface IdBankTransfer {
-        /**
-         * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-         */
-        available: boolean;
-
-        display_preference: IdBankTransfer.DisplayPreference;
-      }
-
-      namespace IdBankTransfer {
-        interface DisplayPreference {
-          /**
-           * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-           */
-          overridable: boolean | null;
-
-          /**
-           * The account's display preference.
-           */
-          preference: DisplayPreference.Preference;
-
-          /**
-           * The effective display preference value.
-           */
-          value: DisplayPreference.Value;
-        }
-
-        namespace DisplayPreference {
-          type Preference = 'none' | 'off' | 'on';
-
-          type Value = 'off' | 'on';
-        }
-      }
-
       interface Ideal {
         /**
          * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
@@ -989,74 +945,6 @@ declare module 'stripe' {
         }
       }
 
-      interface Multibanco {
-        /**
-         * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-         */
-        available: boolean;
-
-        display_preference: Multibanco.DisplayPreference;
-      }
-
-      namespace Multibanco {
-        interface DisplayPreference {
-          /**
-           * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-           */
-          overridable: boolean | null;
-
-          /**
-           * The account's display preference.
-           */
-          preference: DisplayPreference.Preference;
-
-          /**
-           * The effective display preference value.
-           */
-          value: DisplayPreference.Value;
-        }
-
-        namespace DisplayPreference {
-          type Preference = 'none' | 'off' | 'on';
-
-          type Value = 'off' | 'on';
-        }
-      }
-
-      interface Netbanking {
-        /**
-         * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-         */
-        available: boolean;
-
-        display_preference: Netbanking.DisplayPreference;
-      }
-
-      namespace Netbanking {
-        interface DisplayPreference {
-          /**
-           * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-           */
-          overridable: boolean | null;
-
-          /**
-           * The account's display preference.
-           */
-          preference: DisplayPreference.Preference;
-
-          /**
-           * The effective display preference value.
-           */
-          value: DisplayPreference.Value;
-        }
-
-        namespace DisplayPreference {
-          type Preference = 'none' | 'off' | 'on';
-
-          type Value = 'off' | 'on';
-        }
-      }
-
       interface Oxxo {
         /**
          * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
@@ -1101,40 +989,6 @@ declare module 'stripe' {
       }
 
       namespace P24 {
-        interface DisplayPreference {
-          /**
-           * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-           */
-          overridable: boolean | null;
-
-          /**
-           * The account's display preference.
-           */
-          preference: DisplayPreference.Preference;
-
-          /**
-           * The effective display preference value.
-           */
-          value: DisplayPreference.Value;
-        }
-
-        namespace DisplayPreference {
-          type Preference = 'none' | 'off' | 'on';
-
-          type Value = 'off' | 'on';
-        }
-      }
-
-      interface PayByBank {
-        /**
-         * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-         */
-        available: boolean;
-
-        display_preference: PayByBank.DisplayPreference;
-      }
-
-      namespace PayByBank {
         interface DisplayPreference {
           /**
            * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
@@ -1339,40 +1193,6 @@ declare module 'stripe' {
       }
 
       namespace Sofort {
-        interface DisplayPreference {
-          /**
-           * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.
-           */
-          overridable: boolean | null;
-
-          /**
-           * The account's display preference.
-           */
-          preference: DisplayPreference.Preference;
-
-          /**
-           * The effective display preference value.
-           */
-          value: DisplayPreference.Value;
-        }
-
-        namespace DisplayPreference {
-          type Preference = 'none' | 'off' | 'on';
-
-          type Value = 'off' | 'on';
-        }
-      }
-
-      interface Upi {
-        /**
-         * Whether this payment method may be offered at checkout. True if `display_preference` is `on` and the payment method's capability is active.
-         */
-        available: boolean;
-
-        display_preference: Upi.DisplayPreference;
-      }
-
-      namespace Upi {
         interface DisplayPreference {
           /**
            * For child configs, whether or not the account's preference will be observed. If `false`, the parent configuration's default is used.

--- a/types/Reporting/ReportRunsResource.d.ts
+++ b/types/Reporting/ReportRunsResource.d.ts
@@ -101,8 +101,7 @@ declare module 'stripe' {
             | 'topup_reversal'
             | 'transfer'
             | 'transfer_reversal'
-            | 'unreconciled_customer_funds'
-            | 'obligation';
+            | 'unreconciled_customer_funds';
 
           type Timezone =
             | 'Africa/Abidjan'

--- a/types/SetupIntents.d.ts
+++ b/types/SetupIntents.d.ts
@@ -722,11 +722,7 @@ declare module 'stripe' {
             | 'unknown'
             | 'visa';
 
-          type RequestThreeDSecure =
-            | 'any'
-            | 'automatic'
-            | 'challenge'
-            | 'challenge_only';
+          type RequestThreeDSecure = 'any' | 'automatic' | 'challenge';
         }
 
         interface Link {

--- a/types/TaxRates.d.ts
+++ b/types/TaxRates.d.ts
@@ -112,8 +112,7 @@ declare module 'stripe' {
         | 'qst'
         | 'rst'
         | 'sales_tax'
-        | 'vat'
-        | 'service_tax';
+        | 'vat';
     }
   }
 }

--- a/types/TaxRatesResource.d.ts
+++ b/types/TaxRatesResource.d.ts
@@ -72,8 +72,7 @@ declare module 'stripe' {
         | 'qst'
         | 'rst'
         | 'sales_tax'
-        | 'vat'
-        | 'service_tax';
+        | 'vat';
     }
 
     interface TaxRateRetrieveParams {
@@ -143,8 +142,7 @@ declare module 'stripe' {
         | 'qst'
         | 'rst'
         | 'sales_tax'
-        | 'vat'
-        | 'service_tax';
+        | 'vat';
     }
 
     interface TaxRateListParams extends PaginationParams {

--- a/types/WebhookEndpointsResource.d.ts
+++ b/types/WebhookEndpointsResource.d.ts
@@ -369,15 +369,7 @@ declare module 'stripe' {
         | 'treasury.received_credit.created'
         | 'treasury.received_credit.failed'
         | 'treasury.received_credit.succeeded'
-        | 'treasury.received_debit.created'
-        | 'invoiceitem.updated'
-        | 'order.created'
-        | 'recipient.created'
-        | 'recipient.deleted'
-        | 'recipient.updated'
-        | 'sku.created'
-        | 'sku.deleted'
-        | 'sku.updated';
+        | 'treasury.received_debit.created';
     }
 
     interface WebhookEndpointRetrieveParams {
@@ -647,15 +639,7 @@ declare module 'stripe' {
         | 'treasury.received_credit.created'
         | 'treasury.received_credit.failed'
         | 'treasury.received_credit.succeeded'
-        | 'treasury.received_debit.created'
-        | 'invoiceitem.updated'
-        | 'order.created'
-        | 'recipient.created'
-        | 'recipient.deleted'
-        | 'recipient.updated'
-        | 'sku.created'
-        | 'sku.deleted'
-        | 'sku.updated';
+        | 'treasury.received_debit.created';
     }
 
     interface WebhookEndpointListParams extends PaginationParams {


### PR DESCRIPTION
This PR contains the changes generated after removing the shared overides from our code generator that were added for backcompat


## Changelog

* Remove the below deprecated values for the type `BalanceTransaction.Type`
    * `obligation_inbound`
    * `obligation_payout`
    * `obligation_payout_failure`
    * `'obligation_reversal_outbound'`
 * Remove deprecated value `various` for the type `Climate.Supplier.RemovalPathway` 
 * Remove deprecated events 
   * `invoiceitem.updated`
   * `order.created`
   * `recipient.created`
   * `recipient.deleted`
   * `recipient.updated`
   * `sku.created`
   * `sku.deleted`
   * `sku.updated`
 * Remove types for the deprecated events 
    * `InvoiceItemUpdatedEvent`
    * `OrderCreatedEvent`
    * `RecipientCreatedEvent`
    * `RecipientDeletedEvent`
    * `RecipientUpdatedEvent`
    * `SKUCreatedEvent`
    * `SKUDeletedEvent`
 * Remove the deprecated value `include_and_require` for the type`InvoiceCreateParams.PendingInvoiceItemsBehavior`
 * Remove the deprecated value `service_tax` for the types `TaxRate.TaxType`, `TaxRateCreateParams.TaxType`, `TaxRateUpdateParams.TaxType`, and `InvoiceUpdateLineItemParams.TaxAmount.TaxRateData`
 * Remove `request_incremental_authorization` from `PaymentIntentCreateParams.PaymentMethodOptions.CardPresent`, `PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent` and `PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent`
 * Remove support for `id_bank_transfer`, `multibanco`, `netbanking`, `pay_by_bank`, and `upi` on `PaymentMethodConfiguration`
 * Remove the deprecated value `obligation` for the type `Reporting.ReportRunCreateParams.Parameters.ReportingCategory`
 * Remove the deprecated value `challenge_only` from the type `SetupIntent.PaymentMethodOptions.Card.RequestThreeDSecure`

 
 