### PR TITLE
Remove `npm whoami` command from github workflow

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,8 +134,6 @@ jobs:
       - name: Publish to NPM
         run: |
           set -euxo pipefail
-          # print the NPM user name for validation
-          npm whoami
           VERSION=$(cat package.json | jq -r '.version')
           # use the tag correlating to this release channel
           NPM_TAG=$(cat package.json | jq -r '.version | if contains("beta") then "public-preview" else if contains("alpha") then "private-preview" else "latest" end end')


### PR DESCRIPTION
### Why?
After we moved to trusted publishing, we can no longer call `npm whoami`. This is currently a known limitation of [trusted publishing](https://docs.npmjs.com/trusted-publishers#limitations-and-future-improvements).

### What?
Removed `npm whoami` command because it does not work with NPM OIDC publishing.

### See Also
<!-- Include any links or additional information that help explain this change. -->
