### PR TITLE
Add strongly typed Thin Event push payloads

### DIFF
--- a/examples/snippets/thinevent_webhook_handler.js
+++ b/examples/snippets/thinevent_webhook_handler.js
@@ -29,15 +29,15 @@ app.post(
     try {
       const thinEvent = client.parseThinEvent(req.body, sig, webhookSecret);
 
-      // Fetch the event data to understand the failure
-      const event = await client.v2.core.events.retrieve(thinEvent.id);
-      if (event.type == 'v1.billing.meter.error_report_triggered') {
+      if (thinEvent.type == 'v1.billing.meter.error_report_triggered') {
+        // Fetch the event data to understand the failure
+        const event = await thinEvent.pull();
         const meter = await event.fetchRelatedObject();
-        const meterId = meter.id;
-        console.log(`Success! ${meterId}`);
 
-        // Record the failures and alert your team
-        // Add your logic here
+        console.log(
+          `Meter ${meter.display_name} (id: ${meter.id}) encountered an error: ${event.data.developer_message_summary}`
+        );
+        // Add additional logic here
       }
       res.sendStatus(200);
     } catch (err) {

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -468,7 +468,8 @@ export class RequestSender {
     method: string,
     path: string,
     params?: RequestData,
-    options?: RequestOptions
+    options?: RequestOptions,
+    usage?: Array<string>
   ): Promise<any> {
     const requestPromise = new Promise<any>((resolve, reject) => {
       let opts: RequestOpts;
@@ -504,7 +505,8 @@ export class RequestSender {
           host: calculatedOptions.host,
           streaming: !!calculatedOptions.streaming,
           settings: {},
-          usage: ['raw_request'],
+          // We use this for thin event internals, so we should record the more specific `usage`, when available
+          usage: usage || ['raw_request'],
         };
       } catch (err) {
         reject(err);
@@ -712,8 +714,9 @@ export class RequestSender {
           apiVersion: apiVersion,
           clientUserAgent,
           method,
-          userSuppliedHeaders: options.headers,
-          userSuppliedSettings: options.settings,
+          // other callers expect null, but .headers being optional means it's undefined if not supplied. So we normalize to null.
+          userSuppliedHeaders: options.headers ?? null,
+          userSuppliedSettings: options.settings ?? {},
           stripeAccount:
             apiMode == 'v2' ? null : this._stripe.getApiField('stripeAccount'),
           stripeContext:

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -69,9 +69,14 @@ export type RequestEvent = {
 };
 export type RequestHeaders = Record<string, string | number | string[]>;
 export type RequestOptions = {
-  settings: RequestSettings;
-  streaming: boolean;
-  headers: RequestHeaders;
+  settings?: RequestSettings;
+  streaming?: boolean;
+  headers?: RequestHeaders;
+  stripeContext?: string;
+  /**
+   * NOTE: prefer sending `stripeContext` instead of `stripeAccount` for new code. They're currently identical, but we will eventually discourage and (later) drop support for `stripeAccount`.
+   */
+  stripeAccount?: string;
 };
 export type RequestOpts = {
   authenticator: RequestAuthenticator | null;
@@ -180,7 +185,8 @@ export type RequestSender = {
     method: string,
     path: string,
     params?: RequestData,
-    options?: RequestOptions
+    options?: RequestOptions,
+    usage?: Array<string>
   ): Promise<any>;
   _request(
     method: string,

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -20,6 +20,7 @@ import {
 import stripe = require('../src/stripe.cjs.node.js');
 import {NodeHttpClient} from '../src/net/NodeHttpClient.js';
 import {HttpClientResponseInterface} from '../src/net/HttpClient.js';
+import {AddressInfo} from 'net';
 
 const testingHttpAgent = new http.Agent({keepAlive: false});
 
@@ -34,7 +35,8 @@ export const getTestServerStripe = (
   callback: (
     err: Error | null,
     stripe: StripeClient,
-    closeServer: () => void
+    closeServer: () => void,
+    address: string
   ) => void
 ): void => {
   let nPreviousRequests = 0;
@@ -48,17 +50,25 @@ export const getTestServerStripe = (
     }
   });
   server.listen(0, () => {
-    const {port} = server.address() as any;
+    const {port} = server.address() as AddressInfo;
+    const host = 'localhost';
+    const protocol = 'http';
+
     const stripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
-      host: 'localhost',
+      host,
       port,
-      protocol: 'http',
+      protocol,
       httpAgent: testingHttpAgent,
       ...clientOptions,
     });
-    return callback(null, stripe, () => {
-      server.close();
-    });
+    return callback(
+      null,
+      stripe,
+      () => {
+        server.close();
+      },
+      `${protocol}://${host}:${port}`
+    );
   });
 };
 

--- a/types/ThinEvent.d.ts
+++ b/types/ThinEvent.d.ts
@@ -23,14 +23,5 @@ declare module 'stripe' {
         url: string;
       }
     }
-    /**
-     * The Event object as recieved from StripeClient.parseThinEvent.
-     */
-    interface ThinEvent extends V2.EventBase {
-      /**
-       * Object containing the reference to API resource relevant to the event.
-       */
-      related_object: Event.RelatedObject | null;
-    }
   }
 }

--- a/types/V2/EventTypes.d.ts
+++ b/types/V2/EventTypes.d.ts
@@ -6,6 +6,11 @@ declare module 'stripe' {
       | Stripe.Events.V1BillingMeterErrorReportTriggeredEvent
       | Stripe.Events.V1BillingMeterNoMeterFoundEvent
       | Stripe.Events.V2CoreEventDestinationPingEvent;
+
+    export type PushedEvent =
+      | Stripe.Events.PushedV1BillingMeterErrorReportTriggeredEvent
+      | Stripe.Events.PushedV1BillingMeterNoMeterFoundEvent
+      | Stripe.Events.PushedV2CoreEventDestinationPingEvent;
   }
 
   namespace Stripe.Events {
@@ -21,6 +26,15 @@ declare module 'stripe' {
       related_object: Event.RelatedObject;
       // Retrieves the object associated with the event.
       fetchRelatedObject(): Promise<Billing.Meter>;
+    }
+    export interface PushedV1BillingMeterErrorReportTriggeredEvent
+      extends V2.EventBase {
+      type: 'v1.billing.meter.error_report_triggered';
+      // Object containing the reference to API resource relevant to the event.
+      related_object: Event.RelatedObject;
+      // Retrieves the object associated with the event.
+      fetchRelatedObject(): Promise<Billing.Meter>;
+      pull(): Promise<V1BillingMeterErrorReportTriggeredEvent>;
     }
 
     namespace V1BillingMeterErrorReportTriggeredEvent {
@@ -121,6 +135,11 @@ declare module 'stripe' {
       type: 'v1.billing.meter.no_meter_found';
       // Retrieves data specific to this event.
       data: V1BillingMeterNoMeterFoundEvent.Data;
+    }
+    export interface PushedV1BillingMeterNoMeterFoundEvent
+      extends V2.EventBase {
+      type: 'v1.billing.meter.no_meter_found';
+      pull(): Promise<V1BillingMeterNoMeterFoundEvent>;
     }
 
     namespace V1BillingMeterNoMeterFoundEvent {
@@ -223,6 +242,15 @@ declare module 'stripe' {
       related_object: Event.RelatedObject;
       // Retrieves the object associated with the event.
       fetchRelatedObject(): Promise<V2.EventDestination>;
+    }
+    export interface PushedV2CoreEventDestinationPingEvent
+      extends V2.EventBase {
+      type: 'v2.core.event_destination.ping';
+      // Object containing the reference to API resource relevant to the event.
+      related_object: Event.RelatedObject;
+      // Retrieves the object associated with the event.
+      fetchRelatedObject(): Promise<V2.EventDestination>;
+      pull(): Promise<V2CoreEventDestinationPingEvent>;
     }
   }
 }

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -554,7 +554,7 @@ declare module 'stripe' {
        * Optional: timestamp to use when checking signature validity. Defaults to Date.now().
        */
       receivedAt?: number
-    ) => Stripe.ThinEvent;
+    ) => Stripe.V2.PushedEvent;
   }
 
   export default Stripe;


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

As part of the Next Gen Event Handling project, we're adding fully typed push payloads to thin events. These describe the full union of thin events a user could receive. 

> Note: because one of our earlier prototypes was in node, most of this PR is adding that already-reviewed code to the mainline . See node-next `708` & `725` for historical discussion.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- generate push payload interfaces & union of those
- add `pull` and `fetchRelatedObject` methods to result of `parseThinEvent`
- change return type of `parseThinEvent` to use new union
- add tests
- add address to `getTestServerStripe` callback
- make headers inputs nullalbe
- add usage param to internal request sender
- update example

### TODO

- [ ] add `UknownThinEvent` and make sure type narrowing works nicely

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-2662](https://go/j/browse/DEVSDK-2662)