### PR TITLE
Update merge script rule to run on every PR

### DIFF
--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -10,12 +10,15 @@ on:
 jobs:
   require_merge_commit_on_merge_script_pr:
     name: Merge script PRs must create merge commits
-    if: ${{ contains(github.head_ref, '/merge-') }}
     runs-on: ubuntu-latest
     steps:
       - run: |
-          if ${{ github.event.pull_request.auto_merge.merge_method != 'merge' }}; then
-            echo "Auto-merge method must be 'merge' instead of '${{github.event.pull_request.auto_merge.merge_method}}'"
-            exit 1
+          if [[ "${{ github.head_ref }}" == *"/merge-"* ]]; then
+            if [[ "${{ github.event.pull_request.auto_merge.merge_method }}" != "merge" ]]; then
+              echo "Auto-merge method must be 'merge' instead of '${{github.event.pull_request.auto_merge.merge_method}}'"
+              exit 1
+            fi
+          else
+            echo "Not a merge script PR, skipping check"
           fi
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We want to make the merge script rule that checks that a merge script PR uses `merge` instead of `squash` required. However, in branches where this doesn't apply it runs forever. Add this to make this run on every PR, but pass on branches that don't satisfy the `/merge-` format.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

### See Also
<!-- Include any links or additional information that help explain this change. -->
https://jira.corp.stripe.com/browse/RUN_DEVSDK-1798
