### PR TITLE
Add stripeContext to RequestOptions interface

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -132,6 +132,11 @@ declare module 'stripe' {
       stripeAccount?: string;
 
       /**
+       * An account on whose behalf you wish to make a request. See https://docs.corp.stripe.com/context for more information.
+       */
+      stripeContext?: string;
+
+      /**
        * The [API Version](https://stripe.com/docs/upgrades) to use for a given request (e.g., '2020-03-02').
        */
       apiVersion?: string;


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->
The `Stripe-Context` header can be used to set the account on behalf of whom an API call is made. See https://docs.corp.stripe.com/context for more information. We already support its use in StripeClient, but it is not exposed in the `RequestOptions` interface.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- Add `stripeContext` to the`RequestOptions` interface.

```javascript
const customer = await stripeClient.customers.create(
  {
    email: "jenny.rosen@example.com",
    name: "Jenny Rosen",
  },
  {
    stripeContext: "acct_xyz",
  }
);
```

## Changelog
- Add `stripeContext` to the `RequestOptions` interface.
