### PR TITLE
Fix parseHttpHeaderAsNumber to return undefined instead of NaN

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -306,10 +306,7 @@ export class RequestSender {
     return false;
   }
 
-  _getSleepTimeInMS(
-    numRetries: number,
-    retryAfter: number | null = null
-  ): number {
+  _getSleepTimeInMS(numRetries: number, retryAfter?: number): number {
     const initialNetworkRetryDelay = this._stripe.getInitialNetworkRetryDelay();
     const maxNetworkRetryDelay = this._stripe.getMaxNetworkRetryDelay();
 
@@ -590,7 +587,7 @@ export class RequestSender {
       apiVersion: string,
       headers: RequestHeaders,
       requestRetries: number,
-      retryAfter: number | null
+      retryAfter?: number
     ): ReturnType<typeof setTimeout> => {
       return setTimeout(
         requestFn,
@@ -705,8 +702,7 @@ export class RequestSender {
                   makeRequest,
                   apiVersion,
                   headers,
-                  requestRetries,
-                  null
+                  requestRetries
                 );
               } else {
                 const isTimeoutError =

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -459,18 +459,18 @@ export function parseHttpHeaderAsString<K extends keyof RequestHeaders>(
 
 export function parseHttpHeaderAsNumber<K extends keyof RequestHeaders>(
   header: RequestHeaders[K]
-): number | null {
+): number | undefined {
   const value = Array.isArray(header) ? header[0] : header;
   if (value == null) {
-    return null;
+    return undefined;
   }
   const trimmed = String(value).trim();
   if (trimmed === '') {
-    return null;
+    return undefined;
   }
   const parsed = Number(trimmed);
   if (!Number.isFinite(parsed)) {
-    return null;
+    return undefined;
   }
   return parsed;
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -458,7 +458,7 @@ export function parseHttpHeaderAsString<K extends keyof RequestHeaders>(
 }
 
 export function parseHttpHeaderAsNumber<K extends keyof RequestHeaders>(
-  header: RequestHeaders[K]
+  header: RequestHeaders[K] | null | undefined
 ): number | undefined {
   const value = Array.isArray(header) ? header[0] : header;
   if (value == null) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -459,9 +459,20 @@ export function parseHttpHeaderAsString<K extends keyof RequestHeaders>(
 
 export function parseHttpHeaderAsNumber<K extends keyof RequestHeaders>(
   header: RequestHeaders[K]
-): number {
-  const number = Array.isArray(header) ? header[0] : header;
-  return Number(number);
+): number | null {
+  const value = Array.isArray(header) ? header[0] : header;
+  if (value == null) {
+    return null;
+  }
+  const trimmed = String(value).trim();
+  if (trimmed === '') {
+    return null;
+  }
+  const parsed = Number(trimmed);
+  if (!Number.isFinite(parsed)) {
+    return null;
+  }
+  return parsed;
 }
 
 export function parseHeadersForFetch(

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -816,6 +816,65 @@ describe('utils', () => {
     });
   });
 
+  describe('parseHttpHeaderAsNumber', () => {
+    it('returns the number for valid integer strings', () => {
+      expect(utils.parseHttpHeaderAsNumber('30')).to.equal(30);
+      expect(utils.parseHttpHeaderAsNumber('0')).to.equal(0);
+    });
+
+    it('returns the number for valid decimal strings', () => {
+      expect(utils.parseHttpHeaderAsNumber('1.5')).to.equal(1.5);
+    });
+
+    it('returns the number for strings with surrounding whitespace', () => {
+      expect(utils.parseHttpHeaderAsNumber('  42  ')).to.equal(42);
+    });
+
+    it('returns null for undefined', () => {
+      expect(utils.parseHttpHeaderAsNumber(undefined)).to.be.null;
+    });
+
+    it('returns null for null', () => {
+      expect(utils.parseHttpHeaderAsNumber(null)).to.be.null;
+    });
+
+    it('returns null for empty string', () => {
+      expect(utils.parseHttpHeaderAsNumber('')).to.be.null;
+    });
+
+    it('returns null for whitespace-only strings', () => {
+      expect(utils.parseHttpHeaderAsNumber('   ')).to.be.null;
+    });
+
+    it('returns null for non-numeric strings', () => {
+      expect(utils.parseHttpHeaderAsNumber('bad')).to.be.null;
+    });
+
+    it('returns null for "NaN"', () => {
+      expect(utils.parseHttpHeaderAsNumber('NaN')).to.be.null;
+    });
+
+    it('returns null for "Infinity"', () => {
+      expect(utils.parseHttpHeaderAsNumber('Infinity')).to.be.null;
+    });
+
+    it('returns null for "-Infinity"', () => {
+      expect(utils.parseHttpHeaderAsNumber('-Infinity')).to.be.null;
+    });
+
+    it('takes the first element for array input', () => {
+      expect(utils.parseHttpHeaderAsNumber(['30', '60'])).to.equal(30);
+    });
+
+    it('returns null for array with non-numeric first element', () => {
+      expect(utils.parseHttpHeaderAsNumber(['bad', '30'])).to.be.null;
+    });
+
+    it('returns null for array with empty string first element', () => {
+      expect(utils.parseHttpHeaderAsNumber(['', '30'])).to.be.null;
+    });
+  });
+
   describe('concat', () => {
     it('should return a joined Uint8Array', () => {
       const arr1 = new Uint8Array([1, 2, 3]);

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -830,48 +830,48 @@ describe('utils', () => {
       expect(utils.parseHttpHeaderAsNumber('  42  ')).to.equal(42);
     });
 
-    it('returns null for undefined', () => {
-      expect(utils.parseHttpHeaderAsNumber(undefined)).to.be.null;
+    it('returns undefined for undefined', () => {
+      expect(utils.parseHttpHeaderAsNumber(undefined)).to.be.undefined;
     });
 
-    it('returns null for null', () => {
-      expect(utils.parseHttpHeaderAsNumber(null)).to.be.null;
+    it('returns undefined for null', () => {
+      expect(utils.parseHttpHeaderAsNumber(null)).to.be.undefined;
     });
 
-    it('returns null for empty string', () => {
-      expect(utils.parseHttpHeaderAsNumber('')).to.be.null;
+    it('returns undefined for empty string', () => {
+      expect(utils.parseHttpHeaderAsNumber('')).to.be.undefined;
     });
 
-    it('returns null for whitespace-only strings', () => {
-      expect(utils.parseHttpHeaderAsNumber('   ')).to.be.null;
+    it('returns undefined for whitespace-only strings', () => {
+      expect(utils.parseHttpHeaderAsNumber('   ')).to.be.undefined;
     });
 
-    it('returns null for non-numeric strings', () => {
-      expect(utils.parseHttpHeaderAsNumber('bad')).to.be.null;
+    it('returns undefined for non-numeric strings', () => {
+      expect(utils.parseHttpHeaderAsNumber('bad')).to.be.undefined;
     });
 
-    it('returns null for "NaN"', () => {
-      expect(utils.parseHttpHeaderAsNumber('NaN')).to.be.null;
+    it('returns undefined for "NaN"', () => {
+      expect(utils.parseHttpHeaderAsNumber('NaN')).to.be.undefined;
     });
 
-    it('returns null for "Infinity"', () => {
-      expect(utils.parseHttpHeaderAsNumber('Infinity')).to.be.null;
+    it('returns undefined for "Infinity"', () => {
+      expect(utils.parseHttpHeaderAsNumber('Infinity')).to.be.undefined;
     });
 
-    it('returns null for "-Infinity"', () => {
-      expect(utils.parseHttpHeaderAsNumber('-Infinity')).to.be.null;
+    it('returns undefined for "-Infinity"', () => {
+      expect(utils.parseHttpHeaderAsNumber('-Infinity')).to.be.undefined;
     });
 
     it('takes the first element for array input', () => {
       expect(utils.parseHttpHeaderAsNumber(['30', '60'])).to.equal(30);
     });
 
-    it('returns null for array with non-numeric first element', () => {
-      expect(utils.parseHttpHeaderAsNumber(['bad', '30'])).to.be.null;
+    it('returns undefined for array with non-numeric first element', () => {
+      expect(utils.parseHttpHeaderAsNumber(['bad', '30'])).to.be.undefined;
     });
 
-    it('returns null for array with empty string first element', () => {
-      expect(utils.parseHttpHeaderAsNumber(['', '30'])).to.be.null;
+    it('returns undefined for array with empty string first element', () => {
+      expect(utils.parseHttpHeaderAsNumber(['', '30'])).to.be.undefined;
     });
   });
 


### PR DESCRIPTION
### Why?

`parseHttpHeaderAsNumber` returns `NaN` for absent, undefined, empty, or non-numeric header values. The return type claims `number` but NaN silently violates that contract. Today this doesn't cause user-visible bugs because the sole callsite (`_getSleepTimeInMS`) has a `Number.isInteger` guard that accidentally rejects NaN — but the safety is coincidental, not intentional.

### What?

- `parseHttpHeaderAsNumber` now returns `number | undefined` instead of `number`
- Returns `undefined` for absent, null, empty, whitespace-only, or non-numeric inputs
- Returns a valid number only for finite numeric strings
- `retryAfter` parameter in `RequestSender` is now optional (`retryAfter?: number`) instead of `number | null`
- Added 14 unit tests covering all edge cases

### See Also

- https://github.com/stripe/stripe-node/issues/2732
- https://jira.corp.stripe.com/browse/RUN_DEVSDK-2458