### PR TITLE
⚠️ Throw an error when using the wrong webhook parsing method

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -109,6 +109,11 @@ export function createWebhooks(
         payload instanceof Uint8Array
           ? JSON.parse(new TextDecoder('utf8').decode(payload))
           : JSON.parse(payload);
+      if (jsonPayload && jsonPayload.object === 'v2.core.event') {
+        throw new Error(
+          'You passed an event notification to stripe.webhooks.constructEvent, which expects a webhook payload. Use stripe.parseEventNotification instead.'
+        );
+      }
       return jsonPayload;
     },
 
@@ -137,6 +142,11 @@ export function createWebhooks(
         payload instanceof Uint8Array
           ? JSON.parse(new TextDecoder('utf8').decode(payload))
           : JSON.parse(payload);
+      if (jsonPayload && jsonPayload.object === 'v2.core.event') {
+        throw new Error(
+          'You passed an event notification to stripe.webhooks.constructEvent, which expects a webhook payload. Use stripe.parseEventNotification instead.'
+        );
+      }
       return jsonPayload;
     },
 

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -503,15 +503,28 @@ export function createStripe(
       receivedAt?: number
       // this return type is ignored?? picks up types from `types/index.d.ts` instead
     ): unknown {
-      // parses and validates the event payload all in one go
-      const eventNotification = this.webhooks.constructEvent(
+      // Verify the signature using the internal signature helper directly,
+      // bypassing constructEvent's v2 payload check (since v2 payloads are
+      // expected here).
+      this.webhooks.signature.verifyHeader(
         payload,
         header,
         secret,
-        tolerance,
+        tolerance || this.webhooks.DEFAULT_TOLERANCE,
         cryptoProvider,
         receivedAt
       );
+
+      const eventNotification =
+        payload instanceof Uint8Array
+          ? JSON.parse(new TextDecoder('utf8').decode(payload))
+          : JSON.parse(payload as string);
+
+      if (eventNotification && eventNotification.object === 'event') {
+        throw new Error(
+          'You passed a webhook payload to stripe.parseEventNotification, which expects an event notification. Use stripe.webhooks.constructEvent instead.'
+        );
+      }
 
       // Parse string context into StripeContext object if present
       if (eventNotification.context) {

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -10,6 +10,13 @@ const EVENT_PAYLOAD = {
   object: 'event',
 };
 const EVENT_PAYLOAD_STRING = JSON.stringify(EVENT_PAYLOAD, null, 2);
+
+const V2_EVENT_PAYLOAD = {
+  id: 'evt_test_webhook',
+  object: 'v2.core.event',
+};
+const V2_EVENT_PAYLOAD_STRING = JSON.stringify(V2_EVENT_PAYLOAD, null, 2);
+
 const SECRET = 'whsec_test_secret';
 
 describe('Webhooks on static Stripe factory', () => {
@@ -182,6 +189,21 @@ function createWebhooksTestSuite(stripe) {
         );
 
         expect(event.id).to.equal(EVENT_PAYLOAD.id);
+      });
+
+      it('should throw when a v2 webhook payload is passed', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          payload: V2_EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        const err = await constructEventFn(
+          V2_EVENT_PAYLOAD_STRING,
+          header,
+          SECRET
+        ).catch((e: Error) => e);
+        expect(err).to.be.instanceOf(Error);
+        expect(err.message).to.contain('stripe.parseEventNotification');
       });
     };
   };

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -793,6 +793,26 @@ describe('Stripe Module', function() {
       }).to.throw(StripeSignatureVerificationError);
     });
 
+    it('throws an error when a v1 webhook payload is passed', () => {
+      const jsonPayload = {
+        id: 'evt_test_webhook',
+        object: 'event',
+      };
+      const payload = JSON.stringify(jsonPayload);
+      const header = stripe.webhooks.generateTestHeaderString({
+        payload,
+        secret,
+      });
+
+      try {
+        stripe.parseEventNotification(payload, header, secret);
+        expect.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.contain('stripe.webhooks.constructEvent');
+      }
+    });
+
     it('should parse webhook with a functioning fetchEvent method', (done) => {
       const jsonPayload = {
         id: 'evt_123',


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

When users call the wrong webhook parsing method, the call usually works, but happily gives them a malformed object for their troubles. Rather than fail silently, we should fail loudly and help direct users to the correct method.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- throw error in each of constructWebhook and parseEventNotification if it's received the wrong type, pointing the user to the other method
- add tests
- adjust existing tests which used the wrong object type

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3032](https://go/j/DEVSDK-3032)
