### PR TITLE
update object tags for meter-related classes

### DIFF
--- a/types/V2/Billing/MeterEventAdjustments.d.ts
+++ b/types/V2/Billing/MeterEventAdjustments.d.ts
@@ -16,7 +16,7 @@ declare module 'stripe' {
           /**
            * String representing the object's type. Objects of the same type share the same value of the object field.
            */
-          object: 'billing.meter_event_adjustment';
+          object: 'v2.billing.meter_event_adjustment';
 
           /**
            * Specifies which event to cancel.

--- a/types/V2/Billing/MeterEventSessions.d.ts
+++ b/types/V2/Billing/MeterEventSessions.d.ts
@@ -16,7 +16,7 @@ declare module 'stripe' {
           /**
            * String representing the object's type. Objects of the same type share the same value of the object field.
            */
-          object: 'billing.meter_event_session';
+          object: 'v2.billing.meter_event_session';
 
           /**
            * The authentication token for this session.  Use this token when calling the

--- a/types/V2/Billing/MeterEvents.d.ts
+++ b/types/V2/Billing/MeterEvents.d.ts
@@ -11,7 +11,7 @@ declare module 'stripe' {
           /**
            * String representing the object's type. Objects of the same type share the same value of the object field.
            */
-          object: 'billing.meter_event';
+          object: 'v2.billing.meter_event';
 
           /**
            * The creation time of this meter event.


### PR DESCRIPTION
CI failures are expected because stripe-mock doesn't yet have the changes these this PR is responding to

## Changelog

- fixes a bug where the `object` property of the `MeterEvent`, `MeterEventAdjustment`, and `MeterEventSession` didn't match the server.