### PR TITLE
Disable trim_trailing_whitespace for CHANGELOG.md

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -10,3 +10,6 @@ trim_trailing_whitespace = true
 
 [justfile]
 indent_size = 4
+
+[CHANGELOG.md]
+trim_trailing_whitespace = false


### PR DESCRIPTION
Prevents editors from stripping intentional trailing whitespace in changelog entries.

Fixes: https://go/j/DEVSDK-2229