### PR TITLE
Use Node v24 and latest NPM version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
           echo "Publishing $VERSION with $NPM_TAG tag."
           # stop debug logging to avoid dumping the output of `npm publish` command.
           set +x
-          npm publish --tag $NPM_TAG 
+          npm publish --tag $NPM_TAG
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:


### PR DESCRIPTION
### Why?
Trusted publishing requires Node 24 and NPM (11.5.1+).

### What?
- Update Node to 24.
- Install the latest version of NPM on major version 11.

### See Also
https://github.com/npm/cli/issues/8730#issuecomment-3657780285
