### PR TITLE
Add explicit permissions to GitHub workflows

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,10 +18,14 @@ on:
       - sdk-release/**
       - feature/**
 
+permissions: {}
+
 jobs:
   build:
     name: 'Static Checks'
     runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: read
 
     steps:
       - uses: extractions/setup-just@v2
@@ -64,6 +68,8 @@ jobs:
           - '18'
           - '16'
     runs-on: ${{ matrix.os }}
+    permissions:
+      contents: read
     steps:
       - uses: extractions/setup-just@v2
       - uses: actions/checkout@v2
@@ -111,6 +117,8 @@ jobs:
       endsWith(github.actor, '-stripe')
     needs: [build, test]
     runs-on: 'ubuntu-24.04'
+    permissions:
+      contents: read
     steps:
       # just is called in `yarn prepack`, which is called during the `publish` operation
       - uses: extractions/setup-just@v2

--- a/.github/workflows/rules.yml
+++ b/.github/workflows/rules.yml
@@ -10,6 +10,8 @@ on:
       - opened
       - reopened
 
+permissions: {}
+
 jobs:
   check_auto_merge_method_if_enabled:
     name: Check auto-merge method if enabled


### PR DESCRIPTION
### Why?
Fix code scanning alerts about unlimited permissions in GitHub workflows. By default, workflows have read/write access to all scopes, which is a security concern. This change applies the principle of least privilege.

### What?
- Added `permissions: {}` at workflow level to restrict default permissions
- Added `contents: read` permission to each job that needs repository access
- The `rules` workflow gets empty permissions as it only runs shell scripts

### See Also
- [GitHub docs on workflow permissions](https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token)