### PR TITLE
add Amount interface

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -304,5 +304,15 @@ declare module 'stripe' {
       name?: string;
       type?: string;
     }
+
+    namespace V2 {
+      /**
+       * Represents a monetary amount with associated currency
+       */
+      export interface Amount {
+        value: number;
+        currency: string;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Some v2 APIs have the v2 `Amount` shape now, but that interface only existed in the private beta repos. This copies that interface over to clear CI failures.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- copy `Amount` interface

### See Also
<!-- Include any links or additional information that help explain this change. -->
- [DEVSDK-1265](https://go/j/DEVSDK-1265)