### PR TITLE
Add "source" field to user-agent header

### DIFF
--- a/src/platform/NodePlatformFunctions.ts
+++ b/src/platform/NodePlatformFunctions.ts
@@ -69,13 +69,17 @@ export class NodePlatformFunctions extends PlatformFunctions {
 
   /** @override */
   getSourceHash(): string | null {
-    const uname = this.getUname();
-    return uname
-      ? crypto
-          .createHash('md5')
-          .update(uname)
-          .digest('hex')
-      : null;
+    try {
+      const uname = this.getUname();
+      return uname
+        ? crypto
+            .createHash('md5')
+            .update(uname)
+            .digest('hex')
+        : null;
+    } catch {
+      return null;
+    }
   }
 
   /**

--- a/src/platform/NodePlatformFunctions.ts
+++ b/src/platform/NodePlatformFunctions.ts
@@ -1,5 +1,6 @@
 import * as crypto from 'crypto';
 import * as http from 'http';
+import * as os from 'os';
 import {CryptoProvider} from '../crypto/CryptoProvider.js';
 import {EventEmitter} from 'events';
 import {HttpClient, NodeHttpClientInterface} from '../net/HttpClient.js';
@@ -8,7 +9,6 @@ import {NodeHttpClient} from '../net/NodeHttpClient.js';
 import {PlatformFunctions} from './PlatformFunctions.js';
 import {StripeError} from '../Error.js';
 import {concat} from '../utils.js';
-import {arch, release} from 'os';
 import {MultipartRequestData, RequestData, BufferedFile} from '../Types.js';
 
 class StreamProcessingError extends StripeError {}
@@ -28,7 +28,7 @@ export class NodePlatformFunctions extends PlatformFunctions {
 
   /** @override */
   getPlatformInfo(): string {
-    return `${process.platform} ${release()} ${arch()}`;
+    return `${process.platform} ${os.release()} ${os.arch()}`;
   }
 
   /** @override */
@@ -48,6 +48,34 @@ export class NodePlatformFunctions extends PlatformFunctions {
   /** @override */
   getRuntimeVersion(): string {
     return process.version;
+  }
+
+  private getUname(): string | null {
+    try {
+      const parts = [os.type(), os.release(), os.arch()];
+      // os.version() returns detailed kernel version, available since Node 10.7.0
+      // It may not exist in older typings, so access carefully
+      const version = (os as any).version?.();
+      if (version) parts.push(version);
+      try {
+        parts.push(os.hostname());
+        // eslint-disable-next-line no-empty
+      } catch (_e) {}
+      return parts.join(' ');
+    } catch {
+      return null;
+    }
+  }
+
+  /** @override */
+  getSourceHash(): string | null {
+    const uname = this.getUname();
+    return uname
+      ? crypto
+          .createHash('md5')
+          .update(uname)
+          .digest('hex')
+      : null;
   }
 
   /**

--- a/src/platform/PlatformFunctions.ts
+++ b/src/platform/PlatformFunctions.ts
@@ -35,6 +35,10 @@ export class PlatformFunctions {
     return null;
   }
 
+  getSourceHash(): string | null {
+    return null;
+  }
+
   /**
    * Emits a warning. Node.js uses process.emitWarning; other runtimes
    * fall back to console.warn.

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -956,6 +956,7 @@ export class Stripe {
     lang: 'node',
     typescript: false,
   };
+  static SOURCE_HASH: string | null = null;
   static StripeResource = StripeResource;
   static resources = resources;
   static HttpClient = HttpClient;
@@ -1099,6 +1100,8 @@ export class Stripe {
       ...(runtimeVersion ? {lang_version: runtimeVersion} : {}),
       ...(Stripe.aiAgent ? {ai_agent: Stripe.aiAgent} : {}),
     };
+
+    Stripe.SOURCE_HASH = platformFunctions.getSourceHash();
   }
 
   constructor(key: string, config: StripeConfig = {}) {
@@ -1443,6 +1446,10 @@ export class Stripe {
 
     if (this._appInfo) {
       userAgent.application = this._appInfo;
+    }
+
+    if (Stripe.SOURCE_HASH) {
+      userAgent.source = Stripe.SOURCE_HASH;
     }
 
     cb(JSON.stringify(userAgent));

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -160,6 +160,27 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
       }
     });
 
+    describe('getSourceHash', () => {
+      if (isNodeEnvironment) {
+        it('returns a 32-character hex MD5 string', () => {
+          const hash = platformFunctions.getSourceHash();
+          expect(hash).to.be.a('string');
+          expect(hash).to.match(/^[0-9a-f]{32}$/);
+        });
+
+        it('returns null when getUname returns null', () => {
+          const orig = platformFunctions.getUname.bind(platformFunctions);
+          (platformFunctions as any).getUname = () => null;
+          expect(platformFunctions.getSourceHash()).to.be.null;
+          (platformFunctions as any).getUname = orig;
+        });
+      } else {
+        it('returns null on non-Node environments', () => {
+          expect(platformFunctions.getSourceHash()).to.be.null;
+        });
+      }
+    });
+
     describe('createEmitter', () => {
       let emitter;
       beforeEach(() => {

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -253,6 +253,37 @@ describe('Stripe Module', function() {
         })
       ).to.eventually.have.property('httplib', 'node');
     });
+
+    it('Should include source field when SOURCE_HASH is set', async () => {
+      const origSourceHash = StripeCore.SOURCE_HASH;
+      StripeCore.SOURCE_HASH = 'abc123def456abc123def456abc123de';
+
+      const userAgent: Record<string, string> = await new Promise((resolve) => {
+        stripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
+          resolve(JSON.parse(c));
+        });
+      });
+
+      StripeCore.SOURCE_HASH = origSourceHash;
+      expect(userAgent).to.have.property(
+        'source',
+        'abc123def456abc123def456abc123de'
+      );
+    });
+
+    it('Should omit source field when SOURCE_HASH is null', async () => {
+      const origSourceHash = StripeCore.SOURCE_HASH;
+      StripeCore.SOURCE_HASH = null;
+
+      const userAgent: Record<string, string> = await new Promise((resolve) => {
+        stripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
+          resolve(JSON.parse(c));
+        });
+      });
+
+      StripeCore.SOURCE_HASH = origSourceHash;
+      expect(userAgent).to.not.have.property('source');
+    });
   });
 
   describe('AI agent detection', () => {
@@ -324,11 +355,13 @@ describe('Stripe Module', function() {
     const origAIAgent = StripeCore.aiAgent;
     const origAiAgentStatic = StripeCore.AI_AGENT;
     const origUserAgent = StripeCore.USER_AGENT;
+    const origSourceHash = StripeCore.SOURCE_HASH;
 
     afterEach(() => {
       StripeCore.aiAgent = origAIAgent;
       StripeCore.AI_AGENT = origAiAgentStatic;
       StripeCore.USER_AGENT = origUserAgent;
+      StripeCore.SOURCE_HASH = origSourceHash;
       StripeCore.initialize(new NodePlatformFunctions());
     });
 
@@ -357,6 +390,32 @@ describe('Stripe Module', function() {
       expect(StripeCore.AI_AGENT).to.equal('');
       expect(StripeCore.USER_AGENT).to.not.have.property('ai_agent');
       expect(StripeCore.USER_AGENT).to.not.have.property('lang_version');
+    });
+
+    it('sets SOURCE_HASH to an MD5 hex string when getSourceHash is available', () => {
+      const mockPlatform = new NodePlatformFunctions();
+      const expectedHash = crypto
+        .createHash('md5')
+        .update('Linux hostname 5.4.0 #1 SMP x86_64 GNU/Linux')
+        .digest('hex');
+      mockPlatform.getSourceHash = () => expectedHash;
+
+      StripeCore.initialize(mockPlatform);
+
+      expect(StripeCore.SOURCE_HASH).to.be.a('string');
+      expect(StripeCore.SOURCE_HASH).to.match(/^[0-9a-f]{32}$/);
+      expect(StripeCore.SOURCE_HASH).to.equal(expectedHash);
+    });
+
+    it('sets SOURCE_HASH to null when getSourceHash returns null', () => {
+      const {
+        PlatformFunctions,
+      } = require('../src/platform/PlatformFunctions.js');
+      const basePlatform = new PlatformFunctions();
+
+      StripeCore.initialize(basePlatform);
+
+      expect(StripeCore.SOURCE_HASH).to.be.null;
     });
   });
 


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Earlier this year, we removed the output of `uname` from the user-agent header for privacy reasons. It over-collected data we usually didn't need.

Since then, our tech support team has reached out asking us to re-add some of the information to help with complex debugging tasks: sometimes they need to help users identify exactly which machine produced an API call.

Rather than just revert the previous change and reintroduce the same privacy issues that caused its removal in the first place, we're taking a more privacy-focused approach. Rather than send all the PII in plaintext, we hash it first. This way it can still be used to confirm the source of an API call if a user generates the hashes themselves, but isn't sensitive in and of itself.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `source` key to user-agent hash. It's contents are an md5 hash of `uname -a`
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [DEVSDK-3131](https://go/j/DEVSDK-3131)
