### PR TITLE
Adds `parseEventNotificationAsync` to match existing sync function

### DIFF
--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -159,7 +159,7 @@ export function createWebhooks(
           : JSON.parse(payload);
       if (jsonPayload && jsonPayload.object === 'v2.core.event') {
         throw new Error(
-          'You passed an event notification to stripe.webhooks.constructEvent, which expects a webhook payload. Use stripe.parseEventNotification instead.'
+          'You passed an event notification to stripe.webhooks.constructEvent, which expects a webhook payload. Use stripe.parseEventNotificationAsync instead.'
         );
       }
       return jsonPayload;

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1617,6 +1617,85 @@ export class Stripe {
 
     return eventNotification;
   }
+
+  async parseEventNotificationAsync(
+    payload: string | Uint8Array,
+    header: string | Uint8Array,
+    secret: string,
+    tolerance?: number,
+    cryptoProvider?: CryptoProvider,
+    receivedAt?: number
+    // this return type is ignored?? picks up types from `types/index.d.ts` instead
+  ): Promise<V2.Core.EventNotification> {
+    // Verify the signature using the internal signature helper directly,
+    // bypassing constructEvent's v2 payload check (since v2 payloads are
+    // expected here).
+    if (!this.webhooks.signature) {
+      throw new Error('ERR: missing signature helper, unable to verify');
+    }
+    await this.webhooks.signature.verifyHeaderAsync(
+      payload,
+      header,
+      secret,
+      tolerance || this.webhooks.DEFAULT_TOLERANCE,
+      cryptoProvider || this._platformFunctions.createDefaultCryptoProvider(),
+      receivedAt
+    );
+
+    const eventNotification =
+      payload instanceof Uint8Array
+        ? JSON.parse(new TextDecoder('utf8').decode(payload))
+        : JSON.parse(payload as string);
+
+    if (eventNotification && eventNotification.object === 'event') {
+      throw new Error(
+        'You passed a webhook payload to stripe.parseEventNotificationAsync, which expects an event notification. Use stripe.webhooks.constructEventAsync instead.'
+      );
+    }
+
+    // Parse string context into StripeContext object if present
+    if (eventNotification.context) {
+      eventNotification.context = StripeContext.parse(
+        eventNotification.context
+      );
+    }
+
+    eventNotification.fetchEvent = (): Promise<unknown> => {
+      return this._requestSender._rawRequest(
+        'GET',
+        `/v2/core/events/${eventNotification.id}`,
+        undefined,
+        {
+          stripeContext: eventNotification.context,
+          headers: {
+            'Stripe-Request-Trigger': `event=${eventNotification.id}`,
+          },
+        },
+        ['fetch_event']
+      );
+    };
+
+    eventNotification.fetchRelatedObject = (): Promise<unknown> => {
+      if (!eventNotification.related_object) {
+        return Promise.resolve(null);
+      }
+
+      return this._requestSender._rawRequest(
+        'GET',
+        eventNotification.related_object.url,
+        undefined,
+        {
+          stripeContext: eventNotification.context,
+          headers: {
+            'Stripe-Request-Trigger': `event=${eventNotification.id}`,
+          },
+        },
+        ['fetch_related_object']
+      );
+    };
+
+    return eventNotification;
+  }
 }
 
 // For backward compatibility, export createStripe as a factory function

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -1617,6 +1617,85 @@ export class Stripe {
 
     return eventNotification;
   }
