### PR TITLE
Make getConstant public method

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -293,13 +293,6 @@ export function createStripe(
       return this._clientId;
     },
 
-    /**
-     * @private
-     * Please open or upvote an issue at github.com/stripe/stripe-node
-     * if you use this, detailing your use-case.
-     *
-     * It may be deprecated and removed in the future.
-     */
     getConstant: (c: string): unknown => {
       switch (c) {
         case 'DEFAULT_HOST':


### PR DESCRIPTION
### Why?
User [reported](https://github.com/stripe/stripe-node/issues/2357) a use case for fetching constants from their codebase and required a public method to access it. 

### What?
- Make `getConstant` private method public. 

### See Also
https://github.com/stripe/stripe-node/issues/2357

## Changelog
# TKTK
* Add support for `getConstant` method on `Stripe.prototype` method public. As we improve types in 