### PR TITLE
feat: Add getId helper method to extract item IDs from Stripe objects

### DIFF
--- a/src/Types.d.ts
+++ b/src/Types.d.ts
@@ -143,6 +143,7 @@ export type StripeObject = {
   StripeResource: StripeResourceConstructor;
   errors: any;
   webhooks: any;
+  getId: (stripeObject: {id: string} | string) => string;
   _prepResources: () => void;
   _setAppInfo: (appInfo: AppInfo) => void;
   _prevRequestMetrics: Array<{

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -19,6 +19,7 @@ import * as resources from './resources.js';
 import {
   createApiKeyAuthenticator,
   determineProcessUserAgentProperties,
+  getId,
   pascalToCamelCase,
   validateInteger,
 } from './utils.js';
@@ -542,6 +543,10 @@ export function createStripe(
       };
 
       return eventNotification;
+    },
+
+    getId(stripeObject: {id: string} | string): string {
+      return getId(stripeObject);
     },
   } as StripeObject;
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -557,3 +557,13 @@ export function parseHeadersForFetch(
     return [key, parseHttpHeaderAsString(value)];
   });
 }
+
+/**
+ * Extracts the ID from a Stripe object or string.
+ * Handles both expanded objects with an 'id' property and simple string IDs.
+ * @param stripeObject - A Stripe object (with an id property) or an ID string
+ * @returns The ID as a string
+ */
+export function getId(stripeObject: {id: string} | string): string {
+  return typeof stripeObject === 'string' ? stripeObject : stripeObject.id;
+}

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -1093,6 +1093,33 @@ describe('utils', () => {
       expect(mergedBufToString).to.equal('foobar');
     });
   });
+
+  describe('getId', () => {
+    it('should return the string when given a string', () => {
+      expect(utils.getId('prod_12345')).to.equal('prod_12345');
+    });
+
+    it('should return the id property when given an object with an id property', () => {
+      expect(utils.getId({id: 'prod_12345'})).to.equal('prod_12345');
+    });
+
+    it('should work with various object types that have an id property', () => {
+      const product = {
+        id: 'prod_xyz',
+        name: 'Awesome Product',
+        price: 99.99,
+      };
+      expect(utils.getId(product)).to.equal('prod_xyz');
+    });
+
+    it('should handle empty strings', () => {
+      expect(utils.getId('')).to.equal('');
+    });
+
+    it('should handle objects with empty string id', () => {
+      expect(utils.getId({id: ''})).to.equal('');
+    });
+  });
 });
 
 function handleWarnings(doWithShimmedConsoleWarn, onWarn): void {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -587,6 +587,26 @@ declare module 'stripe' {
        */
       receivedAt?: number
     ) => Stripe.V2.Core.EventNotification;
+
+    /**
+     * Extracts the ID from a Stripe object or string.
+     * Handles both expanded objects with an 'id' property and simple string IDs.
+     * @param stripeObject - A Stripe object (with an id property) or an ID string
+     * @returns The ID as a string
+     *
+     * @example
+     * ```typescript
+     * const price = await stripe.prices.retrieve(priceId);
+     * const { product } = price;
+     *
+     * // Instead of:
+     * // const productId = typeof product === 'string' ? product : product.id;
+     *
+     * // You can now use:
+     * const productId = stripe.getId(product);
+     * ```
+     */
+    getId(stripeObject: {id: string} | string): string;
   }
 
   export default Stripe;


### PR DESCRIPTION
**# Add getId() Helper Method
Fixes #1793**

Implements a helper method to simplify extracting IDs from Stripe objects that can be either:
- Expanded objects with an 'id' property
- Simple string IDs

This eliminates the need for the repetitive pattern:

```
const id = (typeof obj === 'string' ? obj : obj.id)
Now users can simply write:
const id = stripe.getId(obj)
hy?
```
Developers frequently need to extract IDs from Stripe API responses. The Stripe API returns expanded objects (e.g., [{ id: 'prod_123', name: 'Product' }] In some cases and simple string IDs in others depending on whether the object was expanded. This forces users to write repetitive defensive code to handle both cases.

By providing a built-in helper method, we:

- Reduce boilerplate code for users
- Improve type safety with proper TypeScript support
- Provide a standard, discoverable API for this common operation
- Improve code readability and maintainability

**What?**

- ✨ Added [getId(stripeObject: {id: string} | string): string]helper function in [utils.ts]
- ✅ Added comprehensive unit tests covering:
- String ID inputs
- Object ID inputs
- Various object types with id properties
- Edge cases (empty strings, etc)
- 📦 Exported the helper through the Stripe instance (available as [stripe.getId()
- 📚 Added complete TypeScript type definitions and JSDoc documentation
- 🔗 Integrated with existing utility exports

**Testing**
All tests pass successfully:
npm test -- --grep "getId"
✓ should return the string when given a string
✓ should return the id property when given an object with an id property
✓ should work with various object types that have an id property
✓ should handle empty strings
✓ should handle objects with empty string id

5 passing


**Before** 
```
const price = await stripe.prices.retrieve(priceId);
const { product } = price;

// Had to write this pattern repeatedly
const productId = (typeof product === 'string' ? product : product.id);
```
**After**:

```
const price = await stripe.prices.retrieve(priceId);
const { product } = price;

// Simply use the helper
const productId = stripe.getId(product);
```