### PR TITLE
Use `TextEncoder` instead of `Buffer` to ensure support in other JS environments

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -722,7 +722,7 @@ export class RequestSender {
             apiMode == 'v2'
               ? 'application/json'
               : 'application/x-www-form-urlencoded',
-          contentLength: Buffer.byteLength(requestData, 'utf8'), // if we calculate this wrong, the server treats it as invalid json
+          contentLength: new TextEncoder().encode(requestData).length, // if we calculate this wrong, the server treats it as invalid json
           apiVersion: apiVersion,
           clientUserAgent,
           method,


### PR DESCRIPTION
### Why?
See #2499 bug description. Buffer is only available in node.js enviroments

### What?
Changed it to TextEncoder which is widely available in all Javascript enviroments and does the same thing