### PR TITLE
Note on `limit` param in `autoPagingToArray`

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,7 +467,8 @@ stripe.customers
 
 This is a convenience for cases where you expect the number of items
 to be relatively small; accordingly, you must pass a `limit` option
-to prevent runaway list growth from consuming too much memory.
+to prevent runaway list growth from consuming too much memory. Once the
+`limit` number of items have been fetched, auto-pagination will stop.
 
 Returns a promise of an array of all items across pages for a list request.
 

--- a/README.md
+++ b/README.md
@@ -474,8 +474,8 @@ Returns a promise of an array of all items across pages for a list request.
 
 ```js
 const allNewCustomers = await stripe.customers
-  .list({created: {gt: lastMonth}})
-  .autoPagingToArray({limit: 10000});
+  .list({created: {gt: lastMonth}, limit: 100}) // 100 items per page
+  .autoPagingToArray({limit: 10000}); // Stop after 10000 items total
 ```
 
 ### Telemetry


### PR DESCRIPTION
This change to the `README.md` file makes it more explicit that the `limit` value passed to `autoPagingToArray` is the limit for the total number of items that will be fetched from Stripe, and *not* a limit for the number of items retrieved per fetch during multiple rounds of fetching. The note about preventing runaway memory growth was suggestive of this behavior, but not entirely explicit.