### PR TITLE
support more npm tags

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -124,13 +124,9 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
           # print the NPM user name for validation
           npm whoami
-          VERSION=$(node -p "require('./package.json').version" )
-          # Only publish stable versions to the latest tag
-          if [[ "$VERSION" =~ ^[^-]+$ ]]; then
-            NPM_TAG="latest"
-          else
-            NPM_TAG="beta"
-          fi
+          VERSION=$(< package.json | jq -r '.version')
+          # use the tag correlating to this release channel
+          NPM_TAG=$(< package.json | jq -r '.version | if contains("beta") then "public-preview" else if contains("alpha") then "private-preview" else "latest" end end')
           echo "Publishing $VERSION with $NPM_TAG tag."
           npm publish --otp="$(oathtool -b --totp $NPM_OTP)" --tag $NPM_TAG
         env:

--- a/README.md
+++ b/README.md
@@ -525,13 +525,21 @@ const stripe = new Stripe('sk_test_...', {
 
 ### Public Preview SDKs
 
-Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `15.2.0-beta.2`.
+Stripe has features in the [public preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-beta.X` suffix like `18.6.0-beta.1`.
 We would love for you to try these as we incrementally release new features and improve them based on your feedback.
 
-To install, pick the latest version with the `beta` suffix by reviewing the [releases page](https://github.com/stripe/stripe-node/releases/) and use it in the below command
+The easiest way to install a public-preview release is to use the dedicated npm tag:
 
 ```
-npm install stripe@<replace-with-the-version-of-your-choice> --save
+npm install stripe@public-preview --save
+```
+
+Or, to install a specific version from the [releases page](https://github.com/stripe/stripe-node/releases/), you can specify that version explicitly:
+
+```
+npm install stripe@<some-version>
+# for example:
+# npm install stripe@18.6.0-beta.1
 ```
 
 > **Note**
@@ -547,7 +555,11 @@ const stripe = new Stripe('sk_test_...', {
 
 ### Private Preview SDKs
 
-Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `15.2.0-alpha.2`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-node?tab=readme-ov-file#public-preview-sdks) above and replacing the term `beta` with `alpha`.
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `18.6.0-alpha.1`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-node?tab=readme-ov-file#public-preview-sdks) above and replacing the term `public-preview` with `private-preview`:
+
+```
+npm install stripe@private-preview --save
+```
 
 ### Custom requests
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

When you release on NPM, you can specify a tag for the release ([docs](https://docs.npmjs.com/cli/v11/commands/npm-dist-tag)). This lets your users install an alias that points to the latest release in a channel:

```
npm install package@whatever
```

Previously, we've tagged everything that wasn't GA with the `beta` tag. That has two issues:

1. Now that there's private-preview releases, not all non-GA releases are "beta"
2. We're moving away from the `beta` nomenclature in favor of `public-preview`

To support this change, we updated the tags we use when publishing. These tags can be any string, so switching them is fine. There's nothing special about the `beta` tag we were using.

The only downside is that for new users who find docs that still say `npm install stripe@beta`, they'll now get an older version of the package (since we're not tagging releases with that anymore). If this is an issue, we can likely give a release multiple tags, but I'm not positive. There's no effect on existing users, since people with existing dependency declarations have a real version specifier.

I've called out this change in the changelog.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- swapped a bash regex for a jq command
- add support for the other release channels
- added docs

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-1935](https://go/j/RUN_DEVSDK-1935)

## Changelog

- Starting with this release, we'll no longer be tagging releases with `beta` npm tag. Instead, we'll use `latest`, `public-preview`, or `private-preview` to more closely align with Stripe's [release phases](https://docs.stripe.com/release-phases)