### PR TITLE
⚠️ remove support for overriding host per-request

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -516,7 +516,9 @@ export class RequestSender {
           queryData: {},
           authenticator,
           headers,
-          host: calculatedOptions.host,
+          host: calculatedOptions.apiBase
+            ? this._stripe.resolveBaseAddress(calculatedOptions.apiBase)
+            : null,
           streaming: !!calculatedOptions.streaming,
           settings: {},
           // We use this for thin event internals, so we should record the more specific `usage`, when available

--- a/src/StripeResource.ts
+++ b/src/StripeResource.ts
@@ -112,6 +112,7 @@ class StripeResource implements StripeResourceObject {
     return parts.join('/').replace(/\/{2,}/g, '/');
   }
 
+  // eslint-disable-next-line complexity
   _getRequestOpts(
     requestArgs: RequestArgs,
     spec: MethodSpec,
@@ -153,7 +154,8 @@ class StripeResource implements StripeResourceObject {
     const dataFromArgs = getDataFromArgs(args);
     const data = encode(Object.assign({}, dataFromArgs, overrideData));
     const options = getOptionsFromArgs(args);
-    const host = options.host || spec.host;
+    const apiBase = options.apiBase || spec.apiBase;
+    const host = apiBase ? this._stripe.resolveBaseAddress(apiBase) : null;
     const streaming = !!spec.streaming || !!options.streaming;
     // Validate that there are no more args.
     if (args.filter((x) => x != null).length) {

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -11,6 +11,13 @@ import {Stripe} from './stripe.core.js';
 import {AppInfo} from './lib.js';
 
 export type ApiMode = 'v1' | 'v2';
+export type BaseAddress = 'api' | 'files' | 'connect' | 'meter_events';
+export const DEFAULT_BASE_ADDRESSES: Record<BaseAddress, string> = {
+  api: 'api.stripe.com',
+  files: 'files.stripe.com',
+  connect: 'connect.stripe.com',
+  meter_events: 'meter-events.stripe.com',
+};
 export type BufferedFile = {
   name: string;
   type: string;
@@ -32,7 +39,7 @@ export type MethodSpec = {
   validator?: (data: RequestData, options: {headers: RequestHeaders}) => void;
   headers?: Record<string, string>;
   streaming?: boolean;
-  host?: string;
+  apiBase?: BaseAddress;
   transformResponseData?: (response: HttpClientResponseInterface) => any;
   usage?: Array<string>;
   requestSchema?: V2RuntimeSchema;

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -156,11 +156,6 @@ export interface RequestOptions {
    * Specify a timeout for this request in milliseconds.
    */
   timeout?: number;
-
-  /**
-   * Specify the host for this request.
-   */
-  host?: string;
 }
 
 export type RawRequestOptions = RequestOptions & {
@@ -168,6 +163,12 @@ export type RawRequestOptions = RequestOptions & {
    * Specify additional request headers. This is an experimental interface and is not yet stable.
    */
   additionalHeaders?: {[headerName: string]: string};
+
+  /**
+   * Specify which Stripe API base address to send this request to.
+   * Allowed values: 'api', 'files', 'connect', 'meter_events'.
+   */
+  apiBase?: 'api' | 'files' | 'connect' | 'meter_events';
 };
 
 export type Response<T> = T & {

--- a/src/resources/Files.ts
+++ b/src/resources/Files.ts
@@ -49,7 +49,7 @@ export class FileResource extends StripeResource {
       headers: {
         'Content-Type': 'multipart/form-data',
       },
-      host: 'files.stripe.com',
+      apiBase: 'files',
     }).call(this, ...args);
   }
 

--- a/src/resources/OAuth.ts
+++ b/src/resources/OAuth.ts
@@ -7,8 +7,6 @@ import {Response, ApiListPromise, ApiList} from '../lib.js';
 
 const stripeMethod = StripeResource.method;
 
-const oAuthHost = 'connect.stripe.com';
-
 export class OAuthResource extends StripeResource {
   basePath = makeURLInterpolator('/');
 
@@ -38,7 +36,10 @@ export class OAuthResource extends StripeResource {
       params.scope = 'read_write';
     }
 
-    return `https://${oAuthHost}/${path}?${queryStringifyRequestData(params)}`;
+    const connectHost = this._stripe.resolveBaseAddress('connect');
+    return `https://${connectHost}/${path}?${queryStringifyRequestData(
+      params
+    )}`;
   }
 
   token(
@@ -50,7 +51,7 @@ export class OAuthResource extends StripeResource {
     return stripeMethod({
       method: 'POST',
       path: 'oauth/token',
-      host: oAuthHost,
+      apiBase: 'connect',
     }).call(this, ...args);
   }
 
@@ -70,7 +71,7 @@ export class OAuthResource extends StripeResource {
     return stripeMethod({
       method: 'POST',
       path: 'oauth/deauthorize',
-      host: oAuthHost,
+      apiBase: 'connect',
     }).apply(this, [params, ...args]);
   }
 }

--- a/src/resources/Quotes.ts
+++ b/src/resources/Quotes.ts
@@ -785,7 +785,7 @@ export class QuoteResource extends StripeResource {
     return stripeMethod({
       method: 'GET',
       fullPath: '/v1/quotes/{quote}/pdf',
-      host: 'files.stripe.com',
+      apiBase: 'files',
       streaming: true,
     }).call(this, ...args);
   }

--- a/src/resources/V2/Billing/MeterEventStream.ts
+++ b/src/resources/V2/Billing/MeterEventStream.ts
@@ -17,7 +17,7 @@ export class MeterEventStreamResource extends StripeResource {
     return stripeMethod({
       method: 'POST',
       fullPath: '/v2/billing/meter_event_stream',
-      host: 'meter-events.stripe.com',
+      apiBase: 'meter_events',
     }).call(this, ...args);
   }
 }

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -3,10 +3,12 @@ import {RequestSender} from './RequestSender.js';
 import {StripeResource} from './StripeResource.js';
 import {StripeContext} from './StripeContext.js';
 import {
+  BaseAddress,
   RequestAuthenticator,
   UserProvidedConfig,
   RequestData,
   StripeRawError,
+  DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
 import {createWebhooks} from './Webhooks.js';
 import {ApiVersion} from './apiVersion.js';
@@ -1332,6 +1334,15 @@ export class Stripe {
         return INITIAL_NETWORK_RETRY_DELAY_SEC;
     }
     return ((Stripe as unknown) as Record<string, unknown>)[c];
+  }
+
+  resolveBaseAddress(apiBase: BaseAddress): string {
+    // can override host globally, but not locally
+    const instanceHost = this.getApiField('host');
+    if (instanceHost !== DEFAULT_HOST) {
+      return instanceHost;
+    }
+    return DEFAULT_BASE_ADDRESSES[apiBase];
   }
 
   getMaxNetworkRetries(): number {

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -4,10 +4,12 @@ import {StripeResource} from './StripeResource.js';
 import {StripeContext} from './StripeContext.js';
 import {NodePlatformFunctions} from './platform/NodePlatformFunctions.js';
 import {
+  BaseAddress,
   RequestAuthenticator,
   UserProvidedConfig,
   RequestData,
   StripeRawError,
+  DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
 import {createWebhooks} from './Webhooks.js';
 import {ApiVersion} from './apiVersion.js';
@@ -1332,6 +1334,15 @@ export class Stripe {
         return INITIAL_NETWORK_RETRY_DELAY_SEC;
     }
     return ((Stripe as unknown) as Record<string, unknown>)[c];
+  }
+
+  resolveBaseAddress(apiBase: BaseAddress): string {
+    // can override host globally, but not locally
+    const instanceHost = this.getApiField('host');
+    if (instanceHost !== DEFAULT_HOST) {
+      return instanceHost;
+    }
+    return DEFAULT_BASE_ADDRESSES[apiBase];
   }
 
   getMaxNetworkRetries(): number {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,5 @@
 import {
+  BaseAddress,
   RequestData,
   UrlInterpolator,
   RequestArgs,
@@ -8,6 +9,7 @@ import {
   RequestAuthenticator,
   StripeRequest,
   ApiMode,
+  DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
 
 const OPTIONS_KEYS = [
@@ -17,7 +19,7 @@ const OPTIONS_KEYS = [
   'apiVersion',
   'maxNetworkRetries',
   'timeout',
-  'host',
+  'apiBase',
   'authenticator',
   'stripeContext',
   'headers',
@@ -32,7 +34,7 @@ type Settings = {
 
 type Options = {
   authenticator?: RequestAuthenticator | null;
-  host: string | null;
+  apiBase: BaseAddress | null;
   settings: Settings;
   streaming?: boolean;
   headers: RequestHeaders;
@@ -212,11 +214,22 @@ export function getDataFromArgs(args: RequestArgs): RequestData {
 }
 
 /**
+ * enforces that only supplied API bases are allowed.
+ */
+export const validateApiBase = (apiBase: unknown): apiBase is BaseAddress => {
+  if (typeof apiBase !== 'string') {
+    throw new Error(`API base must be a string, got: ${typeof apiBase}`);
+  }
+  return apiBase in DEFAULT_BASE_ADDRESSES;
+};
+
+/**
  * Return the options hash from a list of arguments
  */
+// eslint-disable-next-line complexity
 export function getOptionsFromArgs(args: RequestArgs): Options {
   const opts: Options = {
-    host: null,
+    apiBase: null,
     headers: {},
     settings: {},
     streaming: false,
@@ -264,8 +277,8 @@ export function getOptionsFromArgs(args: RequestArgs): Options {
       if (Number.isInteger(params.timeout)) {
         opts.settings.timeout = params.timeout as number;
       }
-      if (params.host) {
-        opts.host = params.host as string;
+      if (params.apiBase && validateApiBase(params.apiBase)) {
+        opts.apiBase = params.apiBase;
       }
       if (params.authenticator) {
         if (params.apiKey) {

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -734,15 +734,15 @@ describe('RequestSender', () => {
         );
       });
 
-      it('allows overriding host', (done) => {
-        const scope = nock('https://myhost')
-          .get('/v1/accounts/acct_123')
+      it('does not allow overriding host per-request', (done) => {
+        const scope = nock('https://api.stripe.com')
+          .get('/v1/accounts/acct_123?host=myhost')
           .reply(200, '{}');
 
         realStripe.accounts.retrieve(
           'acct_123',
-          {},
           {
+            // assumed to be a request param, not an option
             host: 'myhost',
           },
           (err, response) => {
@@ -779,7 +779,7 @@ describe('RequestSender', () => {
             '/v1/files/file_1Mr4LDLkdIwHu7ixFCz0dZiH/contents',
             {},
             {
-              host: 'files.stripe.com',
+              apiBase: 'files',
               streaming: true,
             }
           )

--- a/test/StripeResource.spec.ts
+++ b/test/StripeResource.spec.ts
@@ -88,24 +88,22 @@ describe('StripeResource', () => {
     });
   });
 
-  describe('custom host on method', () => {
+  describe('custom apiBase on method', () => {
     const makeResource = (stripe) => {
       return new (StripeResource.extend({
         path: 'resourceWithHost',
 
         testMethod: stripeMethod({
           method: 'GET',
-          host: 'some.host.stripe.com',
+          apiBase: 'files',
         }),
       }))(stripe);
     };
 
-    it('is not impacted by the global host', (done) => {
-      const stripe = require('../src/stripe.cjs.node.js')('sk_test', {
-        host: 'bad.host.stripe.com',
-      });
+    it('sends to the correct base address', (done) => {
+      const stripe = require('../src/stripe.cjs.node.js')('sk_test');
 
-      const scope = nock('https://some.host.stripe.com')
+      const scope = nock('https://files.stripe.com')
         .get('/v1/resourceWithHost')
         .reply(200, '{}');
 
@@ -115,211 +113,208 @@ describe('StripeResource', () => {
       });
     });
 
-    it('still lets users override the host on a per-request basis', (done) => {
-      const stripe = require('../src/stripe.cjs.node.js')('sk_test');
+    it('custom instance host overrides apiBase', (done) => {
+      const stripe = require('../src/stripe.cjs.node.js')('sk_test', {
+        host: 'custom.host.stripe.com',
+      });
 
-      const scope = nock('https://some.other.host.stripe.com')
+      const scope = nock('https://custom.host.stripe.com')
         .get('/v1/resourceWithHost')
         .reply(200, '{}');
 
-      makeResource(stripe).testMethod(
-        {},
-        {host: 'some.other.host.stripe.com'},
-        (err, response) => {
-          done(err);
-          scope.done();
-        }
-      );
-    });
-  });
-
-  describe('method with fullPath', () => {
-    it('interpolates in parameters', (callback) => {
-      const handleRequest = (req, res) => {
-        expect(req.url).to.equal('/v1/parent/hello/child/world');
-
-        // Write back JSON to close out the server.
-        res.write('{}');
-        res.end();
-      };
-
-      getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
-        const resource = new (StripeResource.extend({
-          test: stripeMethod({
-            method: 'GET',
-            fullPath: '/v1/parent/{param1}/child/{param2}',
-          }),
-        }))(stripe);
-
-        return resource.test('hello', 'world', (err, res) => {
-          closeServer();
-          // Spot check that we received a response.
-          expect(res).to.deep.equal({});
-          return callback(err);
-        });
+      makeResource(stripe).testMethod({}, (err, response) => {
+        done(err);
+        scope.done();
       });
     });
-  });
 
-  describe('streaming', () => {
-    /**
-     * Defines a fake resource with a `pdf` method
-     * with binary streaming enabled.
-     */
-    const makeResourceWithPDFMethod = (stripe) => {
-      return new (StripeResource.extend({
-        path: 'resourceWithPDF',
+    describe('method with fullPath', () => {
+      it('interpolates in parameters', (callback) => {
+        const handleRequest = (req, res) => {
+          expect(req.url).to.equal('/v1/parent/hello/child/world');
 
-        pdf: stripeMethod({
-          method: 'GET',
-          host: 'files.stripe.com',
-          streaming: true,
-        }),
-      }))(stripe);
-    };
+          // Write back JSON to close out the server.
+          res.write('{}');
+          res.end();
+        };
 
-    it('success', (callback) => {
-      const handleRequest = (req, res) => {
-        setTimeout(() => res.write('pretend'), 10);
-        setTimeout(() => res.write(' this'), 20);
-        setTimeout(() => res.write(' is a pdf'), 30);
-        setTimeout(() => res.end(), 40);
-      };
+        getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
+          const resource = new (StripeResource.extend({
+            test: stripeMethod({
+              method: 'GET',
+              fullPath: '/v1/parent/{param1}/child/{param2}',
+            }),
+          }))(stripe);
 
-      getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
-        const foos = makeResourceWithPDFMethod(stripe);
-        if (err) {
-          return callback(err);
-        }
-
-        return foos.pdf({id: 'foo_123'}, {host: 'localhost'}, (err, res) => {
-          closeServer();
-          if (err) {
+          return resource.test('hello', 'world', (err, res) => {
+            closeServer();
+            // Spot check that we received a response.
+            expect(res).to.deep.equal({});
             return callback(err);
-          }
-          const chunks = [];
-          res.on('data', (chunk) => chunks.push(chunk));
-          res.on('error', callback);
-          res.on('end', () => {
-            expect(Buffer.concat(chunks).toString()).to.equal(
-              'pretend this is a pdf'
-            );
-            return callback();
           });
         });
       });
     });
 
-    it('setting streaming in raw request works correctly', (callback) => {
-      const handleRequest = (req, res) => {
-        setTimeout(() => res.write('pretend'), 10);
-        setTimeout(() => res.write(' this'), 20);
-        setTimeout(() => res.write(' is a pdf'), 30);
-        setTimeout(() => res.end(), 40);
+    describe('streaming', () => {
+      /**
+       * Defines a fake resource with a `pdf` method
+       * with binary streaming enabled.
+       */
+      const makeResourceWithPDFMethod = (stripe) => {
+        return new (StripeResource.extend({
+          path: 'resourceWithPDF',
+
+          pdf: stripeMethod({
+            method: 'GET',
+            apiBase: 'files',
+            streaming: true,
+          }),
+        }))(stripe);
       };
 
-      getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
-        if (err) {
-          return callback(err);
-        }
+      it('success', (callback) => {
+        const handleRequest = (req, res) => {
+          setTimeout(() => res.write('pretend'), 10);
+          setTimeout(() => res.write(' this'), 20);
+          setTimeout(() => res.write(' is a pdf'), 30);
+          setTimeout(() => res.end(), 40);
+        };
 
-        stripe
-          .rawRequest(
-            'GET',
-            '/v1/files/file_123/contents',
-            {},
-            {host: 'localhost', streaming: true}
-          )
-          .then((result) => {
+        getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
+          const foos = makeResourceWithPDFMethod(stripe);
+          if (err) {
+            return callback(err);
+          }
+
+          return foos.pdf({id: 'foo_123'}, (err, res) => {
             closeServer();
+            if (err) {
+              return callback(err);
+            }
             const chunks = [];
-            result.on('data', (chunk) => chunks.push(chunk));
-            result.on('error', callback);
-            result.on('end', () => {
+            res.on('data', (chunk) => chunks.push(chunk));
+            res.on('error', callback);
+            res.on('end', () => {
               expect(Buffer.concat(chunks).toString()).to.equal(
                 'pretend this is a pdf'
               );
               return callback();
             });
-          })
-          .catch((error) => {
-            return callback(error);
           });
+        });
       });
-    });
 
-    it('failure', (callback) => {
-      const handleRequest = (_req, res, nPreviousRequests) => {
-        setTimeout(() => res.writeHead(500));
-        setTimeout(
-          () =>
-            res.write(
-              '{"error": "api_error", "error_description": "this is bad"}'
-            ),
-          10
-        );
-        setTimeout(() => res.end(), 20);
-        // fail twice, then close the server
-        return {shouldStayOpen: nPreviousRequests < 1};
-      };
+      it('setting streaming in raw request works correctly', (callback) => {
+        const handleRequest = (req, res) => {
+          setTimeout(() => res.write('pretend'), 10);
+          setTimeout(() => res.write(' this'), 20);
+          setTimeout(() => res.write(' is a pdf'), 30);
+          setTimeout(() => res.end(), 40);
+        };
 
-      getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
-        if (err) {
-          return callback(err);
-        }
-
-        const foos = makeResourceWithPDFMethod(stripe);
-
-        return foos.pdf(
-          {id: 'foo_123'},
-          {host: 'localhost', maxNetworkRetries: 1},
-          (err, res) => {
-            closeServer();
-            expect(err).to.exist;
-            expect(err.raw.type).to.equal('api_error');
-            expect(err.raw.message).to.equal('this is bad');
-            return callback();
+        getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
+          if (err) {
+            return callback(err);
           }
-        );
+
+          stripe
+            .rawRequest(
+              'GET',
+              '/v1/files/file_123/contents',
+              {},
+              {streaming: true}
+            )
+            .then((result) => {
+              closeServer();
+              const chunks = [];
+              result.on('data', (chunk) => chunks.push(chunk));
+              result.on('error', callback);
+              result.on('end', () => {
+                expect(Buffer.concat(chunks).toString()).to.equal(
+                  'pretend this is a pdf'
+                );
+                return callback();
+              });
+            })
+            .catch((error) => {
+              return callback(error);
+            });
+        });
+      });
+
+      it('failure', (callback) => {
+        const handleRequest = (_req, res, nPreviousRequests) => {
+          setTimeout(() => res.writeHead(500));
+          setTimeout(
+            () =>
+              res.write(
+                '{"error": "api_error", "error_description": "this is bad"}'
+              ),
+            10
+          );
+          setTimeout(() => res.end(), 20);
+          // fail twice, then close the server
+          return {shouldStayOpen: nPreviousRequests < 1};
+        };
+
+        getTestServerStripe({}, handleRequest, (err, stripe, closeServer) => {
+          if (err) {
+            return callback(err);
+          }
+
+          const foos = makeResourceWithPDFMethod(stripe);
+
+          return foos.pdf(
+            {id: 'foo_123'},
+            {maxNetworkRetries: 1},
+            (err, res) => {
+              closeServer();
+              expect(err).to.exist;
+              expect(err.raw.type).to.equal('api_error');
+              expect(err.raw.message).to.equal('this is bad');
+              return callback();
+            }
+          );
+        });
       });
     });
-  });
-  describe('makeRequest args', () => {
-    it('does not mutate user-supplied deprecated opts', () => {
-      const args = [
-        {
-          stripe_account: 'bad',
-        },
-      ];
-      const mockSelf = new (StripeResource.extend({}))(stripe);
-      mockSelf._makeRequest(args, {}, {});
-      expect(args).to.deep.equal([
-        {
-          stripe_account: 'bad',
-        },
-      ]);
-    });
-  });
-
-  describe('usage', () => {
-    it('is passed to the request sender', (callback) => {
-      const mockSelf = new (StripeResource.extend({
-        boop: stripeMethod({
-          method: 'GET',
-          fullPath: '/v1/widgets/{widget}/boop',
-          usage: ['llama', 'bufo'],
-        }),
-      }))(stripe);
-
-      mockSelf.boop('foo', {bar: 'baz'}, (err, res) => {
-        if (err) {
-          return callback(err);
-        }
-        expect(stripe._requestSender._stripe.LAST_REQUEST.usage).to.deep.equal([
-          'llama',
-          'bufo',
+    describe('makeRequest args', () => {
+      it('does not mutate user-supplied deprecated opts', () => {
+        const args = [
+          {
+            stripe_account: 'bad',
+          },
+        ];
+        const mockSelf = new (StripeResource.extend({}))(stripe);
+        mockSelf._makeRequest(args, {}, {});
+        expect(args).to.deep.equal([
+          {
+            stripe_account: 'bad',
+          },
         ]);
-        return callback();
+      });
+    });
+
+    describe('usage', () => {
+      it('is passed to the request sender', (callback) => {
+        const mockSelf = new (StripeResource.extend({
+          boop: stripeMethod({
+            method: 'GET',
+            fullPath: '/v1/widgets/{widget}/boop',
+            usage: ['llama', 'bufo'],
+          }),
+        }))(stripe);
+
+        mockSelf.boop('foo', {bar: 'baz'}, (err, res) => {
+          if (err) {
+            return callback(err);
+          }
+          expect(
+            stripe._requestSender._stripe.LAST_REQUEST.usage
+          ).to.deep.equal(['llama', 'bufo']);
+          return callback();
+        });
       });
     });
   });

--- a/test/resources/Quotes.spec.js
+++ b/test/resources/Quotes.spec.js
@@ -145,25 +145,21 @@ describe('Quotes Resource', () => {
             return callback(err);
           }
 
-          return stripe.quotes.pdf(
-            'foo_123',
-            {host: 'localhost'},
-            (err, res) => {
-              closeServer();
-              if (err) {
-                return callback(err);
-              }
-              const chunks = [];
-              res.on('data', (chunk) => chunks.push(chunk));
-              res.on('error', callback);
-              res.on('end', () => {
-                expect(Buffer.concat(chunks).toString()).to.equal(
-                  'Stripe binary response'
-                );
-                return callback();
-              });
+          return stripe.quotes.pdf('foo_123', (err, res) => {
+            closeServer();
+            if (err) {
+              return callback(err);
             }
-          );
+            const chunks = [];
+            res.on('data', (chunk) => chunks.push(chunk));
+            res.on('error', callback);
+            res.on('end', () => {
+              expect(Buffer.concat(chunks).toString()).to.equal(
+                'Stripe binary response'
+              );
+              return callback();
+            });
+          });
         }
       );
     });
@@ -192,7 +188,7 @@ describe('Quotes Resource', () => {
 
           return stripe.quotes.pdf(
             'foo_123',
-            {host: 'localhost', maxNetworkRetries: 1},
+            {maxNetworkRetries: 1},
             (err, res) => {
               closeServer();
               expect(err).to.exist;

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -779,7 +779,7 @@ describe('utils', () => {
   describe('getOptsFromArgs', () => {
     it('handles an empty list', () => {
       expect(utils.getOptionsFromArgs([])).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: false,
         settings: {},
@@ -789,7 +789,7 @@ describe('utils', () => {
     it('handles an list with no object', () => {
       const args = [1, 3];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: false,
         settings: {},
@@ -800,7 +800,7 @@ describe('utils', () => {
     it('ignores a non-options object', () => {
       const args = [{foo: 'bar'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: false,
         settings: {},
@@ -812,7 +812,7 @@ describe('utils', () => {
       const args = ['sk_test_iiiiiiiiiiiiiiiiiiiiiiii'];
       const options = utils.getOptionsFromArgs(args);
       expect(options).to.deep.contain({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: false,
         settings: {},
@@ -827,7 +827,7 @@ describe('utils', () => {
       const args = ['yolo'];
       const options = utils.getOptionsFromArgs(args);
       expect(options).to.deep.contain({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: false,
         settings: {},
@@ -839,7 +839,7 @@ describe('utils', () => {
     it('parses an idempotency key', () => {
       const args = [{foo: 'bar'}, {idempotencyKey: 'foo'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {'Idempotency-Key': 'foo'},
         streaming: false,
         settings: {},
@@ -850,7 +850,7 @@ describe('utils', () => {
     it('parses an api version', () => {
       const args = [{foo: 'bar'}, {apiVersion: '2003-03-30'}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {'Stripe-Version': '2003-03-30'},
         streaming: false,
         settings: {},
@@ -861,7 +861,7 @@ describe('utils', () => {
     it('parses streaming', () => {
       const args = [{foo: 'bar'}, {streaming: true}];
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: true,
         settings: {},
@@ -880,7 +880,7 @@ describe('utils', () => {
       ];
       const options = utils.getOptionsFromArgs(args);
       expect(options).to.deep.contains({
-        host: null,
+        apiBase: null,
         headers: {
           'Idempotency-Key': 'foo',
           'Stripe-Version': '2010-01-10',
@@ -904,7 +904,7 @@ describe('utils', () => {
       ];
       const options = utils.getOptionsFromArgs(args);
       expect(options).to.deep.contains({
-        host: null,
+        apiBase: null,
         headers: {
           'Idempotency-Key': 'foo',
           'Stripe-Version': 'hunter2',
@@ -927,7 +927,7 @@ describe('utils', () => {
       ];
 
       expect(utils.getOptionsFromArgs(args)).to.deep.equal({
-        host: null,
+        apiBase: null,
         headers: {},
         streaming: false,
         settings: {

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -281,9 +281,6 @@ const instanceofCheck2 = {} instanceof Stripe.errors.StripeAPIError;
 const instanceofCheck5 = {} instanceof stripe.errors.StripeError;
 const instanceofCheck6 = {} instanceof stripe.errors.StripeAPIError;
 
-stripe.accounts.retrieve('123', {
-  host: 'my_host',
-});
 stripe.files.create({
   purpose: 'dispute_evidence',
   file: {
@@ -293,6 +290,37 @@ stripe.files.create({
   },
   file_link_data: {create: true},
 });
+
+// rawRequest
+stripe.rawRequest(
+  'GET',
+  '/path/123',
+  {},
+  {
+    // allowed base
+    apiBase: 'files',
+  }
+);
+
+stripe.rawRequest(
+  'GET',
+  '/path/123',
+  {},
+  {
+    // @ts-expect-error - unknown base
+    apiBase: 'missing',
+  }
+);
+
+stripe.rawRequest(
+  'GET',
+  '/path/123',
+  {},
+  {
+    // @ts-expect-error - unknown key
+    host: 'example.com',
+  }
+);
 
 const v1Event = {} as Stripe.AccountApplicationAuthorizedEvent;
 // v1 event context is a string


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Being able to override the entire host per-request was surprising behavior. While each request should be able to set a specific API subdomain, arguments to a specific method shouldn't be able to redirect the entire thing.

Users can still set a per-client host, which will overwrite all 

NOTE: this is part 1/2 of beaking security-related fixes for the Node SDK

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- remove `host` from options
- add `apiBase` to `methodSpec`
- restrict `apiBase` to a few specific types methods
- update tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3060](https://go/j/DEVSDK-3060)

## Changelog

- ⚠️ Removed per-request host override. To use a custom host, set it in the client configuration. All requests from that client will use that host.

Before:
```ts
import Stripe from 'stripe';
const stripe = new Stripe('sk_test_...');

const customer = await stripe.customers.create({
  email: 'customer@example.com',
}, {host: 'example.com'});
```

After:
```ts
import Stripe from 'stripe';
const stripe = new Stripe('sk_test_...', {host: 'example.com'});

// goes to example.com
const customer = await stripe.customers.create({
  email: 'customer@example.com',
});
```