### PR TITLE
Metadata may be undefined

### DIFF
--- a/types/shared.d.ts
+++ b/types/shared.d.ts
@@ -4,7 +4,7 @@ declare module 'stripe' {
      * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
      */
     interface Metadata {
-      [name: string]: string;
+      [name: string]: string | undefined;
     }
 
     /**


### PR DESCRIPTION
Metadata fields may be undefined, as such accessing a field should have a type of `string | undefined`