### PR TITLE
Fix export for Stripe.Decimal in CJS and ESM

### DIFF
--- a/examples/webhook-signing/nextjs/next-env.d.ts
+++ b/examples/webhook-signing/nextjs/next-env.d.ts
@@ -1,5 +1,6 @@
 /// <reference types="next" />
 /// <reference types="next/image-types/global" />
+/// <reference types="next/navigation-types/compat/navigation" />
 
 // NOTE: This file should not be edited
 // see https://nextjs.org/docs/basic-features/typescript for more information.

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -13,6 +13,7 @@ import {
 import {createWebhooks} from './Webhooks.js';
 import {ApiVersion} from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
+import {Decimal} from './Decimal.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
 import {PlatformFunctions} from './platform/PlatformFunctions.js';
 import * as resources from './resources.js';
@@ -82,6 +83,7 @@ export function createStripe(
   Stripe.HttpClientResponse = HttpClientResponse;
   Stripe.CryptoProvider = CryptoProvider;
   Stripe.webhooks = createWebhooks(platformFunctions);
+  Stripe.Decimal = Decimal;
 
   function Stripe(
     this: StripeObject,
@@ -162,6 +164,8 @@ export function createStripe(
     // Expose StripeResource on the instance too
     // @ts-ignore
     this.StripeResource = Stripe.StripeResource;
+    // @ts-ignore
+    this.Decimal = Stripe.Decimal;
   }
 
   Stripe.errors = _Error;

--- a/testProjects/cjs/index.js
+++ b/testProjects/cjs/index.js
@@ -11,7 +11,7 @@ try {
   });
 } catch (e) {
   if (e instanceof stripe.errors.StripeError) {
-    console.log("Caught StripeError");
+    console.log('Caught StripeError');
   } else {
     throw e;
   }
@@ -22,7 +22,7 @@ async function exampleFunction(args) {
     await stripe.paymentIntents.create(args);
   } catch (e) {
     if (e instanceof stripe.errors.StripeInvalidRequestError) {
-      console.log("Caught StripeInvalidRequestError");
+      console.log('Caught StripeInvalidRequestError');
     } else {
       throw e;
     }
@@ -35,3 +35,5 @@ exampleFunction({
   confirm: true,
   payment_method: 'pm_card_visa',
 });
+
+stripe.Decimal.from('1.1');

--- a/testProjects/esbuild/index.js
+++ b/testProjects/esbuild/index.js
@@ -8,6 +8,8 @@ const stripe = new Stripe("i'm not a real key", {
   protocol: 'http',
 });
 
+Stripe.Decimal.from('1.9');
+
 try {
   throw new stripe.errors.StripeAPIError({
     charge: 'foo',

--- a/testProjects/mjs-ts/index.ts
+++ b/testProjects/mjs-ts/index.ts
@@ -47,3 +47,5 @@ exampleFunction({
   confirm: true,
   payment_method: 'pm_card_visa',
 });
+
+Stripe.Decimal.from('1.0');

--- a/testProjects/mjs/index.js
+++ b/testProjects/mjs/index.js
@@ -49,6 +49,7 @@ assert(Stripe.StripeResource.MAX_BUFFERED_REQUEST_METRICS);
 
 assert(Stripe.webhooks);
 assert(Stripe.resources);
+assert(Stripe.Decimal);
 
 const stripe = new Stripe(process.argv[2], {
   host: process.env.STRIPE_MOCK_HOST || 'localhost',
@@ -74,6 +75,8 @@ assert(stripe._emitter);
 assert(stripe.on);
 assert(stripe.off);
 assert(stripe.once);
+
+Stripe.Decimal.from('1.1');
 
 try {
   throw new stripe.errors.StripeError({


### PR DESCRIPTION
### Why?
User reported an issue where they were unable to access `Stripe.Decimal` in the Node SDK while using TypeScript and ESM import. 

Decimal class wasn't exported correctly and this is a problem with both CJS and ESM style of imports.

### What?
- Added a Decimal property on the exported Stripe class. 
- Added integration tests 

### See Also
https://github.com/stripe/stripe-node/issues/2625

## Changelog
* Fixes runtime error when using Stripe.Decimal. Resolves [#2625](https://github.com/stripe/stripe-node/issues/2625)