### PR TITLE
Fix typing of `Stripe.V2.Event`

### DIFF
--- a/types/ThinEvent.d.ts
+++ b/types/ThinEvent.d.ts
@@ -3,26 +3,24 @@
 declare module 'stripe' {
   namespace Stripe {
     namespace Event {
+      /**
+       * Object containing the reference to API resource relevant to the event.
+       */
       interface RelatedObject {
         /**
-         * Object containing the reference to API resource relevant to the event.
+         * Unique identifier for the object relevant to the event.
          */
-        related_object: {
-          /**
-           * Unique identifier for the object relevant to the event.
-           */
-          id: string;
+        id: string;
 
-          /**
-           * Type of the object relevant to the event.
-           */
-          type: string;
+        /**
+         * Type of the object relevant to the event.
+         */
+        type: string;
 
-          /**
-           * URL to retrieve the resource.
-           */
-          url: string;
-        };
+        /**
+         * URL to retrieve the resource.
+         */
+        url: string;
       }
     }
     /**
@@ -32,7 +30,7 @@ declare module 'stripe' {
       /**
        * Object containing the reference to API resource relevant to the event.
        */
-      related_object: Event.RelatedObject;
+      related_object: Event.RelatedObject | null;
     }
   }
 }

--- a/types/V2/Core/EventsResource.d.ts
+++ b/types/V2/Core/EventsResource.d.ts
@@ -1,5 +1,7 @@
 // File generated from our OpenAPI spec
 
+/// <reference path="../EventTypes.d.ts" />
+
 declare module 'stripe' {
   namespace Stripe {
     namespace V2 {

--- a/types/V2/Core/EventsResource.d.ts
+++ b/types/V2/Core/EventsResource.d.ts
@@ -1,6 +1,6 @@
 // File generated from our OpenAPI spec
 
-/// <reference path="../EventTypes.d.ts" />
+/// <reference path='../EventTypes.d.ts' />
 
 declare module 'stripe' {
   namespace Stripe {

--- a/types/V2/Core/EventsResource.d.ts
+++ b/types/V2/Core/EventsResource.d.ts
@@ -31,11 +31,11 @@ declare module 'stripe' {
             id: string,
             params?: EventRetrieveParams,
             options?: RequestOptions
-          ): Promise<Stripe.Response<Event>>;
+          ): Promise<Stripe.Response<Stripe.V2.Event>>;
           retrieve(
             id: string,
             options?: RequestOptions
-          ): Promise<Stripe.Response<Event>>;
+          ): Promise<Stripe.Response<Stripe.V2.Event>>;
 
           /**
            * List events, going back up to 30 days.
@@ -43,7 +43,7 @@ declare module 'stripe' {
           list(
             params: EventListParams,
             options?: RequestOptions
-          ): ApiListPromise<Event>;
+          ): ApiListPromise<Stripe.V2.Event>;
         }
       }
     }


### PR DESCRIPTION
### Why?

There were typing issues with the return value of `client.v2.core.events.list()`. Codegen originally produced `Stripe.V2.Event` but it wasn't able to find that type, despite it being exported. Ramya manually changed the value to `Event`, which being in the `V2` namespace already, picked the correct one. But, we wanted the codegen output to be correct. 

There was also an issue with `ApiListPromise`. It was pulled from the V2 types so I decided to use the V1 type instead. They're very similar and users won't be interacting directly with them, we think.

### What?

- codegens a `<reference path='../EventTypes.d.ts' />` to make `V2.Events` explicitly available
- manually changes the shape of the `relatedObject` interface to not nest the data. Without that change, I had to reference relatedObject as `thin_event.related_object.related_object`
- manually change the `ThinEvent.related_object` to be nullable on the push payload.
- (didn't generate a diff here, but) uses V1's `ApiListPromise` as the list return type instead of the V2 version

Now the full codegen output works out of the box.

### Testing

I was working off a local script to ensure this was free of type errors. Create a new folder and run:

```shell
npm init -y
touch index.ts
```

Then, paste the following into `index.ts`:

```ts
import { Stripe } from "stripe";

const client = new Stripe("sk_test_1234");

console.log(client);
const thinEvent = client.parseThinEvent("", "", "");
// @ts-expect-error - need to check nullability on id
thinEvent.related_object.id;
// @ts-expect-error - there shouldn't be nesting
thinEvent.related_object.related_object.id;
// this works!
thinEvent.related_object?.id;

const doWork = async () => {
  const events = await client.v2.core.events.list({ object_id: "asdf" });

  const e = events.data[0];

  if (e.type === "v1.billing.meter.error_report_triggered") {
    // related_object is populated!
    console.log(e.related_object.id);
  }
  if (e.type === "v1.billing.meter.no_meter_found") {
    // @ts-expect-error - this event has no related object
    console.log(e.related_object.id);
  }
};
```

Then, to package the SDK for use, in the local SDK checkout:

```shell
npm pack && mv stripe-16.12.0.tgz ~/Desktop
```

in your created folder:

```shell
yarn add ~/Desktop/stripe-16.12.0.tgz
rm yarn.lock && yarn cache clean && yarn install --force
```

(only repeat the second line if you need to check local changes)

### See Also

[DEVSDK-2192](https://jira.corp.stripe.com/browse/DEVSDK-2192)