### PR TITLE
Deprecate Node methods and params based on OpenAPI spec

### DIFF
--- a/types/ConfirmationTokens.d.ts
+++ b/types/ConfirmationTokens.d.ts
@@ -879,6 +879,7 @@ declare module 'stripe' {
 
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
         }

--- a/types/Issuing/AuthorizationsResource.d.ts
+++ b/types/Issuing/AuthorizationsResource.d.ts
@@ -119,6 +119,7 @@ declare module 'stripe' {
         /**
          * [Deprecated] Approves a pending Issuing Authorization object. This request should be made within the timeout window of the [real-time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
          * This method is deprecated. Instead, [respond directly to the webhook request to approve an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
+         * @deprecated This method is deprecated, please refer to the description for details.
          */
         approve(
           id: string,
@@ -133,6 +134,7 @@ declare module 'stripe' {
         /**
          * [Deprecated] Declines a pending Issuing Authorization object. This request should be made within the timeout window of the [real time authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations) flow.
          * This method is deprecated. Instead, [respond directly to the webhook request to decline an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
+         * @deprecated This method is deprecated, please refer to the description for details.
          */
         decline(
           id: string,

--- a/types/PaymentIntents.d.ts
+++ b/types/PaymentIntents.d.ts
@@ -1964,6 +1964,7 @@ declare module 'stripe' {
 
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token: string | null;
 

--- a/types/PaymentIntentsResource.d.ts
+++ b/types/PaymentIntentsResource.d.ts
@@ -1889,6 +1889,7 @@ declare module 'stripe' {
 
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
 
@@ -4131,6 +4132,7 @@ declare module 'stripe' {
 
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
 
@@ -6518,6 +6520,7 @@ declare module 'stripe' {
 
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
 

--- a/types/PaymentMethods.d.ts
+++ b/types/PaymentMethods.d.ts
@@ -807,6 +807,7 @@ declare module 'stripe' {
 
         /**
          * [Deprecated] This is a legacy parameter that no longer has any function.
+         * @deprecated
          */
         persistent_token?: string;
       }

--- a/types/SetupIntents.d.ts
+++ b/types/SetupIntents.d.ts
@@ -740,6 +740,7 @@ declare module 'stripe' {
         interface Link {
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token: string | null;
         }

--- a/types/SetupIntentsResource.d.ts
+++ b/types/SetupIntentsResource.d.ts
@@ -1072,6 +1072,7 @@ declare module 'stripe' {
         interface Link {
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
         }
@@ -2149,6 +2150,7 @@ declare module 'stripe' {
         interface Link {
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
         }
@@ -3313,6 +3315,7 @@ declare module 'stripe' {
         interface Link {
           /**
            * [Deprecated] This is a legacy parameter that no longer has any function.
+           * @deprecated
            */
           persistent_token?: string;
         }


### PR DESCRIPTION
This PR adds Node SDK support for automatically marking methods and params as deprecated. 

## Changelog 
- Mark as deprecated the `approve` and `decline` methods on `Issuing.Authorization`. Instead, [respond directly to the webhook request to approve an authorization](https://stripe.com/docs/issuing/controls/real-time-authorizations#authorization-handling).
- Mark as deprecated the `persistent_token` property on `ConfirmationToken.PaymentMethodPreview.Link`, `PaymentIntent.PaymentMethodOptions.Link`, `PaymentIntentResource.PaymentMethodOptions.Link`, `PaymentMethod.Link.persistent_token`. `SetupIntents.PaymentMethodOptions.Card.Link.persistent_token`, `SetupIntentsResource.persistent_token`. This is a legacy parameter that no longer has any function.