### PR TITLE
RawRequest can use custom host

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -500,8 +500,8 @@ export class RequestSender {
           queryData: {},
           authenticator,
           headers,
-          host: null,
-          streaming: false,
+          host: calculatedOptions.host,
+          streaming: !!calculatedOptions.streaming,
           settings: {},
           usage: ['raw_request'],
         };

--- a/src/StripeResource.ts
+++ b/src/StripeResource.ts
@@ -158,7 +158,7 @@ StripeResource.prototype = {
     const data = encode(Object.assign({}, dataFromArgs, overrideData));
     const options = getOptionsFromArgs(args);
     const host = options.host || spec.host;
-    const streaming = !!spec.streaming;
+    const streaming = !!spec.streaming || !!options.streaming;
     // Validate that there are no more args.
     if (args.filter((x) => x != null).length) {
       throw new Error(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,7 @@ const OPTIONS_KEYS = [
   'authenticator',
   'stripeContext',
   'additionalHeaders',
+  'streaming',
 ];
 
 type Settings = {
@@ -153,6 +154,7 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
     host: null,
     headers: {},
     settings: {},
+    streaming: false,
   };
   if (args.length > 0) {
     const arg = args[args.length - 1];
@@ -216,6 +218,9 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
         opts.headers = params.additionalHeaders as {
           [headerName: string]: string;
         };
+      }
+      if (params.streaming) {
+        opts.streaming = true;
       }
     }
   }

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -495,6 +495,32 @@ describe('RequestSender', () => {
         });
       });
     });
+
+    describe('_rawRequest', () => {
+      it('should set the host correctly for raw request', (done) => {
+        const scope = nock(`https://files.stripe.com`)
+          .get(`/v1/files/file_1Mr4LDLkdIwHu7ixFCz0dZiH/contents`)
+          .reply(200, '{}');
+
+        realStripe
+          .rawRequest(
+            'GET',
+            '/v1/files/file_1Mr4LDLkdIwHu7ixFCz0dZiH/contents',
+            {},
+            {
+              host: 'files.stripe.com',
+              streaming: true,
+            }
+          )
+          .then((result) => {
+            done();
+            scope.done();
+          })
+          .catch((error) => {
+            done(error);
+          });
+      });
+    });
   });
 
   describe('Retry Network Requests', () => {

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -198,6 +198,7 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs([])).to.deep.equal({
         host: null,
         headers: {},
+        streaming: false,
         settings: {},
       });
     });
@@ -207,6 +208,7 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         host: null,
         headers: {},
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(2);
@@ -217,6 +219,7 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         host: null,
         headers: {},
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(1);
@@ -228,6 +231,7 @@ describe('utils', () => {
       expect(options).to.deep.contain({
         host: null,
         headers: {},
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(0);
@@ -242,6 +246,7 @@ describe('utils', () => {
       expect(options).to.deep.contain({
         host: null,
         headers: {},
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(0);
@@ -253,6 +258,7 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         host: null,
         headers: {'Idempotency-Key': 'foo'},
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(1);
@@ -263,6 +269,18 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         host: null,
         headers: {'Stripe-Version': '2003-03-30'},
+        streaming: false,
+        settings: {},
+      });
+      expect(args.length).to.equal(1);
+    });
+
+    it('parses streaming', () => {
+      const args = [{foo: 'bar'}, {streaming: true}];
+      expect(utils.getOptionsFromArgs(args)).to.deep.equal({
+        host: null,
+        headers: {},
+        streaming: true,
         settings: {},
       });
       expect(args.length).to.equal(1);
@@ -284,6 +302,7 @@ describe('utils', () => {
           'Idempotency-Key': 'foo',
           'Stripe-Version': '2010-01-10',
         },
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(1);
@@ -307,6 +326,7 @@ describe('utils', () => {
           'Idempotency-Key': 'foo',
           'Stripe-Version': 'hunter2',
         },
+        streaming: false,
         settings: {},
       });
       expect(args.length).to.equal(0);
@@ -326,6 +346,7 @@ describe('utils', () => {
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
         host: null,
         headers: {},
+        streaming: false,
         settings: {
           maxNetworkRetries: 5,
           timeout: 1000,


### PR DESCRIPTION
### Why?
Host and streaming option when passed through raw request are not honored while making the actual request.

### What?
- Host and streaming are now settable when passed as request options when making a raw request.

### See Also
https://jira.corp.stripe.com/browse/RUN_DEVSDK-1525


## Changelog
* RawRequest now allows you set `host` and `streaming` in request options. Eg.
```typescript
const file = await stripe.rawRequest(
  'GET',
  '/v1/files/file_123/contents',
  {},
  {host: 'files.stripe.com', streaming: true}
);
```