### PR TITLE
Add more codex keys to agent detection

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -481,13 +481,18 @@ export function determineProcessUserAgentProperties(): Record<string, string> {
 }
 
 export const AI_AGENTS: [string, string][] = [
+  // The beginning of the section generated from our OpenAPI spec
   ['ANTIGRAVITY_CLI_ALIAS', 'antigravity'],
   ['CLAUDECODE', 'claude_code'],
   ['CLINE_ACTIVE', 'cline'],
   ['CODEX_SANDBOX', 'codex_cli'],
+  ['CODEX_THREAD_ID', 'codex_cli'],
+  ['CODEX_SANDBOX_NETWORK_DISABLED', 'codex_cli'],
+  ['CODEX_CI', 'codex_cli'],
   ['CURSOR_AGENT', 'cursor'],
   ['GEMINI_CLI', 'gemini_cli'],
   ['OPENCODE', 'open_code'],
+  // The end of the section generated from our OpenAPI spec
 ];
 
 export function detectAIAgent(env: Record<string, string | undefined>): string {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Small follow up to my PR from earlier this week that added agent information to the `User-Agent` header. It adds a couple of more vars to check.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- makes the user-agent list generated instead of hardcoded
- adds some new codex-specific env vars to check

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2249](https://go/j/RUN_DEVSDK-2249)
