### PR TITLE
[BREAKING] swap Stripe.webhooks from a factory function to a static property

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -9,7 +9,7 @@ import {
   RequestData,
   RequestOptions,
 } from './Types.js';
-import {WebhookObject, WebhookEvent, createWebhooks} from './Webhooks.js';
+import {WebhookEvent, createWebhooks} from './Webhooks.js';
 import {ApiVersion} from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
@@ -73,20 +73,7 @@ export function createStripe(
   Stripe.HttpClient = HttpClient;
   Stripe.HttpClientResponse = HttpClientResponse;
   Stripe.CryptoProvider = CryptoProvider;
-
-  // Previously Stripe.webhooks was just the createWebhooks() factory function
-  // however going forward it will be a WebhookObject instance. To maintain
-  // backwards compatibility it is currently a factory function that also
-  // complies to the WebhookObject signature. The factory function signature
-  // will be removed as a breaking change in the next major release.
-  // See https://github.com/stripe/stripe-node/issues/1956
-  function createWebhooksDefault(fns = platformFunctions): WebhookObject {
-    return createWebhooks(fns);
-  }
-  Stripe.webhooks = Object.assign(
-    createWebhooksDefault,
-    createWebhooks(platformFunctions)
-  );
+  Stripe.webhooks = createWebhooks(platformFunctions);
 
   function Stripe(
     this: StripeObject,
@@ -157,9 +144,7 @@ export function createStripe(
 
     this.errors = _Error;
 
-    // Once Stripe.webhooks looses the factory function signature in a future release
-    // then this should become this.webhooks = Stripe.webhooks
-    this.webhooks = createWebhooksDefault();
+    this.webhooks = Stripe.webhooks;
 
     this._prevRequestMetrics = [];
     this._enableTelemetry = props.telemetry !== false;


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In https://github.com/stripe/stripe-node/issues/1956, a user flagged that they wanted to be able to use webhook utilities before creating a `Stripe` instance. Since the webhook utilities were standalone (didn't depend on anything inside `Stripe`) we made them static. But because they were factory functions before, we didn't want to break that mid-cycle. Now that it's time for a major version, we can complete this change.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- set `Stripe.webhooks` to the result of `createWebhooks()` directly
- set `this.webhooks` inside the `Stripe` constructor to the value at `Stripe.webhooks`

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-1702](https://go/j/DEVSDK-1702)
- https://github.com/stripe/stripe-node/issues/1956

## Changelog

- ❗ `Stripe.webhooks` and `Stripe().webhooks` are no longer functions (just plain objects)
    - if you were calling `Stripe.webhooks().someMethod()`, you should use `Stripe.webhooks.someMethod()` instead
    - there shouldn't be user-facing functionality changing, just a slight breaking change in our internal organization