### PR TITLE
Add min version for custom request support

### DIFF
--- a/README.md
+++ b/README.md
@@ -565,6 +565,8 @@ npm install stripe@private-preview --save
 
 ### Custom requests
 
+> This feature is only available from version 17 of this SDK.
+
 If you would like to send a request to an undocumented API (for example you are in a private beta), or if you prefer to bypass the method definitions in the library and specify your request details directly, you can use the `rawRequest` method on the StripeClient object.
 
 ```javascript


### PR DESCRIPTION
### Why?
The raw/custom request is only available in recent versions of the SDK

### What?
Add min version for custom request support


