### PR TITLE
Include `OPENAPI_VERSION` into npm bundle

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -8,6 +8,7 @@
 !/LICENSE
 !/README.md
 !/VERSION
+!/OPENAPI_VERSION
 !/package.json
 !/cjs/**/*
 !/esm/**/*


### PR DESCRIPTION
### Why?

Currently, there's no way to trace back the openapi version to the generated client, since only `VERSION` is included, but not `OPENAPI_VERSION`.

When downloading the spec via `https://raw.githubusercontent.com/stripe/openapi/refs/tags/<OPENAPI_VERSION>/openapi/spec3.json`, `OPENAPI_VERSION` is required since versioning is not done using any other version value like `2024-12-18.acacia`.

Having the file there would easily allow for a file read and access the right used version at runtime :)

### What?
This PR simply as [OPENAPI_VERSION](https://github.com/stripe/stripe-node/blob/master/OPENAPI_VERSION) into npm package contents.