### PR TITLE
Fix file upload regression: restore multipart request data processor

### DIFF
--- a/src/resources/Files.ts
+++ b/src/resources/Files.ts
@@ -18,6 +18,7 @@ import {
 } from '../lib.js';
 
 export class FileResource extends StripeResource {
+  requestDataProcessor = multipartRequestDataProcessor;
   /**
    * Returns a list of the files that your account has access to. Stripe sorts and returns the files by their creation dates, placing the most recently created files at the top.
    */

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -47,6 +47,29 @@ describe('Files Resource', () => {
   });
 
   describe('create', () => {
+    it('Encodes file upload as multipart/form-data', () => {
+      const testFilename = path.join(__dirname, 'data/minimal.pdf');
+      const f = fs.readFileSync(testFilename);
+
+      return stripe.files
+        .create({
+          purpose: 'dispute_evidence',
+          file: {
+            data: f,
+            name: 'minimal.pdf',
+            type: 'application/octet-stream',
+          },
+        })
+        .then(() => {
+          const lastData = stripe.REQUESTS[stripe.REQUESTS.length - 1];
+          expect(lastData).to.be.an.instanceOf(Uint8Array);
+          const asString = new TextDecoder().decode(lastData);
+          expect(asString).to.contain('Content-Disposition: form-data');
+          expect(asString).to.contain('name="file"');
+          expect(asString).to.contain('name="purpose"');
+        });
+    });
+
     it('Sends the correct file upload request', () => {
       const testFilename = path.join(__dirname, 'data/minimal.pdf');
       const f = fs.readFileSync(testFilename);

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -63,7 +63,7 @@ describe('Files Resource', () => {
         .then(() => {
           const lastData = stripe.REQUESTS[stripe.REQUESTS.length - 1];
           expect(lastData).to.be.an.instanceOf(Uint8Array);
-          const asString = Buffer.from(lastData).toString();
+          const asString = new TextDecoder('utf8').decode(lastData);
           expect(asString).to.contain('Content-Disposition: form-data');
           expect(asString).to.contain('name="file"');
           expect(asString).to.contain('name="purpose"');

--- a/test/resources/Files.spec.js
+++ b/test/resources/Files.spec.js
@@ -63,7 +63,7 @@ describe('Files Resource', () => {
         .then(() => {
           const lastData = stripe.REQUESTS[stripe.REQUESTS.length - 1];
           expect(lastData).to.be.an.instanceOf(Uint8Array);
-          const asString = new TextDecoder().decode(lastData);
+          const asString = Buffer.from(lastData).toString();
           expect(asString).to.contain('Content-Disposition: form-data');
           expect(asString).to.contain('name="file"');
           expect(asString).to.contain('name="purpose"');


### PR DESCRIPTION
### Why?

File uploads to `/v1/files` broke in v22 (works in v21). When `FileResource` was
converted from `StripeResource.extend({...})` to a class-based pattern in #2619,
the `requestDataProcessor = multipartRequestDataProcessor` assignment was dropped.

Without it, file upload POST bodies go through `queryStringifyRequestData()` instead
of `multipartDataGenerator()`, producing malformed request bodies that the Stripe API
rejects with 400 "Invalid request (check your POST parameters)".

### What?

- Restored `requestDataProcessor = multipartRequestDataProcessor` on `FileResource`
- Added regression test verifying file uploads produce multipart-encoded bodies
  (a `Uint8Array` containing proper `Content-Disposition: form-data` headers)

### See Also
- Introduced in: #2619 (commit 8d8bd302)

## Changelog

- Fixed file uploads failing with `StripeInvalidRequestError` on the `/v1/files` endpoint since v22.