### PR TITLE
Remove tests for endpoints that were removed

### DIFF
--- a/test/resources/SubscriptionItems.spec.js
+++ b/test/resources/SubscriptionItems.spec.js
@@ -82,36 +82,4 @@ describe('SubscriptionItems Resource', () => {
       });
     });
   });
-
-  describe('createUsageRecord', () => {
-    it('Sends the correct request', () => {
-      const data = {
-        quantity: 123,
-        timestamp: 123321,
-        action: 'increment',
-      };
-      stripe.subscriptionItems.createUsageRecord('si_123', data);
-      expect(stripe.LAST_REQUEST).to.deep.equal({
-        method: 'POST',
-        url: '/v1/subscription_items/si_123/usage_records',
-        headers: {},
-        data,
-        settings: {},
-      });
-    });
-  });
-
-  describe('listUsageRecordSummaries', () => {
-    it('Sends the correct request', () => {
-      stripe.subscriptionItems.listUsageRecordSummaries('si_123', {});
-
-      expect(stripe.LAST_REQUEST).to.deep.equal({
-        method: 'GET',
-        url: '/v1/subscription_items/si_123/usage_record_summaries',
-        headers: {},
-        data: null,
-        settings: {},
-      });
-    });
-  });
 });


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a lot of endpoints being (re)moved in the upcoming GA release. This remove manually maintained tests that reference these endpoints.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Removes tests for UsageRecord and UsageRecordSummary

### See Also
<!-- Include any links or additional information that help explain this change. -->
