### PR TITLE
cleanup logging in publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -118,7 +118,7 @@ jobs:
       - run: sudo apt-get install -y oathtool
       - name: Publish to NPM
         run: |
-          set -ex
+          set -euxo pipefail
           npm config set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
           # print the NPM user name for validation
           npm whoami
@@ -126,7 +126,7 @@ jobs:
           # use the tag correlating to this release channel
           NPM_TAG=$(cat package.json | jq -r '.version | if contains("beta") then "public-preview" else if contains("alpha") then "private-preview" else "latest" end end')
           echo "Publishing $VERSION with $NPM_TAG tag."
-          # don't log the OTP
+          # stop debug logging now, so we don't log the OTP
           set +x
           npm publish --otp="$(oathtool -b --totp $NPM_OTP)" --tag $NPM_TAG
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -122,15 +122,12 @@ jobs:
           npm config set //registry.npmjs.org/:_authToken $NPM_AUTH_TOKEN
           # print the NPM user name for validation
           npm whoami
-          cat package.json
-          cat package.json | jq -r '.version'
-          < package.json | jq -r '.version'
-
           VERSION=$(cat package.json | jq -r '.version')
           # use the tag correlating to this release channel
           NPM_TAG=$(cat package.json | jq -r '.version | if contains("beta") then "public-preview" else if contains("alpha") then "private-preview" else "latest" end end')
           echo "Publishing $VERSION with $NPM_TAG tag."
-          set +ex
+          # don't log the OTP
+          set +x
           npm publish --otp="$(oathtool -b --totp $NPM_OTP)" --tag $NPM_TAG
         env:
           NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We added some debug logging in https://github.com/stripe/stripe-node/pull/2437 https://github.com/stripe/stripe-node/pull/2439. Now that the script is working, we don't need them anymore!

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- removed extra `cat` calls
- set pipefail on the script

### See Also
<!-- Include any links or additional information that help explain this change. -->