+
+  async parseEventNotificationAsync(
+    payload: string | Uint8Array,
+    header: string | Uint8Array,
+    secret: string,
+    tolerance?: number,
+    cryptoProvider?: CryptoProvider,
+    receivedAt?: number
+    // this return type is ignored?? picks up types from `types/index.d.ts` instead
+  ): Promise<V2.Core.EventNotification> {
+    // Verify the signature using the internal signature helper directly,
+    // bypassing constructEvent's v2 payload check (since v2 payloads are
+    // expected here).
+    if (!this.webhooks.signature) {
+      throw new Error('ERR: missing signature helper, unable to verify');
+    }
+    await this.webhooks.signature.verifyHeaderAsync(
+      payload,
+      header,
+      secret,
+      tolerance || this.webhooks.DEFAULT_TOLERANCE,
+      cryptoProvider || this._platformFunctions.createDefaultCryptoProvider(),
+      receivedAt
+    );
+
+    const eventNotification =
+      payload instanceof Uint8Array
+        ? JSON.parse(new TextDecoder('utf8').decode(payload))
+        : JSON.parse(payload as string);
+
+    if (eventNotification && eventNotification.object === 'event') {
+      throw new Error(
+        'You passed a webhook payload to stripe.parseEventNotificationAsync, which expects an event notification. Use stripe.webhooks.constructEventAsync instead.'
+      );
+    }
+
+    // Parse string context into StripeContext object if present
+    if (eventNotification.context) {
+      eventNotification.context = StripeContext.parse(
+        eventNotification.context
+      );
+    }
+
+    eventNotification.fetchEvent = (): Promise<unknown> => {
+      return this._requestSender._rawRequest(
+        'GET',
+        `/v2/core/events/${eventNotification.id}`,
+        undefined,
+        {
+          stripeContext: eventNotification.context,
+          headers: {
+            'Stripe-Request-Trigger': `event=${eventNotification.id}`,
+          },
+        },
+        ['fetch_event']
+      );
+    };
+
+    eventNotification.fetchRelatedObject = (): Promise<unknown> => {
+      if (!eventNotification.related_object) {
+        return Promise.resolve(null);
+      }
+
+      return this._requestSender._rawRequest(
+        'GET',
+        eventNotification.related_object.url,
+        undefined,
+        {
+          stripeContext: eventNotification.context,
+          headers: {
+            'Stripe-Request-Trigger': `event=${eventNotification.id}`,
+          },
+        },
+        ['fetch_related_object']
+      );
+    };
+
+    return eventNotification;
+  }
 }
 
 // For backward compatibility, export createStripe as a factory function

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -992,6 +992,331 @@ describe('Stripe Module', function() {
     });
   });
 
