### PR TITLE
Use the right API version 2025-08-27.preview

### DIFF
--- a/src/apiVersion.ts
+++ b/src/apiVersion.ts
@@ -1,3 +1,3 @@
 // File generated from our OpenAPI spec
 
-export const ApiVersion = '2025-08-04.private';
+export const ApiVersion = '2025-08-27.preview';

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -27,7 +27,7 @@ declare module 'stripe' {
       }): (...args: any[]) => Response<ResponseObject>; //eslint-disable-line @typescript-eslint/no-explicit-any
       static MAX_BUFFERED_REQUEST_METRICS: number;
     }
-    export type LatestApiVersion = '2025-08-04.private';
+    export type LatestApiVersion = '2025-08-27.preview';
     export const API_VERSION: string;
     export type HttpAgent = Agent;
     export type HttpProtocol = 'http' | 'https';

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -9,7 +9,7 @@
 import Stripe from 'stripe';
 
 let stripe = new Stripe('sk_test_123', {
-  apiVersion: '2025-08-04.private',
+  apiVersion: '2025-08-27.preview',
 });
 
 stripe = new Stripe('sk_test_123');
@@ -26,7 +26,7 @@ stripe = new Stripe('sk_test_123', {
 
 // Check config object.
 stripe = new Stripe('sk_test_123', {
-  apiVersion: '2025-08-04.private',
+  apiVersion: '2025-08-27.preview',
   typescript: true,
   maxNetworkRetries: 1,
   timeout: 1000,
@@ -44,7 +44,7 @@ stripe = new Stripe('sk_test_123', {
     description: 'test',
   };
   const opts: Stripe.RequestOptions = {
-    apiVersion: '2025-08-04.private',
+    apiVersion: '2025-08-27.preview',
   };
   const customer: Stripe.Customer = await stripe.customers.create(params, opts);
 


### PR DESCRIPTION
### Why?
The Open API spec used to generate the SDK was using an older API version. The spec with the fix for this cannot be used as it also contains changes meant for the next release. Therefore, manually making the API version change here

### What?
Update API version 2025-08-04.private to 2025-08-27.preview 


