### PR TITLE
tolerance, receivedAt, timestamp are now optional in Webhook.ts

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -233,6 +233,11 @@ export function createWebhooks(
         secret
       );
 
+      /**
+       * TODO(MAJOR): https://go/j/DEVSDK-3087
+       * Passing in 0 by default skips timestamp tolerance verifications. Although it is mostly used in test,
+       * we should change the default behavior to pass DEFAULT_TOLERANCE instead of 0 in the next major.
+       */
       validateComputedSignature(
         payload,
         header,
@@ -274,6 +279,11 @@ export function createWebhooks(
         secret
       );
 
+      /**
+       * TODO(MAJOR): https://go/j/DEVSDK-3087
+       * Passing in 0 by default skips timestamp tolerance verifications. Although it is mostly used in test,
+       * we should change the default behavior to pass DEFAULT_TOLERANCE instead of 0 in the next major.
+       */
       return validateComputedSignature(
         payload,
         header,
@@ -374,6 +384,31 @@ export function createWebhooks(
     };
   }
 
+  /**
+   * Validates that at least one signature in the parsed header matches the
+   * expected signature, and that the event timestamp is within the allowed
+   * {@link tolerance} window (in seconds). Set `tolerance` to `0` to skip
+   * timestamp verification.
+   *
+   * TODO(MAJOR): https://go/j/DEVSDK-3087 - Change this default behavior to use DEFAULT_TOLERANCE instead of 0.
+   * By default, validateComputedSignature doesn't perform timestamp verification.
+   *
+   * This method is mostly meant for tests or offline processing where the delivery time
+   * of the event isn't important.
+   * Integrations that process webhooks as they come in should use constructEvent method instead.
+   *
+   * @param payload The decoded webhook payload string.
+   * @param header  The decoded `stripe-signature` header value.
+   * @param details Parsed header containing timestamp and signatures.
+   * @param expectedSignature HMAC signature computed from the payload and secret.
+   * @param tolerance Maximum allowed age of the event in seconds. Use 0 to skip timestamp tolerance verification.
+   * @param suspectPayloadType Whether the payload was not a string or Buffer.
+   * @param secretContainsWhitespace Whether the signing secret contains whitespace.
+   * @param receivedAt - Timestamp for age calculation
+   * @returns `true` if the signature and timestamp are valid.
+   *
+   * @throws {StripeSignatureVerificationError} If verification fails.
+   */
   function validateComputedSignature(
     payload: string,
     header: string,

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -28,12 +28,12 @@ type WebhookParsedEvent = {
   suspectPayloadType: boolean;
 };
 type WebhookTestHeaderOptions = {
-  timestamp: number;
+  timestamp?: number;
   payload: string;
   secret: string;
-  scheme: string;
-  signature: string;
-  cryptoProvider: CryptoProvider;
+  scheme?: string;
+  signature?: string;
+  cryptoProvider?: CryptoProvider;
 };
 
 // export type WebhookEvent = Record<string, unknown>;
@@ -43,16 +43,16 @@ type WebhookSignatureObject = {
     encodedPayload: WebhookPayload,
     encodedHeader: WebhookHeader,
     secret: string,
-    tolerance: number,
-    cryptoProvider: CryptoProvider,
+    tolerance?: number,
+    cryptoProvider?: CryptoProvider,
     receivedAt?: number
   ) => boolean;
   verifyHeaderAsync: (
     encodedPayload: WebhookPayload,
     encodedHeader: WebhookHeader,
     secret: string,
-    tolerance: number,
-    cryptoProvider: CryptoProvider,
+    tolerance?: number,
+    cryptoProvider?: CryptoProvider,
     receivedAt?: number
   ) => Promise<boolean>;
 };
@@ -211,8 +211,8 @@ export function createWebhooks(
       encodedPayload: WebhookPayload,
       encodedHeader: WebhookHeader,
       secret: string,
-      tolerance: number,
-      cryptoProvider: CryptoProvider,
+      tolerance?: number,
+      cryptoProvider?: CryptoProvider,
       receivedAt?: number
     ): boolean {
       const {
@@ -238,7 +238,7 @@ export function createWebhooks(
         header,
         details,
         expectedSignature,
-        tolerance,
+        tolerance || 0,
         suspectPayloadType,
         secretContainsWhitespace,
         receivedAt
@@ -251,8 +251,8 @@ export function createWebhooks(
       encodedPayload: WebhookPayload,
       encodedHeader: WebhookHeader,
       secret: string,
-      tolerance: number,
-      cryptoProvider: CryptoProvider,
+      tolerance?: number,
+      cryptoProvider?: CryptoProvider,
       receivedAt?: number
     ): Promise<boolean> {
       const {
@@ -279,7 +279,7 @@ export function createWebhooks(
         header,
         details,
         expectedSignature,
-        tolerance,
+        tolerance || 0,
         suspectPayloadType,
         secretContainsWhitespace,
         receivedAt
@@ -436,11 +436,12 @@ export function createWebhooks(
 
   function parseHeader(
     header: WebhookHeader,
-    scheme: string
+    scheme?: string
   ): WebhookParsedHeader | null {
     if (typeof header !== 'string') {
       return null;
     }
+    scheme = scheme || signature.EXPECTED_SCHEME;
 
     return header.split(',').reduce<WebhookParsedHeader>(
       (accum, item) => {
@@ -478,7 +479,13 @@ export function createWebhooks(
 
   function prepareOptions(
     opts: WebhookTestHeaderOptions
-  ): WebhookTestHeaderOptions & {
+  ): Omit<
+    WebhookTestHeaderOptions,
+    'timestamp' | 'scheme' | 'cryptoProvider'
+  > & {
+    timestamp: number;
+    scheme: string;
+    cryptoProvider: CryptoProvider;
     payloadString: string;
     generateHeaderString: (signature: string) => string;
   } {
@@ -489,7 +496,8 @@ export function createWebhooks(
     }
 
     const timestamp =
-      Math.floor(opts.timestamp) || Math.floor(Date.now() / 1000);
+      (opts.timestamp && Math.floor(opts.timestamp)) ||
+      Math.floor(Date.now() / 1000);
     const scheme = opts.scheme || signature.EXPECTED_SCHEME;
     const cryptoProvider = opts.cryptoProvider || getCryptoProvider();
     const payloadString = `${timestamp}.${opts.payload}`;

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -476,11 +476,12 @@ function createWebhooksTestSuite(stripe) {
           );
         });
         it('should use the provider to compute a signature (success)', async () => {
+          const timestamp = Date.now() / 1000;
           const header = stripe.webhooks.generateTestHeaderString({
             payload: EVENT_PAYLOAD_STRING,
             secret: SECRET,
             signature: 'fake signature',
-            timestamp: 123,
+            timestamp,
           });
 
           expect(
@@ -511,4 +512,150 @@ function createWebhooksTestSuite(stripe) {
       stripe.webhooks.signature.verifyHeaderAsync(...args)
     )
   );
+
+  describe('optional parameter defaults', () => {
+    describe('.generateTestHeaderString with optional params', () => {
+      it('should use current timestamp when timestamp is not provided', () => {
+        const before = Math.floor(Date.now() / 1000);
+        const header = stripe.webhooks.generateTestHeaderString({
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+        const after = Math.floor(Date.now() / 1000);
+
+        const timestampStr = header.split(',')[0].replace('t=', '');
+        const timestamp = parseInt(timestampStr, 10);
+        expect(timestamp).to.be.at.least(before);
+        expect(timestamp).to.be.at.most(after);
+      });
+
+      it('should use provided timestamp when given', () => {
+        const customTimestamp = 1234567890;
+        const header = stripe.webhooks.generateTestHeaderString({
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+          timestamp: customTimestamp,
+        });
+
+        const timestampStr = header.split(',')[0].replace('t=', '');
+        expect(parseInt(timestampStr, 10)).to.equal(customTimestamp);
+      });
+    });
+
+    describe('.generateTestHeaderStringAsync with optional params', () => {
+      it('should use current timestamp when timestamp is not provided', async () => {
+        const before = Math.floor(Date.now() / 1000);
+        const header = await stripe.webhooks.generateTestHeaderStringAsync({
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+        const after = Math.floor(Date.now() / 1000);
+
+        const timestampStr = header.split(',')[0].replace('t=', '');
+        const timestamp = parseInt(timestampStr, 10);
+        expect(timestamp).to.be.at.least(before);
+        expect(timestamp).to.be.at.most(after);
+      });
+    });
+
+    describe('verifyHeader with optional tolerance and cryptoProvider', () => {
+      it('should use 0 and accept recent timestamps when tolerance is omitted', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          timestamp: Date.now() / 1000 - 100,
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        expect(
+          await stripe.webhooks.signature.verifyHeaderAsync(
+            EVENT_PAYLOAD_STRING,
+            header,
+            SECRET
+          )
+        ).to.equal(true);
+      });
+
+      it('should use default cryptoProvider when cryptoProvider is omitted', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          timestamp: Date.now() / 1000,
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        expect(
+          await stripe.webhooks.signature.verifyHeaderAsync(
+            EVENT_PAYLOAD_STRING,
+            header,
+            SECRET,
+            300
+          )
+        ).to.equal(true);
+      });
+
+      it('should work when both tolerance and cryptoProvider are omitted', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          timestamp: Date.now() / 1000,
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        expect(
+          await stripe.webhooks.signature.verifyHeaderAsync(
+            EVENT_PAYLOAD_STRING,
+            header,
+            SECRET
+          )
+        ).to.equal(true);
+      });
+    });
+
+    describe('constructEvent with optional tolerance and cryptoProvider', () => {
+      it('should use DEFAULT_TOLERANCE when tolerance is omitted', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          timestamp: Date.now() / 1000 - 400,
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        await expect(
+          stripe.webhooks.constructEventAsync(
+            EVENT_PAYLOAD_STRING,
+            header,
+            SECRET
+          )
+        ).to.be.rejectedWith(/Timestamp outside the tolerance zone/);
+      });
+
+      it('should succeed with a recent timestamp when tolerance is omitted', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          timestamp: Date.now() / 1000,
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        const event = await stripe.webhooks.constructEventAsync(
+          EVENT_PAYLOAD_STRING,
+          header,
+          SECRET
+        );
+        expect(event.id).to.equal(EVENT_PAYLOAD.id);
+      });
+
+      it('should succeed without cryptoProvider argument', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          timestamp: Date.now() / 1000,
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        const event = await stripe.webhooks.constructEventAsync(
+          EVENT_PAYLOAD_STRING,
+          header,
+          SECRET,
+          300
+        );
+        expect(event.id).to.equal(EVENT_PAYLOAD.id);
+      });
+    });
+  });
 }


### PR DESCRIPTION
### Why?

In v22, several webhook method parameters that were previously optional in manually maintained became required due to a type consolidation. 
`generateTestHeaderString` only truly requires `payload` and `secret` (all other fields have defaults). `verifyHeader`/`constructEvent` work without explicit `tolerance` and `cryptoProvider` arguments. Users upgrading to v22 now get TypeScript errors when calling these methods with the same arguments that worked in v21.

### What?
- Made `timestamp`, `scheme`, `signature`, and `cryptoProvider` optional in `WebhookTestHeaderOptions`
- Made `tolerance` and `cryptoProvider` optional in `verifyHeader`/`verifyHeaderAsync` signatures
- Made `scheme` optional in `parseHeader`
- Updated `prepareOptions` return type to reflect that defaulted fields are resolved to non-optional
- Added tests covering all optional parameter default behaviors

### See Also

- Fixes #2666 

## Changelog
