### PR TITLE
Change ApiVersion update strategy to avoid future merge conflicts

### DIFF
--- a/justfile
+++ b/justfile
@@ -70,7 +70,7 @@ format-check: (prettier "--check")
 # propagate automatic changes; should be run after generation
 # in practice, that means it runs after formatting, since that's the only recipe that the generator calls
 _update-api-version:
-    ./scripts/updateAPIVersion.js
+    cp src/apiVersion.ts types/apiVersion.d.ts
 
 # called by tooling
 [private]

--- a/types/apiVersion.d.ts
+++ b/types/apiVersion.d.ts
@@ -1,0 +1,4 @@
+// File generated from our OpenAPI spec
+
+export const ApiVersion = '2025-08-27.basil';
+export const ApiMajorVersion = 'basil';

--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -3,6 +3,8 @@
 
 import {Agent} from 'http';
 
+import {ApiVersion} from './apiVersion';
+
 declare module 'stripe' {
   namespace Stripe {
     type StripeResourceClass = typeof StripeResource;
@@ -27,7 +29,7 @@ declare module 'stripe' {
       }): (...args: any[]) => Response<ResponseObject>; //eslint-disable-line @typescript-eslint/no-explicit-any
       static MAX_BUFFERED_REQUEST_METRICS: number;
     }
-    export type LatestApiVersion = '2025-08-27.basil';
+    export type LatestApiVersion = typeof ApiVersion;
     export const API_VERSION: string;
     export type HttpAgent = Agent;
     export type HttpProtocol = 'http' | 'https';

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -8,8 +8,10 @@
 ///<reference types=".." />
 import Stripe from 'stripe';
 
+import {ApiVersion} from '../apiVersion';
+
 let stripe = new Stripe('sk_test_123', {
-  apiVersion: '2025-08-27.basil',
+  apiVersion: ApiVersion,
 });
 
 stripe = new Stripe('sk_test_123');
@@ -26,7 +28,7 @@ stripe = new Stripe('sk_test_123', {
 
 // Check config object.
 stripe = new Stripe('sk_test_123', {
-  apiVersion: '2025-08-27.basil',
+  apiVersion: ApiVersion,
   typescript: true,
   maxNetworkRetries: 1,
   timeout: 1000,
@@ -44,7 +46,7 @@ stripe = new Stripe('sk_test_123', {
     description: 'test',
   };
   const opts: Stripe.RequestOptions = {
-    apiVersion: '2025-08-27.basil',
+    apiVersion: ApiVersion,
   };
   const customer: Stripe.Customer = await stripe.customers.create(params, opts);
 


### PR DESCRIPTION
### Why?
The LatestApiVersion type (in lib.d.ts) and versions in a handful of other files can vary between the different release branches, and as a result there are frequent opportunities for changes in a branch to create a CI merge conflict.  Each branch should manage its own version, but because the value is integrated into other source files we cannot configure it in our automerge script.  This PR moves the version source of truth to a file we can configure.

### What?
- replaced updateAPIVersion.js call with a copy of src/apiVersion.ts to types/apiVersion.d.ts in _update-api-version just recipe
- changed lib.d.ts to import ApiVersion from apiVersion.d.ts and use its type for LatestApiVersion
-  updated test/typescriptTest.ts to use this same constant

### See Also
<!-- Include any links or additional information that help explain this change. -->
