### PR TITLE
Drop support for Node < 16 & clarify policy

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -57,14 +57,12 @@ jobs:
         os:
           - 'ubuntu-24.04'
         node:
-          # should include even numbers >= 12
-          # see: https://nodejs.org/en/about/previous-releases
+          # should include even numbers >= 16
+          # see: https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy
           - '22'
           - '20'
           - '18'
           - '16'
-          - '14'
-          - '12'
     runs-on: ${{ matrix.os }}
     steps:
       - uses: extractions/setup-just@v2

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ See the [`stripe-node` API docs](https://stripe.com/docs/api?lang=node) for Node
 
 ## Requirements
 
-Node 12 or higher.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy), we currently support all LTS versions of **Node.js 16+**.
+
+Support for Node 16 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "bugs": "https://github.com/stripe/stripe-node/issues",
   "engines": {
-    "node": ">=12.*"
+    "node": ">=16"
   },
   "main": "cjs/stripe.cjs.node.js",
   "types": "types/index.d.ts",
@@ -31,7 +31,7 @@
     "@types/chai-as-promised": "^7.1.5",
     "@types/mocha": "^10.0.1",
     "@types/qs": "^6.9.7",
-    "@types/node": ">=12.0.0",
+    "@types/node": "~22",
     "@typescript-eslint/eslint-plugin": "^4.33.0",
     "@typescript-eslint/parser": "^4.33.0",
     "chai": "^4.3.6",
@@ -59,7 +59,7 @@
     "qs": "^6.11.0"
   },
   "peerDependencies": {
-    "@types/node": ">=12.x.x"
+    "@types/node": ">=16"
   },
   "peerDependenciesMeta": {
     "@types/node": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -454,12 +454,12 @@
   resolved "https://registry.yarnpkg.com/@types/mocha/-/mocha-10.0.1.tgz#2f4f65bb08bc368ac39c96da7b2f09140b26851b"
   integrity sha512-/fvYntiO1GeICvqbQ3doGDIP97vWmvFt83GKguJ6prmQM2iXZfFcq6YE8KteFyRtX2/h5Hf91BYvPodJKFYv5Q==
 
-"@types/node@>=12.0.0":
-  version "22.5.4"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.5.4.tgz#83f7d1f65bc2ed223bdbf57c7884f1d5a4fa84e8"
-  integrity sha512-FDuKUJQm/ju9fT/SeX/6+gBzoPzlVCzfzmGkwKvRHQVxi4BntVbyIwf6a4Xn62mrvndLiml6z/UBXIdEVjQLXg==
+"@types/node@~22":
+  version "22.18.7"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-22.18.7.tgz#e1d013d5759fa50ff4d334aee3fd6254f1dbae74"
+  integrity sha512-3E97nlWEVp2V6J7aMkR8eOnw/w0pArPwf/5/W0865f+xzBoGL/ZuHkTAKAGN7cOWNwd+sG+hZOqj+fjzeHS75g==
   dependencies:
-    undici-types "~6.19.2"
+    undici-types "~6.21.0"
 
 "@types/qs@^6.9.7":
   version "6.9.7"
@@ -2878,10 +2878,10 @@ undici-types@^7.8.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
   integrity sha512-9UJ2xGDvQ43tYyVMpuHlsgApydB8ZKfVYTsLDhXkFL/6gfkp+U8xTGdh8pMJv1SpZna0zxG1DwsKZsreLbXBxw==
 
-undici-types@~6.19.2:
-  version "6.19.8"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.19.8.tgz#35111c9d1437ab83a7cdc0abae2f26d88eda0a02"
-  integrity sha512-ve2KP6f/JnbPBFyobGHuerC9g1FYGn/F8n1LWTwNxCEzd6IfqTwUQcNXgEtmmQ6DlRrC1hrSrBnCZPokRrDHjw==
+undici-types@~6.21.0:
+  version "6.21.0"
+  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-6.21.0.tgz#691d00af3909be93a7faa13be61b3a5b50ef12cb"
+  integrity sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==
 
 update-browserslist-db@^1.0.9:
   version "1.0.10"


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Per our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy), we're dropping support for some older runtimes in this release.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- drop unsupported versions from CI
- update readme
- lock node dev types to 22 - was seeing test failures with 24

### See Also
<!-- Include any links or additional information that help explain this change. -->

[DEVSDK-2772](https://go/j/DEVSDK-2772)

## Changelog

- Publish our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy) and add a link to the README.
- ⚠️ Drop support for Node versions < 16
- announce deprecation of Node 16 support, which will be removed in the next scheduled major release (March 2026)
