### PR TITLE
add local pre-req script to bail early if tests will fail

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,7 +12,7 @@ ci-test:
 
 check-prereqs:
 # tests depend on `deno` being available
-	@command -v python >/dev/null 2>&1 || { echo "Error: deno is not installed." >&2; exit 1; }
+	@command -v deno >/dev/null 2>&1 || { echo "Error: deno is not installed." >&2; exit 1; }
 # stripe mock must be running; check its default port for a listener
 	@lsof -i :12112 >/dev/null 2>&1 || { echo "Error: stripe-mock is not running (on port 12112)." >&2; exit 1; }
 

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: codegen-format update-version test ci-test
+.PHONY: codegen-format update-version test check-prereqs ci-test
 update-version:
 	@echo "$(VERSION)" > VERSION
 	@perl -pi -e 's|"version": "[.\-\d\w]+"|"version": "$(VERSION)"|' package.json
@@ -10,4 +10,10 @@ codegen-format:
 ci-test:
 	yarn && yarn test
 
-test: ci-test
+check-prereqs:
+# tests depend on `deno` being available
+	@command -v python >/dev/null 2>&1 || { echo "Error: deno is not installed." >&2; exit 1; }
+# stripe mock must be running; check its default port for a listener
+	@lsof -i :12112 >/dev/null 2>&1 || { echo "Error: stripe-mock is not running (on port 12112)." >&2; exit 1; }
+
+test: check-prereqs ci-test


### PR DESCRIPTION
When running the node test suite, many tests passed but those dependent on `deno` and `stripe-mock` only failed after the rest of the test suite had run. 

For local development, it seems worthwhile to ensure those are running before running the whole suite.

Also, my understanding is `make test` is only run locally, so this PR won't affect CI (or anything besides us running `make test` on our laptops). If that's not the case, let me know!