### PR TITLE
add StripeContext to client types

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -112,6 +112,11 @@ declare module 'stripe' {
        * An account id on whose behalf you wish to make every request.
        */
       stripeAccount?: string;
+
+      /**
+       * The Context this client will use for every request.
+       */
+      stripeContext?: string;
     }
 
     export interface RequestOptions {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We already supported a `stripeContext` arg, but it was erroneously missing from the types for the client constructor. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- added line to type annotation

### See Also
<!-- Include any links or additional information that help explain this change. -->
