### PR TITLE
feat: migrate to picoquery

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "@types/chai": "^4.3.4",
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",
-    "@types/qs": "^6.9.7",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "chai": "^4.3.6",
@@ -56,7 +55,7 @@
   },
   "dependencies": {
     "@types/node": ">=8.1.0",
-    "qs": "^6.11.0"
+    "picoquery": "^1.4.0"
   },
   "license": "MIT",
   "scripts": {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import * as qs from 'qs';
+import * as pq from 'picoquery';
 import {
   RequestData,
   UrlInterpolator,
@@ -45,9 +45,16 @@ export function isOptionsHash(o: unknown): boolean | unknown {
  */
 export function stringifyRequestData(data: RequestData | string): string {
   return (
-    qs
+    pq
       .stringify(data, {
-        serializeDate: (d: Date) => Math.floor(d.getTime() / 1000).toString(),
+        nesting: true,
+        nestingSyntax: 'index',
+        valueSerializer: (val, key) => {
+          if (val instanceof Date) {
+            return Math.floor(val.getTime() / 1000).toString();
+          }
+          return pq.defaultValueSerializer(val, key);
+        },
       })
       // Don't use strict form encoding by changing the square bracket control
       // characters back to their literals. This is fine by the server, and

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -3,6 +3,7 @@
   "compilerOptions": {
     "outDir": "./esm",
     "module": "es2022",
+    "moduleResolution": "node",
   },
   "exclude": ["./src/stripe.cjs.node.ts", "./src/stripe.cjs.worker.ts"],
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -459,11 +459,6 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-18.11.3.tgz#78a6d7ec962b596fc2d2ec102c4dd3ef073fea6a"
   integrity sha512-fNjDQzzOsZeKZu5NATgXUPsaFaTxeRgFXoosrHivTl8RGeV733OLawXsGfEk9a8/tySyZUyiZ6E8LcjPFZ2y1A==
 
-"@types/qs@^6.9.7":
-  version "6.9.7"
-  resolved "https://registry.yarnpkg.com/@types/qs/-/qs-6.9.7.tgz#63bb7d067db107cc1e457c303bc25d511febf6cb"
-  integrity sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==
-
 "@typescript-eslint/eslint-plugin@^4.33.0":
   version "4.33.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-4.33.0.tgz#c24dc7c8069c7706bc40d99f6fa87edcb2005276"
@@ -1407,6 +1402,11 @@ extsprintf@^1.2.0:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
   integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
+
+fast-decode-uri-component@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/fast-decode-uri-component/-/fast-decode-uri-component-1.0.1.tgz#46f8b6c22b30ff7a81357d4f59abfae938202543"
+  integrity sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==
 
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
@@ -2587,6 +2587,13 @@ picomatch@^2.0.4, picomatch@^2.2.1, picomatch@^2.3.1:
   resolved "https://registry.yarnpkg.com/picomatch/-/picomatch-2.3.1.tgz#3ba3833733646d9d3e4995946c1365a67fb07a42"
   integrity sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA==
 
+picoquery@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/picoquery/-/picoquery-1.4.0.tgz#04ed2e9f15d7f2ef00aedae90012c4e670eab530"
+  integrity sha512-VIq9N+nQgmiN6DsAgs7EcAjUezgppBR4zahSu/Q0H0pylLu9e9BORK91n/kmW7wfkHRnNnIn9IIB8uaI7ElvTg==
+  dependencies:
+    fast-decode-uri-component "^1.0.1"
+
 pkg-dir@^4.1.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/pkg-dir/-/pkg-dir-4.2.0.tgz#f099133df7ede422e81d1d8448270eeb3e4261f3"
@@ -2637,13 +2644,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
-
-qs@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
-  dependencies:
-    side-channel "^1.0.4"
 
 qs@~6.5.2:
   version "6.5.3"


### PR DESCRIPTION
Migrates from qs to picoquery for query strings, a faster and lighter alternative.

This is an alternative to #2116 - using pq to provide the logic rather than rolling our own

if you'd prefer to roll your own, feel free to close this