### PR TITLE
add manual amount type

### DIFF
--- a/types/lib.d.ts
+++ b/types/lib.d.ts
@@ -317,5 +317,15 @@ declare module 'stripe' {
       name?: string;
       type?: string;
     }
+
+    namespace V2 {
+      /**
+       * Represents a monetary amount with associated currency
+       */
+      export interface Amount {
+        value: number;
+        currency: string;
+      }
+    }
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

In https://github.com/stripe/stripe-node/pull/2289 we added the `Amount` type to the beta branch. Now that amounts are making their way to GA, we need it here too. Without it, we generate types that fail their type test

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add manual amount type

### See Also
<!-- Include any links or additional information that help explain this change. -->
