### PR TITLE
Update API version for private preview

### DIFF
--- a/src/apiVersion.ts
+++ b/src/apiVersion.ts
@@ -1,3 +1,3 @@
 // File generated from our OpenAPI spec
 
-export const ApiVersion = '2026-03-04.preview';
+export const ApiVersion = '2026-03-18.preview';

--- a/types/apiVersion.d.ts
+++ b/types/apiVersion.d.ts
@@ -1,3 +1,3 @@
 // File generated from our OpenAPI spec
 
-export const ApiVersion = '2026-03-04.preview';
+export const ApiVersion = '2026-03-18.preview';


### PR DESCRIPTION
### Why?
The weekly private preview has breaking changes when compared to the previous preview release and therefore needs a new API version

### What?
Updated the API version manually rather than rely on codegen which will have other breaking changes meant for the March release


