### PR TITLE
Remove parameters sent as part of additional autoPaginatingEach calls in v2

### DIFF
--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -175,12 +175,7 @@ class V2ListIterator<T> implements AsyncIterator<T> {
     const nextPageUrl = await this.nextPageUrl;
     if (!nextPageUrl) return null;
     this.spec.fullPath = nextPageUrl;
-    const page = await this.stripeResource._makeRequest(
-      // this.requestArgs,
-      [],
-      this.spec,
-      {}
-    );
+    const page = await this.stripeResource._makeRequest([], this.spec, {});
     this.nextPageUrl = Promise.resolve(page.next_page_url);
     this.currentPageIterator = Promise.resolve(page.data[Symbol.iterator]());
     return this.currentPageIterator;

--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -176,7 +176,8 @@ class V2ListIterator<T> implements AsyncIterator<T> {
     if (!nextPageUrl) return null;
     this.spec.fullPath = nextPageUrl;
     const page = await this.stripeResource._makeRequest(
-      this.requestArgs,
+      // this.requestArgs,
+      [],
       this.spec,
       {}
     );


### PR DESCRIPTION
##  Why?

The API will error if we send these params twice (once from requestArgs and once from the returned nextPageUrl).

The firstPagePromise will contain the params, which will be passed through with nextPageUrl.