### PR TITLE
Add support for value `payment_record` to enum `InvoicePayment.payment.type`

### DIFF
--- a/types/InvoicePayments.d.ts
+++ b/types/InvoicePayments.d.ts
@@ -92,7 +92,7 @@ declare module 'stripe' {
       }
 
       namespace Payment {
-        type Type = 'charge' | 'payment_intent';
+        type Type = 'charge' | 'payment_intent' | 'payment_record';
       }
 
       interface StatusTransitions {


### PR DESCRIPTION
### Why?
We missed shipping this change with the previous release

### What?
Add support for value `payment_record` to enum `InvoicePayment.payment.type`


