### PR TITLE
Tweak telemetry collection

### DIFF
--- a/src/platform/NodePlatformFunctions.ts
+++ b/src/platform/NodePlatformFunctions.ts
@@ -8,7 +8,7 @@ import {NodeHttpClient} from '../net/NodeHttpClient.js';
 import {PlatformFunctions} from './PlatformFunctions.js';
 import {StripeError} from '../Error.js';
 import {concat} from '../utils.js';
-import {exec} from 'child_process';
+import {arch, release} from 'os';
 import {MultipartRequestData, RequestData, BufferedFile} from '../Types.js';
 
 class StreamProcessingError extends StripeError {}
@@ -17,17 +17,6 @@ class StreamProcessingError extends StripeError {}
  * Specializes WebPlatformFunctions using APIs available in Node.js.
  */
 export class NodePlatformFunctions extends PlatformFunctions {
-  /** For mocking in tests */
-  _exec: any;
-  _UNAME_CACHE: Promise<string | null> | null;
-
-  constructor() {
-    super();
-
-    this._exec = exec;
-    this._UNAME_CACHE = null;
-  }
-
   /** @override */
   uuid4(): string {
     // available in: v14.17.x+
@@ -37,31 +26,9 @@ export class NodePlatformFunctions extends PlatformFunctions {
     return super.uuid4();
   }
 
-  /**
-   * @override
-   * Node's built in `exec` function sometimes throws outright,
-   * and sometimes has a callback with an error,
-   * depending on the type of error.
-   *
-   * This unifies that interface by resolving with a null uname
-   * if an error is encountered.
-   */
-  getUname(): Promise<string | null> {
-    if (!this._UNAME_CACHE) {
-      this._UNAME_CACHE = new Promise<string | null>((resolve, reject) => {
-        try {
-          this._exec('uname -a', (err: unknown, uname: string | null) => {
-            if (err) {
-              return resolve(null);
-            }
-            resolve(uname!);
-          });
-        } catch (e) {
-          resolve(null);
-        }
-      });
-    }
-    return this._UNAME_CACHE;
+  /** @override */
+  getPlatformInfo(): string {
+    return `${process.platform} ${release()} ${arch()}`;
   }
 
   /**

--- a/src/platform/PlatformFunctions.ts
+++ b/src/platform/PlatformFunctions.ts
@@ -21,10 +21,10 @@ export class PlatformFunctions {
   }
 
   /**
-   * Gets uname with Node's built-in `exec` function, if available.
+   * Returns platform info string for telemetry, or null if unavailable.
    */
-  getUname(): Promise<string | null> {
-    throw new Error('getUname not implemented.');
+  getPlatformInfo(): string | null {
+    return null;
   }
 
   /**

--- a/src/platform/WebPlatformFunctions.ts
+++ b/src/platform/WebPlatformFunctions.ts
@@ -9,11 +9,6 @@ import {MultipartRequestData, RequestData, BufferedFile} from '../Types.js';
  */
 export class WebPlatformFunctions extends PlatformFunctions {
   /** @override */
-  getUname(): Promise<string | null> {
-    return Promise.resolve(null);
-  }
-
-  /** @override */
   createEmitter(): StripeEmitter {
     return new StripeEmitter();
   }

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -71,8 +71,6 @@ export function createStripe(
   Stripe.USER_AGENT = {
     bindings_version: Stripe.PACKAGE_VERSION,
     lang: 'node',
-    publisher: 'stripe',
-    uname: null,
     typescript: false,
     ...determineProcessUserAgentProperties(),
     ...(aiAgent ? {ai_agent: aiAgent} : {}),
@@ -384,29 +382,31 @@ export function createStripe(
       seed: Record<string, string | boolean | null>,
       cb: (userAgent: string) => void
     ): void {
-      this._platformFunctions.getUname().then((uname: string | null) => {
-        const userAgent: Record<string, string> = {};
-        for (const field in seed) {
-          if (!Object.prototype.hasOwnProperty.call(seed, field)) {
-            continue;
-          }
-          userAgent[field] = encodeURIComponent(seed[field] ?? 'null');
+      const userAgent: Record<string, string> = {};
+      for (const field in seed) {
+        if (!Object.prototype.hasOwnProperty.call(seed, field)) {
+          continue;
         }
+        userAgent[field] = encodeURIComponent(seed[field] ?? 'null');
+      }
 
-        // URI-encode in case there are unusual characters in the system's uname.
-        userAgent.uname = encodeURIComponent(uname || 'UNKNOWN');
+      const platformInfo = this._platformFunctions.getPlatformInfo();
+      if (platformInfo && this.getTelemetryEnabled()) {
+        userAgent.platform = encodeURIComponent(platformInfo);
+      } else {
+        delete userAgent.platform;
+      }
 
-        const client = this.getApiField('httpClient');
-        if (client) {
-          userAgent.httplib = encodeURIComponent(client.getClientName());
-        }
+      const client = this.getApiField('httpClient');
+      if (client) {
+        userAgent.httplib = encodeURIComponent(client.getClientName());
+      }
 
-        if (this._appInfo) {
-          userAgent.application = this._appInfo;
-        }
+      if (this._appInfo) {
+        userAgent.application = this._appInfo;
+      }
 
-        cb(JSON.stringify(userAgent));
-      });
+      cb(JSON.stringify(userAgent));
     },
 
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -476,7 +476,6 @@ export function determineProcessUserAgentProperties(): Record<string, string> {
     ? {}
     : {
         lang_version: process.version,
-        platform: process.platform,
       };
 }
 

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -146,53 +146,18 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
       });
     });
 
-    describe('getUname', () => {
-      let origGetUname;
-      beforeEach(() => {
-        origGetUname = platformFunctions.getUname;
-      });
-      afterEach(() => {
-        platformFunctions.getUname = origGetUname;
-        platformFunctions._UNAME_CACHE = null;
-      });
-
+    describe('getPlatformInfo', () => {
       if (!isNodeEnvironment) {
-        it('not implemented on non-Node environments', async () => {
-          expect(await platformFunctions.getUname()).to.be.null;
+        it('returns null on non-Node environments', () => {
+          expect(platformFunctions.getPlatformInfo()).to.be.null;
         });
-
-        // No need to run further tests on non-Node environments
-        return;
+      } else {
+        it('returns a platform info string', () => {
+          const info = platformFunctions.getPlatformInfo();
+          expect(info).to.be.a('string');
+          expect(info).to.contain(process.platform);
+        });
       }
-
-      it('runs exec', async () => {
-        const calls: any[] = [];
-        platformFunctions._exec = (cmd: string, cb: any): void => {
-          calls.push([cmd]);
-          cb();
-        };
-
-        await platformFunctions.getUname();
-        expect(calls).to.deep.equal([['uname -a']]);
-      });
-
-      it('passes along normal errors', async () => {
-        const myErr = Error('hi');
-        platformFunctions._exec = (cmd: string, cb: any): void => {
-          cb(myErr, null);
-        };
-
-        expect(await platformFunctions.getUname()).to.be.null;
-      });
-
-      it('passes along thrown errors as normal callback errors', async () => {
-        const myErr = Error('hi');
-        platformFunctions._exec = (cmd: string, cb: any): void => {
-          throw myErr;
-        };
-
-        expect(await platformFunctions.getUname()).to.be.null;
-      });
     });
 
     describe('createEmitter', () => {

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -6,11 +6,9 @@
 import {expect} from 'chai';
 import {StripeSignatureVerificationError} from '../src/Error.js';
 import {ApiVersion} from '../src/apiVersion.js';
-import {createStripe} from '../src/stripe.core.js';
 import {createApiKeyAuthenticator, detectAIAgent} from '../src/utils.js';
 import {
   FAKE_API_KEY,
-  getMockPlatformFunctions,
   getRandomString,
   getStripeMockClient,
   getTestServerStripe,
@@ -150,10 +148,9 @@ describe('Stripe Module', function() {
         })
       ).to.eventually.have.property('lang', 'node'));
 
-    it('Should return platform and version in the serialized user agent JSON object', async () => {
+    it('Should return lang_version and platform in the serialized user agent JSON object', async () => {
       // Check that the testing environment actually has a process global.
       expect(process.version).to.not.be.empty;
-      expect(process.platform).to.not.be.empty;
 
       const userAgent = await new Promise((resolve, reject) => {
         stripe.getClientUserAgent((c) => {
@@ -162,7 +159,25 @@ describe('Stripe Module', function() {
       });
 
       expect(userAgent).to.have.property('lang_version', process.version);
-      expect(userAgent).to.have.property('platform', process.platform);
+      // platform is populated from getPlatformInfo() and URI-encoded
+      expect(userAgent).to.have.property('platform');
+      expect(decodeURIComponent(userAgent.platform)).to.contain(
+        process.platform
+      );
+    });
+
+    it('Should omit platform when telemetry is disabled', async () => {
+      const noTelemetryStripe = new Stripe(FAKE_API_KEY, {
+        telemetry: false,
+      });
+
+      const userAgent = await new Promise((resolve, reject) => {
+        noTelemetryStripe.getClientUserAgent((c) => {
+          resolve(JSON.parse(c));
+        });
+      });
+
+      expect(userAgent).to.not.have.property('platform');
     });
 
     it('Should include whether typescript: true was passed, respecting reinstantiations', () => {
@@ -224,38 +239,6 @@ describe('Stripe Module', function() {
           });
         })
       ).to.eventually.have.property('httplib', 'node');
-    });
-
-    describe('uname', () => {
-      it('gets added to the user-agent', () => {
-        const stripe = createStripe(
-          getMockPlatformFunctions((cmd: string, cb: any): void => {
-            cb(null, 'foøname');
-          })
-        )(FAKE_API_KEY, 'latest');
-        return expect(
-          new Promise((resolve, reject) => {
-            stripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
-              resolve(JSON.parse(c));
-            });
-          })
-        ).to.eventually.have.property('uname', 'fo%C3%B8name');
-      });
-
-      it('sets uname to UNKNOWN in case of an error', () => {
-        const stripe = createStripe(
-          getMockPlatformFunctions((cmd: string, cb: any): void => {
-            cb(new Error('security'), null);
-          })
-        )(FAKE_API_KEY, 'latest');
-        return expect(
-          new Promise((resolve, reject) => {
-            stripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
-              resolve(JSON.parse(c));
-            });
-          })
-        ).to.eventually.have.property('uname', 'UNKNOWN');
-      });
     });
   });
 

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -97,19 +97,6 @@ export const getStripeMockClient = (): StripeClient => {
   });
 };
 
-export const getMockPlatformFunctions = (
-  cb: CallableFunction
-): NodePlatformFunctions => {
-  class MockPlatformFunctions extends NodePlatformFunctions {
-    constructor(cb: CallableFunction) {
-      super();
-      this._exec = cb;
-    }
-  }
-
-  return new MockPlatformFunctions(cb);
-};
-
 export const getMockStripe = (
   config: Record<string, unknown>,
   request: RequestSender['_request']


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've long collected detailed platform information about calls made using the SDK. But a user brought to our attention that we're probably collecting more than we need. To fix, we're no longer sending the full `uname` output and only collecting data we actually care about. Additionally, users can opt out of sending platform information using the existing telemetry opt-out methods.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove unused `publisher` User-Agent key
- condense important data from `uname` into the `platform` key
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [stripe/stripe-php#2015](https://github.com/stripe/stripe-php/issues/2015)
- [doc](https://docs.google.com/document/d/13fq-DtC_6WTfMyyI8b-Gq6jensyECa5K0X3WPL9fZJU/edit?tab=t.0)
- [RUN_DEVSDK-2244](https://go/j/RUN_DEVSDK-2244)
