### PR TITLE
Fixed file uploading in Bun runtimes

### DIFF
--- a/src/net/FetchHttpClient.ts
+++ b/src/net/FetchHttpClient.ts
@@ -141,7 +141,7 @@ export class FetchHttpClient extends HttpClient implements HttpClientInterface {
       {
         method,
         headers: parseHeadersForFetch(headers),
-        body: typeof body === 'object' ? JSON.stringify(body) : body,
+        body: body,
       },
       timeout
     );


### PR DESCRIPTION
### Why?
Merging https://github.com/stripe/stripe-node/pull/2167 introduced a bug in Bun runtimes. Although we don't officially support Bun today, this PR fixes a user reported issue [#2416](https://github.com/stripe/stripe-node/issues/2416)

### What?
Undo JSON.stringifying object bodies in Bun. 

## Changelog
* ⚠️ Fixed issue with file uploads in runtimes using `FetchHttpClient` (e.g. Bun). This bug affected Node SDK versions between 18.1.0 to 18.5.0.