### PR TITLE
⚠️ Drop support for Node 16

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,13 +63,14 @@ jobs:
         os:
           - 'ubuntu-24.04'
         node:
-          # should include even numbers >= 16
+          # should include even numbers >= 18
           # see: https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy
+          # note that in Oct 2026, every version will be LTS, so it's not just even numbers anymore
+          # see: https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule
           - '24'
           - '22'
           - '20'
           - '18'
-          - '16'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -116,8 +117,7 @@ jobs:
     name: Publish
     if: >-
       (github.event_name == 'workflow_dispatch' || github.event_name == 'push') &&
-      startsWith(github.ref, 'refs/tags/v') &&
-      endsWith(github.actor, '-stripe')
+      startsWith(github.ref, 'refs/tags/v')
     needs: [build, test]
     runs-on: 'ubuntu-24.04'
     permissions:

--- a/README.md
+++ b/README.md
@@ -19,9 +19,9 @@ See the [`stripe-node` API docs](https://stripe.com/docs/api?lang=node) for Node
 
 ## Requirements
 
-Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy), we currently support all LTS versions of **Node.js 16+**.
+Per our [Language Version Support Policy](https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy), we currently support all LTS versions of **Node.js 18+**.
 
-Support for Node 16 is deprecated and will be removed in an upcoming major version. Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy
+Read more and see the full schedule in the docs: https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy
 
 ## Installation
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "bugs": "https://github.com/stripe/stripe-node/issues",
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "main": "cjs/stripe.cjs.node.js",
   "types": "types/index.d.ts",
@@ -56,7 +56,7 @@
   },
   "dependencies": {},
   "peerDependencies": {
-    "@types/node": ">=16"
+    "@types/node": ">=18"
   },
   "peerDependenciesMeta": {
     "@types/node": {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Per our [versioning policy](https://docs.stripe.com/sdks/versioning?lang=node), we're dropping support for deprecated versions as part of our twice-yearly major.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove old versions from CI
- drop `-stripe` requirement for releases. This never really protected us (since anyone can make a `-stripe` GH handle) and isn't compatible with being able to use personal GH accounts for work

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://docs.stripe.com/sdks/versioning?lang=node