+  describe('parseEventNotificationAsync', () => {
+    const secret = 'whsec_test_secret';
+
+    it('can parse event from JSON payload', async () => {
+      const jsonPayload = {
+        type: 'account.created',
+        data: 'hello',
+        related_object: {id: '123', url: 'hello_again'},
+      };
+      const payload = JSON.stringify(jsonPayload);
+      const header = await stripe.webhooks.generateTestHeaderStringAsync({
+        payload,
+        secret,
+      });
+      const event = await stripe.parseEventNotificationAsync(
+        payload,
+        header,
+        secret
+      );
+
+      expect(event.type).to.equal(jsonPayload.type);
+      expect(event.data).to.equal(jsonPayload.data);
+      expect(event.related_object.id).to.equal(jsonPayload.related_object.id);
+      expect(event.context).to.be.undefined;
+    });
+
+    it('throws an error for invalid signatures', async () => {
+      const payload = JSON.stringify({event_type: 'account.created'});
+
+      try {
+        await stripe.parseEventNotificationAsync(
+          payload,
+          'bad sigheader',
+          secret
+        );
+        expect.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(StripeSignatureVerificationError);
+      }
+    });
+
+    it('throws an error when a v1 webhook payload is passed', async () => {
+      const jsonPayload = {
+        id: 'evt_test_webhook',
+        object: 'event',
+      };
+      const payload = JSON.stringify(jsonPayload);
+      const header = await stripe.webhooks.generateTestHeaderStringAsync({
+        payload,
+        secret,
+      });
+
+      try {
+        await stripe.parseEventNotificationAsync(payload, header, secret);
+        expect.fail('Expected an error to be thrown');
+      } catch (e) {
+        expect(e).to.be.instanceOf(Error);
+        expect(e.message).to.contain(
+          'stripe.webhooks.constructEventAsync'
+        );
+      }
+    });
+
+    it('should parse webhook with a functioning fetchEvent method', (done) => {
+      const jsonPayload = {
+        id: 'evt_123',
+        type: 'account.created',
+      };
+      const jsonWithData = {
+        ...jsonPayload,
+        data: 'hello',
+      };
+      let telemetryHeader;
+      let shouldStayOpen = true;
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          telemetryHeader = req.headers['x-stripe-client-telemetry'];
+          res.setHeader('Request-Id', `req_1`);
+          if (
+            req.url === '/v2/core/events/evt_123' &&
+            req.headers['stripe-context'] == null &&
+            req.headers['stripe-request-trigger'] === 'event=evt_123'
+          ) {
+            res.write(JSON.stringify(jsonWithData));
+          } else {
+            res.writeHead(404);
+            res.write(
+              JSON.stringify({
+                error: 'not found; something about test setup is wrong',
+              })
+            );
+          }
+          res.end();
+          const ret = {shouldStayOpen};
+          shouldStayOpen = false;
+          return ret;
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const payload = JSON.stringify(jsonPayload);
+            const header =
+              await stripe.webhooks.generateTestHeaderStringAsync({
+                payload,
+                secret,
+              });
+
+            const event = await stripe.parseEventNotificationAsync(
+              payload,
+              header,
+              secret
+            );
+
+            expect(event.fetchEvent).to.be.a('function');
+            expect(event.fetchRelatedObject).to.be.a('function');
+            expect(await event.fetchRelatedObject()).to.be.null;
+            const pulled = await event.fetchEvent();
+            expect(pulled.data).to.equal(jsonWithData.data);
+            await event.fetchEvent();
+            expect(telemetryHeader).to.exist;
+            expect(
+              JSON.parse(telemetryHeader).last_request_metrics.usage
+            ).to.deep.equal(['fetch_event']);
+
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should use the context property when pulling, if available', (done) => {
+      const jsonPayload = {
+        id: 'evt_123',
+        context: 'acct_123',
+        type: 'account.created',
+      };
+      const jsonWithData = {
+        ...jsonPayload,
+        data: 'hello',
+      };
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          if (
+            req.url === '/v2/core/events/evt_123' &&
+            req.headers['stripe-context'] === 'acct_123' &&
+            req.headers['stripe-request-trigger'] === 'event=evt_123'
+          ) {
+            res.write(JSON.stringify(jsonWithData));
+          } else {
+            res.writeHead(404);
+            res.write(
+              JSON.stringify({
+                error: 'not found; something about test setup is wrong',
+              })
+            );
+          }
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          try {
+            const payload = JSON.stringify(jsonPayload);
+            const header =
+              await stripe.webhooks.generateTestHeaderStringAsync({
+                payload,
+                secret,
+              });
+
+            const event = await stripe.parseEventNotificationAsync(
+              payload,
+              header,
+              secret
+            );
+
+            expect(event.context).to.be.instanceOf(StripeContext);
+            expect(event.context.toString()).to.equal('acct_123');
+            expect(event.fetchEvent).to.be.a('function');
+            expect(event.fetch_related_object).not.to.be.a('function');
+            const pulled = await event.fetchEvent();
+            expect(pulled.data).to.equal(jsonWithData.data);
+
+            closeServer();
+            done();
+          } catch (err) {
+            console.log(err);
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should parse webhook with a functioning fetchRelatedObject method', (done) => {
+      let telemetryHeader;
+      let shouldStayOpen = true;
+      getTestServerStripe(
+        {},
+        (req, res) => {
+          telemetryHeader = req.headers['x-stripe-client-telemetry'];
+          res.setHeader('Request-Id', `req_1`);
+          if (
+            req.url === '/api/whatever/obj_123' &&
+            req.headers['stripe-context'] == null &&
+            req.headers['stripe-request-trigger'] === 'event=evt_123'
+          ) {
+            res.write(JSON.stringify({id: 'obj_123', data: 'some data'}));
+          } else {
+            res.writeHead(404);
+            res.write(
+              JSON.stringify({
+                error: 'not found; something about test setup is wrong',
+              })
+            );
+          }
+          res.end();
+          const ret = {shouldStayOpen};
+          shouldStayOpen = false;
+          return ret;
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          const jsonPayload = {
+            id: 'evt_123',
+            type: 'account.created',
+            related_object: {
+              id: '123',
+              url: `/api/whatever/obj_123`,
+            },
+          };
+
+          try {
+            const payload = JSON.stringify(jsonPayload);
+            const header =
+              await stripe.webhooks.generateTestHeaderStringAsync({
+                payload,
+                secret,
+              });
+
+            const event = await stripe.parseEventNotificationAsync(
+              payload,
+              header,
+              secret
+            );
+
+            expect(event.fetchRelatedObject).to.be.a('function');
+            const relatedObj = await event.fetchRelatedObject();
+            expect(relatedObj.id).to.equal('obj_123');
+            expect(relatedObj.data).to.equal('some data');
+
+            await event.fetchRelatedObject();
+            expect(
+              JSON.parse(telemetryHeader).last_request_metrics.usage
+            ).to.deep.equal(['fetch_related_object']);
+
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+
+    it('should use the context property when fetching relatedObject, if available', (done) => {
+      getTestServerStripe(
+        {},
+        (req, res) => {
+          if (
+            req.url === '/api/whatever/obj_123' &&
+            req.headers['stripe-context'] === 'acct_123' &&
+            req.headers['stripe-request-trigger'] === 'event=evt_123'
+          ) {
+            res.write(JSON.stringify({id: 'obj_123', data: 'some data'}));
+          } else {
+            res.writeHead(404);
+            res.write(JSON.stringify({error: 'not found'}));
+          }
+          res.end();
+        },
+        async (err, stripe, closeServer) => {
+          if (err) return done(err);
+          const jsonPayload = {
+            id: 'evt_123',
+            type: 'account.created',
+            context: 'acct_123',
+            related_object: {
+              id: '123',
+              url: `/api/whatever/obj_123`,
+            },
+          };
+
+          try {
+            const payload = JSON.stringify(jsonPayload);
+            const header =
+              await stripe.webhooks.generateTestHeaderStringAsync({
+                payload,
+                secret,
+              });
+
+            const event = await stripe.parseEventNotificationAsync(
+              payload,
+              header,
+              secret
+            );
+
+            expect(event.fetchRelatedObject).to.be.a('function');
+            const relatedObj = await event.fetchRelatedObject();
+
+            expect(relatedObj.id).to.equal('obj_123');
+            expect(relatedObj.data).to.equal('some data');
+
+            closeServer();
+            done();
+          } catch (err) {
+            return done(err);
+          }
+        }
+      );
+    });
+  });
+
   describe('rawRequest', () => {
     const returnedCustomer = {
       id: 'cus_123',

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -1049,9 +1049,7 @@ describe('Stripe Module', function() {
         expect.fail('Expected an error to be thrown');
       } catch (e) {
         expect(e).to.be.instanceOf(Error);
-        expect(e.message).to.contain(
-          'stripe.webhooks.constructEventAsync'
-        );
+        expect(e.message).to.contain('stripe.webhooks.constructEventAsync');
       }
     });
 
@@ -1094,11 +1092,10 @@ describe('Stripe Module', function() {
           if (err) return done(err);
           try {
             const payload = JSON.stringify(jsonPayload);
-            const header =
-              await stripe.webhooks.generateTestHeaderStringAsync({
-                payload,
-                secret,
-              });
+            const header = await stripe.webhooks.generateTestHeaderStringAsync({
+              payload,
+              secret,
+            });
 
             const event = await stripe.parseEventNotificationAsync(
               payload,
@@ -1159,11 +1156,10 @@ describe('Stripe Module', function() {
           if (err) return done(err);
           try {
             const payload = JSON.stringify(jsonPayload);
-            const header =
-              await stripe.webhooks.generateTestHeaderStringAsync({
-                payload,
-                secret,
-              });
+            const header = await stripe.webhooks.generateTestHeaderStringAsync({
+              payload,
+              secret,
+            });
 
             const event = await stripe.parseEventNotificationAsync(
               payload,
@@ -1228,11 +1224,10 @@ describe('Stripe Module', function() {
 
           try {
             const payload = JSON.stringify(jsonPayload);
-            const header =
-              await stripe.webhooks.generateTestHeaderStringAsync({
-                payload,
-                secret,
-              });
+            const header = await stripe.webhooks.generateTestHeaderStringAsync({
+              payload,
+              secret,
+            });
 
             const event = await stripe.parseEventNotificationAsync(
               payload,
@@ -1289,11 +1284,10 @@ describe('Stripe Module', function() {
 
           try {
             const payload = JSON.stringify(jsonPayload);
-            const header =
-              await stripe.webhooks.generateTestHeaderStringAsync({
-                payload,
-                secret,
-              });
+            const header = await stripe.webhooks.generateTestHeaderStringAsync({
+              payload,
+              secret,
+            });
 
             const event = await stripe.parseEventNotificationAsync(
               payload,


### PR DESCRIPTION
### Why?
In environments like Supabase Edge Functions (Deno), Cloudflare Workers, and Vercel Edge:

- `constructEventAsync` does not support `v2.core.event` webhooks
- It suggests using `stripe.parseEventNotification`
- However, `parseEventNotification` relies on a synchronous crypto provider

This results in the runtime error:

```

SubtleCryptoProvider cannot be used in a synchronous context

````

Since these environments only support asynchronous cryptography, there is currently no way to validate `v2.core.event` webhooks.

### What?

- Added `parseEventNotificationAsync` implementation
- Preserved backward compatibility (no changes to existing sync APIs)
- updated tests

### Usage

```ts
const event = await stripe.parseEventNotificationAsync(
  body,
  signature,
  endpointSecret
);
```

### Notes

* No breaking changes
* Unblocks Stripe webhook validation in modern edge runtimes
  * Supabase Edge Functions
  * Cloudflare Workers
  * Vercel Edge Functions
* Aligns SDK behavior with existing async patterns (`constructEventAsync`)
  * About this, i didn't like how it was done (function/code duplication) but it was done following the same bad patterns as in `constructEvent` and `constructEventAsync`

### See Also

- stripe/stripe-node/issues/2684
