### PR TITLE
Allow data to be set in `POST` rawRequests

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -487,7 +487,8 @@ export class RequestSender {
 
         // Pull request data and options (headers, auth) from args.
         const dataFromArgs = getDataFromArgs(args);
-        const data = Object.assign({}, dataFromArgs);
+        const data =
+          requestMethod === 'POST' ? Object.assign({}, dataFromArgs) : null;
         const calculatedOptions = getOptionsFromArgs(args);
 
         const headers = calculatedOptions.headers;

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -520,6 +520,22 @@ describe('RequestSender', () => {
             done(error);
           });
       });
+
+      it('sends empty v2 GET request bodies', (done) => {
+        const scope = nock(`https://api.stripe.com`)
+          .get(`/v2/core/event_destinations`)
+          .reply(200, {data: [], next_page_url: null, previous_page_url: null});
+
+        realStripe
+          .rawRequest('GET', '/v2/core/event_destinations')
+          .then((result) => {
+            done();
+            scope.done();
+          })
+          .catch((error) => {
+            done(error);
+          });
+      });
     });
   });
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Right now rawRequests on v2 GET endpoints emit a warning even when params is not set (it errors if it is), even though the request succeeds. Since we verify beforehand that if the request method isn't POST and params are set and error if they are, we can just check if the method is POST.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

Set `data` in rawRequests to null if the request method isn't POST.

### See Also
<!-- Include any links or additional information that help explain this change. -->
