### PR TITLE
Where params are union of types, merge the types instead of having numbered suffixes in type names

### DIFF
--- a/types/PaymentIntentsResource.d.ts
+++ b/types/PaymentIntentsResource.d.ts
@@ -4871,10 +4871,7 @@ declare module 'stripe' {
        */
       mandate?: string;
 
-      mandate_data?: Stripe.Emptyable<
-        | PaymentIntentConfirmParams.MandateData1
-        | PaymentIntentConfirmParams.MandateData2
-      >;
+      mandate_data?: Stripe.Emptyable<PaymentIntentConfirmParams.MandateData>;
 
       /**
        * Set to `true` to indicate that the customer isn't in your checkout flow during this payment attempt and can't authenticate. Use this parameter in scenarios where you collect card details and [charge them later](https://stripe.com/docs/payments/cards/charging-saved-cards).
@@ -4947,14 +4944,14 @@ declare module 'stripe' {
     namespace PaymentIntentConfirmParams {
       type CaptureMethod = 'automatic' | 'automatic_async' | 'manual';
 
-      interface MandateData1 {
+      interface MandateData {
         /**
          * This hash contains details about the customer acceptance of the Mandate.
          */
-        customer_acceptance: MandateData1.CustomerAcceptance;
+        customer_acceptance?: MandateData.CustomerAcceptance;
       }
 
-      namespace MandateData1 {
+      namespace MandateData {
         interface CustomerAcceptance {
           /**
            * The time at which the customer accepted the Mandate.
@@ -4984,43 +4981,6 @@ declare module 'stripe' {
             /**
              * The IP address from which the Mandate was accepted by the customer.
              */
-            ip_address: string;
-
-            /**
-             * The user agent of the browser from which the Mandate was accepted by the customer.
-             */
-            user_agent: string;
-          }
-
-          type Type = 'offline' | 'online';
-        }
-      }
-
-      interface MandateData2 {
-        /**
-         * This hash contains details about the customer acceptance of the Mandate.
-         */
-        customer_acceptance: MandateData2.CustomerAcceptance;
-      }
-
-      namespace MandateData2 {
-        interface CustomerAcceptance {
-          /**
-           * If this is a Mandate accepted online, this hash contains details about the online acceptance.
-           */
-          online: CustomerAcceptance.Online;
-
-          /**
-           * The type of customer acceptance information included with the Mandate.
-           */
-          type: 'online';
-        }
-
-        namespace CustomerAcceptance {
-          interface Online {
-            /**
-             * The IP address from which the Mandate was accepted by the customer.
-             */
             ip_address?: string;
 
             /**
@@ -5028,6 +4988,8 @@ declare module 'stripe' {
              */
             user_agent?: string;
           }
+
+          type Type = 'offline' | 'online';
         }
       }
 

