### PR TITLE
Add section on private preview SDKs in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -547,6 +547,10 @@ const stripe = new Stripe('sk_test_...', {
 });
 ```
 
+### Private Preview SDKs
+
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `15.2.0-alpha.2`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-node?tab=readme-ov-file#public-preview-sdks) above and replacing the term `beta` with `alpha`.
+
 ### Custom requests
 
 If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `rawRequest` method on the StripeClient object.

--- a/README.md
+++ b/README.md
@@ -537,8 +537,6 @@ npm install stripe@<replace-with-the-version-of-your-choice> --save
 > **Note**
 > There can be breaking changes between two versions of the public preview SDKs without a bump in the major version. Therefore we recommend pinning the package version to a specific version in your package.json file. This way you can install the same version each time without breaking changes unless you are intentionally looking for the latest public preview SDK.
 
-The versions tab on the [stripe page on npm](https://www.npmjs.com/package/stripe) lists the current tags in use. The `beta` tag here corresponds to the the latest public preview SDK.
-
 Some preview features require a name and version to be set in the `Stripe-Version` header like `feature_beta=v3`. If your preview feature has this requirement, use the `apiVersion` property of `config` object to set it:
 
 ```js

--- a/README.md
+++ b/README.md
@@ -528,7 +528,7 @@ const stripe = new Stripe('sk_test_...', {
 Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `15.2.0-beta.2`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-To install, choose the version that includes support for the preview feature you are interested in by reviewing the [releases page](https://github.com/stripe/stripe-node/releases/) and use it in the below command
+To install, pick the latest version with the `beta` suffix by reviewing the [releases page](https://github.com/stripe/stripe-node/releases/) and use it in the below command
 
 ```
 npm install stripe@<replace-with-the-version-of-your-choice> --save


### PR DESCRIPTION
### Why?
Need a section on how to install the private preview SDKs

### What?
- Added a section on private preview SDKs
- Updated the note on public preview SDKs to nudge users to use the latest beta versions - these are guaranteed to have all the active previews and users do not need to go and find which version maps the feature they are interested in
- Removed the note on npm tags - the note on release versions is enough - it has the added benefit of showing the changelog


