### PR TITLE
Fix V2 namespace singularization

### DIFF
--- a/src/resources.ts
+++ b/src/resources.ts
@@ -493,7 +493,7 @@ export const V2 = resourceNamespace('v2', {
     ReportRuns: V2ReportingReportRuns,
     Reports: V2ReportingReports,
   }),
-  Signal: resourceNamespace('signal', {
+  Signals: resourceNamespace('signals', {
     AccountSignals: V2SignalsAccountSignals,
   }),
   Tax: resourceNamespace('tax', {ManualRules: V2TaxManualRules}),

--- a/src/resources/V2/Billing/Contracts.ts
+++ b/src/resources/V2/Billing/Contracts.ts
@@ -4,7 +4,7 @@ import {StripeResource} from '../../../StripeResource.js';
 import {V2Amount} from './../V2Amounts.js';
 import {MetadataParam, Decimal, Metadata} from '../../../shared.js';
 import {RequestOptions, V2ListPromise, Response} from '../../../lib.js';
-
+import {LicensePricingResource} from './Contracts/LicensePricing.js';
 import {Stripe} from '../../../stripe.core.js';
 export class ContractResource extends StripeResource {
   constructor(private readonly stripe: Stripe) {

--- a/src/resources/V2/Signals/index.ts
+++ b/src/resources/V2/Signals/index.ts
@@ -9,7 +9,7 @@ import {
 
 export {AccountSignal} from './AccountSignals.js';
 
-export class Signal {
+export class Signals {
   accountSignals: AccountSignalResource;
 
   constructor(private readonly stripe: Stripe) {
@@ -17,7 +17,7 @@ export class Signal {
   }
 }
 
-export declare namespace Signal {
+export declare namespace Signals {
   export import AccountSignalListParams = V2Namespace0.Signals.AccountSignalListParams;
   export import AccountSignalRetrieveParams = V2Namespace0.Signals.AccountSignalRetrieveParams;
   export {AccountSignal};

--- a/src/resources/V2/index.ts
+++ b/src/resources/V2/index.ts
@@ -15,7 +15,7 @@ import {Network} from './Network/index.js';
 import {OrchestratedCommerce} from './OrchestratedCommerce/index.js';
 import {Payments} from './Payments/index.js';
 import {Reporting} from './Reporting/index.js';
-import {Signal} from './Signal/index.js';
+import {Signals} from './Signals/index.js';
 import {Tax} from './Tax/index.js';
 import {TestHelpers} from './TestHelpers/index.js';
 
@@ -35,7 +35,7 @@ export class V2 {
   orchestratedCommerce: OrchestratedCommerce;
   payments: Payments;
   reporting: Reporting;
-  signal: Signal;
+  signals: Signals;
   tax: Tax;
   testHelpers: TestHelpers;
 
@@ -51,7 +51,7 @@ export class V2 {
     this.orchestratedCommerce = new OrchestratedCommerce(stripe);
     this.payments = new Payments(stripe);
     this.reporting = new Reporting(stripe);
-    this.signal = new Signal(stripe);
+    this.signals = new Signals(stripe);
     this.tax = new Tax(stripe);
     this.testHelpers = new TestHelpers(stripe);
   }
@@ -72,7 +72,7 @@ export declare namespace V2 {
   export {OrchestratedCommerce};
   export {Payments};
   export {Reporting};
-  export {Signal};
+  export {Signals};
   export {Tax};
   export {TestHelpers};
 }

--- a/test/resources/generated_examples_test.spec.js
+++ b/test/resources/generated_examples_test.spec.js
@@ -8261,7 +8261,7 @@ describe('Generated tests', function() {
           '{"data":[{"object":"v2.signals.account_signal","created":"1970-01-12T21:42:34.472Z","id":"obj_123","livemode":true,"type":"fraudulent_merchant"}],"next_page_url":null,"previous_page_url":null}',
       },
     ]);
-    const accountSignals = await stripe.v2.signal.accountSignals.list({
+    const accountSignals = await stripe.v2.signals.accountSignals.list({
       type: ['fraudulent_merchant'],
     });
     expect(accountSignals).not.to.be.null;
@@ -8276,7 +8276,7 @@ describe('Generated tests', function() {
           '{"object":"v2.signals.account_signal","created":"1970-01-12T21:42:34.472Z","id":"obj_123","livemode":true,"type":"fraudulent_merchant"}',
       },
     ]);
-    const accountSignal = await stripe.v2.signal.accountSignals.retrieve(
+    const accountSignal = await stripe.v2.signals.accountSignals.retrieve(
       'id_123'
     );
     expect(accountSignal).not.to.be.null;


### PR DESCRIPTION
## Changelog

(no breaking changes — `Signals` is new this week, `Payments` was already correct)

## Description

Fixes incorrect singularization of V2 namespace-promoted service names and adds missing nested service import for `LicensePricingResource`. Generated from [stripe/sdk-codegen#3663](https://github.com/stripe/sdk-codegen/pull/3663).