### PR TITLE
docs: clarify private preview SDK access in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ const stripeClient = new Stripe('sk_test_...', {
 
 ### Private Preview SDKs
 
-Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `18.6.0-alpha.1`. You can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-node?tab=readme-ov-file#public-preview-sdks) above and replacing the term `public-preview` with `private-preview`. Note that access to specific private preview API features may require separate approval:
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `18.6.0-alpha.1`. You can install the private preview SDKs by following the same instructions as for the [public preview SDKs](#public-preview-sdks) above and replacing the term `public-preview` with `private-preview`. Note that access to specific private preview API features may require separate approval:
 
 ```
 npm install stripe@private-preview --save-exact

--- a/README.md
+++ b/README.md
@@ -581,7 +581,7 @@ const stripeClient = new Stripe('sk_test_...', {
 
 ### Private Preview SDKs
 
-Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `18.6.0-alpha.1`. These are invite-only features. Once invited, you can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-node?tab=readme-ov-file#public-preview-sdks) above and replacing the term `public-preview` with `private-preview`:
+Stripe has features in the [private preview phase](https://docs.stripe.com/release-phases) that can be accessed via versions of this package that have the `-alpha.X` suffix like `18.6.0-alpha.1`. You can install the private preview SDKs by following the same instructions as for the [public preview SDKs](https://github.com/stripe/stripe-node?tab=readme-ov-file#public-preview-sdks) above and replacing the term `public-preview` with `private-preview`. Note that access to specific private preview API features may require separate approval:
 
 ```
 npm install stripe@private-preview --save-exact


### PR DESCRIPTION
### Why?

The private preview SDK section previously said "These are invite-only features. Once invited, you can install..." — implying users need an invitation to _install_ the SDK. In reality, anyone can install the private preview SDK versions. It's the private preview API _features_ that may require separate access approval.

This updates the README to remove the invite-only framing and clarify that SDK installation is open to anyone, while noting that access to specific private preview API features may require separate approval.

### What?

- README: remove "invite-only" language from Private Preview SDKs section; rewrite to clarify anyone can install and only specific API features may require approval

### See Also

<!-- Include any links or additional information that help explain this change. -->