### PR TITLE
Add file upload integration tests against stripe-mock

### DIFF
--- a/test/resources/Integration.spec.js
+++ b/test/resources/Integration.spec.js
@@ -4,6 +4,8 @@
 
 const stripe = require('../testUtils.js').getStripeMockClient();
 const expect = require('chai').expect;
+const fs = require('fs');
+const path = require('path');
 
 describe('Customers Resource', () => {
   describe('retrieve', () => {
@@ -39,6 +41,40 @@ describe('Charges Resource', () => {
           cnt += 1;
         });
       expect(cnt).to.equal(1);
+    });
+  });
+});
+
+describe('Files Resource', () => {
+  describe('create', () => {
+    it('Uploads a file with a Buffer', async () => {
+      const file = await stripe.files.create({
+        purpose: 'dispute_evidence',
+        file: {
+          data: fs.readFileSync(
+            path.join(__dirname, 'data/minimal.pdf')
+          ),
+          name: 'minimal.pdf',
+          type: 'application/pdf',
+        },
+      });
+      expect(file).to.not.be.null;
+      expect(file.object).to.equal('file');
+    });
+
+    it('Uploads a file with a ReadStream', async () => {
+      const file = await stripe.files.create({
+        purpose: 'dispute_evidence',
+        file: {
+          data: fs.createReadStream(
+            path.join(__dirname, 'data/minimal.pdf')
+          ),
+          name: 'minimal.pdf',
+          type: 'application/pdf',
+        },
+      });
+      expect(file).to.not.be.null;
+      expect(file.object).to.equal('file');
     });
   });
 });

--- a/test/resources/Integration.spec.js
+++ b/test/resources/Integration.spec.js
@@ -51,9 +51,7 @@ describe('Files Resource', () => {
       const file = await stripe.files.create({
         purpose: 'dispute_evidence',
         file: {
-          data: fs.readFileSync(
-            path.join(__dirname, 'data/minimal.pdf')
-          ),
+          data: fs.readFileSync(path.join(__dirname, 'data/minimal.pdf')),
           name: 'minimal.pdf',
           type: 'application/pdf',
         },
@@ -66,9 +64,7 @@ describe('Files Resource', () => {
       const file = await stripe.files.create({
         purpose: 'dispute_evidence',
         file: {
-          data: fs.createReadStream(
-            path.join(__dirname, 'data/minimal.pdf')
-          ),
+          data: fs.createReadStream(path.join(__dirname, 'data/minimal.pdf')),
           name: 'minimal.pdf',
           type: 'application/pdf',
         },


### PR DESCRIPTION
### Why?

We've had multiple regressions in `/v1/files` file uploads (#2704, #2542) that weren't caught by existing unit tests because those tests use a spy that intercepts before the request hits the HTTP layer. By testing against stripe-mock end-to-end, we verify the full pipeline: multipart encoding, Content-Length calculation, and actual HTTP transmission.

### What?

- Added two integration tests to `Integration.spec.js` that call `stripe.files.create()` against stripe-mock
- Tests both `Buffer` (synchronous read) and `ReadStream` (async stream) input paths
- Verified these tests fail when simulating the regressions from #2704 (missing `requestDataProcessor`) and #2542 (wrong Content-Length for `Uint8Array`)

### See Also

- #2704 — `requestDataProcessor` dropped during class conversion
- #2542 — Content-Length wrong for `Uint8Array` after `TextEncoder` refactor
- #2485 — Content-Length wrong for unicode (different code path; already has its own test in `RequestSender.spec.ts`)
