### PR TITLE
Update CHANGELOG.md to remove changes on Events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,7 +24,6 @@ This release changes the pinned API version to `2025-11-17.clover`.
   * Add support for `hooks` on `PaymentIntentCaptureParams`, `PaymentIntentConfirmParams`, `PaymentIntentCreateParams`, `PaymentIntentIncrementAuthorizationParams`, `PaymentIntentUpdateParams`, and `PaymentIntent`
   * Add support for `mb_way` and `twint` on `Refund.destination_details`
   * Add support for new values `financial_connections.account.account_numbers_updated` and `financial_connections.account.upcoming_account_number_expiry` on enums `WebhookEndpointCreateParams.enabled_events` and `WebhookEndpointUpdateParams.enabled_events`
-  * Add support for `changes` on `V2.Core.Event`
   * Add support for snapshot events `FinancialConnectionsAccountAccountNumbersUpdatedEvent` and `FinancialConnectionsAccountUpcomingAccountNumberExpiryEvent` with resource `FinancialConnections.Account`
 
 ## 19.3.1 - 2025-11-12


### PR DESCRIPTION
### Why?
The adding of `events` to the Events API was reverted.

### What?
Update changelog.md


