### PR TITLE
Update API version in TS example project

### DIFF
--- a/testProjects/mjs-ts/index.ts
+++ b/testProjects/mjs-ts/index.ts
@@ -1,13 +1,13 @@
 import DefaultStripe, {Stripe} from 'stripe';
 
 const stripe = new Stripe(process.argv[2], {
-  apiVersion: '2024-04-10',
+  apiVersion: '2024-06-20',
   host: process.env.STRIPE_MOCK_HOST || 'localhost',
   port: process.env.STRIPE_MOCK_PORT || 12111,
   protocol: 'http',
 });
 const defaultStripe = new DefaultStripe(process.argv[2], {
-  apiVersion: '2024-04-10',
+  apiVersion: '2024-06-20',
   host: process.env.STRIPE_MOCK_HOST || 'localhost',
   port: process.env.STRIPE_MOCK_PORT || 12111,
   protocol: 'http',


### PR DESCRIPTION
The latest API version means a different string literal when creating a client, causing a type error in a test. I've updated the test.