### PR TITLE
Updated API version in types/lib.d.ts

### DIFF
--- a/scripts/updateAPIVersion.js
+++ b/scripts/updateAPIVersion.js
@@ -8,7 +8,7 @@ const read = (file) => fs.readFileSync(path.resolve(file)).toString();
 const write = (file, str) => fs.writeFileSync(path.resolve(file), str);
 const edit = (file, cb) => write(file, cb(read(file)));
 
-const API_VERSION = '2[0-9][2-9][0-9]-[0-9]{2}-[0-9]{2}';
+const API_VERSION = '2[0-9][2-9][0-9]-[0-9]{2}-[0-9]{2}.[a-z]+';
 
 const main = () => {
   const matches = [
@@ -35,9 +35,6 @@ const main = () => {
           : 'UNEXPECTED'
       );
     });
-
-  replaceAPIVersion('README.md', 'apiVersion: [\'"]API_VERSION[\'"]');
-  replaceAPIVersion('package.json', '"types": "types/API_VERSION/index.d.ts');
 
   replaceAPIVersion(
     'types/lib.d.ts',

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -27,7 +27,7 @@ declare module 'stripe' {
       }): (...args: any[]) => Response<ResponseObject>; //eslint-disable-line @typescript-eslint/no-explicit-any
       static MAX_BUFFERED_REQUEST_METRICS: number;
     }
-    export type LatestApiVersion = '2024-09-30.acacia';
+    export type LatestApiVersion = '2024-10-28.acacia';
     export type HttpAgent = Agent;
     export type HttpProtocol = 'http' | 'https';
 

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -9,7 +9,7 @@
 import Stripe from 'stripe';
 
 let stripe = new Stripe('sk_test_123', {
-  apiVersion: '2024-09-30.acacia',
+  apiVersion: '2024-10-28.acacia',
 });
 
 stripe = new Stripe('sk_test_123');
@@ -26,7 +26,7 @@ stripe = new Stripe('sk_test_123', {
 
 // Check config object.
 stripe = new Stripe('sk_test_123', {
-  apiVersion: '2024-09-30.acacia',
+  apiVersion: '2024-10-28.acacia',
   typescript: true,
   maxNetworkRetries: 1,
   timeout: 1000,
@@ -44,7 +44,7 @@ stripe = new Stripe('sk_test_123', {
     description: 'test',
   };
   const opts: Stripe.RequestOptions = {
-    apiVersion: '2024-09-30.acacia',
+    apiVersion: '2024-10-28.acacia',
   };
   const customer: Stripe.Customer = await stripe.customers.create(params, opts);
 


### PR DESCRIPTION
1. Updated the API version regex in the `updateApiVersion,.js` script to handle new format of API versions(eg. `2024-09-30.acacia`). This script is run every time we run `codegen-format`.
2. Cleanup of lines that tried to update API version in files(Readme and package.json) that no longer reference an API Version.