### PR TITLE
Add `StripeContext` object

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -8,6 +8,7 @@ import {
   generateV1Error,
   generateV2Error,
 } from './Error.js';
+import {StripeContext} from './StripeContext.js';
 import {
   StripeObject,
   RequestHeaders,
@@ -360,7 +361,7 @@ export class RequestSender {
     userSuppliedHeaders: RequestHeaders | null;
     userSuppliedSettings: RequestSettings;
     stripeAccount: string | null;
-    stripeContext: string | null;
+    stripeContext: string | StripeContext | null;
     apiMode: ApiMode;
   }): RequestHeaders {
     const defaultHeaders = {
@@ -371,7 +372,7 @@ export class RequestSender {
       'X-Stripe-Client-Telemetry': this._getTelemetryHeader(),
       'Stripe-Version': apiVersion,
       'Stripe-Account': stripeAccount,
-      'Stripe-Context': stripeContext,
+      'Stripe-Context': stripeContext?.toString(),
       'Idempotency-Key': this._defaultIdempotencyKey(
         method,
         userSuppliedSettings,

--- a/src/StripeContext.ts
+++ b/src/StripeContext.ts
@@ -1,0 +1,46 @@
+export class StripeContext {
+  private readonly _segments: string[];
+
+  /**
+   * Initialize a StripeContext with the given segments.
+   */
+  constructor(segments?: string[]) {
+    this._segments = segments ? [...segments] : [];
+  }
+
+  /**
+   * Parse a context string into a StripeContext instance.
+   */
+  static parse(contextString: string): StripeContext {
+    if (!contextString) {
+      return new StripeContext([]);
+    }
+    return new StripeContext(contextString.split('/'));
+  }
+
+  /**
+   * Create a new StripeContext with the last segment removed.
+   *
+   * @throws {Error} If context has no segments to remove
+   */
+  parent(): StripeContext {
+    if (this._segments.length === 0) {
+      throw new Error('Cannot get parent of empty context');
+    }
+    return new StripeContext(this._segments.slice(0, -1));
+  }
+
+  /**
+   * Create a new StripeContext with an additional segment appended.
+   */
+  child(segment: string): StripeContext {
+    return new StripeContext([...this._segments, segment]);
+  }
+
+  /**
+   * Convert the StripeContext to its string representation.
+   */
+  toString(): string {
+    return this._segments.join('/');
+  }
+}

--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -6,6 +6,7 @@ import {
 } from './net/HttpClient.js';
 import {PlatformFunctions} from './platform/PlatformFunctions.js';
 import {HttpClientResponseError} from './RequestSender.js';
+import {StripeContext} from './StripeContext.ts';
 
 export type AppInfo = {name?: string} & Record<string, unknown>;
 export type ApiMode = 'v1' | 'v2';
@@ -155,7 +156,7 @@ export type StripeObject = {
     httpClient: HttpClientInterface;
     dev: boolean;
     stripeAccount: string | null;
-    stripeContext: string | null;
+    stripeContext: string | StripeContext | null;
   };
   _authenticator?: RequestAuthenticator;
   _emitter: EventEmitter;
@@ -259,7 +260,7 @@ export type UserProvidedConfig = {
   maxNetworkRetries?: number;
   httpClient?: HttpClientInterface;
   stripeAccount?: string;
-  stripeContext?: string;
+  stripeContext?: string | StripeContext;
   typescript?: boolean;
   telemetry?: boolean;
   appInfo?: AppInfo;

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -4,6 +4,7 @@ import {
   CryptoProviderOnlySupportsAsyncError,
 } from './crypto/CryptoProvider.js';
 import {PlatformFunctions} from './platform/PlatformFunctions.js';
+import {StripeContext} from './StripeContext.ts';
 
 type WebhookHeader = string | Uint8Array;
 type WebhookParsedHeader = {
@@ -109,6 +110,12 @@ export function createWebhooks(
         payload instanceof Uint8Array
           ? JSON.parse(new TextDecoder('utf8').decode(payload))
           : JSON.parse(payload);
+
+      // Transform context string to StripeContext if present
+      if (jsonPayload.context) {
+        jsonPayload.context = StripeContext.parse(jsonPayload.context);
+      }
+
       return jsonPayload;
     },
 
@@ -137,6 +144,12 @@ export function createWebhooks(
         payload instanceof Uint8Array
           ? JSON.parse(new TextDecoder('utf8').decode(payload))
           : JSON.parse(payload);
+
+      // Transform context string to StripeContext if present
+      if (jsonPayload.context) {
+        jsonPayload.context = StripeContext.parse(jsonPayload.context);
+      }
+
       return jsonPayload;
     },
 

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1,6 +1,7 @@
 import * as _Error from './Error.js';
 import {RequestSender} from './RequestSender.js';
 import {StripeResource} from './StripeResource.js';
+import {StripeContext} from './StripeContext.ts';
 import {
   AppInfo,
   RequestAuthenticator,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -188,7 +188,7 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
             "Can't specify both stripeAccount and stripeContext."
           );
         }
-        opts.headers['Stripe-Context'] = params.stripeContext as string;
+        opts.headers['Stripe-Context'] = params.stripeContext.toString();
       }
       if (params.apiVersion) {
         opts.headers['Stripe-Version'] = params.apiVersion as string;

--- a/test/StripeContext.spec.ts
+++ b/test/StripeContext.spec.ts
@@ -1,0 +1,96 @@
+// @ts-nocheck
+
+'use strict';
+
+import {expect} from 'chai';
+import {StripeContext} from '../src/StripeContext.ts';
+
+describe('StripeContext', () => {
+  describe('constructor', () => {
+    it('should create empty context with no arguments', () => {
+      const context = new StripeContext();
+      expect(context.toString()).to.equal('');
+    });
+
+    it('should create context with provided segments', () => {
+      const context = new StripeContext(['a', 'b', 'c']);
+      expect(context.toString()).to.equal('a/b/c');
+    });
+  });
+
+  describe('parse', () => {
+    it('should parse empty string', () => {
+      const context = StripeContext.parse('');
+      expect(context.toString()).to.equal('');
+    });
+
+    it('should parse single segment', () => {
+      const context = StripeContext.parse('a');
+      expect(context.toString()).to.equal('a');
+    });
+
+    it('should parse multiple segments', () => {
+      const context = StripeContext.parse('a/b/c');
+      expect(context.toString()).to.equal('a/b/c');
+    });
+  });
+
+  describe('parent', () => {
+    it('should return new instance with last segment removed', () => {
+      const context = StripeContext.parse('a/b/c');
+      const parent = context.parent();
+
+      expect(context.toString()).to.equal('a/b/c'); // Original unchanged
+      expect(parent.toString()).to.equal('a/b'); // New instance
+    });
+
+    it('should return empty context for single segment', () => {
+      const context = StripeContext.parse('a');
+      const parent = context.parent();
+      expect(parent.toString()).to.equal('');
+    });
+
+    it('should throw error for empty context', () => {
+      const context = new StripeContext();
+      expect(() => context.parent()).to.throw('Cannot get parent of empty context');
+    });
+  });
+
+  describe('child', () => {
+    it('should return new instance with segment added', () => {
+      const context = StripeContext.parse('a/b');
+      const child = context.child('c');
+
+      expect(context.toString()).to.equal('a/b'); // Original unchanged
+      expect(child.toString()).to.equal('a/b/c'); // New instance
+    });
+
+    it('should add segment to empty context', () => {
+      const context = new StripeContext();
+      const child = context.child('a');
+      expect(child.toString()).to.equal('a');
+    });
+  });
+
+  describe('chaining operations', () => {
+    it('should support method chaining', () => {
+      const context = StripeContext.parse('a');
+      const result = context.child('b').child('c').parent();
+      expect(result.toString()).to.equal('a/b');
+    });
+  });
+
+  describe('header behavior', () => {
+    it('should not set header for empty context', () => {
+      const emptyContext = new StripeContext();
+      // Empty context should convert to empty string
+      expect(emptyContext.toString()).to.equal('');
+    });
+
+    it('should set header for non-empty context', () => {
+      const context = StripeContext.parse('org_123/proj_456');
+      // Non-empty context should convert to proper string
+      expect(context.toString()).to.equal('org_123/proj_456');
+    });
+  });
+});

--- a/types/StripeContext.d.ts
+++ b/types/StripeContext.d.ts
@@ -1,0 +1,38 @@
+// This is a manually maintained file
+
+declare module 'stripe' {
+  namespace Stripe {
+    /**
+     * StripeContext represents a context path for Stripe API requests.
+     * The context is used to access child accounts by adding segments,
+     * or parent accounts by removing segments.
+     */
+    class StripeContext {
+      /**
+       * Initialize a StripeContext with the given segments.
+       */
+      constructor(segments?: string[]);
+
+      /**
+       * Parse a context string into a StripeContext instance.
+       */
+      static parse(contextString: string): StripeContext;
+
+      /**
+       * Create a new StripeContext with the last segment removed.
+       * @throws {Error} If context has no segments to remove
+       */
+      parent(): StripeContext;
+
+      /**
+       * Create a new StripeContext with an additional segment appended.
+       */
+      child(segment: string): StripeContext;
+
+      /**
+       * Convert the StripeContext to its string representation.
+       */
+      toString(): string;
+    }
+  }
+}

--- a/types/ThinEvent.d.ts
+++ b/types/ThinEvent.d.ts
@@ -1,5 +1,7 @@
 // This is a manually maintained file
 
+import {StripeContext} from '../src/StripeContext.ts';
+
 declare module 'stripe' {
   namespace Stripe {
     namespace Event {

--- a/types/V2/Events.d.ts
+++ b/types/V2/Events.d.ts
@@ -48,7 +48,7 @@ declare module 'stripe' {
         /**
          * Authentication context needed to fetch the event or related object.
          */
-        context?: string;
+        context?: StripeContext;
 
         /**
          * Time at which the object was created.

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -8,6 +8,7 @@
 ///<reference path='./EventTypes.d.ts' />
 ///<reference path='./UpcomingInvoices.d.ts' />
 ///<reference path='./ThinEvent.d.ts' />
+///<reference path='./StripeContext.d.ts' />
 ///<reference path='./crypto/crypto.d.ts' />
 // Imports: The beginning of the section generated from our OpenAPI spec
 ///<reference path='./AccountLinksResource.d.ts' />


### PR DESCRIPTION
### Why?

As the `stripe-context` header is evolving, we want to give better tools for creating and managing contexts. This PR adds a new class, `StripeContext`. It can be used anywhere the context option is supplied and gets serialized to a string when making requests. It's also found on the `EventNotification.context` property.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `StripeContext` class
- allow it to be supplied for RequestOptions.context; serialize it into strings
- add tests

## Changelog

- Add the `StripeContext` class
- ⚠️ Change `EventNotification` (formerly known as `ThinEvent`)'s `context` property from `string` to `StripeContext`
