### PR TITLE
Add raw request

### DIFF
--- a/README.md
+++ b/README.md
@@ -517,6 +517,40 @@ const stripe = new Stripe('sk_test_...', {
 });
 ```
 
+### Custom requests
+
+If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `rawRequest` method on the StripeClient object.
+
+```javascript
+const client = new Stripe('sk_test_...');
+
+client.rawRequest(
+    'POST',
+    '/v1/beta_endpoint',
+    { param: 123 },
+    { apiVersion: '2022-11-15; feature_beta=v3' }
+  )
+  .then((response) => /* handle response */ )
+  .catch((error) => console.error(error));
+```
+
+Or using ES modules and `async`/`await`:
+
+```javascript
+import Stripe from 'stripe';
+const stripe = new Stripe('sk_test_...');
+
+const response = await stripe.rawRequest(
+  'POST',
+  '/v1/beta_endpoint',
+  { param: 123 },
+  { apiVersion: '2022-11-15; feature_beta=v3' }
+);
+
+// handle response
+```
+
+
 ## Support
 
 New features and bug fixes are released on the latest major version of the `stripe` package. If you are on an older major version, we recommend that you upgrade to the latest in order to use the new features and bug fixes including those for security vulnerabilities. Older major versions of the package will continue to be available for use, but will not be receiving any updates.

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -185,8 +185,20 @@ export type StripeObject = {
     key: string,
     authenticator: RequestAuthenticator | undefined
   ) => void;
+  rawRequest: (
+    method: string,
+    path: string,
+    data: RequestData,
+    options: RequestOptions
+  ) => Promise<any>;
 };
 export type RequestSender = {
+  _rawRequest(
+    method: string,
+    path: string,
+    params?: RequestData,
+    options?: RequestOptions
+  ): Promise<any>;
   _request(
     method: string,
     host: string | null,

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -8,6 +8,8 @@ import {
   StripeObject,
   StripeRequest,
   UserProvidedConfig,
+  RequestData,
+  RequestOptions,
 } from './Types.js';
 import {WebhookObject, WebhookEvent, createWebhooks} from './Webhooks.js';
 import {ApiVersion} from './apiVersion.js';
@@ -321,6 +323,15 @@ export function createStripe(
     _enableTelemetry: null!,
     _requestSender: null!,
     _platformFunctions: null!,
+
+    rawRequest(
+      method: string,
+      path: string,
+      params?: RequestData,
+      options?: RequestOptions
+    ): Promise<any> {
+      return this._requestSender._rawRequest(method, path, params, options);
+    },
 
     /**
      * @private

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -21,6 +21,7 @@ const OPTIONS_KEYS = [
   'host',
   'authenticator',
   'stripeContext',
+  'additionalHeaders',
 ];
 
 type Settings = {
@@ -33,7 +34,7 @@ type Options = {
   host: string | null;
   settings: Settings;
   streaming?: boolean;
-  headers: Record<string, unknown>;
+  headers: RequestHeaders;
 };
 
 export function isOptionsHash(o: unknown): boolean | unknown {
@@ -166,10 +167,10 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
         opts.authenticator = createApiKeyAuthenticator(params.apiKey as string);
       }
       if (params.idempotencyKey) {
-        opts.headers['Idempotency-Key'] = params.idempotencyKey;
+        opts.headers['Idempotency-Key'] = params.idempotencyKey as string;
       }
       if (params.stripeAccount) {
-        opts.headers['Stripe-Account'] = params.stripeAccount;
+        opts.headers['Stripe-Account'] = params.stripeAccount as string;
       }
       if (params.stripeContext) {
         if (opts.headers['Stripe-Account']) {
@@ -177,10 +178,10 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
             "Can't specify both stripeAccount and stripeContext."
           );
         }
-        opts.headers['Stripe-Context'] = params.stripeContext;
+        opts.headers['Stripe-Context'] = params.stripeContext as string;
       }
       if (params.apiVersion) {
-        opts.headers['Stripe-Version'] = params.apiVersion;
+        opts.headers['Stripe-Version'] = params.apiVersion as string;
       }
       if (Number.isInteger(params.maxNetworkRetries)) {
         opts.settings.maxNetworkRetries = params.maxNetworkRetries as number;
@@ -202,6 +203,11 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
           );
         }
         opts.authenticator = params.authenticator as RequestAuthenticator;
+      }
+      if (params.additionalHeaders) {
+        opts.headers = params.additionalHeaders as {
+          [headerName: string]: string;
+        };
       }
     }
   }

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -865,4 +865,214 @@ describe('Stripe Module', function() {
       }).to.throw(StripeSignatureVerificationError);
     });
   });
+
+  describe('rawRequest', () => {
+    const returnedCustomer = {
+      id: 'cus_123',
+    };
+
+    it('should make request with specified encoding FORM', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          expect(req.headers['content-type']).to.equal(
+            'application/x-www-form-urlencoded'
+          );
+          expect(req.headers['stripe-version']).to.equal(ApiVersion);
+          const requestBody = [];
+          req.on('data', (chunks) => {
+            requestBody.push(chunks);
+          });
+          req.on('end', () => {
+            const body = Buffer.concat(requestBody).toString();
+            expect(body).to.equal('description=test%20customer');
+          });
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest(
+              'POST',
+              '/v1/customers',
+              {description: 'test customer'},
+              {}
+            );
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    // Uncomment this after merging v2 infra changes
+    // it('should make request with specified encoding JSON', (done) => {
+    //   return getTestServerStripe(
+    //     {},
+    //     (req, res) => {
+    //       expect(req.headers['content-type']).to.equal('application/json');
+    //       expect(req.headers['stripe-version']).to.equal(PreviewVersion);
+    //       expect(req.headers.foo).to.equal('bar');
+    //       const requestBody = [];
+    //       req.on('data', (chunks) => {
+    //         requestBody.push(chunks);
+    //       });
+    //       req.on('end', () => {
+    //         const body = Buffer.concat(requestBody).toString();
+    //         expect(body).to.equal(
+    //           '{"description":"test customer","created":"1234567890"}'
+    //         );
+    //       });
+    //       res.write(JSON.stringify(returnedCustomer));
+    //       res.end();
+    //     },
+    //     async (err, stripe, closeServer) => {
+    //       if (err) return done(err);
+    //       try {
+    //         const result = await stripe.rawRequest(
+    //           'POST',
+    //           '/v1/customers',
+    //           {
+    //             description: 'test customer',
+    //             created: new Date('2009-02-13T23:31:30Z'),
+    //           },
+    //           {additionalHeaders: {foo: 'bar'}}
+    //         );
+    //         expect(result).to.deep.equal(returnedCustomer);
+    //         closeServer();
+    //         done();
+    //       } catch (err) {
+    //         return done(err);
+    //       }
+    //     }
+    //   );
+    // });
+
+    it('defaults to form encoding request if not specified', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          expect(req.headers['content-type']).to.equal(
+            'application/x-www-form-urlencoded'
+          );
+          const requestBody = [];
+          req.on('data', (chunks) => {
+            requestBody.push(chunks);
+          });
+          req.on('end', () => {
+            const body = Buffer.concat(requestBody).toString();
+            expect(body).to.equal(
+              'description=test%20customer&created=1234567890'
+            );
+          });
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest('POST', '/v1/customers', {
+              description: 'test customer',
+              created: new Date('2009-02-13T23:31:30Z'),
+            });
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should make request with specified additional headers', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          console.log(req.headers);
+          expect(req.headers.foo).to.equal('bar');
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest(
+              'GET',
+              '/v1/customers/cus_123',
+              {},
+              {additionalHeaders: {foo: 'bar'}}
+            );
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should make request successfully', async () => {
+      const response = await stripe.rawRequest('GET', '/v1/customers', {});
+
+      expect(response).to.have.property('object', 'list');
+    });
+
+    it("should include 'raw_request' in usage telemetry", (done) => {
+      let telemetryHeader;
+      let shouldStayOpen = true;
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          telemetryHeader = req.headers['x-stripe-client-telemetry'];
+          res.setHeader('Request-Id', `req_1`);
+          res.writeHeader(200);
+          res.write('{}');
+          res.end();
+          const ret = {shouldStayOpen};
+          shouldStayOpen = false;
+          return ret;
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            await stripe.rawRequest(
+              'POST',
+              '/v1/customers',
+              {description: 'test customer'},
+              {}
+            );
+            expect(telemetryHeader).to.equal(undefined);
+            await stripe.rawRequest(
+              'POST',
+              '/v1/customers',
+              {description: 'test customer'},
+              {}
+            );
+            expect(
+              JSON.parse(telemetryHeader).last_request_metrics.usage
+            ).to.deep.equal(['raw_request']);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should throw error when passing in params to non-POST request', async () => {
+      await expect(
+        stripe.rawRequest('GET', '/v1/customers/cus_123', {foo: 'bar'})
+      ).to.be.rejectedWith(
+        Error,
+        /rawRequest only supports params on POST requests. Please pass null and add your parameters to path./
+      );
+    });
+  });
 });

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -909,48 +909,47 @@ describe('Stripe Module', function() {
       );
     });
 
-    // Uncomment this after merging v2 infra changes
-    // it('should make request with specified encoding JSON', (done) => {
-    //   return getTestServerStripe(
-    //     {},
-    //     (req, res) => {
-    //       expect(req.headers['content-type']).to.equal('application/json');
-    //       expect(req.headers['stripe-version']).to.equal(PreviewVersion);
-    //       expect(req.headers.foo).to.equal('bar');
-    //       const requestBody = [];
-    //       req.on('data', (chunks) => {
-    //         requestBody.push(chunks);
-    //       });
-    //       req.on('end', () => {
-    //         const body = Buffer.concat(requestBody).toString();
-    //         expect(body).to.equal(
-    //           '{"description":"test customer","created":"1234567890"}'
-    //         );
-    //       });
-    //       res.write(JSON.stringify(returnedCustomer));
-    //       res.end();
-    //     },
-    //     async (err, stripe, closeServer) => {
-    //       if (err) return done(err);
-    //       try {
-    //         const result = await stripe.rawRequest(
-    //           'POST',
-    //           '/v1/customers',
-    //           {
-    //             description: 'test customer',
-    //             created: new Date('2009-02-13T23:31:30Z'),
-    //           },
-    //           {additionalHeaders: {foo: 'bar'}}
-    //         );
-    //         expect(result).to.deep.equal(returnedCustomer);
-    //         closeServer();
-    //         done();
-    //       } catch (err) {
-    //         return done(err);
-    //       }
-    //     }
-    //   );
-    // });
+    it('should make request with specified encoding JSON', (done) => {
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          expect(req.headers['content-type']).to.equal('application/json');
+          expect(req.headers['stripe-version']).to.equal(ApiVersion);
+          expect(req.headers.foo).to.equal('bar');
+          const requestBody = [];
+          req.on('data', (chunks) => {
+            requestBody.push(chunks);
+          });
+          req.on('end', () => {
+            const body = Buffer.concat(requestBody).toString();
+            expect(body).to.equal(
+              '{"description":"test meter event","created":"1234567890"}'
+            );
+          });
+          res.write(JSON.stringify(returnedCustomer));
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const result = await stripe.rawRequest(
+              'POST',
+              '/v2/billing/meter_events',
+              {
+                description: 'test meter event',
+                created: new Date('2009-02-13T23:31:30Z'),
+              },
+              {additionalHeaders: {foo: 'bar'}}
+            );
+            expect(result).to.deep.equal(returnedCustomer);
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
 
     it('defaults to form encoding request if not specified', (done) => {
       return getTestServerStripe(

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -472,6 +472,25 @@ declare module 'stripe' {
       event: 'response',
       handler: (event: Stripe.ResponseEvent) => void
     ): void;
+
+    /**
+     * Allows for sending "raw" requests to the Stripe API, which can be used for
+     * testing new API endpoints or performing requests that the library does
+     * not support yet.
+     *
+     * This is an experimental interface and is not yet stable.
+     *
+     * @param method - HTTP request method, 'GET', 'POST', or 'DELETE'
+     * @param path - The path of the request, e.g. '/v1/beta_endpoint'
+     * @param params - The parameters to include in the request body.
+     * @param options - Additional request options.
+     */
+    rawRequest(
+      method: string,
+      path: string,
+      params?: {[key: string]: unknown},
+      options?: Stripe.RawRequestOptions
+    ): Promise<Stripe.Response<unknown>>;
   }
 
   export default Stripe;

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -153,6 +153,13 @@ declare module 'stripe' {
       host?: string;
     }
 
+    export type RawRequestOptions = RequestOptions & {
+      /**
+       * Specify additional request headers. This is an experimental interface and is not yet stable.
+       */
+      additionalHeaders?: {[headerName: string]: string};
+    };
+
     export type Response<T> = T & {
       lastResponse: {
         headers: {[key: string]: string};

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -27,7 +27,7 @@ declare module 'stripe' {
       }): (...args: any[]) => Response<ResponseObject>; //eslint-disable-line @typescript-eslint/no-explicit-any
       static MAX_BUFFERED_REQUEST_METRICS: number;
     }
-    export type LatestApiVersion = '2024-06-20';
+    export type LatestApiVersion = '2024-09-30.acacia';
     export type HttpAgent = Agent;
     export type HttpProtocol = 'http' | 'https';
 

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -9,7 +9,7 @@
 import Stripe from 'stripe';
 
 let stripe = new Stripe('sk_test_123', {
-  apiVersion: '2024-06-20',
+  apiVersion: '2024-09-30.acacia',
 });
 
 stripe = new Stripe('sk_test_123');
@@ -26,7 +26,7 @@ stripe = new Stripe('sk_test_123', {
 
 // Check config object.
 stripe = new Stripe('sk_test_123', {
-  apiVersion: '2024-06-20',
+  apiVersion: '2024-09-30.acacia',
   typescript: true,
   maxNetworkRetries: 1,
   timeout: 1000,
@@ -44,7 +44,7 @@ stripe = new Stripe('sk_test_123', {
     description: 'test',
   };
   const opts: Stripe.RequestOptions = {
-    apiVersion: '2024-06-20',
+    apiVersion: '2024-09-30.acacia',
   };
   const customer: Stripe.Customer = await stripe.customers.create(params, opts);
 


### PR DESCRIPTION
## Changelog
Adds the ability to make requests to the Stripe API that are not directly supported in the SDK, by providing an HTTP method, url and relevant parameters

Example:
```node
import Stripe from 'stripe';
const stripe = new Stripe('sk_test_...');

const response = await stripe.rawRequest(
  'POST',
  '/v1/beta_endpoint',
  { param: 123 },
  { apiVersion: '2022-11-15; feature_beta=v3' }
);

```