### PR TITLE
Emit warning when `stripe-notify` header is present in response

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -9,6 +9,7 @@ import {
 import {StripeContext} from './StripeContext.js';
 import {
   RequestHeaders,
+  ResponseHeaders,
   RequestEvent,
   ResponseEvent,
   RequestCallback,
@@ -96,6 +97,15 @@ export class RequestSender {
     return headers['request-id'] as string;
   }
 
+  private _emitStripeNotice(headers: ResponseHeaders): void {
+    const notice = headers['stripe-notice'];
+    if (notice) {
+      this._stripe._platformFunctions.emitWarning(
+        typeof notice === 'string' ? notice : notice[0]
+      );
+    }
+  }
+
   /**
    * Used by methods with spec.streaming === true. For these methods, we do not
    * buffer successful responses into memory or do parse them into stripe
@@ -113,6 +123,7 @@ export class RequestSender {
   ): (res: HttpClientResponseInterface) => RequestCallbackReturn {
     return (res: HttpClientResponseInterface): RequestCallbackReturn => {
       const headers = res.getHeaders();
+      this._emitStripeNotice(headers);
 
       const streamCompleteCallback = (): void => {
         const responseEvent = this._makeResponseEvent(
@@ -152,6 +163,7 @@ export class RequestSender {
   ) {
     return (res: HttpClientResponseInterface): void => {
       const headers = res.getHeaders();
+      this._emitStripeNotice(headers);
       const requestId = this._getRequestId(headers);
       const statusCode = res.getStatusCode();
 

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -1850,6 +1850,75 @@ describe('RequestSender', () => {
     });
   });
 
+  describe('Stripe-Notice header', () => {
+    it('emits a warning when stripe-notice header is present', (done) => {
+      const warnings: Array<string> = [];
+
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          res.setHeader('stripe-notice', 'test notice');
+          res.writeHead(200, {'Content-Type': 'application/json'});
+          res.write('{}');
+          res.end();
+        },
+        (err, stripe, closeServer) => {
+          if (err) {
+            return done(err);
+          }
+
+          const originalEmitWarning = stripe._platformFunctions.emitWarning.bind(
+            stripe._platformFunctions
+          );
+          stripe._platformFunctions.emitWarning = (warning: string): void => {
+            warnings.push(warning);
+            originalEmitWarning(warning);
+          };
+
+          stripe.balance
+            .retrieve()
+            .then(() => {
+              expect(warnings).to.include('test notice');
+              closeServer();
+              done();
+            })
+            .catch(done);
+        }
+      );
+    });
+
+    it('does not emit a warning when stripe-notice header is absent', (done) => {
+      const warnings: Array<string> = [];
+
+      return getTestServerStripe(
+        {},
+        (req, res) => {
+          res.writeHead(200, {'Content-Type': 'application/json'});
+          res.write('{}');
+          res.end();
+        },
+        (err, stripe, closeServer) => {
+          if (err) {
+            return done(err);
+          }
+
+          stripe._platformFunctions.emitWarning = (warning: string): void => {
+            warnings.push(warning);
+          };
+
+          stripe.balance
+            .retrieve()
+            .then(() => {
+              expect(warnings).to.be.empty;
+              closeServer();
+              done();
+            })
+            .catch(done);
+        }
+      );
+    });
+  });
+
   describe('Request Timeout', () => {
     it('should allow the setting of a request timeout on a per-request basis', (done) => {
       stripe.charges.create({});

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -1857,7 +1857,7 @@ describe('RequestSender', () => {
       return getTestServerStripe(
         {},
         (req, res) => {
-          res.setHeader('stripe-notice', 'test notice');
+          res.setHeader('Stripe-Notice', 'test notice');
           res.writeHead(200, {'Content-Type': 'application/json'});
           res.write('{}');
           res.end();


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've noticed a trend where users (and their agents) will sometimes reach for suboptimal API endpoints/methods because of outdated information. For example, using `/v1/accounts` when `/v2/core/accounts` is available and has a superset of the functionality from v1.

In an effort to help steer users towards best practices, we're introducing a new header to provide feedback during the development process. The SDK is responsible for surfacing this header, if present.

Once enabled internally, the header will be returned by the server for:

- all testmode calls
- livemode calls made by an agent

We may tweak that going forwards. But no matter the conditions, the SDKs will act as a thin pipe.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- Emit warning when we see the `Stripe-Notice` header in a response
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://go/agent-steering
- [DEVSDK-2430](https://go/j/browse/DEVSDK-2430)
