### PR TITLE
update node versions in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,10 @@ jobs:
         os:
           - "ubuntu-latest"
         node:
-          - "19"
+          # should include even numbers >= 12
+          # see: https://nodejs.org/en/about/previous-releases
+          - "22"
+          - "20"
           - "18"
           - "16"
           - "14"

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,0 +1,3 @@
+[tools]
+# used in unit tests
+deno = "1"

--- a/examples/webhook-signing/.gitignore
+++ b/examples/webhook-signing/.gitignore
@@ -3,3 +3,4 @@
 **/package-lock.json
 .env
 express-ts.js
+deno.lock


### PR DESCRIPTION
Updates CI to test against the latest Node.js versions

Full list is here: https://nodejs.org/en/about/previous-releases

We should focus on the even-numbered releases, since those are (or will be) LTS.

Also:

- added `deno` to the local install so the full unit test suite passes
- added its lockfile to the gitignore