--- a/types/PaymentMethodsResource.d.ts
+++ b/types/PaymentMethodsResource.d.ts
@@ -66,7 +66,7 @@ declare module 'stripe' {
       /**
        * If this is a `card` PaymentMethod, this hash contains the user's card details. For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format `card: {token: "tok_visa"}`. When providing a card number, you must meet the requirements for [PCI compliance](https://stripe.com/docs/security#validating-pci-compliance). We strongly recommend using Stripe.js instead of interacting with this API directly.
        */
-      card?: PaymentMethodCreateParams.Card1 | PaymentMethodCreateParams.Card2;
+      card?: PaymentMethodCreateParams.Card;
 
       /**
        * If this is a `cashapp` PaymentMethod, this hash contains details about the Cash App Pay payment method.
@@ -319,7 +319,7 @@ declare module 'stripe' {
         tax_id: string;
       }
 
-      interface Card1 {
+      interface Card {
         /**
          * The card's CVC. It is highly recommended to always include this value.
          */
@@ -328,25 +328,30 @@ declare module 'stripe' {
         /**
          * Two-digit number representing the card's expiration month.
          */
-        exp_month: number;
+        exp_month?: number;
 
         /**
          * Four-digit number representing the card's expiration year.
          */
-        exp_year: number;
+        exp_year?: number;
 
         /**
          * Contains information about card networks used to process the payment.
          */
-        networks?: Card1.Networks;
+        networks?: Card.Networks;
 
         /**
          * The card number, as a string without any separators.
          */
-        number: string;
+        number?: string;
+
+        /**
+         * For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format card: {token: "tok_visa"}.
+         */
+        token?: string;
       }
 
-      namespace Card1 {
+      namespace Card {
         interface Networks {
           /**
            * The customer's preferred card network for co-branded cards. Supports `cartes_bancaires`, `mastercard`, or `visa`. Selection of a network that does not apply to the card will be stored as `invalid_preference` on the card.
@@ -357,13 +362,6 @@ declare module 'stripe' {
         namespace Networks {
           type Preferred = 'cartes_bancaires' | 'mastercard' | 'visa';
         }
-      }
-
-      interface Card2 {
-        /**
-         * For backwards compatibility, you can alternatively provide a Stripe token (e.g., for Apple Pay, Amex Express Checkout, or legacy Checkout) into the card hash with format card: {token: "tok_visa"}.
-         */
-        token: string;
       }
 
       interface Cashapp {}

--- a/types/SetupIntentsResource.d.ts
+++ b/types/SetupIntentsResource.d.ts
@@ -2339,10 +2339,7 @@ declare module 'stripe' {
        */
       expand?: Array<string>;
 
-      mandate_data?: Stripe.Emptyable<
-        | SetupIntentConfirmParams.MandateData1
-        | SetupIntentConfirmParams.MandateData2
-      >;
+      mandate_data?: Stripe.Emptyable<SetupIntentConfirmParams.MandateData>;
 
       /**
        * ID of the payment method (a PaymentMethod, Card, or saved Source object) to attach to this SetupIntent.
@@ -2374,14 +2371,14 @@ declare module 'stripe' {
     }
 
     namespace SetupIntentConfirmParams {
-      interface MandateData1 {
+      interface MandateData {
         /**
          * This hash contains details about the customer acceptance of the Mandate.
          */
-        customer_acceptance: MandateData1.CustomerAcceptance;
+        customer_acceptance?: MandateData.CustomerAcceptance;
       }
 
-      namespace MandateData1 {
+      namespace MandateData {
         interface CustomerAcceptance {
           /**
            * The time at which the customer accepted the Mandate.
@@ -2411,43 +2408,6 @@ declare module 'stripe' {
             /**
              * The IP address from which the Mandate was accepted by the customer.
              */
-            ip_address: string;
-
-            /**
-             * The user agent of the browser from which the Mandate was accepted by the customer.
-             */
-            user_agent: string;
-          }
-
-          type Type = 'offline' | 'online';
-        }
-      }
-
-      interface MandateData2 {
-        /**
-         * This hash contains details about the customer acceptance of the Mandate.
-         */
-        customer_acceptance: MandateData2.CustomerAcceptance;
-      }
-
-      namespace MandateData2 {
-        interface CustomerAcceptance {
-          /**
-           * If this is a Mandate accepted online, this hash contains details about the online acceptance.
-           */
-          online: CustomerAcceptance.Online;
-
-          /**
-           * The type of customer acceptance information included with the Mandate.
-           */
-          type: 'online';
-        }
-
-        namespace CustomerAcceptance {
-          interface Online {
-            /**
-             * The IP address from which the Mandate was accepted by the customer.
-             */
             ip_address?: string;
 
             /**
@@ -2455,6 +2415,8 @@ declare module 'stripe' {
              */
             user_agent?: string;
           }
+
+          type Type = 'offline' | 'online';
         }
       }
 


### PR DESCRIPTION


## Changelog
* Change type of `PaymentIntentConfirmParams.mandate_data` from `Stripe.Emptyable<PaymentIntentConfirmParams.MandateData1 | PaymentIntentConfirmParams.MandateData2>` to `Stripe.Emptyable<PaymentIntentConfirmParams.MandateData>` where the new MandateData is a union of all the properties of MandateData1 and MandateData2
* Change type of `PaymentMethodCreateParams.card` from `PaymentMethodCreateParams.Card1 | PaymentMethodCreateParams.Card2` to `PaymentMethodCreateParams.Card` where the new Card is a union of all the properties of Card1 and Card2
* Change type of `SetupIntentConfirmParams.mandate_data` from `Stripe.Emptyable<SetupIntentConfirmParams.MandateData1 | SetupIntentConfirmParams.MandateData2>` to `Stripe.Emptyable<SetupIntentConfirmParams.MandateData>` where the new MandateData is a union of all the properties of MandateData1 and MandateData2