### PR TITLE
Revert "Remove Node 12 from CI (#2306)"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,9 +63,7 @@ jobs:
           - '18'
           - '16'
           - '14'
-          # Node subdependency(eslint-utils) added optional chaining syntax that does not work in v12
-          # TODO: https://jira.corp.stripe.com/browse/RUN_DEVSDK-1610
-          # - "12"
+          - '12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: extractions/setup-just@v2


### PR DESCRIPTION
This reverts commit 23739dbcae6dbfd81567b9bbbfd7b3f0b3149c50.

### Why?
Adding this back in, and will be skipping the integration linting test. 

https://jira.corp.stripe.com/browse/RUN_DEVSDK-1610?focusedId=20826574&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-20826574

### What?
Reverted removal of node 12 changes

### See Also
<!-- Include any links or additional information that help explain this change. -->
