### PR TITLE
Remove TS test that cares about a specific API version

### DIFF
--- a/testProjects/mjs-ts/index.ts
+++ b/testProjects/mjs-ts/index.ts
@@ -1,13 +1,15 @@
 import DefaultStripe, {Stripe} from 'stripe';
 
 const stripe = new Stripe(process.argv[2], {
-  apiVersion: '2024-06-20',
+  // if we specify a version, then our smoke tests fail every time there's a new API version being prepped
+  apiVersion: undefined,
   host: process.env.STRIPE_MOCK_HOST || 'localhost',
   port: process.env.STRIPE_MOCK_PORT || 12111,
   protocol: 'http',
 });
 const defaultStripe = new DefaultStripe(process.argv[2], {
-  apiVersion: '2024-06-20',
+  // if we specify a version, then our smoke tests fail every time there's a new API version being prepped
+  apiVersion: undefined,
   host: process.env.STRIPE_MOCK_HOST || 'localhost',
   port: process.env.STRIPE_MOCK_PORT || 12111,
   protocol: 'http',


### PR DESCRIPTION
When releasing the most recent major, the types required a specific API version: 

https://github.com/stripe/stripe-node/blob/e219b05f02f09efb57b13e50977012d001a49223/types/lib.d.ts#L30

So this test was failing until we adjusted the string. A test that fails on a schedule isn't great and the test isn't verifying anything especially useful. I think it's more trouble than it's worth, so I pulled it.