### PR TITLE
Add promiseCache concurrency guard to V2ListIterator.next()

### DIFF
--- a/src/autoPagination.ts
+++ b/src/autoPagination.ts
@@ -176,6 +176,7 @@ class V2ListIterator<T> implements AsyncIterator<T> {
   private options: RequestOptions | undefined;
   private spec: MakeRequestSpec | undefined;
   private stripeResource: StripeResourceObject;
+  private promiseCache: PromiseCache;
   constructor(
     firstPagePromise: Promise<PageResult<T>>,
     options: RequestOptions | undefined,
@@ -188,6 +189,7 @@ class V2ListIterator<T> implements AsyncIterator<T> {
     this.options = options;
     this.spec = spec;
     this.stripeResource = stripeResource;
+    this.promiseCache = {currentPromise: null};
   }
   private async initFirstPage(): Promise<void> {
     if (this.firstPagePromise) {
@@ -210,7 +212,7 @@ class V2ListIterator<T> implements AsyncIterator<T> {
     this.currentPageIterator = page.data[Symbol.iterator]();
     return this.currentPageIterator;
   }
-  async next(): Promise<IteratorResult<T>> {
+  private async _next(): Promise<IteratorResult<T>> {
     await this.initFirstPage();
     if (this.currentPageIterator) {
       const result = this.currentPageIterator.next();
@@ -223,6 +225,18 @@ class V2ListIterator<T> implements AsyncIterator<T> {
     const result = nextPageIterator.next();
     if (!result.done) return {done: false, value: result.value};
     return {done: true, value: undefined};
+  }
+  next(): Promise<IteratorResult<T>> {
+    if (this.promiseCache.currentPromise) {
+      return this.promiseCache.currentPromise;
+    }
+    const nextPromise = (async (): Promise<IteratorResult<T>> => {
+      const ret = await this._next();
+      this.promiseCache.currentPromise = null;
+      return ret;
+    })();
+    this.promiseCache.currentPromise = nextPromise;
+    return nextPromise;
   }
 }
 


### PR DESCRIPTION
Port the `promiseCache` deduplication pattern from `V1Iterator` to `V2ListIterator` to prevent duplicate HTTP requests when `.next()` is called in parallel while a page transition is in flight.

## Problem

`V2ListIterator.next()` had no concurrency guard. If two pieces of code called `.next()` simultaneously while a page was in flight — which can happen inside `autoPagingEach` under certain async patterns — both calls independently reached `turnPage()`, issuing two HTTP requests for the same next page.

## Fix

This ports the exact same `promiseCache` pattern used in `V1Iterator` (lines ~111–130 of `src/autoPagination.ts`):

- Added a `promiseCache: PromiseCache` property to `V2ListIterator`
- Renamed the core logic to a private `_next()` method
- Wrapped `_next()` in a new `next()` that checks `promiseCache.currentPromise` before proceeding, coalescing parallel calls into a single in-flight promise

## Changes

- `src/autoPagination.ts`: Added `promiseCache` property, constructor init, and guarded `next()` + private `_next()` methods in `V2ListIterator`

Fixes #2730