### PR TITLE
Add table of contents to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,34 @@ applications written in server-side JavaScript.
 
 For collecting customer and payment information in the browser, use [Stripe.js][stripe-js].
 
+## Table of Contents
+
+- [Documentation](#documentation)
+- [Requirements](#requirements)
+- [Installation](#installation)
+- [Usage](#usage)
+  - [Usage with TypeScript](#usage-with-typescript)
+  - [Using Promises](#using-promises)
+  - [Usage with Deno](#usage-with-deno)
+- [Configuration](#configuration)
+  - [Initialize with config object](#initialize-with-config-object)
+  - [Configuring Timeout](#configuring-timeout)
+  - [Configuring For Connect](#configuring-for-connect)
+  - [Configuring a Proxy](#configuring-a-proxy)
+  - [Network retries](#network-retries)
+  - [Examining Responses](#examining-responses)
+  - [`request` and `response` events](#request-and-response-events)
+  - [Webhook signing](#webhook-signing)
+  - [Writing a Plugin](#writing-a-plugin)
+  - [Auto-pagination](#auto-pagination)
+  - [Telemetry](#telemetry)
+  - [Public Preview SDKs](#public-preview-sdks)
+  - [Private Preview SDKs](#private-preview-sdks)
+  - [Custom requests](#custom-requests)
+- [Support](#support)
+- [More Information](#more-information)
+- [Development](#development)
+
 ## Documentation
 
 See the [`stripe-node` API docs](https://stripe.com/docs/api?lang=node) for Node.js.


### PR DESCRIPTION
### Why?
Improves README navigation and discoverability by adding a comprehensive table of contents. This makes it easier for developers to quickly find the documentation section they need.

### What?
- Adds a table of contents section to README.md with links to all major sections
- Organizes sections hierarchically to reflect the document structure

### See Also
N/A