### PR TITLE
Export API_Version string in Stripe class

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -60,6 +60,7 @@ export function createStripe(
   requestSender: RequestSenderFactory = defaultRequestSenderFactory
 ): typeof Stripe {
   Stripe.PACKAGE_VERSION = '18.3.0';
+  Stripe.API_VERSION = ApiVersion;
   Stripe.USER_AGENT = {
     bindings_version: Stripe.PACKAGE_VERSION,
     lang: 'node',

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -28,6 +28,7 @@ declare module 'stripe' {
       static MAX_BUFFERED_REQUEST_METRICS: number;
     }
     export type LatestApiVersion = '2025-06-30.basil';
+    export const API_VERSION: string;
     export type HttpAgent = Agent;
     export type HttpProtocol = 'http' | 'https';
 


### PR DESCRIPTION
### Why?
A [user requested](https://github.com/stripe/stripe-node/issues/2357) that Stripe class should export the API_VERSION. 

### What?
- Export `API_VERSION` on non-instantiated Stripe class. 

### See Also
https://github.com/stripe/stripe-node/issues/2357

## Changelog
* Use `API_VERSION` on `Stripe` class to access API version pinned to the current SDK.
```typescript
import { Stripe } from "stripe";

console.log(Stripe.API_VERSION);  // 2025-06-30.basil
```