### PR TITLE
Remove qs package and implement URLSearchParams serializer

### DIFF
--- a/package.json
+++ b/package.json
@@ -55,8 +55,7 @@
     "nanoid": "^3.2.0"
   },
   "dependencies": {
-    "@types/node": ">=8.1.0",
-    "qs": "^6.11.0"
+    "@types/node": ">=8.1.0"
   },
   "license": "MIT",
   "scripts": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2638,13 +2638,6 @@ punycode@^2.1.0, punycode@^2.1.1:
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
-qs@^6.11.0:
-  version "6.11.0"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.11.0.tgz#fd0d963446f7a65e1367e01abd85429453f0c37a"
-  integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
-  dependencies:
-    side-channel "^1.0.4"
-
 qs@~6.5.2:
   version "6.5.3"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"


### PR DESCRIPTION
Hello

This pull request removes the qs package and replaces it with a custom implementation of URLSearchParams serializer.

The `stringifyRequestData` function now serializes an object or string into URL-encoded parameters, accommodating nested objects and arrays.

The goal of this change is to remove the `qs` dependency which was used for this single function. 
It will allow to reduce the size of the stripe-node library.

URLSearchParams is available in all evergreen browser, NodeJS since v10, Deno since v1, and Bun.

Source : https://developer.mozilla.org/en-US/docs/Web/API/URLSearchParams
https://bun.sh/docs/runtime/nodejs-apis#urlsearchparams