### PR TITLE
Null out empty data sent to GET/DELETE APIs

### DIFF
--- a/src/StripeResource.ts
+++ b/src/StripeResource.ts
@@ -178,7 +178,7 @@ StripeResource.prototype = {
     }
 
     const dataInQuery = spec.method === 'GET' || spec.method === 'DELETE';
-    const bodyData = dataInQuery ? {} : data;
+    const bodyData = dataInQuery ? null : data;
     const queryData = dataInQuery ? data : {};
 
     return {

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -61,7 +61,7 @@ export type RequestOptions = {
 export type RequestOpts = {
   requestMethod: string;
   requestPath: string;
-  bodyData: RequestData;
+  bodyData: RequestData | null;
   queryData: RequestData;
   auth: string | null;
   headers: RequestHeaders;
@@ -155,7 +155,7 @@ export type RequestSender = {
     method: string,
     host: string | null,
     path: string,
-    data: RequestData,
+    data: RequestData | null,
     auth: string | null,
     options: RequestOptions,
     usage: Array<string>,

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -33,7 +33,7 @@ describe('Account Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'DELETE',
         url: '/v1/accounts/acct_16Tzq6DBahdM4C8s',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -59,7 +59,7 @@ describe('Account Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/account',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -70,7 +70,7 @@ describe('Account Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/accounts/foo',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -83,7 +83,7 @@ describe('Account Resource', () => {
         auth: key,
         method: 'GET',
         url: '/v1/account',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -96,7 +96,7 @@ describe('Account Resource', () => {
         auth: params.apiKey,
         method: 'GET',
         url: '/v1/account',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -107,7 +107,7 @@ describe('Account Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/account',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -122,7 +122,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/capabilities',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -133,7 +133,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/capabilities',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -147,7 +147,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/capabilities/acap_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -162,7 +162,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/capabilities/acap_123',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -216,7 +216,7 @@ describe('Account Resource', () => {
           url:
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -232,7 +232,7 @@ describe('Account Resource', () => {
           url:
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -307,7 +307,7 @@ describe('Account Resource', () => {
           url:
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -323,7 +323,7 @@ describe('Account Resource', () => {
           url:
             '/v1/accounts/accountIdFoo321/external_accounts/externalAccountIdFoo456',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -337,7 +337,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/accountIdFoo321/external_accounts',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -348,7 +348,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/accountIdFoo321/external_accounts',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -379,7 +379,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -390,7 +390,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -471,7 +471,7 @@ describe('Account Resource', () => {
           method: 'DELETE',
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -482,7 +482,7 @@ describe('Account Resource', () => {
           method: 'DELETE',
           url: '/v1/accounts/acct_123/persons/person_123',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -496,7 +496,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/persons',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -507,7 +507,7 @@ describe('Account Resource', () => {
           method: 'GET',
           url: '/v1/accounts/acct_123/persons',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });

--- a/test/resources/ApplePayDomains.spec.js
+++ b/test/resources/ApplePayDomains.spec.js
@@ -11,7 +11,7 @@ describe('ApplePayDomains Resource', () => {
         method: 'GET',
         url: '/v1/apple_pay/domains/apwc_retrieve',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('ApplePayDomains Resource', () => {
         method: 'DELETE',
         url: '/v1/apple_pay/domains/apwc_delete',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -55,7 +55,7 @@ describe('ApplePayDomains Resource', () => {
         method: 'GET',
         url: '/v1/apple_pay/domains',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/ApplicationFees.spec.js
+++ b/test/resources/ApplicationFees.spec.js
@@ -10,7 +10,7 @@ describe('ApplicationFee Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/application_fees',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -50,7 +50,7 @@ describe('ApplicationFee Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/application_fees/appFeeIdExample3242/refunds',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -65,7 +65,7 @@ describe('ApplicationFee Resource', () => {
         method: 'GET',
         url:
           '/v1/application_fees/appFeeIdExample3242/refunds/refundIdExample2312',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Balance.spec.js
+++ b/test/resources/Balance.spec.js
@@ -10,7 +10,7 @@ describe('Balance Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/balance',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -21,7 +21,7 @@ describe('Balance Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/balance',
-        data: {},
+        data: null,
         auth: 'aGN0bIwXnHdw5645VABjPdSn8nWY7G11',
         headers: {},
         settings: {},

--- a/test/resources/BalanceTransactions.spec.js
+++ b/test/resources/BalanceTransactions.spec.js
@@ -11,7 +11,7 @@ describe('BalanceTransactions Resource', function() {
         method: 'GET',
         url: '/v1/balance_transactions/txn_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('BalanceTransactions Resource', function() {
         method: 'GET',
         url: '/v1/balance_transactions',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/BillingPortal/Configurations.spec.js
+++ b/test/resources/BillingPortal/Configurations.spec.js
@@ -52,7 +52,7 @@ describe('BillingPortal', () => {
           method: 'GET',
           url: '/v1/billing_portal/configurations/bpc_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -64,7 +64,7 @@ describe('BillingPortal', () => {
           method: 'GET',
           url: '/v1/billing_portal/configurations',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Charges.spec.js
+++ b/test/resources/Charges.spec.js
@@ -10,7 +10,7 @@ describe('Charge Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/charges/chargeIdFoo123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -52,7 +52,7 @@ describe('Charge Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/charges',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Checkout/Sessions.spec.js
+++ b/test/resources/Checkout/Sessions.spec.js
@@ -45,7 +45,7 @@ describe('Checkout', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/checkout/sessions/cs_123',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });
@@ -59,7 +59,7 @@ describe('Checkout', () => {
           method: 'GET',
           url: '/v1/checkout/sessions/cs_123/line_items',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/CountrySpecs.spec.js
+++ b/test/resources/CountrySpecs.spec.js
@@ -10,7 +10,7 @@ describe('CountrySpecs Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/country_specs',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -24,7 +24,7 @@ describe('CountrySpecs Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: `/v1/country_specs/${country}`,
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Coupons.spec.js
+++ b/test/resources/Coupons.spec.js
@@ -11,7 +11,7 @@ describe('Coupons Resource', () => {
         method: 'GET',
         url: '/v1/coupons/couponId123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('Coupons Resource', () => {
         method: 'DELETE',
         url: '/v1/coupons/couponId123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -76,7 +76,7 @@ describe('Coupons Resource', () => {
         method: 'GET',
         url: '/v1/coupons',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/CreditNotes.spec.js
+++ b/test/resources/CreditNotes.spec.js
@@ -11,7 +11,7 @@ describe('CreditNotes Resource', () => {
         method: 'GET',
         url: '/v1/credit_notes/cn_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -42,7 +42,7 @@ describe('CreditNotes Resource', () => {
         method: 'GET',
         url: '/v1/credit_notes?count=25',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -55,7 +55,7 @@ describe('CreditNotes Resource', () => {
         method: 'GET',
         url: '/v1/credit_notes/cn_123/lines',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -68,7 +68,7 @@ describe('CreditNotes Resource', () => {
         method: 'GET',
         url: '/v1/credit_notes/preview/lines',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -98,7 +98,7 @@ describe('CreditNotes Resource', () => {
         method: 'GET',
         url: '/v1/credit_notes/preview?amount=100&invoice=in_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -13,7 +13,7 @@ describe('Customers Resource', () => {
         method: 'GET',
         url: '/v1/customers/cus_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('Customers Resource', () => {
         method: 'GET',
         url: '/v1/customers/cus_123',
         headers: {},
-        data: {},
+        data: null,
         auth: TEST_AUTH_KEY,
         settings: {},
       });
@@ -146,7 +146,7 @@ describe('Customers Resource', () => {
         method: 'DELETE',
         url: '/v1/customers/cus_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -159,7 +159,7 @@ describe('Customers Resource', () => {
         method: 'GET',
         url: '/v1/customers',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -170,7 +170,7 @@ describe('Customers Resource', () => {
         method: 'GET',
         url: '/v1/customers',
         headers: {},
-        data: {},
+        data: null,
         auth: TEST_AUTH_KEY,
         settings: {},
       });
@@ -185,7 +185,7 @@ describe('Customers Resource', () => {
           method: 'DELETE',
           url: '/v1/customers/cus_123/discount',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -200,7 +200,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -211,7 +211,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -281,7 +281,7 @@ describe('Customers Resource', () => {
           method: 'DELETE',
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -292,7 +292,7 @@ describe('Customers Resource', () => {
           method: 'DELETE',
           url: '/v1/customers/cus_123/sources/card_123',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -306,7 +306,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/sources',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -317,7 +317,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/sources',
           headers: {},
-          data: {},
+          data: null,
           auth: TEST_AUTH_KEY,
           settings: {},
         });
@@ -354,7 +354,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/tax_ids/txi_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -384,7 +384,7 @@ describe('Customers Resource', () => {
           method: 'DELETE',
           url: '/v1/customers/cus_123/tax_ids/txi_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -397,7 +397,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/tax_ids',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -412,7 +412,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/balance_transactions/cbtxn_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -456,7 +456,7 @@ describe('Customers Resource', () => {
           method: 'GET',
           url: '/v1/customers/cus_123/balance_transactions',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Disputes.spec.js
+++ b/test/resources/Disputes.spec.js
@@ -10,7 +10,7 @@ describe('Dispute Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/disputes/dp_123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -23,7 +23,7 @@ describe('Dispute Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/disputes',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/EphemeralKeys.spec.js
+++ b/test/resources/EphemeralKeys.spec.js
@@ -87,7 +87,7 @@ describe('EphemeralKey Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'DELETE',
         url: '/v1/ephemeral_keys/ephkey_123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Events.spec.js
+++ b/test/resources/Events.spec.js
@@ -11,7 +11,7 @@ describe('Events Resource', () => {
         method: 'GET',
         url: '/v1/events/eventIdBaz',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('Events Resource', () => {
         method: 'GET',
         url: '/v1/events?count=25',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/ExchangeRates.spec.js
+++ b/test/resources/ExchangeRates.spec.js
@@ -10,7 +10,7 @@ describe('ExchangeRates Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/exchange_rates',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -24,7 +24,7 @@ describe('ExchangeRates Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: `/v1/exchange_rates/${currency}`,
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/FileLinks.spec.js
+++ b/test/resources/FileLinks.spec.js
@@ -11,7 +11,7 @@ describe('FileLinks Resource', () => {
         method: 'GET',
         url: '/v1/file_links/link_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -50,7 +50,7 @@ describe('FileLinks Resource', () => {
         method: 'GET',
         url: '/v1/file_links',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -15,7 +15,7 @@ describe('Files Resource', () => {
         method: 'GET',
         url: '/v1/files/fil_12345',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -26,7 +26,7 @@ describe('Files Resource', () => {
         method: 'GET',
         url: '/v1/files/fil_12345',
         headers: {},
-        data: {},
+        data: null,
         auth: TEST_AUTH_KEY,
         settings: {},
       });
@@ -40,7 +40,7 @@ describe('Files Resource', () => {
         method: 'GET',
         url: '/v1/files',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Identity/VerificationReport.spec.js
+++ b/test/resources/Identity/VerificationReport.spec.js
@@ -11,7 +11,7 @@ describe('Identity', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/identity/verification_reports/vr_123',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });
@@ -24,7 +24,7 @@ describe('Identity', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/identity/verification_reports',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });

--- a/test/resources/Identity/VerificationSession.spec.js
+++ b/test/resources/Identity/VerificationSession.spec.js
@@ -24,7 +24,7 @@ describe('Identity', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/identity/verification_sessions/vs_123',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });
@@ -37,7 +37,7 @@ describe('Identity', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/identity/verification_sessions',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });

--- a/test/resources/InvoiceItems.spec.js
+++ b/test/resources/InvoiceItems.spec.js
@@ -11,7 +11,7 @@ describe('InvoiceItems Resource', () => {
         method: 'GET',
         url: '/v1/invoiceitems/invoiceItemIdTesting123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -54,7 +54,7 @@ describe('InvoiceItems Resource', () => {
         method: 'DELETE',
         url: '/v1/invoiceitems/invoiceItemId2',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -67,7 +67,7 @@ describe('InvoiceItems Resource', () => {
         method: 'GET',
         url: '/v1/invoiceitems',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Invoices.spec.js
+++ b/test/resources/Invoices.spec.js
@@ -11,7 +11,7 @@ describe('Invoices Resource', () => {
         method: 'GET',
         url: '/v1/invoices/in_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -37,7 +37,7 @@ describe('Invoices Resource', () => {
         method: 'GET',
         url: '/v1/invoices?count=25',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -63,7 +63,7 @@ describe('Invoices Resource', () => {
         method: 'DELETE',
         url: '/v1/invoices/in_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -76,7 +76,7 @@ describe('Invoices Resource', () => {
         method: 'GET',
         url: '/v1/invoices/in_123/lines',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -89,7 +89,7 @@ describe('Invoices Resource', () => {
         method: 'GET',
         url: '/v1/invoices/upcoming/lines',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -107,7 +107,7 @@ describe('Invoices Resource', () => {
         url:
           '/v1/invoices/upcoming?customer=cus_abc&subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -126,7 +126,7 @@ describe('Invoices Resource', () => {
         url:
           '/v1/invoices/upcoming/lines?customer=cus_abc&subscription_items[0][plan]=potato&subscription_items[1][plan]=rutabaga&limit=5',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Issuing/Authorization.spec.js
+++ b/test/resources/Issuing/Authorization.spec.js
@@ -11,7 +11,7 @@ describe('Issuing', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/issuing/authorizations/iauth_123',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });
@@ -24,7 +24,7 @@ describe('Issuing', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/issuing/authorizations',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });

--- a/test/resources/Issuing/Cardholders.spec.js
+++ b/test/resources/Issuing/Cardholders.spec.js
@@ -14,7 +14,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/cardholders/ich_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -71,7 +71,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/cardholders',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Issuing/Cards.spec.js
+++ b/test/resources/Issuing/Cards.spec.js
@@ -14,7 +14,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/cards/ic_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -69,7 +69,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/cards',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Issuing/Disputes.spec.js
+++ b/test/resources/Issuing/Disputes.spec.js
@@ -14,7 +14,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/disputes/idp_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -67,7 +67,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/disputes',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Issuing/Transactions.spec.js
+++ b/test/resources/Issuing/Transactions.spec.js
@@ -14,7 +14,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/transactions/ipi_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -50,7 +50,7 @@ describe('Issuing', () => {
           method: 'GET',
           url: '/v1/issuing/transactions',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Mandates.spec.js
+++ b/test/resources/Mandates.spec.js
@@ -12,7 +12,7 @@ describe('Mandate Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: `/v1/mandates/${MANDATE_TEST_ID}`,
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/PaymentIntents.spec.js
+++ b/test/resources/PaymentIntents.spec.js
@@ -31,7 +31,7 @@ describe('Payment Intents Resource', () => {
         method: 'GET',
         url: '/v1/payment_intents',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -44,7 +44,7 @@ describe('Payment Intents Resource', () => {
         method: 'GET',
         url: `/v1/payment_intents/${PAYMENT_INTENT_TEST_ID}`,
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/PaymentMethods.spec.js
+++ b/test/resources/PaymentMethods.spec.js
@@ -11,7 +11,7 @@ describe('PaymentMethods Resource', () => {
         method: 'GET',
         url: '/v1/payment_methods/pm_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -44,7 +44,7 @@ describe('PaymentMethods Resource', () => {
         method: 'GET',
         url: '/v1/payment_methods?customer=cus_123&type=card',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Payouts.spec.js
+++ b/test/resources/Payouts.spec.js
@@ -13,7 +13,7 @@ describe('Payouts Resource', () => {
         method: 'GET',
         url: `/v1/payouts/${PAYOUT_TEST_ID}`,
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -70,7 +70,7 @@ describe('Payouts Resource', () => {
         method: 'GET',
         url: '/v1/payouts',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Plans.spec.js
+++ b/test/resources/Plans.spec.js
@@ -11,7 +11,7 @@ describe('Plans Resource', () => {
         method: 'GET',
         url: '/v1/plans/plan_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -116,7 +116,7 @@ describe('Plans Resource', () => {
         method: 'DELETE',
         url: '/v1/plans/plan_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -129,7 +129,7 @@ describe('Plans Resource', () => {
         method: 'GET',
         url: '/v1/plans',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Prices.spec.js
+++ b/test/resources/Prices.spec.js
@@ -11,7 +11,7 @@ describe('Plans Resource', () => {
         method: 'GET',
         url: '/v1/prices/price_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -70,7 +70,7 @@ describe('Plans Resource', () => {
         method: 'GET',
         url: '/v1/prices',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Products.spec.js
+++ b/test/resources/Products.spec.js
@@ -10,7 +10,7 @@ describe('Product Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/products/productIdFoo123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -46,7 +46,7 @@ describe('Product Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/products?limit=3',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -59,7 +59,7 @@ describe('Product Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/products?shippable=true',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -86,7 +86,7 @@ describe('Product Resource', () => {
         method: 'DELETE',
         url: '/v1/products/productIdFoo3242',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/PromotionCodes.spec.js
+++ b/test/resources/PromotionCodes.spec.js
@@ -11,7 +11,7 @@ describe('PromotionCodes Resource', () => {
         method: 'GET',
         url: '/v1/promotion_codes/promo_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -61,7 +61,7 @@ describe('PromotionCodes Resource', () => {
         method: 'GET',
         url: '/v1/promotion_codes',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Quotes.spec.js
+++ b/test/resources/Quotes.spec.js
@@ -31,7 +31,7 @@ describe('Quotes Resource', () => {
         method: 'GET',
         url: '/v1/quotes',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -44,7 +44,7 @@ describe('Quotes Resource', () => {
         method: 'GET',
         url: `/v1/quotes/${QUOTE_TEST_ID}`,
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -111,7 +111,7 @@ describe('Quotes Resource', () => {
         method: 'GET',
         url: `/v1/quotes/${QUOTE_TEST_ID}/line_items`,
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -124,7 +124,7 @@ describe('Quotes Resource', () => {
         method: 'GET',
         url: `/v1/quotes/${QUOTE_TEST_ID}/computed_upfront_line_items`,
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Radar/EarlyFraudWarnings.spec.js
+++ b/test/resources/Radar/EarlyFraudWarnings.spec.js
@@ -11,7 +11,7 @@ describe('Radar', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/radar/early_fraud_warnings/issfr_123',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });
@@ -24,7 +24,7 @@ describe('Radar', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/radar/early_fraud_warnings',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });

--- a/test/resources/Radar/ValueListItems.spec.js
+++ b/test/resources/Radar/ValueListItems.spec.js
@@ -14,7 +14,7 @@ describe('Radar', () => {
           method: 'GET',
           url: '/v1/radar/value_list_items/rsli_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -48,7 +48,7 @@ describe('Radar', () => {
           method: 'GET',
           url: '/v1/radar/value_list_items?value_list=rsl_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -61,7 +61,7 @@ describe('Radar', () => {
           method: 'DELETE',
           url: '/v1/radar/value_list_items/rsli_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Radar/ValueLists.spec.js
+++ b/test/resources/Radar/ValueLists.spec.js
@@ -14,7 +14,7 @@ describe('Radar', () => {
           method: 'GET',
           url: '/v1/radar/value_lists/rsl_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -46,7 +46,7 @@ describe('Radar', () => {
           method: 'GET',
           url: '/v1/radar/value_lists',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -59,7 +59,7 @@ describe('Radar', () => {
           method: 'DELETE',
           url: '/v1/radar/value_lists/rsl_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Refunds.spec.js
+++ b/test/resources/Refunds.spec.js
@@ -30,7 +30,7 @@ describe('Refund Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/refunds/re_123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -43,7 +43,7 @@ describe('Refund Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/refunds',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Reporting/ReportRuns.spec.js
+++ b/test/resources/Reporting/ReportRuns.spec.js
@@ -14,7 +14,7 @@ describe('Reporting', () => {
           method: 'GET',
           url: '/v1/reporting/report_runs/frr_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -50,7 +50,7 @@ describe('Reporting', () => {
           method: 'GET',
           url: '/v1/reporting/report_runs',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Reporting/ReportTypes.spec.js
+++ b/test/resources/Reporting/ReportTypes.spec.js
@@ -14,7 +14,7 @@ describe('Reporting', () => {
           method: 'GET',
           url: '/v1/reporting/report_types/activity.summary.1',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -27,7 +27,7 @@ describe('Reporting', () => {
           method: 'GET',
           url: '/v1/reporting/report_types',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Reviews.spec.js
+++ b/test/resources/Reviews.spec.js
@@ -10,7 +10,7 @@ describe('Review Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/reviews/prv_123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -23,7 +23,7 @@ describe('Review Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/reviews',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/SetupAttempts.spec.js
+++ b/test/resources/SetupAttempts.spec.js
@@ -11,7 +11,7 @@ describe('Setup Attempts Resource', () => {
         method: 'GET',
         url: '/v1/setup_attempts?setup_intent=si_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/SetupIntents.spec.js
+++ b/test/resources/SetupIntents.spec.js
@@ -29,7 +29,7 @@ describe('Setup Intents Resource', () => {
         method: 'GET',
         url: '/v1/setup_intents',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -42,7 +42,7 @@ describe('Setup Intents Resource', () => {
         method: 'GET',
         url: `/v1/setup_intents/${SETUP_INTENT_TEST_ID}`,
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Sigma/ScheduledQueryRuns.spec.js
+++ b/test/resources/Sigma/ScheduledQueryRuns.spec.js
@@ -11,7 +11,7 @@ describe('Sigma', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/sigma/scheduled_query_runs/sqr_123',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });
@@ -24,7 +24,7 @@ describe('Sigma', () => {
         expect(stripe.LAST_REQUEST).to.deep.equal({
           method: 'GET',
           url: '/v1/sigma/scheduled_query_runs',
-          data: {},
+          data: null,
           headers: {},
           settings: {},
         });

--- a/test/resources/Sources.spec.js
+++ b/test/resources/Sources.spec.js
@@ -11,7 +11,7 @@ describe('Sources Resource', () => {
         method: 'GET',
         url: '/v1/sources/sourceId1',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -70,7 +70,7 @@ describe('Sources Resource', () => {
         method: 'GET',
         url: '/v1/sources/src_foo/source_transactions',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/SubscriptionItems.spec.js
+++ b/test/resources/SubscriptionItems.spec.js
@@ -11,7 +11,7 @@ describe('SubscriptionItems Resource', () => {
         method: 'GET',
         url: '/v1/subscription_items/test_sub_item',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('SubscriptionItems Resource', () => {
         method: 'DELETE',
         url: '/v1/subscription_items/test_sub_item',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -77,7 +77,7 @@ describe('SubscriptionItems Resource', () => {
         method: 'GET',
         url: '/v1/subscription_items?limit=3&subscription=test_sub',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -109,7 +109,7 @@ describe('SubscriptionItems Resource', () => {
         method: 'GET',
         url: '/v1/subscription_items/si_123/usage_record_summaries',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/SubscriptionSchedule.spec.js
+++ b/test/resources/SubscriptionSchedule.spec.js
@@ -44,7 +44,7 @@ describe('Subscription Schedule Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/subscription_schedules',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -73,7 +73,7 @@ describe('Subscription Schedule Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/subscription_schedules/sub_sched_123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Subscriptions.spec.js
+++ b/test/resources/Subscriptions.spec.js
@@ -11,7 +11,7 @@ describe('subscriptions Resource', () => {
         method: 'GET',
         url: '/v1/subscriptions/test_sub',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -175,7 +175,7 @@ describe('subscriptions Resource', () => {
         method: 'GET',
         url: '/v1/subscriptions?limit=3&customer=test_cus&plan=gold',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -189,7 +189,7 @@ describe('subscriptions Resource', () => {
           method: 'DELETE',
           url: '/v1/subscriptions/test_sub/discount',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/TaxCodes.spec.js
+++ b/test/resources/TaxCodes.spec.js
@@ -11,7 +11,7 @@ describe('TaxCodes Resource', () => {
         method: 'GET',
         url: '/v1/tax_codes/txcd_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('TaxCodes Resource', () => {
         method: 'GET',
         url: '/v1/tax_codes',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/TaxRates.spec.js
+++ b/test/resources/TaxRates.spec.js
@@ -11,7 +11,7 @@ describe('TaxRates Resource', () => {
         method: 'GET',
         url: '/v1/tax_rates/txr_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -59,7 +59,7 @@ describe('TaxRates Resource', () => {
         method: 'GET',
         url: '/v1/tax_rates',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Terminal/Locations.spec.js
+++ b/test/resources/Terminal/Locations.spec.js
@@ -14,7 +14,7 @@ describe('Terminal', () => {
           method: 'GET',
           url: '/v1/terminal/locations/loc_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -58,7 +58,7 @@ describe('Terminal', () => {
           method: 'DELETE',
           url: '/v1/terminal/locations/loc_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -88,7 +88,7 @@ describe('Terminal', () => {
           method: 'GET',
           url: '/v1/terminal/locations',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Terminal/Readers.spec.js
+++ b/test/resources/Terminal/Readers.spec.js
@@ -14,7 +14,7 @@ describe('Terminal', () => {
           method: 'GET',
           url: '/v1/terminal/readers/rdr_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -46,7 +46,7 @@ describe('Terminal', () => {
           method: 'DELETE',
           url: '/v1/terminal/readers/rdr_123',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });
@@ -76,7 +76,7 @@ describe('Terminal', () => {
           method: 'GET',
           url: '/v1/terminal/readers',
           headers: {},
-          data: {},
+          data: null,
           settings: {},
         });
       });

--- a/test/resources/Tokens.spec.js
+++ b/test/resources/Tokens.spec.js
@@ -26,7 +26,7 @@ describe('Tokens Resource', () => {
         method: 'GET',
         url: '/v1/tokens/tokenId1',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/Topups.spec.js
+++ b/test/resources/Topups.spec.js
@@ -10,7 +10,7 @@ describe('Topup Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/topups/tu_123',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });
@@ -48,7 +48,7 @@ describe('Topup Resource', () => {
       expect(stripe.LAST_REQUEST).to.deep.equal({
         method: 'GET',
         url: '/v1/topups',
-        data: {},
+        data: null,
         headers: {},
         settings: {},
       });

--- a/test/resources/Transfers.spec.js
+++ b/test/resources/Transfers.spec.js
@@ -11,7 +11,7 @@ describe('Transfers Resource', () => {
         method: 'GET',
         url: '/v1/transfers/transferId1',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -56,7 +56,7 @@ describe('Transfers Resource', () => {
         method: 'GET',
         url: '/v1/transfers',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });

--- a/test/resources/WebhookEndpoints.spec.js
+++ b/test/resources/WebhookEndpoints.spec.js
@@ -11,7 +11,7 @@ describe('WebhookEndpoints Resource', () => {
         method: 'GET',
         url: '/v1/webhook_endpoints/we_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -24,7 +24,7 @@ describe('WebhookEndpoints Resource', () => {
         method: 'DELETE',
         url: '/v1/webhook_endpoints/we_123',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });
@@ -74,7 +74,7 @@ describe('WebhookEndpoints Resource', () => {
         method: 'GET',
         url: '/v1/webhook_endpoints',
         headers: {},
-        data: {},
+        data: null,
         settings: {},
       });
     });


### PR DESCRIPTION
We can null out the data sent to API endpoints for GET and DELETE requests. 