### PR TITLE
Remove Node 12 from CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,9 @@ jobs:
           - '18'
           - '16'
           - '14'
-          - '12'
+          # Node subdependency(eslint-utils) added optional chaining syntax that does not work in v12
+          # TODO: https://jira.corp.stripe.com/browse/RUN_DEVSDK-1610
+          # - "12"
     runs-on: ${{ matrix.os }}
     steps:
       - uses: extractions/setup-just@v2


### PR DESCRIPTION
### Why?
Node sub dependency(eslint-util) added optional chaining which isn't supported in Node 12.

### What? 
Removed 12 tests from CI.

### See Also
https://jira.corp.stripe.com/browse/RUN_DEVSDK-1610
