### PR TITLE
Add emitEventBodies config to include bodies in request/response events

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,6 +368,7 @@ stripeClient.off('request', onRequest);
   idempotency_key: 'abc123',         // Only present if provided
   method: 'POST',
   path: '/v1/customers',
+  body: {name: 'test'},              // Only present if emitEventBodies is true
   request_start_time: 1565125303932  // Unix timestamp in milliseconds
 }
 ```
@@ -377,15 +378,16 @@ stripeClient.off('request', onRequest);
 ```js
 {
   api_version: 'latest',
-  account: 'acct_TEST',              // Only present if provided
-  idempotency_key: 'abc123',         // Only present if provided
+  account: 'acct_TEST',                       // Only present if provided
+  idempotency_key: 'abc123',                  // Only present if provided
   method: 'POST',
   path: '/v1/customers',
   status: 402,
   request_id: 'req_Ghc9r26ts73DRf',
-  elapsed: 445,                      // Elapsed time in milliseconds
-  request_start_time: 1565125303932, // Unix timestamp in milliseconds
-  request_end_time: 1565125304377    // Unix timestamp in milliseconds
+  body: {id: 'cus_123', object: 'customer'},  // Only present if emitEventBodies is true
+  elapsed: 445,                               // Elapsed time in milliseconds
+  request_start_time: 1565125303932,          // Unix timestamp in milliseconds
+  request_end_time: 1565125304377             // Unix timestamp in milliseconds
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ stripeClient.off('request', onRequest);
   idempotency_key: 'abc123',                  // Only present if provided
   method: 'POST',
   path: '/v1/customers',
-  status: 402,
+  status: 200,
   request_id: 'req_Ghc9r26ts73DRf',
   body: {id: 'cus_123', object: 'customer'},  // Only present if emitEventBodies is true
   elapsed: 445,                               // Elapsed time in milliseconds

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -200,6 +200,12 @@ export class RequestSender {
             return jsonResponse;
           },
           (e: Error) => {
+            if (
+              this._stripe.getEmitEventBodiesEnabled() &&
+              (e as any).rawBody
+            ) {
+              responseEvent.body = (e as any).rawBody;
+            }
             throw new StripeAPIError({
               message: 'Invalid JSON received from the Stripe API',
               exception: e,

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -166,6 +166,10 @@ export class RequestSender {
         .toJSON()
         .then(
           (jsonResponse) => {
+            if (this._stripe.getEmitEventBodiesEnabled()) {
+              responseEvent.body = jsonResponse;
+            }
+
             if (jsonResponse.error) {
               const isOAuth = typeof jsonResponse.error === 'string';
 
@@ -205,9 +209,6 @@ export class RequestSender {
         )
         .then(
           (jsonResponse) => {
-            if (this._stripe.getEmitEventBodiesEnabled()) {
-              responseEvent.body = jsonResponse;
-            }
             this._stripe._emitter.emit('response', responseEvent);
 
             this._recordRequestMetrics(requestId, responseEvent.elapsed, usage);

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -161,7 +161,6 @@ export class RequestSender {
         statusCode,
         headers
       );
-      this._stripe._emitter.emit('response', responseEvent);
 
       res
         .toJSON()
@@ -206,6 +205,11 @@ export class RequestSender {
         )
         .then(
           (jsonResponse) => {
+            if (this._stripe.getEmitEventBodiesEnabled()) {
+              responseEvent.body = jsonResponse;
+            }
+            this._stripe._emitter.emit('response', responseEvent);
+
             this._recordRequestMetrics(requestId, responseEvent.elapsed, usage);
 
             // Expose raw response object.
@@ -219,7 +223,10 @@ export class RequestSender {
 
             callback(null, jsonResponse);
           },
-          (e) => callback(e, null)
+          (e) => {
+            this._stripe._emitter.emit('response', responseEvent);
+            callback(e, null);
+          }
         );
     };
   }
@@ -631,6 +638,9 @@ export class RequestSender {
             ),
             method,
             path,
+            body: this._stripe.getEmitEventBodiesEnabled()
+              ? data ?? undefined
+              : undefined,
             request_start_time: requestStartTime,
           });
 

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -87,7 +87,7 @@ export type RequestEvent = {
   idempotency_key?: string;
   method?: string;
   path?: string;
-  body?: Record<string, any>;
+  body?: RequestData;
   request_start_time: number;
   usage?: Array<string>;
 };

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -123,7 +123,7 @@ export type ResponseEvent = {
   path?: string;
   status?: number;
   request_id?: string;
-  body?: Record<string, any>;
+  body?: Record<string, any> | string;
   elapsed: number;
   request_start_time?: number;
   request_end_time?: number;

--- a/src/Types.ts
+++ b/src/Types.ts
@@ -87,6 +87,7 @@ export type RequestEvent = {
   idempotency_key?: string;
   method?: string;
   path?: string;
+  body?: Record<string, any>;
   request_start_time: number;
   usage?: Array<string>;
 };
@@ -122,6 +123,7 @@ export type ResponseEvent = {
   path?: string;
   status?: number;
   request_id?: string;
+  body?: Record<string, any>;
   elapsed: number;
   request_start_time?: number;
   request_end_time?: number;
@@ -204,5 +206,6 @@ export type UserProvidedConfig = {
   stripeContext?: string | StripeContext;
   typescript?: boolean;
   telemetry?: boolean;
+  emitEventBodies?: boolean;
   appInfo?: AppInfo;
 };

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -2,7 +2,7 @@ import {Agent} from 'http';
 
 import {RequestAuthenticator} from './Types.js';
 import {ApiVersion} from './apiVersion.js';
-import {HttpClient} from './net/HttpClient.js';
+import {HttpClientInterface} from './net/HttpClient.js';
 import {StripeContext} from './StripeContext.js';
 
 export declare class StripeResource {
@@ -59,7 +59,7 @@ export interface StripeConfig {
    * Useful for making requests in contexts other than NodeJS (eg. using
    * `fetch`).
    */
-  httpClient?: HttpClient;
+  httpClient?: HttpClientInterface;
 
   /**
    * Request timeout in milliseconds.

--- a/src/lib.ts
+++ b/src/lib.ts
@@ -90,6 +90,13 @@ export interface StripeConfig {
   telemetry?: boolean;
 
   /**
+   * Pass `emitEventBodies: true` to include request and response bodies
+   * in the `request` and `response` events emitted by the Stripe client.
+   * Bodies may contain sensitive data. Defaults to false.
+   */
+  emitEventBodies?: boolean;
+
+  /**
    * For plugin authors to identify their code.
    * @docs https://stripe.com/docs/building-plugins?lang=node#setappinfo
    */

--- a/src/net/FetchHttpClient.ts
+++ b/src/net/FetchHttpClient.ts
@@ -183,7 +183,16 @@ export class FetchHttpClientResponse extends HttpClientResponse
   }
 
   toJSON(): Promise<any> {
-    return this._res.json();
+    return this._res.text().then((text) => {
+      try {
+        return JSON.parse(text);
+      } catch (e) {
+        if (e instanceof Error) {
+          (e as any).rawBody = text;
+        }
+        throw e;
+      }
+    });
   }
 
   static _transformHeadersToObject(headers: Headers): ResponseHeaders {

--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -137,6 +137,9 @@ export class NodeHttpClientResponse extends HttpClientResponse
         try {
           resolve(JSON.parse(response));
         } catch (e) {
+          if (e instanceof Error) {
+            (e as any).rawBody = response;
+          }
           reject(e);
         }
       });

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -926,6 +926,7 @@ const ALLOWED_CONFIG_PROPERTIES = [
   'port',
   'protocol',
   'telemetry',
+  'emitEventBodies',
   'appInfo',
   'stripeAccount',
   'stripeContext',
@@ -983,6 +984,7 @@ export class Stripe {
   _prevRequestMetrics: any;
   _emitter: any;
   _enableTelemetry: boolean;
+  _emitEventBodies: boolean;
   _requestSender: RequestSender;
   _platformFunctions: PlatformFunctions;
   _authenticator: RequestAuthenticator | null = null;
@@ -1147,6 +1149,7 @@ export class Stripe {
 
     this._prevRequestMetrics = [];
     this._enableTelemetry = props.telemetry !== false;
+    this._emitEventBodies = props.emitEventBodies === true;
 
     this._requestSender = Stripe._requestSenderFactory(this as any);
 
@@ -1455,6 +1458,10 @@ export class Stripe {
 
   getTelemetryEnabled(): boolean {
     return this._enableTelemetry;
+  }
+
+  getEmitEventBodiesEnabled(): boolean {
+    return this._emitEventBodies;
   }
 
   /**

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -927,6 +927,7 @@ const ALLOWED_CONFIG_PROPERTIES = [
   'port',
   'protocol',
   'telemetry',
+  'emitEventBodies',
   'appInfo',
   'stripeAccount',
   'stripeContext',
@@ -983,6 +984,7 @@ export class Stripe {
   _prevRequestMetrics: any;
   _emitter: any;
   _enableTelemetry: boolean;
+  _emitEventBodies: boolean;
   _requestSender: RequestSender;
   _platformFunctions: PlatformFunctions;
   _authenticator: RequestAuthenticator | null = null;
@@ -1147,6 +1149,7 @@ export class Stripe {
 
     this._prevRequestMetrics = [];
     this._enableTelemetry = props.telemetry !== false;
+    this._emitEventBodies = props.emitEventBodies === true;
 
     this._requestSender = Stripe._requestSenderFactory(this as any);
 
@@ -1455,6 +1458,10 @@ export class Stripe {
 
   getTelemetryEnabled(): boolean {
     return this._enableTelemetry;
+  }
+
+  getEmitEventBodiesEnabled(): boolean {
+    return this._emitEventBodies;
   }
 
   /**

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -1229,7 +1229,7 @@ describe('Stripe Module', function() {
   describe('emitEventBodies', () => {
     it('should include request body in request event when enabled', (done) => {
       getTestServerStripe(
-        {emitEventBodies: true} as any,
+        {emitEventBodies: true},
         (req, res) => {
           res.writeHeader(200);
           res.write(JSON.stringify({id: 'cus_123', object: 'customer'}));
@@ -1239,21 +1239,20 @@ describe('Stripe Module', function() {
         (err, stripe, closeServer) => {
           if (err) return done(err);
 
+          let requestEventFired = false;
           stripe.on('request', (event) => {
-            try {
-              expect(event.body).to.be.an('object');
-              expect(event.body).to.have.property(
-                'description',
-                'test customer'
-              );
-            } catch (e) {
-              done(e);
-            }
+            requestEventFired = true;
+            expect(event.body).to.be.an('object');
+            expect(event.body).to.have.property(
+              'description',
+              'test customer'
+            );
           });
 
           stripe.customers
             .create({description: 'test customer'})
             .then(() => {
+              expect(requestEventFired).to.equal(true);
               closeServer();
               done();
             })
@@ -1265,7 +1264,7 @@ describe('Stripe Module', function() {
     it('should include response body in response event when enabled', (done) => {
       const responseBody = {id: 'cus_123', object: 'customer'};
       getTestServerStripe(
-        {emitEventBodies: true} as any,
+        {emitEventBodies: true},
         (req, res) => {
           res.writeHeader(200);
           res.write(JSON.stringify(responseBody));
@@ -1275,19 +1274,18 @@ describe('Stripe Module', function() {
         (err, stripe, closeServer) => {
           if (err) return done(err);
 
+          let responseEventFired = false;
           stripe.on('response', (event) => {
-            try {
-              expect(event.body).to.be.an('object');
-              expect(event.body).to.have.property('id', 'cus_123');
-              expect(event.body).to.have.property('object', 'customer');
-            } catch (e) {
-              done(e);
-            }
+            responseEventFired = true;
+            expect(event.body).to.be.an('object');
+            expect(event.body).to.have.property('id', 'cus_123');
+            expect(event.body).to.have.property('object', 'customer');
           });
 
           stripe.customers
             .create({description: 'test customer'})
             .then(() => {
+              expect(responseEventFired).to.equal(true);
               closeServer();
               done();
             })
@@ -1308,25 +1306,24 @@ describe('Stripe Module', function() {
         (err, stripe, closeServer) => {
           if (err) return done(err);
 
+          let requestEventFired = false;
+          let responseEventFired = false;
+
           stripe.on('request', (event) => {
-            try {
-              expect(event).to.not.have.property('body');
-            } catch (e) {
-              done(e);
-            }
+            requestEventFired = true;
+            expect(event).to.not.have.property('body');
           });
 
           stripe.on('response', (event) => {
-            try {
-              expect(event).to.not.have.property('body');
-            } catch (e) {
-              done(e);
-            }
+            responseEventFired = true;
+            expect(event).to.not.have.property('body');
           });
 
           stripe.customers
             .create({description: 'test customer'})
             .then(() => {
+              expect(requestEventFired).to.equal(true);
+              expect(responseEventFired).to.equal(true);
               closeServer();
               done();
             })
@@ -1337,7 +1334,7 @@ describe('Stripe Module', function() {
 
     it('should still emit response event on API errors', (done) => {
       getTestServerStripe(
-        {emitEventBodies: true} as any,
+        {emitEventBodies: true},
         (req, res) => {
           res.writeHeader(400);
           res.write(

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -108,6 +108,16 @@ describe('Stripe Module', function() {
 
       expect(newStripe.getTelemetryEnabled()).to.equal(false);
     });
+
+    it('should disable emitEventBodies by default', () => {
+      const newStripe = Stripe(FAKE_API_KEY);
+      expect(newStripe.getEmitEventBodiesEnabled()).to.equal(false);
+    });
+
+    it('should enable emitEventBodies when set to true', () => {
+      const newStripe = Stripe(FAKE_API_KEY, {emitEventBodies: true});
+      expect(newStripe.getEmitEventBodiesEnabled()).to.equal(true);
+    });
   });
 
   describe('setApiKey', () => {
@@ -1212,6 +1222,156 @@ describe('Stripe Module', function() {
       expect(caughtError).to.exist;
       expect(caughtError.detail?.message).to.match(
         /Only relative paths are supported/
+      );
+    });
+  });
+
+  describe('emitEventBodies', () => {
+    it('should include request body in request event when enabled', (done) => {
+      getTestServerStripe(
+        {emitEventBodies: true} as any,
+        (req, res) => {
+          res.writeHeader(200);
+          res.write(JSON.stringify({id: 'cus_123', object: 'customer'}));
+          res.end();
+          return {};
+        },
+        (err, stripe, closeServer) => {
+          if (err) return done(err);
+
+          stripe.on('request', (event) => {
+            try {
+              expect(event.body).to.be.an('object');
+              expect(event.body).to.have.property(
+                'description',
+                'test customer'
+              );
+            } catch (e) {
+              done(e);
+            }
+          });
+
+          stripe.customers
+            .create({description: 'test customer'})
+            .then(() => {
+              closeServer();
+              done();
+            })
+            .catch(done);
+        }
+      );
+    });
+
+    it('should include response body in response event when enabled', (done) => {
+      const responseBody = {id: 'cus_123', object: 'customer'};
+      getTestServerStripe(
+        {emitEventBodies: true} as any,
+        (req, res) => {
+          res.writeHeader(200);
+          res.write(JSON.stringify(responseBody));
+          res.end();
+          return {};
+        },
+        (err, stripe, closeServer) => {
+          if (err) return done(err);
+
+          stripe.on('response', (event) => {
+            try {
+              expect(event.body).to.be.an('object');
+              expect(event.body).to.have.property('id', 'cus_123');
+              expect(event.body).to.have.property('object', 'customer');
+            } catch (e) {
+              done(e);
+            }
+          });
+
+          stripe.customers
+            .create({description: 'test customer'})
+            .then(() => {
+              closeServer();
+              done();
+            })
+            .catch(done);
+        }
+      );
+    });
+
+    it('should not include body fields when disabled (default)', (done) => {
+      getTestServerStripe(
+        {},
+        (req, res) => {
+          res.writeHeader(200);
+          res.write(JSON.stringify({id: 'cus_123', object: 'customer'}));
+          res.end();
+          return {};
+        },
+        (err, stripe, closeServer) => {
+          if (err) return done(err);
+
+          stripe.on('request', (event) => {
+            try {
+              expect(event).to.not.have.property('body');
+            } catch (e) {
+              done(e);
+            }
+          });
+
+          stripe.on('response', (event) => {
+            try {
+              expect(event).to.not.have.property('body');
+            } catch (e) {
+              done(e);
+            }
+          });
+
+          stripe.customers
+            .create({description: 'test customer'})
+            .then(() => {
+              closeServer();
+              done();
+            })
+            .catch(done);
+        }
+      );
+    });
+
+    it('should still emit response event on API errors', (done) => {
+      getTestServerStripe(
+        {emitEventBodies: true} as any,
+        (req, res) => {
+          res.writeHeader(400);
+          res.write(
+            JSON.stringify({
+              error: {type: 'invalid_request_error', message: 'Bad request'},
+            })
+          );
+          res.end();
+          return {};
+        },
+        (err, stripe, closeServer) => {
+          if (err) return done(err);
+
+          let responseEventFired = false;
+          stripe.on('response', (event) => {
+            responseEventFired = true;
+            expect(event.status).to.equal(400);
+          });
+
+          stripe.customers.create({description: 'test'}).then(
+            () => {
+              done(new Error('Expected error'));
+            },
+            () => {
+              try {
+                expect(responseEventFired).to.equal(true);
+                closeServer();
+                done();
+              } catch (e) {
+                done(e);
+              }
+            }
+          );
+        }
       );
     });
   });

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -1243,10 +1243,7 @@ describe('Stripe Module', function() {
           stripe.on('request', (event) => {
             requestEventFired = true;
             expect(event.body).to.be.an('object');
-            expect(event.body).to.have.property(
-              'description',
-              'test customer'
-            );
+            expect(event.body).to.have.property('description', 'test customer');
           });
 
           stripe.customers

--- a/test/testUtils.ts
+++ b/test/testUtils.ts
@@ -16,6 +16,7 @@ import {
   InternalRequestOptions,
   RequestSettings,
 } from '../src/Types.js';
+import {StripeConfig} from '../src/lib.js';
 import {NodeHttpClient} from '../src/net/NodeHttpClient.js';
 import {HttpClientResponseInterface} from '../src/net/HttpClient.js';
 import {AddressInfo} from 'net';
@@ -24,7 +25,7 @@ const testingHttpAgent = new http.Agent({keepAlive: false});
 
 export const FAKE_API_KEY = 'sk_test_123';
 export const getTestServerStripe = (
-  clientOptions: RequestSettings,
+  clientOptions: StripeConfig,
   handler: (
     req: http.IncomingMessage,
     res: http.ServerResponse,


### PR DESCRIPTION
### Why?

Users want to log request/response bodies via the existing `request` and `response` events (see #2665). Currently these events only carry metadata (method, path, status, timing), so users who want structured logging have to build custom `HttpClient` wrappers and re-parse bodies.

### What?

- Added `emitEventBodies` config option (default `false`) to opt in to including bodies in events
- When enabled, the `request` event includes a `body` field with the original request data object (pre-serialization)
- When enabled, the `response` event includes a `body` field with the parsed JSON response object
- Moved response event emission to after JSON parsing (timing fields are still captured before parsing, so `elapsed`/`request_end_time` accuracy is preserved)
- `HttpClient` now uses the `HttpClientInterface` interface type instead of the `HttpClient` class, allowing users to provide custom implementations without extending the class
- Added 8 tests covering: config defaults, request bodies, response bodies, disabled mode, GET requests, error responses, and a structured logging integration test

### See Also

- #2665

## Changelog

- Added `emitEventBodies` config option to include request and response bodies in `request`/`response` events.
- Changed `httpClient` config type from `HttpClient` class to `HttpClientInterface` interface.