### PR TITLE
Remove defunct RunKit badge from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,6 @@
 [![Version](https://img.shields.io/npm/v/stripe.svg)](https://www.npmjs.org/package/stripe)
 [![Build Status](https://github.com/stripe/stripe-node/actions/workflows/main.yml/badge.svg?branch=master)](https://github.com/stripe/stripe-node/actions?query=branch%3Amaster)
 [![Downloads](https://img.shields.io/npm/dm/stripe.svg)](https://www.npmjs.com/package/stripe)
-[![Try on RunKit](https://badge.runkitcdn.com/stripe.svg)](https://runkit.com/npm/stripe)
 
 > [!TIP]
 > Want to chat live with Stripe engineers? Join us on our [Discord server](https://stripe.com/go/discord/node).


### PR DESCRIPTION
### Why?

RunKit is offline. The "Try on RunKit" badge in the README has two problems:
1. The badge image (`badge.runkitcdn.com/stripe.svg`) returns a 404
2. The link target (`runkit.com/npm/stripe`) is down — RunKit appears to be permanently shut down

### What?

- Removed the broken RunKit badge line from `README.md`

### See Also
