### PR TITLE
Update param in deprecation docs link

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -58,7 +58,7 @@ jobs:
           - 'ubuntu-24.04'
         node:
           # should include even numbers >= 16
-          # see: https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy
+          # see: https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy
           - '22'
           - '20'
           - '18'

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ This release changes the pinned API version to `2025-09-30.clover` and contains 
       - This function now returns a `Stripe.V2.EventNotification` which is a union of all possible event notifications instead of `Stripe.ThinEvent`. When applicable, these event notifications will have the `relatedObject` field and a function `fetchRelatedObject()`. They also have a `fetchEvent()` method to retrieve their corresponding event.
       - If this union type does not cover a new event notification that you parsed, you can cast it to `UnknownEventNotification` to then access the `relatedObject` field and the function `fetchRelatedObject()`
 * [#2432](https://github.com/stripe/stripe-node/pull/2432) Drop support for Node < 16 & clarify policy
-  - Publish our new [language version support policy](https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy) and add a link to the README.
+  - Publish our new [language version support policy](https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy) and add a link to the README.
   - ⚠️ Drop support for Node versions < 16
   - Node 16 support is deprecated and will be removed in the next scheduled major release (March 2026)
 * [#2426](https://github.com/stripe/stripe-node/pull/2426) Add `StripeContext` object

--- a/README.md
+++ b/README.md
@@ -16,9 +16,9 @@ See the [`stripe-node` API docs](https://stripe.com/docs/api?lang=node) for Node
 
 ## Requirements
 
-Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy), we currently support all LTS versions of **Node.js 16+**.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy), we currently support all LTS versions of **Node.js 16+**.
 
-Support for Node 16 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?server=node#stripe-sdk-language-version-support-policy
+Support for Node 16 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy
 
 ## Installation
 


### PR DESCRIPTION
### Why?

We're using a different `pref` name in the docs for the version deprecation policy, so these links need to be updated.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- replace `?server=` with `?lang=` in links
