### PR TITLE
Fix WinterTC lint issue in beta branch

### DIFF
--- a/src/StripeEventNotificationHandler.ts
+++ b/src/StripeEventNotificationHandler.ts
@@ -147,8 +147,8 @@ export class StripeEventNotificationHandler {
 
   public async handle(
     // these types are duplicated in the manual types, so they're just here for internal use
-    rawBody: string | Buffer,
-    signature: string | Buffer
+    rawBody: string | Uint8Array,
+    signature: string | Uint8Array
   ): Promise<void> {
     // we're not worried about thread safety here because we expect callbacks will be registered synchronously on app startup
     this.hasHandledEvent = true;


### PR DESCRIPTION
### Why?
https://github.com/stripe/stripe-node/pull/2715 added a lint rule to ensure we conform to the WinterTC Minimum Web Platform API standard.  The EventNotificationHandler class in the private-preview uses `Buffer` which is not allowed by these rules.

### What?
- replaced `Buffer` with `Uint8Array` in `src/StripeEventNotificationHandler.ts`

### See Also
<!-- Include any links or additional information that help explain this change. -->
