### PR TITLE
fix(types): add missing 'trial' property to SubscriptionSchedule.Phase

### DIFF
--- a/types/SubscriptionSchedules.d.ts
+++ b/types/SubscriptionSchedules.d.ts
@@ -378,6 +378,11 @@ declare module 'stripe' {
          * When the trial ends within the phase.
          */
         trial_end: number | null;
+
+        /**
+         * Whether this phase is a trial phase.
+         */
+        trial?: boolean;
       }
 
       namespace Phase {


### PR DESCRIPTION
…e (#2267)

### Why?
The `trial` property is missing in the TypeScript type for `Stripe.SubscriptionSchedule.Phase`. This prevents developers from safely accessing `phase.trial` without manually extending the type. Adding it ensures TypeScript reflects the actual API response.

### What?
- Added `trial?: boolean` to the `Phase` interface in the type definitions.
- Verified that all existing tests pass with this update.

### See Also
- GitHub issue: [#2267](https://github.com/stripe/stripe-node/issues/2267)
