### PR TITLE
add missing fetchEvent type for UnknownEventNotification

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -525,19 +525,21 @@ export function createStripe(
         );
       };
 
-      if (eventNotification.related_object) {
-        eventNotification.fetchRelatedObject = (): Promise<unknown> => {
-          return this._requestSender._rawRequest(
-            'GET',
-            eventNotification.related_object.url,
-            undefined,
-            {
-              stripeContext: eventNotification.context,
-            },
-            ['fetch_related_object']
-          );
-        };
-      }
+      eventNotification.fetchRelatedObject = (): Promise<unknown> => {
+        if (!eventNotification.related_object) {
+          return Promise.resolve(null);
+        }
+
+        return this._requestSender._rawRequest(
+          'GET',
+          eventNotification.related_object.url,
+          undefined,
+          {
+            stripeContext: eventNotification.context,
+          },
+          ['fetch_related_object']
+        );
+      };
 
       return eventNotification;
     },

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -802,7 +802,10 @@ describe('Stripe Module', function() {
             );
 
             expect(event.fetchEvent).to.be.a('function');
-            expect(event.fetchRelatedObject).not.to.be.a('function');
+            // this is always present, but hidden in the types if there's no object
+            // not easy to add conditionally because we don't know at runtime if we have a type for the event or not
+            expect(event.fetchRelatedObject).to.be.a('function');
+            expect(await event.fetchRelatedObject()).to.be.null;
             const pulled = await event.fetchEvent();
             expect(pulled.data).to.equal(jsonWithData.data);
             // Have to call another requests for metrics to be sent.

--- a/types/V2/EventMisc.d.ts
+++ b/types/V2/EventMisc.d.ts
@@ -36,7 +36,15 @@ declare module 'stripe' {
          * Object containing the reference to API resource relevant to the event.
          */
         related_object: V2.Core.Events.RelatedObject | null;
+        /**
+         * Fetches the full object corresponding to the `related_object` field.
+         * Returns `null` if there is no `related_object`.
+         */
         fetchRelatedObject: () => Promise<unknown>;
+        /**
+         * Fetches the full Event object corresponding to this notification.
+         */
+        fetchEvent: () => Promise<V2.Core.EventBase>;
       }
     }
 

--- a/types/test/typescriptTest.ts
+++ b/types/test/typescriptTest.ts
@@ -333,6 +333,13 @@ async (): Promise<void> => {
     // @ts-expect-error - shouldn't be available
     eventNotification.related_object;
     const e: Stripe.Events.V1BillingMeterNoMeterFoundEvent = await eventNotification.fetchEvent();
+    // @ts-expect-error - isn't a known type
+  } else if (eventNotification.type === 'some.unknown.event') {
+    const e = eventNotification as Stripe.Events.UnknownEventNotification;
+    e.fetchEvent();
+    // these exist, but may be null
+    e.related_object;
+    e.fetchRelatedObject();
   }
 };
 


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

When writing the improved events example, I found that I missed adding a type to a manual interface. I also realized that we need to always define `fetchRelatedObject` because on unknown events it says the function is always defined. This now matches how the function works in every other SDK.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- always define `fetchRelatedObject` so that it won't error out if called on an `UnknownEventNotification` with no `related_object`
- add `fetchEvent` to `UnknownEventNotification` interface
- add tests

## Changelog

- Add missing `fetchEvent()` declaration to the `Stripe.Events.UnknownEventNotification` interface
- Tweak `Stripe.Events.fetchRelatedObject` so that it's always defined and returns `null` if there's no `related_object`. This fixes the situation where the `UnknownEventNotification` says that `fetchRelatedObject()` is defined, but calling it throws an error.