### PR TITLE
Export Decimal type from Stripe namespace

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -2553,6 +2553,8 @@ export declare namespace Stripe {
     Emptyable,
   };
 
+  export type Decimal = import('./shared.js').Decimal;
+
   export {StripeContext as StripeContextType};
   export {StripeRawError};
   export import ErrorType = _Error;

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -2553,6 +2553,8 @@ export declare namespace Stripe {
     Emptyable,
   };
 
+  export type Decimal = import('./shared.js').Decimal;
+
   export {StripeContext as StripeContextType};
   export {StripeRawError};
   export import ErrorType = _Error;

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -354,7 +354,15 @@ async (): Promise<void> => {
   let g: Stripe.V2.Core.Event;
 }
 
-Stripe.Decimal.from('1.0');
+// Test that the Decimal type is exported
+{
+  function takesDecimal(decimal: Stripe.Decimal) {
+    return decimal;
+  }
+
+  const testDecimal = Stripe.Decimal.from('1.0');
+  takesDecimal(testDecimal);
+}
 
 let event: Stripe.Event = stripe.webhooks.constructEvent(
   'payload',


### PR DESCRIPTION
### Why?

Users cannot use `Stripe.Decimal` as a type annotation (e.g. `function takesDecimal(d: Stripe.Decimal)`) because TypeScript only sees the companion object value, not the branded type. This forces ugly workarounds like `typeof Stripe.Decimal.zero`.

### What?

- Added `export type Decimal = import('./shared.js').Decimal` to the `declare namespace Stripe` block in both `stripe.core.ts` and `stripe.esm.node.ts`
- Uses an inline import type to avoid the circular definition that a direct re-export would cause (since the class already has a `static Decimal` property)
- Updated the type test project to verify `Stripe.Decimal` works as a type annotation

### See Also

- #2698
- #2634

## Changelog

- Added `Stripe.Decimal` as a usable type in the `Stripe` namespace, enabling type annotations like `function takesDecimal(d: Stripe.Decimal)`.