### PR TITLE
Use worker module in Bun

### DIFF
--- a/package.json
+++ b/package.json
@@ -80,6 +80,10 @@
       "import": "./esm/stripe.esm.worker.js",
       "require": "./cjs/stripe.cjs.worker.js"
     },
+    "bun": {
+      "import": "./esm/stripe.esm.worker.js",
+      "require": "./cjs/stripe.cjs.worker.js"
+    },
     "deno": {
       "import": "./esm/stripe.esm.worker.js",
       "require": "./cjs/stripe.cjs.worker.js"


### PR DESCRIPTION
Add `bun` conditional exports target. Currently, Bun users who import Stripe get the default version of stripe-node, which produces errors if they don't configure Stripe with the `httpClient` option. Adding this target will allow Bun users to receive the web platform version of `stripe-node`.

https://github.com/stripe/stripe-node/pull/2090