### PR TITLE
Use `fetch`-based client in Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
       "import": "./esm/stripe.esm.worker.js",
       "require": "./cjs/stripe.cjs.worker.js"
     },
+    "bun": {
+      "import": "./esm/stripe.esm.worker.js",
+      "require": "./cjs/stripe.cjs.worker.js"
+    },
     "deno": {
       "import": "./esm/stripe.esm.worker.js",
       "require": "./cjs/stripe.cjs.worker.js"


### PR DESCRIPTION
In Bun, `"node:http"` internally is implemented as a wrapper on top of `fetch`. `"stripe"` might as well skip the wrapper and just use fetch instead, assuming that it doesn't change the interface for users

In Bun v1.0, we removed the `"worker"` package.json `"exports"` condition which unfortunately caused `"stripe"` to load the `"node:http"`-based implementation. This `"node:http"`-based implementation usually works fine, however there is an edgecase where `https.Agent` has the wrong `protocol` set, [causing errors](https://github.com/oven-sh/bun/issues/10975) when a request is retried. This is a difficult to reproduce bug in Bun and not in `stripe`, which Bun will fix separately.

If we add the `BUN_JSC_dumpModuleLoadingState=1` environment variable, Bun logs some information about which modules have loaded.

Bun v0.6.1:
```js
❯ BUN_JSC_dumpModuleLoadingState=1 bun-0.6.1 terminy.js 2>&1 | rg "\.esm.*.js"
Loader [resolve] ./node_modules/stripe/esm/stripe.esm.worker.js
Loader [fetch] ./node_modules/stripe/esm/stripe.esm.worker.js
loader [parsing] ./node_modules/stripe/esm/stripe.esm.worker.js
Loader [link] ./node_modules/stripe/esm/stripe.esm.worker.js
Loader [evaluate] ./node_modules/stripe/esm/stripe.esm.worker.js
```

Bun v1.1.7:
```js
❯ BUN_JSC_dumpModuleLoadingState=1 bun-1.1.7 terminy.js 2>&1 | rg "\.esm.*.js"
Loader [fetch] ./node_modules/stripe/esm/stripe.esm.node.js
loader [parsing] ./node_modules/stripe/esm/stripe.esm.node.js
Loader [link] ./node_modules/stripe/esm/stripe.esm.node.js
Loader [evaluate] ./node_modules/stripe/esm/stripe.esm.node.js
```

We can see that in older versions of Bun, it used the `worker` condition instead of the `default` condition.

I looked through `WebPlatformFunctions.js` and it looks like the main downside to this approach is the lack of `tryBufferData` and a slower `secureCompare`.  I don't have enough context to know if `tryBufferData` is important - it's for file uploads, is what it seems like?