### PR TITLE
fix(example): expires_at is in milliseconds

### DIFF
--- a/examples/snippets/meter_event_stream.ts
+++ b/examples/snippets/meter_event_stream.ts
@@ -20,7 +20,7 @@ let meterEventSession: null | any = null;
 async function refreshMeterEventSession() {
   if (
     meterEventSession === null ||
-    new Date(meterEventSession.expires_at * 1000) <= new Date()
+    new Date(meterEventSession.expires_at) <= new Date()
   ) {
     // Create a new meter event session in case the existing session expired
     const client = new Stripe(apiKey);


### PR DESCRIPTION
I didn't find any place where it's referenced that expires_at is in seconds.