### PR TITLE
Merge into beta using the merge script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # Changelog
 
 ## 17.2.0-beta.1 - 2024-10-03
-* [#2200](https://github.com/stripe/stripe-node/pull/2200) Updates beta branch with changes in master 
+* [#2200](https://github.com/stripe/stripe-node/pull/2200) Updates beta branch with changes in master
   * Add support for `reporting_chart` on `AccountSessionCreateParams.components`
   * Remove support for `from_schedule` on `Quote.subscription_data`
   * Add support for `allow_redisplay` on `Terminal.ReaderCollectPaymentMethodParams.collect_config`
+
+## 17.1.0 - 2024-10-03
+* [#2199](https://github.com/stripe/stripe-node/pull/2199) Update generated code
+  * Remove the support for resource `Margin` that was accidentally made public in the last release
 
 ## 17.0.0 - 2024-10-01
 * [#2192](https://github.com/stripe/stripe-node/pull/2192) Support for APIs in the new API version 2024-09-30.acacia

--- a/README.md
+++ b/README.md
@@ -519,12 +519,13 @@ const stripe = new Stripe('sk_test_...', {
 
 ### Custom requests
 
-If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `rawRequest` method on the Stripe object.
+If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `rawRequest` method on the StripeClient object.
 
 ```javascript
-const stripe = require('stripe')('sk_test_...');
+import Stripe from 'stripe';
+const client = new Stripe('sk_test_...');
 
-stripe.rawRequest(
+client.rawRequest(
     'POST',
     '/v1/beta_endpoint',
     { param: 123 },


### PR DESCRIPTION
When we merged from master to beta yesterday, we should have used our merge script and then NOT used the squash option when merging the PR as this results in future merges by the automation to not know how to resolve certain merge conflicts.

This PR has the changes from running our merge script and resolving the resulting merge conflicts.

Note: DO NOT use the squash option when merging