### PR TITLE
check `hasOwnProperty` when using `for..in`

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -39,7 +39,7 @@ module.exports = {
     'func-style': ['error', 'declaration', {allowArrowFunctions: true}],
     'generator-star-spacing': 'error',
     'global-require': 'off',
-    'guard-for-in': 'off',
+    'guard-for-in': 'error',
     'handle-callback-err': 'off',
     'id-blacklist': 'error',
     'id-length': 'off',

--- a/src/ResourceNamespace.ts
+++ b/src/ResourceNamespace.ts
@@ -16,6 +16,9 @@ function ResourceNamespace(
   >
 ): void {
   for (const name in resources) {
+    if (!Object.prototype.hasOwnProperty.call(resources, name)) {
+      continue;
+    }
     const camelCaseName = name[0].toLowerCase() + name.substring(1);
 
     const resource = new resources[name](stripe);

--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -1,8 +1,8 @@
 import {
   MultipartRequestData,
+  RequestData,
   RequestHeaders,
   StripeResourceObject,
-  RequestData,
 } from './Types.js';
 import {flattenAndStringify, stringifyRequestData} from './utils.js';
 
@@ -46,6 +46,10 @@ const multipartDataGenerator = (
   const flattenedData = flattenAndStringify(data);
 
   for (const k in flattenedData) {
+    if (!Object.prototype.hasOwnProperty.call(flattenedData, k)) {
+      continue;
+    }
+
     const v = flattenedData[k];
     push(`--${segno}`);
     if (Object.prototype.hasOwnProperty.call(v, 'data')) {

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1,18 +1,18 @@
 import * as _Error from './Error.js';
+import {RequestSender} from './RequestSender.js';
+import {StripeResource} from './StripeResource.js';
+import {AppInfo, StripeObject, UserProvidedConfig} from './Types.js';
+import {WebhookObject, createWebhooks} from './Webhooks.js';
 import * as apiVersion from './apiVersion.js';
-import * as resources from './resources.js';
+import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
+import {PlatformFunctions} from './platform/PlatformFunctions.js';
+import * as resources from './resources.js';
 import {
   determineProcessUserAgentProperties,
   pascalToCamelCase,
   validateInteger,
 } from './utils.js';
-import {CryptoProvider} from './crypto/CryptoProvider.js';
-import {PlatformFunctions} from './platform/PlatformFunctions.js';
-import {RequestSender} from './RequestSender.js';
-import {StripeResource} from './StripeResource.js';
-import {WebhookObject, createWebhooks} from './Webhooks.js';
-import {StripeObject, AppInfo, UserProvidedConfig} from './Types.js';
 
 const DEFAULT_HOST = 'api.stripe.com';
 const DEFAULT_PORT = '443';
@@ -363,6 +363,9 @@ export function createStripe(
       this._platformFunctions.getUname().then((uname: string | null) => {
         const userAgent: Record<string, string> = {};
         for (const field in seed) {
+          if (!Object.prototype.hasOwnProperty.call(seed, field)) {
+            continue;
+          }
           userAgent[field] = encodeURIComponent(seed[field] ?? 'null');
         }
 
@@ -417,6 +420,10 @@ export function createStripe(
      */
     _prepResources(): void {
       for (const name in resources) {
+        if (!Object.prototype.hasOwnProperty.call(resources, name)) {
+          continue;
+        }
+
         // @ts-ignore
         this[pascalToCamelCase(name)] = new resources[name](this);
       }


### PR DESCRIPTION
When using iterating over the properties of an object, we should be defensive and ensure we're only using the properties that belong directly to that object (not anything inherited from the prototype chain). If users have modified the base `Object`, then we'll modify _those_ modifications in a way we shouldn't, causing issues.

This seemed like something we could catch in lint, and it is! We just disabled the rule for some reason. So I re-enabled it and fixed the errors.

More info: https://eslint.org/docs/latest/rules/guard-for-in

---

Fixes #2114 

Fixes [RUN_DEVSDK-1209](https://jira.corp.stripe.com/browse/RUN_DEVSDK-1209)