### PR TITLE
add justfile, remove coveralls, tweak ESLint

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -7,3 +7,6 @@ indent_size = 2
 indent_style = space
 insert_final_newline = true
 trim_trailing_whitespace = true
+
+[justfile]
+indent_size = 4

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -242,17 +242,19 @@ module.exports = {
   parserOptions: {
     ecmaVersion: 2018,
   },
-  plugins: ['prettier', 'import'],
-  extends: ['plugin:prettier/recommended'],
+  plugins: ['import'],
+  // disable formatting rules - prettier will handle this itself
+  extends: ['prettier'],
   overrides: [
     {
       files: ['**/*.ts'],
-      plugins: ['@typescript-eslint', 'prettier'],
+      plugins: ['@typescript-eslint'],
       extends: [
         'eslint:recommended',
         'plugin:@typescript-eslint/eslint-recommended',
         'plugin:@typescript-eslint/recommended',
-        'plugin:prettier/recommended',
+        // disable formatting rules - prettier will handle this itself
+        'prettier',
       ],
       rules: {
         '@typescript-eslint/no-use-before-define': 0,

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -19,7 +19,7 @@ on:
 
 jobs:
   build:
-    name: Build
+    name: 'Static Checks'
     runs-on: 'ubuntu-24.04'
 
     steps:
@@ -40,9 +40,6 @@ jobs:
           key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
-
-      - name: Compile JS -> TS
-        run: just install build
 
       - name: Verify Linting
         run: just lint-check

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -54,6 +54,7 @@ jobs:
     name: Test (${{ matrix.node }})
     needs: [build]
     strategy:
+      fail-fast: false
       matrix:
         os:
           - 'ubuntu-latest'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,13 +17,13 @@ on:
       - sdk-release/**
       - feature/**
 
-
 jobs:
   build:
     name: Build
     runs-on: ubuntu-latest
 
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v2
 
       - name: Setup node
@@ -41,11 +41,11 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-yarn-
 
-      - name: Build Typescript
-        run: yarn && yarn build
+      - name: Compile JS -> TS
+        run: just install build
 
-      - name: Lint
-        run: yarn lint
+      - name: Verify Linting & Formatting
+        run: just lint-check format-check
 
   test:
     name: Test (${{ matrix.node }})
@@ -53,18 +53,19 @@ jobs:
     strategy:
       matrix:
         os:
-          - "ubuntu-latest"
+          - 'ubuntu-latest'
         node:
           # should include even numbers >= 12
           # see: https://nodejs.org/en/about/previous-releases
-          - "22"
-          - "20"
-          - "18"
-          - "16"
-          - "14"
-          - "12"
+          - '22'
+          - '20'
+          - '18'
+          - '16'
+          - '14'
+          - '12'
     runs-on: ${{ matrix.os }}
     steps:
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v2
 
       - name: Setup node
@@ -75,6 +76,7 @@ jobs:
       - name: Print Node.js version
         run: node -v
 
+      # used for one of the integration tests
       - name: Setup Deno
         uses: denoland/setup-deno@v1
         with:
@@ -98,15 +100,7 @@ jobs:
       - uses: stripe/openapi/actions/stripe-mock@master
 
       - name: Test
-        run: make ci-test
-
-      - name: Coveralls
-        run: yarn report && yarn coveralls
-        if: env.COVERALLS_REPO_TOKEN && matrix.node == '18'
-        env:
-          GITHUB_TOKEN: ${{ secrets.github_token }}
-          COVERALLS_REPO_TOKEN: ${{ secrets.COVERALLS_REPO_TOKEN }}
-          COVERALLS_FLAG_NAME: node-${{ matrix.node }}
+        run: just ci-test
 
   publish:
     name: Publish
@@ -117,6 +111,8 @@ jobs:
     needs: [build, test]
     runs-on: ubuntu-latest
     steps:
+      # just is called in `yarn prepack`, which is called during the `publish` operation
+      - uses: extractions/setup-just@v2
       - uses: actions/checkout@v2
       - run: sudo apt-get install -y oathtool
       - name: Publish to NPM

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ on:
 jobs:
   build:
     name: Build
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
 
     steps:
       - uses: extractions/setup-just@v2
@@ -57,7 +57,7 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - 'ubuntu-latest'
+          - 'ubuntu-24.04'
         node:
           # should include even numbers >= 12
           # see: https://nodejs.org/en/about/previous-releases
@@ -114,7 +114,7 @@ jobs:
       startsWith(github.ref, 'refs/tags/v') &&
       endsWith(github.actor, '-stripe')
     needs: [build, test]
-    runs-on: ubuntu-latest
+    runs-on: 'ubuntu-24.04'
     steps:
       # just is called in `yarn prepack`, which is called during the `publish` operation
       - uses: extractions/setup-just@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -97,7 +97,8 @@ jobs:
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
+          # searching very deep deps can time out, so only cache on the root yarn.lock
+          key: ${{ runner.os }}-yarn-${{ hashFiles('yarn.lock') }}
           restore-keys: |
             ${{ runner.os }}-yarn-
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -44,8 +44,11 @@ jobs:
       - name: Compile JS -> TS
         run: just install build
 
-      - name: Verify Linting & Formatting
-        run: just lint-check format-check
+      - name: Verify Linting
+        run: just lint-check
+
+      - name: Verify Formatting
+        run: just format-check
 
   test:
     name: Test (${{ matrix.node }})

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+# internal files of the nextjs example
+.next

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+# NOTE: this file is deprecated and slated for deletion; prefer using the equivalent `just` commands.
+
 .PHONY: codegen-format update-version test ci-test
 update-version:
 	@echo "$(VERSION)" > VERSION

--- a/README.md
+++ b/README.md
@@ -595,16 +595,7 @@ New features and bug fixes are released on the latest major version of the `stri
 
 ## Development
 
-Run all tests (installing the dependencies first, if needed)
-
-```bash
-$ just install
-$ just test
-```
-
-If you do not have `yarn` installed, consult its [installation instructions](https://classic.yarnpkg.com/lang/en/docs/install/).
-
-The tests also depends on [stripe-mock][stripe-mock], so make sure to fetch and
+The tests depend on [stripe-mock][stripe-mock], so make sure to fetch and
 run it from a background terminal ([stripe-mock's README][stripe-mock-usage]
 also contains instructions for installing via Homebrew and other methods):
 
@@ -615,24 +606,36 @@ stripe-mock
 
 We use [just](https://github.com/casey/just) for conveniently running development tasks. You can use them directly, or copy the commands out of the `justfile`. To our help docs, run `just`.
 
-Run a single test suite without a coverage report:
+Run all tests (installing the dependencies first, if needed)
 
 ```bash
-$ just test test/Error.spec.ts
+just test
+# or: yarn && yarn test
+```
+
+If you do not have `yarn` installed, consult its [installation instructions](https://classic.yarnpkg.com/lang/en/docs/install/).
+
+Run a single test suite:
+
+```bash
+just test test/Error.spec.ts
+# or: yarn test test/Error.spec.ts
 ```
 
 Run a single test (case sensitive) in watch mode:
 
 ```bash
-$ just test test/Error.spec.ts --grep 'StripeError' --watch
+just test test/Error.spec.ts --grep 'StripeError' --watch
+# or: yarn test test/Error.spec.ts --grep 'StripeError' --watch
 ```
 
 If you wish, you may run tests using your Stripe _Test_ API key by setting the
 environment variable `STRIPE_TEST_API_KEY` before running the tests:
 
 ```bash
-$ export STRIPE_TEST_API_KEY='sk_test....'
-$ just test
+export STRIPE_TEST_API_KEY='sk_test....'
+just test
+# or: yarn test
 ```
 
 Run prettier:
@@ -640,7 +643,8 @@ Run prettier:
 Add an [editor integration](https://prettier.io/docs/en/editors.html) or:
 
 ```bash
-$ just format
+just format
+# or: yarn prettier src/**/*.ts --write
 ```
 
 [api-keys]: https://dashboard.stripe.com/account/apikeys

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@
 
 [![Version](https://img.shields.io/npm/v/stripe.svg)](https://www.npmjs.org/package/stripe)
 [![Build Status](https://github.com/stripe/stripe-node/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-node/actions?query=branch%3Amaster)
-[![Coverage Status](https://coveralls.io/repos/github/stripe/stripe-node/badge.svg?branch=master)](https://coveralls.io/github/stripe/stripe-node?branch=master)
 [![Downloads](https://img.shields.io/npm/dm/stripe.svg)](https://www.npmjs.com/package/stripe)
 [![Try on RunKit](https://badge.runkitcdn.com/stripe.svg)](https://runkit.com/npm/stripe)
 
@@ -596,14 +595,14 @@ New features and bug fixes are released on the latest major version of the `stri
 
 ## Development
 
-Run all tests:
+Run all tests (installing the dependencies first, if needed)
 
 ```bash
-$ yarn install
-$ yarn test
+$ just install
+$ just test
 ```
 
-If you do not have `yarn` installed, you can get it with `npm install --global yarn`.
+If you do not have `yarn` installed, consult its [installation instructions](https://classic.yarnpkg.com/lang/en/docs/install/).
 
 The tests also depends on [stripe-mock][stripe-mock], so make sure to fetch and
 run it from a background terminal ([stripe-mock's README][stripe-mock-usage]
@@ -614,16 +613,18 @@ go get -u github.com/stripe/stripe-mock
 stripe-mock
 ```
 
+We use [just](https://github.com/casey/just) for conveniently running development tasks. You can use them directly, or copy the commands out of the `justfile`. To our help docs, run `just`.
+
 Run a single test suite without a coverage report:
 
 ```bash
-$ yarn mocha-only test/Error.spec.ts
+$ just test test/Error.spec.ts
 ```
 
 Run a single test (case sensitive) in watch mode:
 
 ```bash
-$ yarn mocha-only test/Error.spec.ts --grep 'Populates with type' --watch
+$ just test test/Error.spec.ts --grep 'StripeError' --watch
 ```
 
 If you wish, you may run tests using your Stripe _Test_ API key by setting the
@@ -631,7 +632,7 @@ environment variable `STRIPE_TEST_API_KEY` before running the tests:
 
 ```bash
 $ export STRIPE_TEST_API_KEY='sk_test....'
-$ yarn test
+$ just test
 ```
 
 Run prettier:
@@ -639,7 +640,7 @@ Run prettier:
 Add an [editor integration](https://prettier.io/docs/en/editors.html) or:
 
 ```bash
-$ yarn fix
+$ just format
 ```
 
 [api-keys]: https://dashboard.stripe.com/account/apikeys

--- a/examples/webhook-signing/prepare.sh
+++ b/examples/webhook-signing/prepare.sh
@@ -4,5 +4,4 @@ set -eu -o pipefail
 cp -f ../.eslintrc.js .
 cp -f ../tsconfig.json .
 cp -n ../.env.example ./.env || true
-echo "$PATH"
 eslint --quiet .

--- a/examples/webhook-signing/prepare.sh
+++ b/examples/webhook-signing/prepare.sh
@@ -4,4 +4,5 @@ set -eu -o pipefail
 cp -f ../.eslintrc.js .
 cp -f ../tsconfig.json .
 cp -n ../.env.example ./.env || true
+echo "$PATH"
 eslint --quiet .

--- a/justfile
+++ b/justfile
@@ -24,7 +24,7 @@ integrations-test: build
     RUN_INTEGRATION_TESTS=1 mocha test/Integration.spec.ts
 
 # run the full test suite; you probably want `test`
-ci-test: test types-test integrations-test
+ci-test: install test types-test integrations-test
 
 _build mode packageType:
     mkdir -p {{ mode }}

--- a/justfile
+++ b/justfile
@@ -27,7 +27,7 @@ integrations-test: build
 # run the full test suite; you probably want `test`
 ci-test: install test types-test integrations-test
 
-_build mode packageType:
+_build mode packageType: install
     mkdir -p {{ mode }}
     tsc -p tsconfig.{{ mode }}.json
     echo '{"type":"{{ packageType }}"}' > {{ mode }}/package.json
@@ -45,7 +45,7 @@ build: build-esm build-cjs
 lint: (lint-check "--fix")
 
 # run style checks without changing anything
-lint-check *args:
+lint-check *args: install
     eslint --ext .js,.ts . {{ args }}
 
 # reinstall dependencies, if needed

--- a/justfile
+++ b/justfile
@@ -4,8 +4,10 @@ import? '../sdk-codegen/justfile'
 
 # make locally installed binaries available without a longer specifier
 export PATH := "./node_modules/.bin:" + env_var('PATH')
+# export PATH := `pwd` + "/node_modules/.bin:" + env('PATH')
 
 _default:
+    echo $PATH
     just --list --unsorted
 
 # this uses positional-args so that mixed quoted and unquoted arguments
@@ -20,8 +22,9 @@ types-test: build
     tsc --build types/test
 
 # run full integration tests by installing a bunch of packages and starting servers (slow)
-integrations-test: build
-    RUN_INTEGRATION_TESTS=1 mocha test/Integration.spec.ts
+[positional-arguments]
+integrations-test *args: build
+    RUN_INTEGRATION_TESTS=1 mocha test/Integration.spec.ts "$@"
 
 # run the full test suite; you probably want `test`
 ci-test: install test types-test integrations-test

--- a/justfile
+++ b/justfile
@@ -1,4 +1,4 @@
-set quiet := true
+set quiet
 
 import? '../sdk-codegen/justfile'
 
@@ -13,7 +13,7 @@ _default:
 # (like filtering for a certain test) work the way we expect
 # ⭐ run unit tests
 [positional-arguments]
-test *args: build
+test *args: install build
     mocha "$@"
 
 # try to compile the example TS file to make sure exports work

--- a/justfile
+++ b/justfile
@@ -59,12 +59,15 @@ prettier *args: install
     prettier "{src,examples,scripts,test,types}/**/*.{ts,js}" {{ args }}
 
 # ⭐ format all files
-format: (prettier "--write --loglevel silent")
-    # ensure other files reflect the version in package.json
-    ./scripts/updateAPIVersion.js
+format: (prettier "--write --loglevel silent") _update-api-version
 
 # verify formatting of files (without changes)
 format-check: (prettier "--check")
+
+# propagate automatic changes; should be run after generation
+# in practice, that means it runs after formatting, since that's the only recipe that the generator calls
+_update-api-version:
+    ./scripts/updateAPIVersion.js
 
 # called by tooling
 [private]

--- a/justfile
+++ b/justfile
@@ -1,6 +1,6 @@
 set quiet
 
-import? '../sdk-codegen/justfile'
+import? '../sdk-codegen/utils.just'
 
 # make locally installed binaries available throughout the tree without a longer specifier
 # this is useful in this file, but also depended on by webhook tests that expect to be able to call `eslint` and (I think) don't set it up correctly themselves.
@@ -54,13 +54,12 @@ install:
 
 [no-exit-message]
 [private]
-prettier *args:
+prettier *args: install
     # all the project-relevant JS code
     prettier "{src,examples,scripts,test,types}/**/*.{ts,js}" {{ args }}
 
-# `format` needs to install since other scripts run it cold
 # ⭐ format all files
-format: install (prettier "--write --loglevel silent")
+format: (prettier "--write --loglevel silent")
     # ensure other files reflect the version in package.json
     ./scripts/updateAPIVersion.js
 

--- a/justfile
+++ b/justfile
@@ -10,7 +10,6 @@ _default:
 
 # this uses positional-args so that mixed quoted and unquoted arguments
 # (like filtering for a certain test) work the way we expect
-
 # ⭐ run unit tests
 [positional-arguments]
 test *args: build
@@ -59,7 +58,6 @@ prettier *args:
     prettier "{src,examples,scripts,test,types}/**/*.{ts,js}" {{ args }}
 
 # `format` needs to install since other scripts run it cold
-
 # ⭐ format all files
 format: install (prettier "--write --loglevel silent")
     # ensure other files reflect the version in package.json

--- a/justfile
+++ b/justfile
@@ -2,8 +2,8 @@ set quiet := true
 
 import? '../sdk-codegen/justfile'
 
-# make locally installed binaries available without a longer specifier
-# export PATH := "./node_modules/.bin:" + env_var('PATH')
+# make locally installed binaries available throughout the tree without a longer specifier
+# this is useful in this file, but also depended on by webhook tests that expect to be able to call `eslint` and (I think) don't set it up correctly themselves.
 export PATH := `pwd` + "/node_modules/.bin:" + env('PATH')
 
 _default:
@@ -21,9 +21,8 @@ types-test: build
     tsc --build types/test
 
 # run full integration tests by installing a bunch of packages and starting servers (slow)
-[positional-arguments]
-integrations-test *args: build
-    RUN_INTEGRATION_TESTS=1 mocha test/Integration.spec.ts "$@"
+integrations-test: build
+    RUN_INTEGRATION_TESTS=1 mocha test/Integration.spec.ts
 
 # run the full test suite; you probably want `test`
 ci-test: install test types-test integrations-test

--- a/justfile
+++ b/justfile
@@ -1,0 +1,80 @@
+set quiet := true
+
+import? '../sdk-codegen/justfile'
+
+# make locally installed binaries available without a longer specifier
+export PATH := "./node_modules/.bin:" + env_var('PATH')
+
+_default:
+    just --list --unsorted
+
+# this uses positional-args so that mixed quoted and unquoted arguments
+# (like filtering for a certain test) work the way we expect
+
+# ⭐ run unit tests
+[positional-arguments]
+test *args: build
+    mocha "$@"
+
+# try to compile the example TS file to make sure exports work
+types-test: build
+    tsc --build types/test
+
+# run full integration tests by installing a bunch of packages and starting servers (slow)
+integrations-test: build
+    RUN_INTEGRATION_TESTS=1 mocha test/Integration.spec.ts
+
+# run the full test suite; you probably want `test`
+ci-test: test types-test integrations-test
+
+_build mode packageType:
+    mkdir -p {{ mode }}
+    tsc -p tsconfig.{{ mode }}.json
+    echo '{"type":"{{ packageType }}"}' > {{ mode }}/package.json
+
+[private]
+build-esm: (_build "esm" "module")
+
+[private]
+build-cjs: (_build "cjs" "commonjs")
+
+# generate CJS and ESM versions of the package; mostly used as a pre-req for other steps
+build: build-esm build-cjs
+
+# ⭐ run style checks, fixing issues if possible
+lint: (lint-check "--fix")
+
+# run style checks without changing anything
+lint-check *args:
+    eslint --ext .js,.ts . {{ args }}
+
+# reinstall dependencies, if needed
+install:
+    yarn {{ if is_dependency() == "true" { "--silent" } else { "" } }}
+
+[no-exit-message]
+[private]
+prettier *args:
+    # all the project-relevant JS code
+    prettier "{src,examples,scripts,test,types}/**/*.{ts,js}" {{ args }}
+
+# `format` needs to install since other scripts run it cold
+
+# ⭐ format all files
+format: install (prettier "--write --loglevel silent")
+    # ensure other files reflect the version in package.json
+    ./scripts/updateAPIVersion.js
+
+# verify formatting of files (without changes)
+format-check: (prettier "--check")
+
+# called by tooling
+[private]
+update-version version:
+    echo "{{ version }}" > VERSION
+    perl -pi -e 's|"version": "[.\-\d\w]+"|"version": "{{ version }}"|' package.json
+    perl -pi -e "s|Stripe.PACKAGE_VERSION = '[.\-\d\w]+'|Stripe.PACKAGE_VERSION = '{{ version }}'|" src/stripe.core.ts
+
+# remove build artifacts
+clean:
+    rm -rf ./node_modules/.cache ./esm ./cjs

--- a/justfile
+++ b/justfile
@@ -3,11 +3,10 @@ set quiet := true
 import? '../sdk-codegen/justfile'
 
 # make locally installed binaries available without a longer specifier
-export PATH := "./node_modules/.bin:" + env_var('PATH')
-# export PATH := `pwd` + "/node_modules/.bin:" + env('PATH')
+# export PATH := "./node_modules/.bin:" + env_var('PATH')
+export PATH := `pwd` + "/node_modules/.bin:" + env('PATH')
 
 _default:
-    echo $PATH
     just --list --unsorted
 
 # this uses positional-args so that mixed quoted and unquoted arguments

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "@typescript-eslint/parser": "^4.33.0",
     "chai": "^4.3.6",
     "chai-as-promised": "~7.1.1",
-    "coveralls": "^3.1.1",
     "eslint": "^7.32.0",
     "eslint-config-prettier": "^8.5.0",
     "eslint-plugin-chai-friendly": "^0.7.2",
@@ -60,19 +59,7 @@
   },
   "license": "MIT",
   "scripts": {
-    "build": "yarn build-esm && yarn build-cjs",
-    "build-esm": "mkdir -p esm && tsc -p tsconfig.esm.json && echo '{\"type\":\"module\"}' > esm/package.json",
-    "build-cjs": "mkdir -p cjs && tsc -p tsconfig.cjs.json && echo '{\"type\":\"commonjs\"}' > cjs/package.json",
-    "clean": "rm -rf ./.nyc_output ./node_modules/.cache ./coverage ./esm ./cjs",
-    "prepack": "yarn install && yarn build",
-    "mocha": "nyc mocha",
-    "mocha-only": "mocha",
-    "test": "yarn build && yarn test-typescript && yarn mocha",
-    "test-typescript": "tsc --build types/test",
-    "lint": "eslint --ext .js,.jsx,.ts .",
-    "fix": "yarn lint --fix && ./scripts/updateAPIVersion.js",
-    "report": "nyc -r text -r lcov report",
-    "coveralls": "cat coverage/lcov.info | ./node_modules/coveralls/bin/coveralls.js"
+    "prepack": "just install && just build"
   },
   "exports": {
     "types": "./types/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -59,6 +59,7 @@
   },
   "license": "MIT",
   "scripts": {
+    "test": "tsc -p tsconfig.cjs.json && mocha",
     "prepack": "just install && just build"
   },
   "exports": {

--- a/scripts/updateAPIVersion.js
+++ b/scripts/updateAPIVersion.js
@@ -1,5 +1,10 @@
 #!/usr/bin/env node
 
+/**
+ * Reads the current API version from src/apiVersion.ts and updates all
+ * references to it in the types/ directory.
+ */
+
 /* eslint-disable no-sync,no-nested-ternary */
 const fs = require('fs');
 const path = require('path');
@@ -12,7 +17,7 @@ const API_VERSION = '2[0-9][2-9][0-9]-[0-9]{2}-[0-9]{2}.[a-z]+';
 
 const main = () => {
   const matches = [
-    ...read('src/apiVersion.ts').matchAll(/ApiVersion . '([^']*)'/g),
+    ...read('src/apiVersion.ts').matchAll(/ApiVersion = '([^']*)'/g),
   ];
   if (matches.length !== 1) {
     throw new Error(

--- a/test/Integration.spec.ts
+++ b/test/Integration.spec.ts
@@ -4,6 +4,15 @@ import {FAKE_API_KEY} from './testUtils.js';
 const nodeVersion = parseInt(process.versions.node.split('.')[0], 10);
 
 describe('Integration test', function() {
+  // these tests are expensive and start processes they don't clean up
+  // so, skip them in the regular test suite (which we run locally) and run them via `just test-integrations`
+  // (which is also called in CI)
+  before(function() {
+    if (process.env.RUN_INTEGRATION_TESTS !== '1') {
+      this.skip();
+    }
+  });
+
   this.timeout(50000);
   const testExec = (cmd: string): Promise<void> => {
     const child = childProcess.exec(cmd);

--- a/yarn.lock
+++ b/yarn.lock
@@ -567,7 +567,7 @@ aggregate-error@^3.0.0:
     clean-stack "^2.0.0"
     indent-string "^4.0.0"
 
-ajv@^6.10.0, ajv@^6.12.3, ajv@^6.12.4:
+ajv@^6.10.0, ajv@^6.12.4:
   version "6.12.6"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.12.6.tgz#baf5a62e802b07d977034586f8c3baf5adf26df4"
   integrity sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
@@ -702,18 +702,6 @@ array.prototype.flatmap@^1.3.1:
     es-abstract "^1.20.4"
     es-shim-unscopables "^1.0.0"
 
-asn1@~0.2.3:
-  version "0.2.6"
-  resolved "https://registry.yarnpkg.com/asn1/-/asn1-0.2.6.tgz#0d3a7bb6e64e02a90c0303b31f292868ea09a08d"
-  integrity sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==
-  dependencies:
-    safer-buffer "~2.1.0"
-
-assert-plus@1.0.0, assert-plus@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/assert-plus/-/assert-plus-1.0.0.tgz#f12e0f3c5d77b0b1cdd9146942e4e96c1e4dd525"
-  integrity sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==
-
 assertion-error@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/assertion-error/-/assertion-error-1.1.0.tgz#e60b6b0e8f301bd97e5375215bda406c85118c0b"
@@ -724,37 +712,15 @@ astral-regex@^2.0.0:
   resolved "https://registry.yarnpkg.com/astral-regex/-/astral-regex-2.0.0.tgz#483143c567aeed4785759c0865786dc77d7d2e31"
   integrity sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
 
-asynckit@^0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/asynckit/-/asynckit-0.4.0.tgz#c79ed97f7f34cb8f2ba1bc9790bcc366474b4b79"
-  integrity sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==
-
 available-typed-arrays@^1.0.5:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/available-typed-arrays/-/available-typed-arrays-1.0.5.tgz#92f95616501069d07d10edb2fc37d3e1c65123b7"
   integrity sha512-DMD0KiN46eipeziST1LPP/STfDU0sufISXmjSgvVsoU2tqxctQeASejWcfNtxYKqETM1UxQ8sp2OrSBWpHY6sw==
 
-aws-sign2@~0.7.0:
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/aws-sign2/-/aws-sign2-0.7.0.tgz#b46e890934a9591f2d2f6f86d7e6a9f1b3fe76a8"
-  integrity sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==
-
-aws4@^1.8.0:
-  version "1.11.0"
-  resolved "https://registry.yarnpkg.com/aws4/-/aws4-1.11.0.tgz#d61f46d83b2519250e2784daf5b09479a8b41c59"
-  integrity sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-
 balanced-match@^1.0.0:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/balanced-match/-/balanced-match-1.0.2.tgz#e83e3a7e3f300b34cb9d87f615fa0cbf357690ee"
   integrity sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==
-
-bcrypt-pbkdf@^1.0.0:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz#a4301d389b6a43f9b67ff3ca11a3f6637e360e9e"
-  integrity sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==
-  dependencies:
-    tweetnacl "^0.14.3"
 
 binary-extensions@^2.0.0:
   version "2.2.0"
@@ -828,11 +794,6 @@ caniuse-lite@^1.0.30001400:
   version "1.0.30001423"
   resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001423.tgz#57176d460aa8cd85ee1a72016b961eb9aca55d91"
   integrity sha512-09iwWGOlifvE1XuHokFMP7eR38a0JnajoyL3/i87c8ZjRWRrdKo1fqjNfugfBD0UDBIOz0U+jtNhJ0EPm1VleQ==
-
-caseless@~0.12.0:
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/caseless/-/caseless-0.12.0.tgz#1b681c21ff84033c826543090689420d187151dc"
-  integrity sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw==
 
 chai-as-promised@~7.1.1:
   version "7.1.1"
@@ -943,13 +904,6 @@ color-name@~1.1.4:
   resolved "https://registry.yarnpkg.com/color-name/-/color-name-1.1.4.tgz#c2a09a87acbde69543de6f63fa3995c826c536a2"
   integrity sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
 
-combined-stream@^1.0.6, combined-stream@~1.0.6:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/combined-stream/-/combined-stream-1.0.8.tgz#c3d45a8b34fd730631a110a8a2520682b31d5a7f"
-  integrity sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
-  dependencies:
-    delayed-stream "~1.0.0"
-
 commondir@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/commondir/-/commondir-1.0.1.tgz#ddd800da0c66127393cca5950ea968a3aaf1253b"
@@ -964,22 +918,6 @@ convert-source-map@^1.7.0:
   version "1.9.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.9.0.tgz#7faae62353fb4213366d0ca98358d22e8368b05f"
   integrity sha512-ASFBup0Mz1uyiIjANan1jzLQami9z1PoYSZCiiYW2FczPbenXc45FZdBZLzOT+r6+iciuEModtmCti+hjaAk0A==
-
-core-util-is@1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.2.tgz#b5fd54220aa2bc5ab57aab7140c940754503c1a7"
-  integrity sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==
-
-coveralls@^3.1.1:
-  version "3.1.1"
-  resolved "https://registry.yarnpkg.com/coveralls/-/coveralls-3.1.1.tgz#f5d4431d8b5ae69c5079c8f8ca00d64ac77cf081"
-  integrity sha512-+dxnG2NHncSD1NrqbSM3dn/lE57O6Qf/koe9+I7c+wzkqRmEvcp0kgJdxKInzYzkICKkFMZsX3Vct3++tsF9ww==
-  dependencies:
-    js-yaml "^3.13.1"
-    lcov-parse "^1.0.0"
-    log-driver "^1.2.7"
-    minimist "^1.2.5"
-    request "^2.88.2"
 
 create-require@^1.1.0:
   version "1.1.1"
@@ -999,13 +937,6 @@ crypt@0.0.2:
   version "0.0.2"
   resolved "https://registry.yarnpkg.com/crypt/-/crypt-0.0.2.tgz#88d7ff7ec0dfb86f713dc87bbb42d044d3e6c41b"
   integrity sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==
-
-dashdash@^1.12.0:
-  version "1.14.1"
-  resolved "https://registry.yarnpkg.com/dashdash/-/dashdash-1.14.1.tgz#853cfa0f7cbe2fed5de20326b8dd581035f6e2f0"
-  integrity sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==
-  dependencies:
-    assert-plus "^1.0.0"
 
 debug@4.3.1:
   version "4.3.1"
@@ -1072,11 +1003,6 @@ define-properties@^1.1.3, define-properties@^1.1.4:
     has-property-descriptors "^1.0.0"
     object-keys "^1.1.1"
 
-delayed-stream@~1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
-  integrity sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==
-
 diff@5.0.0:
   version "5.0.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-5.0.0.tgz#7ed6ad76d859d030787ec35855f5b1daf31d852b"
@@ -1107,14 +1033,6 @@ doctrine@^3.0.0:
   integrity sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
   dependencies:
     esutils "^2.0.2"
-
-ecc-jsbn@~0.1.1:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz#3a83a904e54353287874c564b7549386849a98c9"
-  integrity sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==
-  dependencies:
-    jsbn "~0.1.0"
-    safer-buffer "^2.1.0"
 
 electron-to-chromium@^1.4.251:
   version "1.4.284"
@@ -1393,21 +1311,6 @@ esutils@^2.0.2:
   resolved "https://registry.yarnpkg.com/esutils/-/esutils-2.0.3.tgz#74d2eb4de0b8da1293711910d50775b9b710ef64"
   integrity sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
 
-extend@~3.0.2:
-  version "3.0.2"
-  resolved "https://registry.yarnpkg.com/extend/-/extend-3.0.2.tgz#f8b1136b4071fbd8eb140aff858b1019ec2915fa"
-  integrity sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
-
-extsprintf@1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.3.0.tgz#96918440e3041a7a414f8c52e3c574eb3c3e1e05"
-  integrity sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==
-
-extsprintf@^1.2.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/extsprintf/-/extsprintf-1.4.1.tgz#8d172c064867f235c0c84a596806d279bf4bcc07"
-  integrity sha512-Wrk35e8ydCKDj/ArClo1VrPVmN8zph5V4AtHwIuHhvMXsKf73UT3BOD+azBIW+3wOJ4FhEH7zyaJCFvChjYvMA==
-
 fast-deep-equal@^3.1.1, fast-deep-equal@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz#3a7d56b559d6cbc3eb512325244e619a65c6c525"
@@ -1518,20 +1421,6 @@ foreground-child@^2.0.0:
     cross-spawn "^7.0.0"
     signal-exit "^3.0.2"
 
-forever-agent@~0.6.1:
-  version "0.6.1"
-  resolved "https://registry.yarnpkg.com/forever-agent/-/forever-agent-0.6.1.tgz#fbc71f0c41adeb37f96c577ad1ed42d8fdacca91"
-  integrity sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==
-
-form-data@~2.3.2:
-  version "2.3.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.3.3.tgz#dcce52c05f644f298c6a7ab936bd724ceffbf3a6"
-  integrity sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.6"
-    mime-types "^2.1.12"
-
 fromentries@^1.2.0:
   version "1.3.2"
   resolved "https://registry.yarnpkg.com/fromentries/-/fromentries-1.3.2.tgz#e4bca6808816bf8f93b52750f1127f5a6fd86e3a"
@@ -1618,13 +1507,6 @@ get-symbol-description@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.1"
 
-getpass@^0.1.1:
-  version "0.1.7"
-  resolved "https://registry.yarnpkg.com/getpass/-/getpass-0.1.7.tgz#5eff8e3e684d569ae4cb2b1282604e8ba62149fa"
-  integrity sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==
-  dependencies:
-    assert-plus "^1.0.0"
-
 glob-parent@^5.1.2, glob-parent@~5.1.0:
   version "5.1.2"
   resolved "https://registry.yarnpkg.com/glob-parent/-/glob-parent-5.1.2.tgz#869832c58034fe68a4093c17dc15e8340d8401c4"
@@ -1704,19 +1586,6 @@ growl@1.10.5:
   resolved "https://registry.yarnpkg.com/growl/-/growl-1.10.5.tgz#f2735dc2283674fa67478b10181059355c369e5e"
   integrity sha512-qBr4OuELkhPenW6goKVXiv47US3clb3/IbuWF9KNKEijAy9oeHxU9IgzjvJhHkUzhaj7rOUD7+YGWqUjLp5oSA==
 
-har-schema@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/har-schema/-/har-schema-2.0.0.tgz#a94c2224ebcac04782a0d9035521f24735b7ec92"
-  integrity sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==
-
-har-validator@~5.1.3:
-  version "5.1.5"
-  resolved "https://registry.yarnpkg.com/har-validator/-/har-validator-5.1.5.tgz#1f0803b9f8cb20c0fa13822df1ecddb36bde1efd"
-  integrity sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
-  dependencies:
-    ajv "^6.12.3"
-    har-schema "^2.0.0"
-
 has-bigints@^1.0.1, has-bigints@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/has-bigints/-/has-bigints-1.0.2.tgz#0871bd3e3d51626f6ca0966668ba35d5602d6eaa"
@@ -1780,15 +1649,6 @@ html-escaper@^2.0.0:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/html-escaper/-/html-escaper-2.0.2.tgz#dfd60027da36a36dfcbe236262c00a5822681453"
   integrity sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
-
-http-signature@~1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/http-signature/-/http-signature-1.2.0.tgz#9aecd925114772f3d95b65a60abb8f7c18fbace1"
-  integrity sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.2.2"
-    sshpk "^1.7.0"
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -1984,7 +1844,7 @@ is-typed-array@^1.1.10, is-typed-array@^1.1.9:
     gopd "^1.0.1"
     has-tostringtag "^1.0.0"
 
-is-typedarray@^1.0.0, is-typedarray@~1.0.0:
+is-typedarray@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-typedarray/-/is-typedarray-1.0.0.tgz#e479c80858df0c1b11ddda6940f96011fcda4a9a"
   integrity sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==
@@ -2005,11 +1865,6 @@ isexe@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
-
-isstream@~0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
-  integrity sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.0"
@@ -2091,11 +1946,6 @@ js-yaml@^3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
-jsbn@~0.1.0:
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/jsbn/-/jsbn-0.1.1.tgz#a5e654c2e5a2deb5f201d96cefbca80c0ef2f513"
-  integrity sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==
-
 jsesc@^2.5.1:
   version "2.5.2"
   resolved "https://registry.yarnpkg.com/jsesc/-/jsesc-2.5.2.tgz#80564d2e483dacf6e8ef209650a67df3f0c283a4"
@@ -2111,17 +1961,12 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.4.0:
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
-  integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==
-
 json-stable-stringify-without-jsonify@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz#9db7b59496ad3f3cfef30a75142d2d930ad72651"
   integrity sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==
 
-json-stringify-safe@^5.0.1, json-stringify-safe@~5.0.1:
+json-stringify-safe@^5.0.1:
   version "5.0.1"
   resolved "https://registry.yarnpkg.com/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz#1296a2d58fd45f19a0f6ce01d65701e2c735b6eb"
   integrity sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA==
@@ -2137,21 +1982,6 @@ json5@^2.2.1:
   version "2.2.3"
   resolved "https://registry.yarnpkg.com/json5/-/json5-2.2.3.tgz#78cd6f1a19bdc12b73db5ad0c61efd66c1e29283"
   integrity sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg==
-
-jsprim@^1.2.2:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.2.tgz#712c65533a15c878ba59e9ed5f0e26d5b77c5feb"
-  integrity sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==
-  dependencies:
-    assert-plus "1.0.0"
-    extsprintf "1.3.0"
-    json-schema "0.4.0"
-    verror "1.10.0"
-
-lcov-parse@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/lcov-parse/-/lcov-parse-1.0.0.tgz#eb0d46b54111ebc561acb4c408ef9363bdc8f7e0"
-  integrity sha512-aprLII/vPzuQvYZnDRU78Fns9I2Ag3gi4Ipga/hxnVMCZC8DnR2nI7XBqrPoywGfxqIx/DgarGvDJZAD3YBTgQ==
 
 levn@^0.4.1:
   version "0.4.1"
@@ -2194,11 +2024,6 @@ lodash@^4.17.21:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
-
-log-driver@^1.2.7:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/log-driver/-/log-driver-1.2.7.tgz#63b95021f0702fedfa2c9bb0a24e7797d71871d8"
-  integrity sha512-U7KCmLdqsGHBLeWqYlFA0V0Sl6P08EE1ZrmA9cxjUE0WVqT9qnyVDPz1kzpFEP0jdJuFnasWIfSd7fsaNXkpbg==
 
 log-symbols@4.0.0:
   version "4.0.0"
@@ -2255,18 +2080,6 @@ micromatch@^4.0.4:
     braces "^3.0.2"
     picomatch "^2.3.1"
 
-mime-db@1.52.0:
-  version "1.52.0"
-  resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.52.0.tgz#bbabcdc02859f4987301c856e3387ce5ec43bf70"
-  integrity sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==
-
-mime-types@^2.1.12, mime-types@~2.1.19:
-  version "2.1.35"
-  resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
-  integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
-  dependencies:
-    mime-db "1.52.0"
-
 minimatch@3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
@@ -2281,7 +2094,7 @@ minimatch@^3.0.4, minimatch@^3.1.1, minimatch@^3.1.2:
   dependencies:
     brace-expansion "^1.1.7"
 
-minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.5, minimist@^1.2.6:
+minimist@1.2.6, minimist@^1.2.0, minimist@^1.2.6:
   version "1.2.6"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.6.tgz#8637a5b759ea0d6e98702cfb3a9283323c93af44"
   integrity sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==
@@ -2427,11 +2240,6 @@ nyc@^15.1.0:
     test-exclude "^6.0.0"
     yargs "^15.0.2"
 
-oauth-sign@~0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.9.0.tgz#47a7b016baa68b5fa0ecf3dee08a85c679ac6455"
-  integrity sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
-
 object-inspect@^1.12.3:
   version "1.12.3"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.12.3.tgz#ba62dffd67ee256c8c086dfae69e016cd1f198b9"
@@ -2572,11 +2380,6 @@ pathval@^1.1.1:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-1.1.1.tgz#8534e77a77ce7ac5a2512ea21e0fdb8fcf6c3d8d"
   integrity sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==
 
-performance-now@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/performance-now/-/performance-now-2.1.0.tgz#6309f4e0e5fa913ec1c69307ae364b4b377c9e7b"
-  integrity sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==
-
 picocolors@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.0.0.tgz#cb5bdc74ff3f51892236eaf79d68bc44564ab81c"
@@ -2628,12 +2431,7 @@ propagate@^2.0.0:
   resolved "https://registry.yarnpkg.com/propagate/-/propagate-2.0.1.tgz#40cdedab18085c792334e64f0ac17256d38f9a45"
   integrity sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==
 
-psl@^1.1.28:
-  version "1.9.0"
-  resolved "https://registry.yarnpkg.com/psl/-/psl-1.9.0.tgz#d0df2a137f00794565fcaf3b2c00cd09f8d5a5a7"
-  integrity sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag==
-
-punycode@^2.1.0, punycode@^2.1.1:
+punycode@^2.1.0:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/punycode/-/punycode-2.1.1.tgz#b58b010ac40c22c5657616c8d2c2c02c7bf479ec"
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
@@ -2644,11 +2442,6 @@ qs@^6.11.0:
   integrity sha512-MvjoMCJwEarSbUYk5O+nmoSzSutSsTwF85zcHPQ9OrlFoZOYIjaqBAJIqIXjptyD5vThxGq52Xu/MaJzRkIk4Q==
   dependencies:
     side-channel "^1.0.4"
-
-qs@~6.5.2:
-  version "6.5.3"
-  resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
-  integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
 queue-microtask@^1.2.2:
   version "1.2.3"
@@ -2689,32 +2482,6 @@ release-zalgo@^1.0.0:
   integrity sha512-gUAyHVHPPC5wdqX/LG4LWtRYtgjxyX78oanFNTMMyFEfOqdC54s3eE82imuWKbOeqYht2CrNf64Qb8vgmmtZGA==
   dependencies:
     es6-error "^4.0.1"
-
-request@^2.88.2:
-  version "2.88.2"
-  resolved "https://registry.yarnpkg.com/request/-/request-2.88.2.tgz#d73c918731cb5a87da047e207234146f664d12b3"
-  integrity sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
-  dependencies:
-    aws-sign2 "~0.7.0"
-    aws4 "^1.8.0"
-    caseless "~0.12.0"
-    combined-stream "~1.0.6"
-    extend "~3.0.2"
-    forever-agent "~0.6.1"
-    form-data "~2.3.2"
-    har-validator "~5.1.3"
-    http-signature "~1.2.0"
-    is-typedarray "~1.0.0"
-    isstream "~0.1.2"
-    json-stringify-safe "~5.0.1"
-    mime-types "~2.1.19"
-    oauth-sign "~0.9.0"
-    performance-now "^2.1.0"
-    qs "~6.5.2"
-    safe-buffer "^5.1.2"
-    tough-cookie "~2.5.0"
-    tunnel-agent "^0.6.0"
-    uuid "^3.3.2"
 
 require-directory@^2.1.1:
   version "2.1.1"
@@ -2769,7 +2536,7 @@ run-parallel@^1.1.9:
   dependencies:
     queue-microtask "^1.2.2"
 
-safe-buffer@^5.0.1, safe-buffer@^5.1.0, safe-buffer@^5.1.2:
+safe-buffer@^5.1.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -2782,11 +2549,6 @@ safe-regex-test@^1.0.0:
     call-bind "^1.0.2"
     get-intrinsic "^1.1.3"
     is-regex "^1.1.4"
-
-safer-buffer@^2.0.2, safer-buffer@^2.1.0, safer-buffer@~2.1.0:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
-  integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
 semver@^6.0.0, semver@^6.3.0:
   version "6.3.1"
@@ -2873,21 +2635,6 @@ sprintf-js@~1.0.2:
   version "1.0.3"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.0.3.tgz#04e6926f662895354f3dd015203633b857297e2c"
   integrity sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==
-
-sshpk@^1.7.0:
-  version "1.17.0"
-  resolved "https://registry.yarnpkg.com/sshpk/-/sshpk-1.17.0.tgz#578082d92d4fe612b13007496e543fa0fbcbe4c5"
-  integrity sha512-/9HIEs1ZXGhSPE8X6Ccm7Nam1z8KcoCqPdI7ecm1N33EzAetWahvQWVqLZtaZQ+IDKX4IyA2o0gBzqIMkAagHQ==
-  dependencies:
-    asn1 "~0.2.3"
-    assert-plus "^1.0.0"
-    bcrypt-pbkdf "^1.0.0"
-    dashdash "^1.12.0"
-    ecc-jsbn "~0.1.1"
-    getpass "^0.1.1"
-    jsbn "~0.1.0"
-    safer-buffer "^2.0.2"
-    tweetnacl "~0.14.0"
 
 "string-width@^1.0.2 || 2":
   version "2.1.1"
@@ -3025,14 +2772,6 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
-tough-cookie@~2.5.0:
-  version "2.5.0"
-  resolved "https://registry.yarnpkg.com/tough-cookie/-/tough-cookie-2.5.0.tgz#cd9fb2a0aa1d5a12b473bd9fb96fa3dcff65ade2"
-  integrity sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
-  dependencies:
-    psl "^1.1.28"
-    punycode "^2.1.1"
-
 tr46@~0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/tr46/-/tr46-0.0.3.tgz#8184fd347dac9cdc185992f3a6622e14b9d9ab6a"
@@ -3078,18 +2817,6 @@ tsutils@^3.21.0:
   integrity sha512-mHKK3iUXL+3UF6xL5k0PEhKRUBKPBCv/+RkEOpjRWxxx27KKRBmmA60A9pgOUvMi8GKhRMPEmjBRPzs2W7O1OA==
   dependencies:
     tslib "^1.8.1"
-
-tunnel-agent@^0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/tunnel-agent/-/tunnel-agent-0.6.0.tgz#27a5dea06b36b04a0a9966774b290868f0fc40fd"
-  integrity sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==
-  dependencies:
-    safe-buffer "^5.0.1"
-
-tweetnacl@^0.14.3, tweetnacl@~0.14.0:
-  version "0.14.5"
-  resolved "https://registry.yarnpkg.com/tweetnacl/-/tweetnacl-0.14.5.tgz#5ae68177f192d4456269d108afa93ff8743f4f64"
-  integrity sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==
 
 type-check@^0.4.0, type-check@~0.4.0:
   version "0.4.0"
@@ -3159,11 +2886,6 @@ uri-js@^4.2.2:
   dependencies:
     punycode "^2.1.0"
 
-uuid@^3.3.2:
-  version "3.4.0"
-  resolved "https://registry.yarnpkg.com/uuid/-/uuid-3.4.0.tgz#b23e4358afa8a202fe7a100af1f5f883f02007ee"
-  integrity sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
-
 uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
@@ -3178,15 +2900,6 @@ v8-compile-cache@^2.0.3:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/v8-compile-cache/-/v8-compile-cache-2.3.0.tgz#2de19618c66dc247dcfb6f99338035d8245a2cee"
   integrity sha512-l8lCEmLcLYZh4nbunNZvQCJc5pv7+RCwa8q/LdUx8u7lsWvPDKmpodJAJNwkAhJC//dFY48KuIEmjtd4RViDrA==
-
-verror@1.10.0:
-  version "1.10.0"
-  resolved "https://registry.yarnpkg.com/verror/-/verror-1.10.0.tgz#3a105ca17053af55d6e270c1f8288682e18da400"
-  integrity sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==
-  dependencies:
-    assert-plus "^1.0.0"
-    core-util-is "1.0.2"
-    extsprintf "^1.2.0"
 
 webidl-conversions@^3.0.0:
   version "3.0.1"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In an effort to modernize and simplify our local tooling, we're moving our dev commands from makefiles to [justfiles](https://github.com/casey/just). This is intended to be mostly a drop-in replacement, but some command names may change per standardization efforts.

To be in line with our other SDKs, I removed most of the scripts in `package.json`. But, if we find that potential contributors are having trouble with muscle memory, we can re-add common ones (`test`, `lint`, etc) that call into `just`.

In order to untangle formatting and linting (which [Prettier recommends](https://prettier.io/docs/en/integrating-with-linters.html#notes) keeping separate, I removed `plugin:prettier` from the eslint config. This mean the formatting-related lint rules are disabled, deferring to `prettier` instead. This has the added bonus of formatting violations not showing up as linting errors in-editor!

Lastly,  I've moved the integration test suite out of the main test suite. It starts a bunch of processes that don't get canceled (eating up CPU locally). So now they're run _only_ in CI by default (and via the `just integrations-test`, if you really want).

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `justfile`
- remove coveralls
- tweak CI to use just
- move prettier out of eslint
- add a prettierignore (since prettier no longer gets to piggyback on eslint's file selection and we're on a super old version that doesn't respect `.gitignore`)
- update README

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2325](https://go/j/DEVSDK-2325)
