### PR TITLE
remove type checks for removed endpoints

### DIFF
--- a/types/Deprecations.d.ts
+++ b/types/Deprecations.d.ts
@@ -201,15 +201,5 @@ declare module 'stripe' {
      * @deprecated prefer {@link TransferUpdateReversalParams}
      **/
     type TransferReversalUpdateParams = TransferUpdateReversalParams;
-
-    /**
-     * @deprecated prefer {@link SubscriptionItemCreateUsageRecordParams}
-     **/
-    type UsageRecordCreateParams = SubscriptionItemCreateUsageRecordParams;
-
-    /**
-     * @deprecated prefer {@link SubscriptionItemListUsageRecordSummariesParams}
-     **/
-    type UsageRecordSummaryListParams = SubscriptionItemListUsageRecordSummariesParams;
   }
 }

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -305,4 +305,4 @@ stripe.files.create({
 });
 
 // Test deprecated parameters still work
-const param: Stripe.UsageRecordSummaryListParams = {expand: []};
+const param: Stripe.TransferListReversalsParams = {expand: []};


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We had some manually maintained types that reference types that have now been removed, failing the build.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- removed unavailable types
- update test to use a still-present deprecated type

### See Also
<!-- Include any links or additional information that help explain this change. -->
