### PR TITLE
Add raw_request

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,40 @@ const stripe = new Stripe('sk_test_...', {
 });
 ```
 
+### Custom requests
+
+If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `rawRequest` method on the StripeClient object.
+
+```javascript
+const client = new Stripe('sk_test_...');
+
+client.rawRequest(
+    'POST',
+    '/v1/beta_endpoint',
+    { param: 123 },
+    { apiVersion: '2022-11-15; feature_beta=v3' }
+  )
+  .then((response) => /* handle response */ )
+  .catch((error) => console.error(error));
+```
+
+Or using ES modules and `async`/`await`:
+
+```javascript
+import Stripe from 'stripe';
+const stripe = new Stripe('sk_test_...');
+
+const response = await stripe.rawRequest(
+  'POST',
+  '/v1/beta_endpoint',
+  { param: 123 },
+  { apiVersion: '2022-11-15; feature_beta=v3' }
+);
+
+// handle response
+```
+
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the `stripe` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -11,6 +11,8 @@ import {
   normalizeHeaders,
   removeNullish,
   stringifyRequestData,
+  getDataFromArgs,
+  getOptionsFromArgs,
 } from './utils.js';
 import {HttpClient, HttpClientResponseInterface} from './net/HttpClient.js';
 import {
@@ -24,6 +26,8 @@ import {
   RequestData,
   RequestOptions,
   RequestDataProcessor,
+  RequestOpts,
+  RequestArgs,
 } from './Types.js';
 
 export type HttpClientResponseError = {code: string};
@@ -422,11 +426,84 @@ export class RequestSender {
     }
   }
 
+  _rawRequest(
+    method: string,
+    path: string,
+    params?: RequestData,
+    options?: RequestOptions
+  ): Promise<any> {
+    const requestPromise = new Promise<any>((resolve, reject) => {
+      let opts: RequestOpts;
+      try {
+        const requestMethod = method.toUpperCase();
+        if (
+          requestMethod !== 'POST' &&
+          params &&
+          Object.keys(params).length !== 0
+        ) {
+          throw new Error(
+            'rawRequest only supports params on POST requests. Please pass null and add your parameters to path.'
+          );
+        }
+        const args: RequestArgs = [].slice.call([params, options]);
+
+        // Pull request data and options (headers, auth) from args.
+        const dataFromArgs = getDataFromArgs(args);
+        const data = Object.assign({}, dataFromArgs);
+        const calculatedOptions = getOptionsFromArgs(args);
+
+        const headers = calculatedOptions.headers;
+
+        opts = {
+          requestMethod,
+          requestPath: path,
+          bodyData: data,
+          queryData: {},
+          auth: calculatedOptions.auth,
+          headers,
+          host: null,
+          streaming: false,
+          settings: {},
+          usage: ['raw_request'],
+        };
+      } catch (err) {
+        reject(err);
+        return;
+      }
+
+      function requestCallback(
+        err: any,
+        response: HttpClientResponseInterface
+      ): void {
+        if (err) {
+          reject(err);
+        } else {
+          resolve(response);
+        }
+      }
+
+      const {headers, settings} = opts;
+
+      this._request(
+        opts.requestMethod,
+        opts.host,
+        path,
+        opts.bodyData,
+        opts.auth,
+        {headers, settings, streaming: opts.streaming},
+        opts.usage,
+        requestCallback
+      );
+    });
+
+    return requestPromise;
+  }
+
   _request(
     method: string,
     host: string | null,
     path: string,
-    data: RequestData,
+    data: RequestData | null,
     auth: string | null,
     options: RequestOptions = {},
     usage: Array<string> = [],

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -149,8 +149,20 @@ export type StripeObject = {
   _getPropsFromConfig: (config: Record<string, unknown>) => UserProvidedConfig;
   _clientId?: string;
   _platformFunctions: PlatformFunctions;
+  rawRequest: (
+    method: string,
+    path: string,
+    data: RequestData,
+    options: RequestOptions
+  ) => Promise<any>;
 };
 export type RequestSender = {
+  _rawRequest(
+    method: string,
+    path: string,
+    params?: RequestData,
+    options?: RequestOptions
+  ): Promise<any>;
   _request(
     method: string,
     host: string | null,
@@ -211,7 +223,7 @@ export type StripeResourceObject = {
 };
 export type RequestDataProcessor = (
   method: string,
-  data: RequestData,
+  data: RequestData | null,
   headers: RequestHeaders | undefined,
   prepareAndMakeRequest: (error: Error | null, data: string) => void
 ) => void;

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1,7 +1,13 @@
 import * as _Error from './Error.js';
 import {RequestSender} from './RequestSender.js';
 import {StripeResource} from './StripeResource.js';
-import {AppInfo, StripeObject, UserProvidedConfig} from './Types.js';
+import {
+  AppInfo,
+  StripeObject,
+  RequestData,
+  RequestOptions,
+  UserProvidedConfig,
+} from './Types.js';
 import {WebhookObject, createWebhooks} from './Webhooks.js';
 import * as apiVersion from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
@@ -207,6 +213,15 @@ export function createStripe(
     _enableTelemetry: null!,
     _requestSender: null!,
     _platformFunctions: null!,
+
+    rawRequest(
+      method: string,
+      path: string,
+      params?: RequestData,
+      options?: RequestOptions
+    ): Promise<any> {
+      return this._requestSender._rawRequest(method, path, params, options);
+    },
 
     /**
      * @private

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -16,6 +16,7 @@ const OPTIONS_KEYS = [
   'maxNetworkRetries',
   'timeout',
   'host',
+  'additionalHeaders',
 ];
 
 type Settings = {
@@ -28,7 +29,7 @@ type Options = {
   host: string | null;
   settings: Settings;
   streaming?: boolean;
-  headers: Record<string, unknown>;
+  headers: RequestHeaders;
 };
 
 export function isOptionsHash(o: unknown): boolean | unknown {
@@ -158,13 +159,13 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
         opts.auth = params.apiKey as string;
       }
       if (params.idempotencyKey) {
-        opts.headers['Idempotency-Key'] = params.idempotencyKey;
+        opts.headers['Idempotency-Key'] = params.idempotencyKey as string;
       }
       if (params.stripeAccount) {
-        opts.headers['Stripe-Account'] = params.stripeAccount;
+        opts.headers['Stripe-Account'] = params.stripeAccount as string;
       }
       if (params.apiVersion) {
-        opts.headers['Stripe-Version'] = params.apiVersion;
+        opts.headers['Stripe-Version'] = params.apiVersion as string;
       }
       if (Number.isInteger(params.maxNetworkRetries)) {
         opts.settings.maxNetworkRetries = params.maxNetworkRetries as number;
@@ -174,6 +175,11 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
       }
       if (params.host) {
         opts.host = params.host as string;
+      }
+      if (params.additionalHeaders) {
+        opts.headers = params.additionalHeaders as {
+          [headerName: string]: string;
+        };
       }
     }
   }

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -584,4 +584,214 @@ describe('Stripe Module', function() {
       expect(newStripe.VERSION).to.equal(Stripe.PACKAGE_VERSION);
     });
   });
+
+  describe('rawRequest', () => {
+    const returnedCustomer = {
+      id: 'cus_123',
+    };
+
+    it('should make request with specified encoding FORM', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          expect(req.headers['content-type']).to.equal(
+            'application/x-www-form-urlencoded'
+          );
+          expect(req.headers['stripe-version']).to.equal(ApiVersion);
+          const requestBody = [];
+          req.on('data', (chunks) => {
+            requestBody.push(chunks);
+          });
+          req.on('end', () => {
+            const body = Buffer.concat(requestBody).toString();
+            expect(body).to.equal('description=test%20customer');
+          });
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest(
+              'POST',
+              '/v1/customers',
+              {description: 'test customer'},
+              {}
+            );
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    // Uncomment this after merging v2 infra changes
+    // it('should make request with specified encoding JSON', (done) => {
+    //   return getTestServerStripe(
+    //     {},
+    //     (req, res) => {
+    //       expect(req.headers['content-type']).to.equal('application/json');
+    //       expect(req.headers['stripe-version']).to.equal(PreviewVersion);
+    //       expect(req.headers.foo).to.equal('bar');
+    //       const requestBody = [];
+    //       req.on('data', (chunks) => {
+    //         requestBody.push(chunks);
+    //       });
+    //       req.on('end', () => {
+    //         const body = Buffer.concat(requestBody).toString();
+    //         expect(body).to.equal(
+    //           '{"description":"test customer","created":"1234567890"}'
+    //         );
+    //       });
+    //       res.write(JSON.stringify(returnedCustomer));
+    //       res.end();
+    //     },
+    //     async (err, stripe, closeServer) => {
+    //       if (err) return done(err);
+    //       try {
+    //         const result = await stripe.rawRequest(
+    //           'POST',
+    //           '/v1/customers',
+    //           {
+    //             description: 'test customer',
+    //             created: new Date('2009-02-13T23:31:30Z'),
+    //           },
+    //           {additionalHeaders: {foo: 'bar'}}
+    //         );
+    //         expect(result).to.deep.equal(returnedCustomer);
+    //         closeServer();
+    //         done();
+    //       } catch (err) {
+    //         return done(err);
+    //       }
+    //     }
+    //   );
+    // });
+
+    it('defaults to form encoding request if not specified', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          expect(req.headers['content-type']).to.equal(
+            'application/x-www-form-urlencoded'
+          );
+          const requestBody = [];
+          req.on('data', (chunks) => {
+            requestBody.push(chunks);
+          });
+          req.on('end', () => {
+            const body = Buffer.concat(requestBody).toString();
+            expect(body).to.equal(
+              'description=test%20customer&created=1234567890'
+            );
+          });
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest('POST', '/v1/customers', {
+              description: 'test customer',
+              created: new Date('2009-02-13T23:31:30Z'),
+            });
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should make request with specified additional headers', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          console.log(req.headers);
+          expect(req.headers.foo).to.equal('bar');
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest(
+              'GET',
+              '/v1/customers/cus_123',
+              {},
+              {additionalHeaders: {foo: 'bar'}}
+            );
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should make request successfully', async () => {
+      const response = await stripe.rawRequest('GET', '/v1/customers', {});
+
+      expect(response).to.have.property('object', 'list');
+    });
+
+    it("should include 'raw_request' in usage telemetry", (done) => {
+      let telemetryHeader;
+      let shouldStayOpen = true;
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          telemetryHeader = req.headers['x-stripe-client-telemetry'];
+          res.setHeader('Request-Id', `req_1`);
+          res.writeHeader(200);
+          res.write('{}');
+          res.end();
+          const ret = {shouldStayOpen};
+          shouldStayOpen = false;
+          return ret;
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            await stripe.rawRequest(
+              'POST',
+              '/v1/customers',
+              {description: 'test customer'},
+              {}
+            );
+            expect(telemetryHeader).to.equal(undefined);
+            await stripe.rawRequest(
+              'POST',
+              '/v1/customers',
+              {description: 'test customer'},
+              {}
+            );
+            expect(
+              JSON.parse(telemetryHeader).last_request_metrics.usage
+            ).to.deep.equal(['raw_request']);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should throw error when passing in params to non-POST request', async () => {
+      await expect(
+        stripe.rawRequest('GET', '/v1/customers/cus_123', {foo: 'bar'})
+      ).to.be.rejectedWith(
+        Error,
+        /rawRequest only supports params on POST requests. Please pass null and add your parameters to path./
+      );
+    });
+  });
 });

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -459,6 +459,25 @@ declare module 'stripe' {
       event: 'response',
       handler: (event: Stripe.ResponseEvent) => void
     ): void;
+
+    /**
+     * Allows for sending "raw" requests to the Stripe API, which can be used for
+     * testing new API endpoints or performing requests that the library does
+     * not support yet.
+     *
+     * This is an experimental interface and is not yet stable.
+     *
+     * @param method - HTTP request method, 'GET', 'POST', or 'DELETE'
+     * @param path - The path of the request, e.g. '/v1/beta_endpoint'
+     * @param params - The parameters to include in the request body.
+     * @param options - Additional request options.
+     */
+    rawRequest(
+      method: string,
+      path: string,
+      params?: {[key: string]: unknown},
+      options?: Stripe.RawRequestOptions
+    ): Promise<Stripe.Response<unknown>>;
   }
 
   export default Stripe;

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -153,6 +153,13 @@ declare module 'stripe' {
       host?: string;
     }
 
+    export type RawRequestOptions = RequestOptions & {
+      /**
+       * Specify additional request headers. This is an experimental interface and is not yet stable.
+       */
+      additionalHeaders?: {[headerName: string]: string};
+    };
+
     export type Response<T> = T & {
       lastResponse: {
         headers: {[key: string]: string};


### PR DESCRIPTION
## Changelog
Adds the ability to make raw requests to the Stripe API, by providing an HTTP method and url.

Example:
```node
import Stripe from 'stripe';
const stripe = new Stripe('sk_test_...');

const response = await stripe.rawRequest(
  'POST',
  '/v1/beta_endpoint',
  { param: 123 },
  { apiVersion: '2022-11-15; feature_beta=v3' }
);

```