### PR TITLE
URI Encode path params

### DIFF
--- a/src/resources/Accounts.ts
+++ b/src/resources/Accounts.ts
@@ -36,7 +36,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<DeletedAccount>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/accounts/${id}`,
+      `/v1/accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -82,7 +82,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${id}`,
+      `/v1/accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -133,7 +133,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${id}/reject`,
+      `/v1/accounts/${encodeURIComponent(id)}/reject`,
       params,
       options
     ) as any;
@@ -148,7 +148,7 @@ export class AccountResource extends StripeResource {
   ): ApiListPromise<Capability> {
     return this._makeRequest(
       'GET',
-      `/v1/accounts/${id}/capabilities`,
+      `/v1/accounts/${encodeURIComponent(id)}/capabilities`,
       params,
       options,
       {
@@ -167,7 +167,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Capability>> {
     return this._makeRequest(
       'GET',
-      `/v1/accounts/${accountId}/capabilities/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/capabilities/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -183,7 +185,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Capability>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${accountId}/capabilities/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/capabilities/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -199,7 +203,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<DeletedExternalAccount>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/accounts/${accountId}/external_accounts/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/external_accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -215,7 +221,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<ExternalAccount>> {
     return this._makeRequest(
       'GET',
-      `/v1/accounts/${accountId}/external_accounts/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/external_accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -238,7 +246,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<ExternalAccount>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${accountId}/external_accounts/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/external_accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -253,7 +263,7 @@ export class AccountResource extends StripeResource {
   ): ApiListPromise<ExternalAccount> {
     return this._makeRequest(
       'GET',
-      `/v1/accounts/${id}/external_accounts`,
+      `/v1/accounts/${encodeURIComponent(id)}/external_accounts`,
       params,
       options,
       {
@@ -271,7 +281,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<ExternalAccount>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${id}/external_accounts`,
+      `/v1/accounts/${encodeURIComponent(id)}/external_accounts`,
       params,
       options
     ) as any;
@@ -288,7 +298,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<LoginLink>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${id}/login_links`,
+      `/v1/accounts/${encodeURIComponent(id)}/login_links`,
       params,
       options
     ) as any;
@@ -304,7 +314,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<DeletedPerson>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/accounts/${accountId}/persons/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/persons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -320,7 +332,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Person>> {
     return this._makeRequest(
       'GET',
-      `/v1/accounts/${accountId}/persons/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/persons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -336,7 +350,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Person>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${accountId}/persons/${id}`,
+      `/v1/accounts/${encodeURIComponent(
+        accountId
+      )}/persons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -351,7 +367,7 @@ export class AccountResource extends StripeResource {
   ): ApiListPromise<Person> {
     return this._makeRequest(
       'GET',
-      `/v1/accounts/${id}/persons`,
+      `/v1/accounts/${encodeURIComponent(id)}/persons`,
       params,
       options,
       {
@@ -369,7 +385,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Person>> {
     return this._makeRequest(
       'POST',
-      `/v1/accounts/${id}/persons`,
+      `/v1/accounts/${encodeURIComponent(id)}/persons`,
       params,
       options
     ) as any;

--- a/src/resources/ApplePayDomains.ts
+++ b/src/resources/ApplePayDomains.ts
@@ -15,7 +15,7 @@ export class ApplePayDomainResource extends StripeResource {
   ): Promise<Response<DeletedApplePayDomain>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/apple_pay/domains/${id}`,
+      `/v1/apple_pay/domains/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -30,7 +30,7 @@ export class ApplePayDomainResource extends StripeResource {
   ): Promise<Response<ApplePayDomain>> {
     return this._makeRequest(
       'GET',
-      `/v1/apple_pay/domains/${id}`,
+      `/v1/apple_pay/domains/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/ApplicationFees.ts
+++ b/src/resources/ApplicationFees.ts
@@ -36,7 +36,7 @@ export class ApplicationFeeResource extends StripeResource {
   ): Promise<Response<ApplicationFee>> {
     return this._makeRequest(
       'GET',
-      `/v1/application_fees/${id}`,
+      `/v1/application_fees/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -52,7 +52,9 @@ export class ApplicationFeeResource extends StripeResource {
   ): Promise<Response<FeeRefund>> {
     return this._makeRequest(
       'GET',
-      `/v1/application_fees/${feeId}/refunds/${id}`,
+      `/v1/application_fees/${encodeURIComponent(
+        feeId
+      )}/refunds/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -70,7 +72,9 @@ export class ApplicationFeeResource extends StripeResource {
   ): Promise<Response<FeeRefund>> {
     return this._makeRequest(
       'POST',
-      `/v1/application_fees/${feeId}/refunds/${id}`,
+      `/v1/application_fees/${encodeURIComponent(
+        feeId
+      )}/refunds/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -85,7 +89,7 @@ export class ApplicationFeeResource extends StripeResource {
   ): ApiListPromise<FeeRefund> {
     return this._makeRequest(
       'GET',
-      `/v1/application_fees/${id}/refunds`,
+      `/v1/application_fees/${encodeURIComponent(id)}/refunds`,
       params,
       options,
       {
@@ -111,7 +115,7 @@ export class ApplicationFeeResource extends StripeResource {
   ): Promise<Response<FeeRefund>> {
     return this._makeRequest(
       'POST',
-      `/v1/application_fees/${id}/refunds`,
+      `/v1/application_fees/${encodeURIComponent(id)}/refunds`,
       params,
       options
     ) as any;

--- a/src/resources/BalanceTransactions.ts
+++ b/src/resources/BalanceTransactions.ts
@@ -37,7 +37,7 @@ export class BalanceTransactionResource extends StripeResource {
   ): Promise<Response<BalanceTransaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/balance_transactions/${id}`,
+      `/v1/balance_transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Billing/Alerts.ts
+++ b/src/resources/Billing/Alerts.ts
@@ -42,7 +42,7 @@ export class AlertResource extends StripeResource {
   ): Promise<Response<Alert>> {
     return this._makeRequest(
       'GET',
-      `/v1/billing/alerts/${id}`,
+      `/v1/billing/alerts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -57,7 +57,7 @@ export class AlertResource extends StripeResource {
   ): Promise<Response<Alert>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/alerts/${id}/activate`,
+      `/v1/billing/alerts/${encodeURIComponent(id)}/activate`,
       params,
       options
     ) as any;
@@ -72,7 +72,7 @@ export class AlertResource extends StripeResource {
   ): Promise<Response<Alert>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/alerts/${id}/archive`,
+      `/v1/billing/alerts/${encodeURIComponent(id)}/archive`,
       params,
       options
     ) as any;
@@ -87,7 +87,7 @@ export class AlertResource extends StripeResource {
   ): Promise<Response<Alert>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/alerts/${id}/deactivate`,
+      `/v1/billing/alerts/${encodeURIComponent(id)}/deactivate`,
       params,
       options
     ) as any;

--- a/src/resources/Billing/CreditBalanceTransactions.ts
+++ b/src/resources/Billing/CreditBalanceTransactions.ts
@@ -35,7 +35,7 @@ export class CreditBalanceTransactionResource extends StripeResource {
   ): Promise<Response<CreditBalanceTransaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/billing/credit_balance_transactions/${id}`,
+      `/v1/billing/credit_balance_transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Billing/CreditGrants.ts
+++ b/src/resources/Billing/CreditGrants.ts
@@ -53,7 +53,7 @@ export class CreditGrantResource extends StripeResource {
   ): Promise<Response<CreditGrant>> {
     return this._makeRequest(
       'GET',
-      `/v1/billing/credit_grants/${id}`,
+      `/v1/billing/credit_grants/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -68,7 +68,7 @@ export class CreditGrantResource extends StripeResource {
   ): Promise<Response<CreditGrant>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/credit_grants/${id}`,
+      `/v1/billing/credit_grants/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -83,7 +83,7 @@ export class CreditGrantResource extends StripeResource {
   ): Promise<Response<CreditGrant>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/credit_grants/${id}/expire`,
+      `/v1/billing/credit_grants/${encodeURIComponent(id)}/expire`,
       params,
       options
     ) as any;
@@ -98,7 +98,7 @@ export class CreditGrantResource extends StripeResource {
   ): Promise<Response<CreditGrant>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/credit_grants/${id}/void`,
+      `/v1/billing/credit_grants/${encodeURIComponent(id)}/void`,
       params,
       options
     ) as any;

--- a/src/resources/Billing/Meters.ts
+++ b/src/resources/Billing/Meters.ts
@@ -41,7 +41,7 @@ export class MeterResource extends StripeResource {
   ): Promise<Response<Meter>> {
     return this._makeRequest(
       'GET',
-      `/v1/billing/meters/${id}`,
+      `/v1/billing/meters/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -56,7 +56,7 @@ export class MeterResource extends StripeResource {
   ): Promise<Response<Meter>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/meters/${id}`,
+      `/v1/billing/meters/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -71,7 +71,7 @@ export class MeterResource extends StripeResource {
   ): Promise<Response<Meter>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/meters/${id}/deactivate`,
+      `/v1/billing/meters/${encodeURIComponent(id)}/deactivate`,
       params,
       options
     ) as any;
@@ -86,7 +86,7 @@ export class MeterResource extends StripeResource {
   ): Promise<Response<Meter>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing/meters/${id}/reactivate`,
+      `/v1/billing/meters/${encodeURIComponent(id)}/reactivate`,
       params,
       options
     ) as any;
@@ -101,7 +101,7 @@ export class MeterResource extends StripeResource {
   ): ApiListPromise<MeterEventSummary> {
     return this._makeRequest(
       'GET',
-      `/v1/billing/meters/${id}/event_summaries`,
+      `/v1/billing/meters/${encodeURIComponent(id)}/event_summaries`,
       params,
       options,
       {

--- a/src/resources/BillingPortal/Configurations.ts
+++ b/src/resources/BillingPortal/Configurations.ts
@@ -52,7 +52,7 @@ export class ConfigurationResource extends StripeResource {
   ): Promise<Response<Configuration>> {
     return this._makeRequest(
       'GET',
-      `/v1/billing_portal/configurations/${id}`,
+      `/v1/billing_portal/configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -67,7 +67,7 @@ export class ConfigurationResource extends StripeResource {
   ): Promise<Response<Configuration>> {
     return this._makeRequest(
       'POST',
-      `/v1/billing_portal/configurations/${id}`,
+      `/v1/billing_portal/configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Charges.ts
+++ b/src/resources/Charges.ts
@@ -63,7 +63,7 @@ export class ChargeResource extends StripeResource {
   ): Promise<Response<Charge>> {
     return this._makeRequest(
       'GET',
-      `/v1/charges/${id}`,
+      `/v1/charges/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -78,7 +78,7 @@ export class ChargeResource extends StripeResource {
   ): Promise<Response<Charge>> {
     return this._makeRequest(
       'POST',
-      `/v1/charges/${id}`,
+      `/v1/charges/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -111,7 +111,7 @@ export class ChargeResource extends StripeResource {
   ): Promise<Response<Charge>> {
     return this._makeRequest(
       'POST',
-      `/v1/charges/${id}/capture`,
+      `/v1/charges/${encodeURIComponent(id)}/capture`,
       params,
       options
     ) as any;

--- a/src/resources/Checkout/Sessions.ts
+++ b/src/resources/Checkout/Sessions.ts
@@ -246,7 +246,7 @@ export class SessionResource extends StripeResource {
   ): Promise<Response<Session>> {
     return this._makeRequest(
       'GET',
-      `/v1/checkout/sessions/${id}`,
+      `/v1/checkout/sessions/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -346,7 +346,7 @@ export class SessionResource extends StripeResource {
   ): Promise<Response<Session>> {
     return this._makeRequest(
       'POST',
-      `/v1/checkout/sessions/${id}`,
+      `/v1/checkout/sessions/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -463,7 +463,7 @@ export class SessionResource extends StripeResource {
   ): Promise<Response<Session>> {
     return this._makeRequest(
       'POST',
-      `/v1/checkout/sessions/${id}/expire`,
+      `/v1/checkout/sessions/${encodeURIComponent(id)}/expire`,
       params,
       options,
       {
@@ -561,7 +561,7 @@ export class SessionResource extends StripeResource {
   ): ApiListPromise<LineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/checkout/sessions/${id}/line_items`,
+      `/v1/checkout/sessions/${encodeURIComponent(id)}/line_items`,
       params,
       options,
       {

--- a/src/resources/Climate/Orders.ts
+++ b/src/resources/Climate/Orders.ts
@@ -66,7 +66,7 @@ export class OrderResource extends StripeResource {
   ): Promise<Response<Order>> {
     return this._makeRequest(
       'GET',
-      `/v1/climate/orders/${id}`,
+      `/v1/climate/orders/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -87,7 +87,7 @@ export class OrderResource extends StripeResource {
   ): Promise<Response<Order>> {
     return this._makeRequest(
       'POST',
-      `/v1/climate/orders/${id}`,
+      `/v1/climate/orders/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -111,7 +111,7 @@ export class OrderResource extends StripeResource {
   ): Promise<Response<Order>> {
     return this._makeRequest(
       'POST',
-      `/v1/climate/orders/${id}/cancel`,
+      `/v1/climate/orders/${encodeURIComponent(id)}/cancel`,
       params,
       options,
       {

--- a/src/resources/Climate/Products.ts
+++ b/src/resources/Climate/Products.ts
@@ -39,7 +39,7 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<Product>> {
     return this._makeRequest(
       'GET',
-      `/v1/climate/products/${id}`,
+      `/v1/climate/products/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/Climate/Suppliers.ts
+++ b/src/resources/Climate/Suppliers.ts
@@ -26,7 +26,7 @@ export class SupplierResource extends StripeResource {
   ): Promise<Response<Supplier>> {
     return this._makeRequest(
       'GET',
-      `/v1/climate/suppliers/${id}`,
+      `/v1/climate/suppliers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/ConfirmationTokens.ts
+++ b/src/resources/ConfirmationTokens.ts
@@ -18,7 +18,7 @@ export class ConfirmationTokenResource extends StripeResource {
   ): Promise<Response<ConfirmationToken>> {
     return this._makeRequest(
       'GET',
-      `/v1/confirmation_tokens/${id}`,
+      `/v1/confirmation_tokens/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/CountrySpecs.ts
+++ b/src/resources/CountrySpecs.ts
@@ -26,7 +26,7 @@ export class CountrySpecResource extends StripeResource {
   ): Promise<Response<CountrySpec>> {
     return this._makeRequest(
       'GET',
-      `/v1/country_specs/${id}`,
+      `/v1/country_specs/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Coupons.ts
+++ b/src/resources/Coupons.ts
@@ -21,7 +21,7 @@ export class CouponResource extends StripeResource {
   ): Promise<Response<DeletedCoupon>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/coupons/${id}`,
+      `/v1/coupons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -36,7 +36,7 @@ export class CouponResource extends StripeResource {
   ): Promise<Response<Coupon>> {
     return this._makeRequest(
       'GET',
-      `/v1/coupons/${id}`,
+      `/v1/coupons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -51,7 +51,7 @@ export class CouponResource extends StripeResource {
   ): Promise<Response<Coupon>> {
     return this._makeRequest(
       'POST',
-      `/v1/coupons/${id}`,
+      `/v1/coupons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/CreditNotes.ts
+++ b/src/resources/CreditNotes.ts
@@ -126,21 +126,27 @@ export class CreditNoteResource extends StripeResource {
     params?: CreditNoteRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<CreditNote>> {
-    return this._makeRequest('GET', `/v1/credit_notes/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          lines: {
-            kind: 'object',
-            fields: {
-              data: {
-                kind: 'array',
-                element: {
-                  kind: 'object',
-                  fields: {
-                    unit_amount_decimal: {
-                      kind: 'nullable',
-                      inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'GET',
+      `/v1/credit_notes/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            lines: {
+              kind: 'object',
+              fields: {
+                data: {
+                  kind: 'array',
+                  element: {
+                    kind: 'object',
+                    fields: {
+                      unit_amount_decimal: {
+                        kind: 'nullable',
+                        inner: {kind: 'decimal_string'},
+                      },
                     },
                   },
                 },
@@ -148,8 +154,8 @@ export class CreditNoteResource extends StripeResource {
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Updates an existing credit note.
@@ -161,7 +167,7 @@ export class CreditNoteResource extends StripeResource {
   ): Promise<Response<CreditNote>> {
     return this._makeRequest(
       'POST',
-      `/v1/credit_notes/${id}`,
+      `/v1/credit_notes/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -250,7 +256,7 @@ export class CreditNoteResource extends StripeResource {
   ): Promise<Response<CreditNote>> {
     return this._makeRequest(
       'POST',
-      `/v1/credit_notes/${id}/void`,
+      `/v1/credit_notes/${encodeURIComponent(id)}/void`,
       params,
       options,
       {
@@ -335,7 +341,7 @@ export class CreditNoteResource extends StripeResource {
   ): ApiListPromise<CreditNoteLineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/credit_notes/${id}/lines`,
+      `/v1/credit_notes/${encodeURIComponent(id)}/lines`,
       params,
       options,
       {

--- a/src/resources/Customers.ts
+++ b/src/resources/Customers.ts
@@ -40,7 +40,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<DeletedCustomer>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/customers/${id}`,
+      `/v1/customers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -55,7 +55,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<Customer | DeletedCustomer>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}`,
+      `/v1/customers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -70,101 +70,111 @@ export class CustomerResource extends StripeResource {
     params?: CustomerUpdateParams,
     options?: RequestOptions
   ): Promise<Response<Customer>> {
-    return this._makeRequest('POST', `/v1/customers/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          subscriptions: {
-            kind: 'object',
-            fields: {
-              data: {
-                kind: 'array',
-                element: {
-                  kind: 'object',
-                  fields: {
-                    items: {
-                      kind: 'object',
-                      fields: {
-                        data: {
-                          kind: 'array',
-                          element: {
-                            kind: 'object',
-                            fields: {
-                              plan: {
-                                kind: 'object',
-                                fields: {
-                                  amount_decimal: {
-                                    kind: 'nullable',
-                                    inner: {kind: 'decimal_string'},
-                                  },
-                                  tiers: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        flat_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'POST',
+      `/v1/customers/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            subscriptions: {
+              kind: 'object',
+              fields: {
+                data: {
+                  kind: 'array',
+                  element: {
+                    kind: 'object',
+                    fields: {
+                      items: {
+                        kind: 'object',
+                        fields: {
+                          data: {
+                            kind: 'array',
+                            element: {
+                              kind: 'object',
+                              fields: {
+                                plan: {
+                                  kind: 'object',
+                                  fields: {
+                                    amount_decimal: {
+                                      kind: 'nullable',
+                                      inner: {kind: 'decimal_string'},
+                                    },
+                                    tiers: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          flat_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
                                         },
                                       },
                                     },
                                   },
                                 },
-                              },
-                              price: {
-                                kind: 'object',
-                                fields: {
-                                  currency_options: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        tiers: {
-                                          kind: 'array',
-                                          element: {
-                                            kind: 'object',
-                                            fields: {
-                                              flat_amount_decimal: {
-                                                kind: 'nullable',
-                                                inner: {kind: 'decimal_string'},
-                                              },
-                                              unit_amount_decimal: {
-                                                kind: 'nullable',
-                                                inner: {kind: 'decimal_string'},
+                                price: {
+                                  kind: 'object',
+                                  fields: {
+                                    currency_options: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          tiers: {
+                                            kind: 'array',
+                                            element: {
+                                              kind: 'object',
+                                              fields: {
+                                                flat_amount_decimal: {
+                                                  kind: 'nullable',
+                                                  inner: {
+                                                    kind: 'decimal_string',
+                                                  },
+                                                },
+                                                unit_amount_decimal: {
+                                                  kind: 'nullable',
+                                                  inner: {
+                                                    kind: 'decimal_string',
+                                                  },
+                                                },
                                               },
                                             },
                                           },
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                      },
-                                    },
-                                  },
-                                  tiers: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        flat_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
                                         },
                                       },
                                     },
-                                  },
-                                  unit_amount_decimal: {
-                                    kind: 'nullable',
-                                    inner: {kind: 'decimal_string'},
+                                    tiers: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          flat_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                        },
+                                      },
+                                    },
+                                    unit_amount_decimal: {
+                                      kind: 'nullable',
+                                      inner: {kind: 'decimal_string'},
+                                    },
                                   },
                                 },
                               },
@@ -179,8 +189,8 @@ export class CustomerResource extends StripeResource {
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Removes the currently applied discount on a customer.
@@ -192,7 +202,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<DeletedDiscount>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/customers/${id}/discount`,
+      `/v1/customers/${encodeURIComponent(id)}/discount`,
       params,
       options
     ) as any;
@@ -593,7 +603,7 @@ export class CustomerResource extends StripeResource {
   ): ApiListPromise<CustomerBalanceTransaction> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}/balance_transactions`,
+      `/v1/customers/${encodeURIComponent(id)}/balance_transactions`,
       params,
       options,
       {
@@ -611,7 +621,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerBalanceTransaction>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${id}/balance_transactions`,
+      `/v1/customers/${encodeURIComponent(id)}/balance_transactions`,
       params,
       options
     ) as any;
@@ -627,7 +637,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerBalanceTransaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${customerId}/balance_transactions/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/balance_transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -643,7 +655,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerBalanceTransaction>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${customerId}/balance_transactions/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/balance_transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -658,7 +672,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CashBalance>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}/cash_balance`,
+      `/v1/customers/${encodeURIComponent(id)}/cash_balance`,
       params,
       options
     ) as any;
@@ -673,7 +687,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CashBalance>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${id}/cash_balance`,
+      `/v1/customers/${encodeURIComponent(id)}/cash_balance`,
       params,
       options
     ) as any;
@@ -688,7 +702,7 @@ export class CustomerResource extends StripeResource {
   ): ApiListPromise<CustomerCashBalanceTransaction> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}/cash_balance_transactions`,
+      `/v1/customers/${encodeURIComponent(id)}/cash_balance_transactions`,
       params,
       options,
       {
@@ -707,7 +721,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerCashBalanceTransaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${customerId}/cash_balance_transactions/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/cash_balance_transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -724,7 +740,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<FundingInstructions>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${id}/funding_instructions`,
+      `/v1/customers/${encodeURIComponent(id)}/funding_instructions`,
       params,
       options
     ) as any;
@@ -739,7 +755,7 @@ export class CustomerResource extends StripeResource {
   ): ApiListPromise<PaymentMethod> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}/payment_methods`,
+      `/v1/customers/${encodeURIComponent(id)}/payment_methods`,
       params,
       options,
       {
@@ -758,7 +774,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<PaymentMethod>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${customerId}/payment_methods/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/payment_methods/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -773,7 +791,7 @@ export class CustomerResource extends StripeResource {
   ): ApiListPromise<CustomerSource> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}/sources`,
+      `/v1/customers/${encodeURIComponent(id)}/sources`,
       params,
       options,
       {
@@ -795,7 +813,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerSource>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${id}/sources`,
+      `/v1/customers/${encodeURIComponent(id)}/sources`,
       params,
       options
     ) as any;
@@ -811,7 +829,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerSource>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${customerId}/sources/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/sources/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -827,7 +847,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerSource>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${customerId}/sources/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/sources/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -843,7 +865,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerSource | DeletedCustomerSource>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/customers/${customerId}/sources/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/sources/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -859,7 +883,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<BankAccount>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${customerId}/sources/${id}/verify`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/sources/${encodeURIComponent(id)}/verify`,
       params,
       options
     ) as any;
@@ -875,7 +901,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<DeletedTaxId>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/customers/${customerId}/tax_ids/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/tax_ids/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -891,7 +919,9 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<TaxId>> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${customerId}/tax_ids/${id}`,
+      `/v1/customers/${encodeURIComponent(
+        customerId
+      )}/tax_ids/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -906,7 +936,7 @@ export class CustomerResource extends StripeResource {
   ): ApiListPromise<TaxId> {
     return this._makeRequest(
       'GET',
-      `/v1/customers/${id}/tax_ids`,
+      `/v1/customers/${encodeURIComponent(id)}/tax_ids`,
       params,
       options,
       {
@@ -924,7 +954,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<TaxId>> {
     return this._makeRequest(
       'POST',
-      `/v1/customers/${id}/tax_ids`,
+      `/v1/customers/${encodeURIComponent(id)}/tax_ids`,
       params,
       options
     ) as any;

--- a/src/resources/Disputes.ts
+++ b/src/resources/Disputes.ts
@@ -38,7 +38,7 @@ export class DisputeResource extends StripeResource {
   ): Promise<Response<Dispute>> {
     return this._makeRequest(
       'GET',
-      `/v1/disputes/${id}`,
+      `/v1/disputes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -55,7 +55,7 @@ export class DisputeResource extends StripeResource {
   ): Promise<Response<Dispute>> {
     return this._makeRequest(
       'POST',
-      `/v1/disputes/${id}`,
+      `/v1/disputes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -72,7 +72,7 @@ export class DisputeResource extends StripeResource {
   ): Promise<Response<Dispute>> {
     return this._makeRequest(
       'POST',
-      `/v1/disputes/${id}/close`,
+      `/v1/disputes/${encodeURIComponent(id)}/close`,
       params,
       options
     ) as any;

--- a/src/resources/Entitlements/ActiveEntitlements.ts
+++ b/src/resources/Entitlements/ActiveEntitlements.ts
@@ -33,7 +33,7 @@ export class ActiveEntitlementResource extends StripeResource {
   ): Promise<Response<ActiveEntitlement>> {
     return this._makeRequest(
       'GET',
-      `/v1/entitlements/active_entitlements/${id}`,
+      `/v1/entitlements/active_entitlements/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Entitlements/Features.ts
+++ b/src/resources/Entitlements/Features.ts
@@ -51,7 +51,7 @@ export class FeatureResource extends StripeResource {
   ): Promise<Response<Feature>> {
     return this._makeRequest(
       'GET',
-      `/v1/entitlements/features/${id}`,
+      `/v1/entitlements/features/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -66,7 +66,7 @@ export class FeatureResource extends StripeResource {
   ): Promise<Response<Feature>> {
     return this._makeRequest(
       'POST',
-      `/v1/entitlements/features/${id}`,
+      `/v1/entitlements/features/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/EphemeralKeys.ts
+++ b/src/resources/EphemeralKeys.ts
@@ -14,7 +14,7 @@ export class EphemeralKeyResource extends StripeResource {
   ): Promise<Response<EphemeralKey>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/ephemeral_keys/${id}`,
+      `/v1/ephemeral_keys/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Events.ts
+++ b/src/resources/Events.ts
@@ -24,7 +24,12 @@ export class EventResource extends StripeResource {
     params?: EventRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Event>> {
-    return this._makeRequest('GET', `/v1/events/${id}`, params, options) as any;
+    return this._makeRequest(
+      'GET',
+      `/v1/events/${encodeURIComponent(id)}`,
+      params,
+      options
+    ) as any;
   }
 }
 export interface EventBase {

--- a/src/resources/ExchangeRates.ts
+++ b/src/resources/ExchangeRates.ts
@@ -32,7 +32,7 @@ export class ExchangeRateResource extends StripeResource {
   ): Promise<Response<ExchangeRate>> {
     return this._makeRequest(
       'GET',
-      `/v1/exchange_rates/${id}`,
+      `/v1/exchange_rates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/FileLinks.ts
+++ b/src/resources/FileLinks.ts
@@ -42,7 +42,7 @@ export class FileLinkResource extends StripeResource {
   ): Promise<Response<FileLink>> {
     return this._makeRequest(
       'GET',
-      `/v1/file_links/${id}`,
+      `/v1/file_links/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -57,7 +57,7 @@ export class FileLinkResource extends StripeResource {
   ): Promise<Response<FileLink>> {
     return this._makeRequest(
       'POST',
-      `/v1/file_links/${id}`,
+      `/v1/file_links/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Files.ts
+++ b/src/resources/Files.ts
@@ -54,7 +54,12 @@ export class FileResource extends StripeResource {
     params?: FileRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<File>> {
-    return this._makeRequest('GET', `/v1/files/${id}`, params, options) as any;
+    return this._makeRequest(
+      'GET',
+      `/v1/files/${encodeURIComponent(id)}`,
+      params,
+      options
+    ) as any;
   }
 }
 export interface File {

--- a/src/resources/FinancialConnections/Accounts.ts
+++ b/src/resources/FinancialConnections/Accounts.ts
@@ -35,7 +35,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'GET',
-      `/v1/financial_connections/accounts/${id}`,
+      `/v1/financial_connections/accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -50,7 +50,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v1/financial_connections/accounts/${id}/disconnect`,
+      `/v1/financial_connections/accounts/${encodeURIComponent(id)}/disconnect`,
       params,
       options
     ) as any;
@@ -65,7 +65,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v1/financial_connections/accounts/${id}/refresh`,
+      `/v1/financial_connections/accounts/${encodeURIComponent(id)}/refresh`,
       params,
       options
     ) as any;
@@ -80,7 +80,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v1/financial_connections/accounts/${id}/subscribe`,
+      `/v1/financial_connections/accounts/${encodeURIComponent(id)}/subscribe`,
       params,
       options
     ) as any;
@@ -95,7 +95,9 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v1/financial_connections/accounts/${id}/unsubscribe`,
+      `/v1/financial_connections/accounts/${encodeURIComponent(
+        id
+      )}/unsubscribe`,
       params,
       options
     ) as any;
@@ -110,7 +112,7 @@ export class AccountResource extends StripeResource {
   ): ApiListPromise<AccountOwner> {
     return this._makeRequest(
       'GET',
-      `/v1/financial_connections/accounts/${id}/owners`,
+      `/v1/financial_connections/accounts/${encodeURIComponent(id)}/owners`,
       params,
       options,
       {

--- a/src/resources/FinancialConnections/Sessions.ts
+++ b/src/resources/FinancialConnections/Sessions.ts
@@ -16,7 +16,7 @@ export class SessionResource extends StripeResource {
   ): Promise<Response<Session>> {
     return this._makeRequest(
       'GET',
-      `/v1/financial_connections/sessions/${id}`,
+      `/v1/financial_connections/sessions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/FinancialConnections/Transactions.ts
+++ b/src/resources/FinancialConnections/Transactions.ts
@@ -32,7 +32,7 @@ export class TransactionResource extends StripeResource {
   ): Promise<Response<Transaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/financial_connections/transactions/${id}`,
+      `/v1/financial_connections/transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Forwarding/Requests.ts
+++ b/src/resources/Forwarding/Requests.ts
@@ -51,7 +51,7 @@ export class RequestResource extends StripeResource {
   ): Promise<Response<Request>> {
     return this._makeRequest(
       'GET',
-      `/v1/forwarding/requests/${id}`,
+      `/v1/forwarding/requests/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Identity/VerificationReports.ts
+++ b/src/resources/Identity/VerificationReports.ts
@@ -32,7 +32,7 @@ export class VerificationReportResource extends StripeResource {
   ): Promise<Response<VerificationReport>> {
     return this._makeRequest(
       'GET',
-      `/v1/identity/verification_reports/${id}`,
+      `/v1/identity/verification_reports/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Identity/VerificationSessions.ts
+++ b/src/resources/Identity/VerificationSessions.ts
@@ -63,7 +63,7 @@ export class VerificationSessionResource extends StripeResource {
   ): Promise<Response<VerificationSession>> {
     return this._makeRequest(
       'GET',
-      `/v1/identity/verification_sessions/${id}`,
+      `/v1/identity/verification_sessions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -81,7 +81,7 @@ export class VerificationSessionResource extends StripeResource {
   ): Promise<Response<VerificationSession>> {
     return this._makeRequest(
       'POST',
-      `/v1/identity/verification_sessions/${id}`,
+      `/v1/identity/verification_sessions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -98,7 +98,7 @@ export class VerificationSessionResource extends StripeResource {
   ): Promise<Response<VerificationSession>> {
     return this._makeRequest(
       'POST',
-      `/v1/identity/verification_sessions/${id}/cancel`,
+      `/v1/identity/verification_sessions/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;
@@ -131,7 +131,7 @@ export class VerificationSessionResource extends StripeResource {
   ): Promise<Response<VerificationSession>> {
     return this._makeRequest(
       'POST',
-      `/v1/identity/verification_sessions/${id}/redact`,
+      `/v1/identity/verification_sessions/${encodeURIComponent(id)}/redact`,
       params,
       options
     ) as any;

--- a/src/resources/InvoiceItems.ts
+++ b/src/resources/InvoiceItems.ts
@@ -28,7 +28,7 @@ export class InvoiceItemResource extends StripeResource {
   ): Promise<Response<DeletedInvoiceItem>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/invoiceitems/${id}`,
+      `/v1/invoiceitems/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -41,26 +41,32 @@ export class InvoiceItemResource extends StripeResource {
     params?: InvoiceItemRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<InvoiceItem>> {
-    return this._makeRequest('GET', `/v1/invoiceitems/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          pricing: {
-            kind: 'nullable',
-            inner: {
-              kind: 'object',
-              fields: {
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'GET',
+      `/v1/invoiceitems/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            pricing: {
+              kind: 'nullable',
+              inner: {
+                kind: 'object',
+                fields: {
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
                 },
               },
             },
+            quantity_decimal: {kind: 'decimal_string'},
           },
-          quantity_decimal: {kind: 'decimal_string'},
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Updates the amount or description of an invoice item on an upcoming invoice. Updating an invoice item is only possible before the invoice it's attached to is closed.
@@ -72,7 +78,7 @@ export class InvoiceItemResource extends StripeResource {
   ): Promise<Response<InvoiceItem>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoiceitems/${id}`,
+      `/v1/invoiceitems/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/InvoicePayments.ts
+++ b/src/resources/InvoicePayments.ts
@@ -30,7 +30,7 @@ export class InvoicePaymentResource extends StripeResource {
   ): Promise<Response<InvoicePayment>> {
     return this._makeRequest(
       'GET',
-      `/v1/invoice_payments/${id}`,
+      `/v1/invoice_payments/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/InvoiceRenderingTemplates.ts
+++ b/src/resources/InvoiceRenderingTemplates.ts
@@ -32,7 +32,7 @@ export class InvoiceRenderingTemplateResource extends StripeResource {
   ): Promise<Response<InvoiceRenderingTemplate>> {
     return this._makeRequest(
       'GET',
-      `/v1/invoice_rendering_templates/${id}`,
+      `/v1/invoice_rendering_templates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -47,7 +47,7 @@ export class InvoiceRenderingTemplateResource extends StripeResource {
   ): Promise<Response<InvoiceRenderingTemplate>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoice_rendering_templates/${id}/archive`,
+      `/v1/invoice_rendering_templates/${encodeURIComponent(id)}/archive`,
       params,
       options
     ) as any;
@@ -62,7 +62,7 @@ export class InvoiceRenderingTemplateResource extends StripeResource {
   ): Promise<Response<InvoiceRenderingTemplate>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoice_rendering_templates/${id}/unarchive`,
+      `/v1/invoice_rendering_templates/${encodeURIComponent(id)}/unarchive`,
       params,
       options
     ) as any;

--- a/src/resources/Invoices.ts
+++ b/src/resources/Invoices.ts
@@ -46,7 +46,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<DeletedInvoice>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/invoices/${id}`,
+      `/v1/invoices/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -59,33 +59,39 @@ export class InvoiceResource extends StripeResource {
     params?: InvoiceRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Invoice>> {
-    return this._makeRequest('GET', `/v1/invoices/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          lines: {
-            kind: 'object',
-            fields: {
-              data: {
-                kind: 'array',
-                element: {
-                  kind: 'object',
-                  fields: {
-                    pricing: {
-                      kind: 'nullable',
-                      inner: {
-                        kind: 'object',
-                        fields: {
-                          unit_amount_decimal: {
-                            kind: 'nullable',
-                            inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'GET',
+      `/v1/invoices/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            lines: {
+              kind: 'object',
+              fields: {
+                data: {
+                  kind: 'array',
+                  element: {
+                    kind: 'object',
+                    fields: {
+                      pricing: {
+                        kind: 'nullable',
+                        inner: {
+                          kind: 'object',
+                          fields: {
+                            unit_amount_decimal: {
+                              kind: 'nullable',
+                              inner: {kind: 'decimal_string'},
+                            },
                           },
                         },
                       },
-                    },
-                    quantity_decimal: {
-                      kind: 'nullable',
-                      inner: {kind: 'decimal_string'},
+                      quantity_decimal: {
+                        kind: 'nullable',
+                        inner: {kind: 'decimal_string'},
+                      },
                     },
                   },
                 },
@@ -93,8 +99,8 @@ export class InvoiceResource extends StripeResource {
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Draft invoices are fully editable. Once an invoice is [finalized](https://docs.stripe.com/docs/billing/invoices/workflow#finalized),
@@ -109,33 +115,39 @@ export class InvoiceResource extends StripeResource {
     params?: InvoiceUpdateParams,
     options?: RequestOptions
   ): Promise<Response<Invoice>> {
-    return this._makeRequest('POST', `/v1/invoices/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          lines: {
-            kind: 'object',
-            fields: {
-              data: {
-                kind: 'array',
-                element: {
-                  kind: 'object',
-                  fields: {
-                    pricing: {
-                      kind: 'nullable',
-                      inner: {
-                        kind: 'object',
-                        fields: {
-                          unit_amount_decimal: {
-                            kind: 'nullable',
-                            inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'POST',
+      `/v1/invoices/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            lines: {
+              kind: 'object',
+              fields: {
+                data: {
+                  kind: 'array',
+                  element: {
+                    kind: 'object',
+                    fields: {
+                      pricing: {
+                        kind: 'nullable',
+                        inner: {
+                          kind: 'object',
+                          fields: {
+                            unit_amount_decimal: {
+                              kind: 'nullable',
+                              inner: {kind: 'decimal_string'},
+                            },
                           },
                         },
                       },
-                    },
-                    quantity_decimal: {
-                      kind: 'nullable',
-                      inner: {kind: 'decimal_string'},
+                      quantity_decimal: {
+                        kind: 'nullable',
+                        inner: {kind: 'decimal_string'},
+                      },
                     },
                   },
                 },
@@ -143,8 +155,8 @@ export class InvoiceResource extends StripeResource {
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * You can list all invoices, or list the invoices for a specific customer. The invoices are returned sorted by creation date, with the most recently created invoices appearing first.
@@ -309,7 +321,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/add_lines`,
+      `/v1/invoices/${encodeURIComponent(id)}/add_lines`,
       params,
       options,
       {
@@ -387,7 +399,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/attach_payment`,
+      `/v1/invoices/${encodeURIComponent(id)}/attach_payment`,
       params,
       options,
       {
@@ -438,7 +450,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/finalize`,
+      `/v1/invoices/${encodeURIComponent(id)}/finalize`,
       params,
       options,
       {
@@ -489,7 +501,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/mark_uncollectible`,
+      `/v1/invoices/${encodeURIComponent(id)}/mark_uncollectible`,
       params,
       options,
       {
@@ -540,7 +552,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/pay`,
+      `/v1/invoices/${encodeURIComponent(id)}/pay`,
       params,
       options,
       {
@@ -591,7 +603,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/remove_lines`,
+      `/v1/invoices/${encodeURIComponent(id)}/remove_lines`,
       params,
       options,
       {
@@ -644,7 +656,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/send`,
+      `/v1/invoices/${encodeURIComponent(id)}/send`,
       params,
       options,
       {
@@ -695,7 +707,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/update_lines`,
+      `/v1/invoices/${encodeURIComponent(id)}/update_lines`,
       params,
       options,
       {
@@ -766,7 +778,7 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<Invoice>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${id}/void`,
+      `/v1/invoices/${encodeURIComponent(id)}/void`,
       params,
       options,
       {
@@ -952,7 +964,7 @@ export class InvoiceResource extends StripeResource {
   ): ApiListPromise<InvoiceLineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/invoices/${id}/lines`,
+      `/v1/invoices/${encodeURIComponent(id)}/lines`,
       params,
       options,
       {
@@ -1003,7 +1015,9 @@ export class InvoiceResource extends StripeResource {
   ): Promise<Response<InvoiceLineItem>> {
     return this._makeRequest(
       'POST',
-      `/v1/invoices/${invoiceId}/lines/${id}`,
+      `/v1/invoices/${encodeURIComponent(invoiceId)}/lines/${encodeURIComponent(
+        id
+      )}`,
       params,
       options,
       {

--- a/src/resources/Issuing/Authorizations.ts
+++ b/src/resources/Issuing/Authorizations.ts
@@ -222,7 +222,7 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/authorizations/${id}`,
+      `/v1/issuing/authorizations/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -401,7 +401,7 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/authorizations/${id}`,
+      `/v1/issuing/authorizations/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -582,7 +582,7 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/authorizations/${id}/approve`,
+      `/v1/issuing/authorizations/${encodeURIComponent(id)}/approve`,
       params,
       options,
       {
@@ -763,7 +763,7 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/authorizations/${id}/decline`,
+      `/v1/issuing/authorizations/${encodeURIComponent(id)}/decline`,
       params,
       options,
       {

--- a/src/resources/Issuing/Cardholders.ts
+++ b/src/resources/Issuing/Cardholders.ts
@@ -54,7 +54,7 @@ export class CardholderResource extends StripeResource {
   ): Promise<Response<Cardholder>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/cardholders/${id}`,
+      `/v1/issuing/cardholders/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -69,7 +69,7 @@ export class CardholderResource extends StripeResource {
   ): Promise<Response<Cardholder>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/cardholders/${id}`,
+      `/v1/issuing/cardholders/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Issuing/Cards.ts
+++ b/src/resources/Issuing/Cards.ts
@@ -49,7 +49,7 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/cards/${id}`,
+      `/v1/issuing/cards/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -64,7 +64,7 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/cards/${id}`,
+      `/v1/issuing/cards/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Issuing/Disputes.ts
+++ b/src/resources/Issuing/Disputes.ts
@@ -49,7 +49,7 @@ export class DisputeResource extends StripeResource {
   ): Promise<Response<Dispute>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/disputes/${id}`,
+      `/v1/issuing/disputes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -64,7 +64,7 @@ export class DisputeResource extends StripeResource {
   ): Promise<Response<Dispute>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/disputes/${id}`,
+      `/v1/issuing/disputes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -79,7 +79,7 @@ export class DisputeResource extends StripeResource {
   ): Promise<Response<Dispute>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/disputes/${id}/submit`,
+      `/v1/issuing/disputes/${encodeURIComponent(id)}/submit`,
       params,
       options
     ) as any;

--- a/src/resources/Issuing/PersonalizationDesigns.ts
+++ b/src/resources/Issuing/PersonalizationDesigns.ts
@@ -53,7 +53,7 @@ export class PersonalizationDesignResource extends StripeResource {
   ): Promise<Response<PersonalizationDesign>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/personalization_designs/${id}`,
+      `/v1/issuing/personalization_designs/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -68,7 +68,7 @@ export class PersonalizationDesignResource extends StripeResource {
   ): Promise<Response<PersonalizationDesign>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/personalization_designs/${id}`,
+      `/v1/issuing/personalization_designs/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Issuing/PhysicalBundles.ts
+++ b/src/resources/Issuing/PhysicalBundles.ts
@@ -32,7 +32,7 @@ export class PhysicalBundleResource extends StripeResource {
   ): Promise<Response<PhysicalBundle>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/physical_bundles/${id}`,
+      `/v1/issuing/physical_bundles/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Issuing/Tokens.ts
+++ b/src/resources/Issuing/Tokens.ts
@@ -27,7 +27,7 @@ export class TokenResource extends StripeResource {
   ): Promise<Response<Token>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/tokens/${id}`,
+      `/v1/issuing/tokens/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -42,7 +42,7 @@ export class TokenResource extends StripeResource {
   ): Promise<Response<Token>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/tokens/${id}`,
+      `/v1/issuing/tokens/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Issuing/Transactions.ts
+++ b/src/resources/Issuing/Transactions.ts
@@ -135,7 +135,7 @@ export class TransactionResource extends StripeResource {
   ): Promise<Response<Transaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/issuing/transactions/${id}`,
+      `/v1/issuing/transactions/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -234,7 +234,7 @@ export class TransactionResource extends StripeResource {
   ): Promise<Response<Transaction>> {
     return this._makeRequest(
       'POST',
-      `/v1/issuing/transactions/${id}`,
+      `/v1/issuing/transactions/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/Mandates.ts
+++ b/src/resources/Mandates.ts
@@ -15,7 +15,7 @@ export class MandateResource extends StripeResource {
   ): Promise<Response<Mandate>> {
     return this._makeRequest(
       'GET',
-      `/v1/mandates/${id}`,
+      `/v1/mandates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/PaymentAttemptRecords.ts
+++ b/src/resources/PaymentAttemptRecords.ts
@@ -34,7 +34,7 @@ export class PaymentAttemptRecordResource extends StripeResource {
   ): Promise<Response<PaymentAttemptRecord>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_attempt_records/${id}`,
+      `/v1/payment_attempt_records/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/PaymentIntents.ts
+++ b/src/resources/PaymentIntents.ts
@@ -76,7 +76,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_intents/${id}`,
+      `/v1/payment_intents/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -97,7 +97,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}`,
+      `/v1/payment_intents/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -132,7 +132,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}/apply_customer_balance`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/apply_customer_balance`,
       params,
       options
     ) as any;
@@ -151,7 +151,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}/cancel`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;
@@ -170,7 +170,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}/capture`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/capture`,
       params,
       options
     ) as any;
@@ -214,7 +214,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}/confirm`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/confirm`,
       params,
       options
     ) as any;
@@ -254,7 +254,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}/increment_authorization`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/increment_authorization`,
       params,
       options
     ) as any;
@@ -269,7 +269,7 @@ export class PaymentIntentResource extends StripeResource {
   ): Promise<Response<PaymentIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_intents/${id}/verify_microdeposits`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/verify_microdeposits`,
       params,
       options
     ) as any;
@@ -284,7 +284,7 @@ export class PaymentIntentResource extends StripeResource {
   ): ApiListPromise<PaymentIntentAmountDetailsLineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_intents/${id}/amount_details_line_items`,
+      `/v1/payment_intents/${encodeURIComponent(id)}/amount_details_line_items`,
       params,
       options,
       {

--- a/src/resources/PaymentLinks.ts
+++ b/src/resources/PaymentLinks.ts
@@ -220,7 +220,7 @@ export class PaymentLinkResource extends StripeResource {
   ): Promise<Response<PaymentLink>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_links/${id}`,
+      `/v1/payment_links/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -311,7 +311,7 @@ export class PaymentLinkResource extends StripeResource {
   ): Promise<Response<PaymentLink>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_links/${id}`,
+      `/v1/payment_links/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -402,7 +402,7 @@ export class PaymentLinkResource extends StripeResource {
   ): ApiListPromise<LineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_links/${id}/line_items`,
+      `/v1/payment_links/${encodeURIComponent(id)}/line_items`,
       params,
       options,
       {

--- a/src/resources/PaymentMethodConfigurations.ts
+++ b/src/resources/PaymentMethodConfigurations.ts
@@ -46,7 +46,7 @@ export class PaymentMethodConfigurationResource extends StripeResource {
   ): Promise<Response<PaymentMethodConfiguration>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_method_configurations/${id}`,
+      `/v1/payment_method_configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -61,7 +61,7 @@ export class PaymentMethodConfigurationResource extends StripeResource {
   ): Promise<Response<PaymentMethodConfiguration>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_method_configurations/${id}`,
+      `/v1/payment_method_configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/PaymentMethodDomains.ts
+++ b/src/resources/PaymentMethodDomains.ts
@@ -46,7 +46,7 @@ export class PaymentMethodDomainResource extends StripeResource {
   ): Promise<Response<PaymentMethodDomain>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_method_domains/${id}`,
+      `/v1/payment_method_domains/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -61,7 +61,7 @@ export class PaymentMethodDomainResource extends StripeResource {
   ): Promise<Response<PaymentMethodDomain>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_method_domains/${id}`,
+      `/v1/payment_method_domains/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -81,7 +81,7 @@ export class PaymentMethodDomainResource extends StripeResource {
   ): Promise<Response<PaymentMethodDomain>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_method_domains/${id}/validate`,
+      `/v1/payment_method_domains/${encodeURIComponent(id)}/validate`,
       params,
       options
     ) as any;

--- a/src/resources/PaymentMethods.ts
+++ b/src/resources/PaymentMethods.ts
@@ -52,7 +52,7 @@ export class PaymentMethodResource extends StripeResource {
   ): Promise<Response<PaymentMethod>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_methods/${id}`,
+      `/v1/payment_methods/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -67,7 +67,7 @@ export class PaymentMethodResource extends StripeResource {
   ): Promise<Response<PaymentMethod>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_methods/${id}`,
+      `/v1/payment_methods/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -94,7 +94,7 @@ export class PaymentMethodResource extends StripeResource {
   ): Promise<Response<PaymentMethod>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_methods/${id}/attach`,
+      `/v1/payment_methods/${encodeURIComponent(id)}/attach`,
       params,
       options
     ) as any;
@@ -109,7 +109,7 @@ export class PaymentMethodResource extends StripeResource {
   ): Promise<Response<PaymentMethod>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_methods/${id}/detach`,
+      `/v1/payment_methods/${encodeURIComponent(id)}/detach`,
       params,
       options
     ) as any;

--- a/src/resources/PaymentRecords.ts
+++ b/src/resources/PaymentRecords.ts
@@ -23,7 +23,7 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'GET',
-      `/v1/payment_records/${id}`,
+      `/v1/payment_records/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -39,7 +39,7 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_records/${id}/report_payment_attempt`,
+      `/v1/payment_records/${encodeURIComponent(id)}/report_payment_attempt`,
       params,
       options
     ) as any;
@@ -55,7 +55,9 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_records/${id}/report_payment_attempt_canceled`,
+      `/v1/payment_records/${encodeURIComponent(
+        id
+      )}/report_payment_attempt_canceled`,
       params,
       options
     ) as any;
@@ -71,7 +73,9 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_records/${id}/report_payment_attempt_failed`,
+      `/v1/payment_records/${encodeURIComponent(
+        id
+      )}/report_payment_attempt_failed`,
       params,
       options
     ) as any;
@@ -87,7 +91,9 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_records/${id}/report_payment_attempt_guaranteed`,
+      `/v1/payment_records/${encodeURIComponent(
+        id
+      )}/report_payment_attempt_guaranteed`,
       params,
       options
     ) as any;
@@ -102,7 +108,9 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_records/${id}/report_payment_attempt_informational`,
+      `/v1/payment_records/${encodeURIComponent(
+        id
+      )}/report_payment_attempt_informational`,
       params,
       options
     ) as any;
@@ -118,7 +126,7 @@ export class PaymentRecordResource extends StripeResource {
   ): Promise<Response<PaymentRecord>> {
     return this._makeRequest(
       'POST',
-      `/v1/payment_records/${id}/report_refund`,
+      `/v1/payment_records/${encodeURIComponent(id)}/report_refund`,
       params,
       options
     ) as any;

--- a/src/resources/Payouts.ts
+++ b/src/resources/Payouts.ts
@@ -48,7 +48,7 @@ export class PayoutResource extends StripeResource {
   ): Promise<Response<Payout>> {
     return this._makeRequest(
       'GET',
-      `/v1/payouts/${id}`,
+      `/v1/payouts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -63,7 +63,7 @@ export class PayoutResource extends StripeResource {
   ): Promise<Response<Payout>> {
     return this._makeRequest(
       'POST',
-      `/v1/payouts/${id}`,
+      `/v1/payouts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -78,7 +78,7 @@ export class PayoutResource extends StripeResource {
   ): Promise<Response<Payout>> {
     return this._makeRequest(
       'POST',
-      `/v1/payouts/${id}/cancel`,
+      `/v1/payouts/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;
@@ -95,7 +95,7 @@ export class PayoutResource extends StripeResource {
   ): Promise<Response<Payout>> {
     return this._makeRequest(
       'POST',
-      `/v1/payouts/${id}/reverse`,
+      `/v1/payouts/${encodeURIComponent(id)}/reverse`,
       params,
       options
     ) as any;

--- a/src/resources/Plans.ts
+++ b/src/resources/Plans.ts
@@ -23,7 +23,7 @@ export class PlanResource extends StripeResource {
   ): Promise<Response<DeletedPlan>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/plans/${id}`,
+      `/v1/plans/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -36,30 +36,36 @@ export class PlanResource extends StripeResource {
     params?: PlanRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Plan>> {
-    return this._makeRequest('GET', `/v1/plans/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          amount_decimal: {kind: 'nullable', inner: {kind: 'decimal_string'}},
-          tiers: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                flat_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
-                },
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'GET',
+      `/v1/plans/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            amount_decimal: {kind: 'nullable', inner: {kind: 'decimal_string'}},
+            tiers: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  flat_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
                 },
               },
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Updates the specified plan by setting the values of the parameters passed. Any parameters not provided are left unchanged. By design, you cannot change a plan's ID, amount, currency, or billing cycle.
@@ -69,30 +75,36 @@ export class PlanResource extends StripeResource {
     params?: PlanUpdateParams,
     options?: RequestOptions
   ): Promise<Response<Plan>> {
-    return this._makeRequest('POST', `/v1/plans/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          amount_decimal: {kind: 'nullable', inner: {kind: 'decimal_string'}},
-          tiers: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                flat_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
-                },
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'POST',
+      `/v1/plans/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            amount_decimal: {kind: 'nullable', inner: {kind: 'decimal_string'}},
+            tiers: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  flat_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
                 },
               },
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Returns a list of your plans.

--- a/src/resources/Prices.ts
+++ b/src/resources/Prices.ts
@@ -196,61 +196,67 @@ export class PriceResource extends StripeResource {
     params?: PriceRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Price>> {
-    return this._makeRequest('GET', `/v1/prices/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          currency_options: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                tiers: {
-                  kind: 'array',
-                  element: {
-                    kind: 'object',
-                    fields: {
-                      flat_amount_decimal: {
-                        kind: 'nullable',
-                        inner: {kind: 'decimal_string'},
-                      },
-                      unit_amount_decimal: {
-                        kind: 'nullable',
-                        inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'GET',
+      `/v1/prices/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            currency_options: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  tiers: {
+                    kind: 'array',
+                    element: {
+                      kind: 'object',
+                      fields: {
+                        flat_amount_decimal: {
+                          kind: 'nullable',
+                          inner: {kind: 'decimal_string'},
+                        },
+                        unit_amount_decimal: {
+                          kind: 'nullable',
+                          inner: {kind: 'decimal_string'},
+                        },
                       },
                     },
                   },
-                },
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
-                },
-              },
-            },
-          },
-          tiers: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                flat_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
-                },
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
                 },
               },
             },
-          },
-          unit_amount_decimal: {
-            kind: 'nullable',
-            inner: {kind: 'decimal_string'},
+            tiers: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  flat_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
+                },
+              },
+            },
+            unit_amount_decimal: {
+              kind: 'nullable',
+              inner: {kind: 'decimal_string'},
+            },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Updates the specified price by setting the values of the parameters passed. Any parameters not provided are left unchanged.
@@ -260,61 +266,67 @@ export class PriceResource extends StripeResource {
     params?: PriceUpdateParams,
     options?: RequestOptions
   ): Promise<Response<Price>> {
-    return this._makeRequest('POST', `/v1/prices/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          currency_options: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                tiers: {
-                  kind: 'array',
-                  element: {
-                    kind: 'object',
-                    fields: {
-                      flat_amount_decimal: {
-                        kind: 'nullable',
-                        inner: {kind: 'decimal_string'},
-                      },
-                      unit_amount_decimal: {
-                        kind: 'nullable',
-                        inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'POST',
+      `/v1/prices/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            currency_options: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  tiers: {
+                    kind: 'array',
+                    element: {
+                      kind: 'object',
+                      fields: {
+                        flat_amount_decimal: {
+                          kind: 'nullable',
+                          inner: {kind: 'decimal_string'},
+                        },
+                        unit_amount_decimal: {
+                          kind: 'nullable',
+                          inner: {kind: 'decimal_string'},
+                        },
                       },
                     },
                   },
-                },
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
-                },
-              },
-            },
-          },
-          tiers: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                flat_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
-                },
-                unit_amount_decimal: {
-                  kind: 'nullable',
-                  inner: {kind: 'decimal_string'},
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
                 },
               },
             },
-          },
-          unit_amount_decimal: {
-            kind: 'nullable',
-            inner: {kind: 'decimal_string'},
+            tiers: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  flat_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
+                  unit_amount_decimal: {
+                    kind: 'nullable',
+                    inner: {kind: 'decimal_string'},
+                  },
+                },
+              },
+            },
+            unit_amount_decimal: {
+              kind: 'nullable',
+              inner: {kind: 'decimal_string'},
+            },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Search for prices you've previously created using Stripe's [Search Query Language](https://docs.stripe.com/docs/search#search-query-language).

--- a/src/resources/Products.ts
+++ b/src/resources/Products.ts
@@ -30,7 +30,7 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<DeletedProduct>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/products/${id}`,
+      `/v1/products/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -45,7 +45,7 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<Product>> {
     return this._makeRequest(
       'GET',
-      `/v1/products/${id}`,
+      `/v1/products/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -60,7 +60,7 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<Product>> {
     return this._makeRequest(
       'POST',
-      `/v1/products/${id}`,
+      `/v1/products/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -141,7 +141,9 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<DeletedProductFeature>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/products/${productId}/features/${id}`,
+      `/v1/products/${encodeURIComponent(
+        productId
+      )}/features/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -157,7 +159,9 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<ProductFeature>> {
     return this._makeRequest(
       'GET',
-      `/v1/products/${productId}/features/${id}`,
+      `/v1/products/${encodeURIComponent(
+        productId
+      )}/features/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -172,7 +176,7 @@ export class ProductResource extends StripeResource {
   ): ApiListPromise<ProductFeature> {
     return this._makeRequest(
       'GET',
-      `/v1/products/${id}/features`,
+      `/v1/products/${encodeURIComponent(id)}/features`,
       params,
       options,
       {
@@ -190,7 +194,7 @@ export class ProductResource extends StripeResource {
   ): Promise<Response<ProductFeature>> {
     return this._makeRequest(
       'POST',
-      `/v1/products/${id}/features`,
+      `/v1/products/${encodeURIComponent(id)}/features`,
       params,
       options
     ) as any;

--- a/src/resources/PromotionCodes.ts
+++ b/src/resources/PromotionCodes.ts
@@ -48,7 +48,7 @@ export class PromotionCodeResource extends StripeResource {
   ): Promise<Response<PromotionCode>> {
     return this._makeRequest(
       'GET',
-      `/v1/promotion_codes/${id}`,
+      `/v1/promotion_codes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -63,7 +63,7 @@ export class PromotionCodeResource extends StripeResource {
   ): Promise<Response<PromotionCode>> {
     return this._makeRequest(
       'POST',
-      `/v1/promotion_codes/${id}`,
+      `/v1/promotion_codes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Quotes.ts
+++ b/src/resources/Quotes.ts
@@ -253,76 +253,86 @@ export class QuoteResource extends StripeResource {
     params?: QuoteRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Quote>> {
-    return this._makeRequest('GET', `/v1/quotes/${id}`, params, options, {
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          computed: {
-            kind: 'object',
-            fields: {
-              upfront: {
-                kind: 'object',
-                fields: {
-                  line_items: {
-                    kind: 'object',
-                    fields: {
-                      data: {
-                        kind: 'array',
-                        element: {
-                          kind: 'object',
-                          fields: {
-                            price: {
-                              kind: 'nullable',
-                              inner: {
-                                kind: 'object',
-                                fields: {
-                                  currency_options: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        tiers: {
-                                          kind: 'array',
-                                          element: {
-                                            kind: 'object',
-                                            fields: {
-                                              flat_amount_decimal: {
-                                                kind: 'nullable',
-                                                inner: {kind: 'decimal_string'},
-                                              },
-                                              unit_amount_decimal: {
-                                                kind: 'nullable',
-                                                inner: {kind: 'decimal_string'},
+    return this._makeRequest(
+      'GET',
+      `/v1/quotes/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            computed: {
+              kind: 'object',
+              fields: {
+                upfront: {
+                  kind: 'object',
+                  fields: {
+                    line_items: {
+                      kind: 'object',
+                      fields: {
+                        data: {
+                          kind: 'array',
+                          element: {
+                            kind: 'object',
+                            fields: {
+                              price: {
+                                kind: 'nullable',
+                                inner: {
+                                  kind: 'object',
+                                  fields: {
+                                    currency_options: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          tiers: {
+                                            kind: 'array',
+                                            element: {
+                                              kind: 'object',
+                                              fields: {
+                                                flat_amount_decimal: {
+                                                  kind: 'nullable',
+                                                  inner: {
+                                                    kind: 'decimal_string',
+                                                  },
+                                                },
+                                                unit_amount_decimal: {
+                                                  kind: 'nullable',
+                                                  inner: {
+                                                    kind: 'decimal_string',
+                                                  },
+                                                },
                                               },
                                             },
                                           },
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                      },
-                                    },
-                                  },
-                                  tiers: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        flat_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
                                         },
                                       },
                                     },
-                                  },
-                                  unit_amount_decimal: {
-                                    kind: 'nullable',
-                                    inner: {kind: 'decimal_string'},
+                                    tiers: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          flat_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                        },
+                                      },
+                                    },
+                                    unit_amount_decimal: {
+                                      kind: 'nullable',
+                                      inner: {kind: 'decimal_string'},
+                                    },
                                   },
                                 },
                               },
@@ -337,8 +347,8 @@ export class QuoteResource extends StripeResource {
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * A quote models prices and services for a customer.
@@ -348,93 +358,103 @@ export class QuoteResource extends StripeResource {
     params?: QuoteUpdateParams,
     options?: RequestOptions
   ): Promise<Response<Quote>> {
-    return this._makeRequest('POST', `/v1/quotes/${id}`, params, options, {
-      requestSchema: {
-        kind: 'object',
-        fields: {
-          line_items: {
-            kind: 'array',
-            element: {
-              kind: 'object',
-              fields: {
-                price_data: {
-                  kind: 'object',
-                  fields: {unit_amount_decimal: {kind: 'decimal_string'}},
+    return this._makeRequest(
+      'POST',
+      `/v1/quotes/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        requestSchema: {
+          kind: 'object',
+          fields: {
+            line_items: {
+              kind: 'array',
+              element: {
+                kind: 'object',
+                fields: {
+                  price_data: {
+                    kind: 'object',
+                    fields: {unit_amount_decimal: {kind: 'decimal_string'}},
+                  },
                 },
               },
             },
           },
         },
-      },
-      responseSchema: {
-        kind: 'object',
-        fields: {
-          computed: {
-            kind: 'object',
-            fields: {
-              upfront: {
-                kind: 'object',
-                fields: {
-                  line_items: {
-                    kind: 'object',
-                    fields: {
-                      data: {
-                        kind: 'array',
-                        element: {
-                          kind: 'object',
-                          fields: {
-                            price: {
-                              kind: 'nullable',
-                              inner: {
-                                kind: 'object',
-                                fields: {
-                                  currency_options: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        tiers: {
-                                          kind: 'array',
-                                          element: {
-                                            kind: 'object',
-                                            fields: {
-                                              flat_amount_decimal: {
-                                                kind: 'nullable',
-                                                inner: {kind: 'decimal_string'},
-                                              },
-                                              unit_amount_decimal: {
-                                                kind: 'nullable',
-                                                inner: {kind: 'decimal_string'},
+        responseSchema: {
+          kind: 'object',
+          fields: {
+            computed: {
+              kind: 'object',
+              fields: {
+                upfront: {
+                  kind: 'object',
+                  fields: {
+                    line_items: {
+                      kind: 'object',
+                      fields: {
+                        data: {
+                          kind: 'array',
+                          element: {
+                            kind: 'object',
+                            fields: {
+                              price: {
+                                kind: 'nullable',
+                                inner: {
+                                  kind: 'object',
+                                  fields: {
+                                    currency_options: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          tiers: {
+                                            kind: 'array',
+                                            element: {
+                                              kind: 'object',
+                                              fields: {
+                                                flat_amount_decimal: {
+                                                  kind: 'nullable',
+                                                  inner: {
+                                                    kind: 'decimal_string',
+                                                  },
+                                                },
+                                                unit_amount_decimal: {
+                                                  kind: 'nullable',
+                                                  inner: {
+                                                    kind: 'decimal_string',
+                                                  },
+                                                },
                                               },
                                             },
                                           },
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                      },
-                                    },
-                                  },
-                                  tiers: {
-                                    kind: 'array',
-                                    element: {
-                                      kind: 'object',
-                                      fields: {
-                                        flat_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
-                                        },
-                                        unit_amount_decimal: {
-                                          kind: 'nullable',
-                                          inner: {kind: 'decimal_string'},
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
                                         },
                                       },
                                     },
-                                  },
-                                  unit_amount_decimal: {
-                                    kind: 'nullable',
-                                    inner: {kind: 'decimal_string'},
+                                    tiers: {
+                                      kind: 'array',
+                                      element: {
+                                        kind: 'object',
+                                        fields: {
+                                          flat_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                          unit_amount_decimal: {
+                                            kind: 'nullable',
+                                            inner: {kind: 'decimal_string'},
+                                          },
+                                        },
+                                      },
+                                    },
+                                    unit_amount_decimal: {
+                                      kind: 'nullable',
+                                      inner: {kind: 'decimal_string'},
+                                    },
                                   },
                                 },
                               },
@@ -449,8 +469,8 @@ export class QuoteResource extends StripeResource {
             },
           },
         },
-      },
-    }) as any;
+      }
+    ) as any;
   }
   /**
    * Accepts the specified quote.
@@ -462,7 +482,7 @@ export class QuoteResource extends StripeResource {
   ): Promise<Response<Quote>> {
     return this._makeRequest(
       'POST',
-      `/v1/quotes/${id}/accept`,
+      `/v1/quotes/${encodeURIComponent(id)}/accept`,
       params,
       options,
       {
@@ -567,7 +587,7 @@ export class QuoteResource extends StripeResource {
   ): Promise<Response<Quote>> {
     return this._makeRequest(
       'POST',
-      `/v1/quotes/${id}/cancel`,
+      `/v1/quotes/${encodeURIComponent(id)}/cancel`,
       params,
       options,
       {
@@ -672,7 +692,7 @@ export class QuoteResource extends StripeResource {
   ): Promise<Response<Quote>> {
     return this._makeRequest(
       'POST',
-      `/v1/quotes/${id}/finalize`,
+      `/v1/quotes/${encodeURIComponent(id)}/finalize`,
       params,
       options,
       {
@@ -775,10 +795,16 @@ export class QuoteResource extends StripeResource {
     params?: QuotePdfParams,
     options?: RequestOptions
   ): Promise<StripeStreamResponse> {
-    return this._makeRequest('GET', `/v1/quotes/${id}/pdf`, params, options, {
-      apiBase: 'files',
-      streaming: true,
-    }) as any;
+    return this._makeRequest(
+      'GET',
+      `/v1/quotes/${encodeURIComponent(id)}/pdf`,
+      params,
+      options,
+      {
+        apiBase: 'files',
+        streaming: true,
+      }
+    ) as any;
   }
   /**
    * When retrieving a quote, there is an includable [computed.upfront.line_items](https://stripe.com/docs/api/quotes/object#quote_object-computed-upfront-line_items) property containing the first handful of those items. There is also a URL where you can retrieve the full (paginated) list of upfront line items.
@@ -790,7 +816,7 @@ export class QuoteResource extends StripeResource {
   ): ApiListPromise<LineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/quotes/${id}/computed_upfront_line_items`,
+      `/v1/quotes/${encodeURIComponent(id)}/computed_upfront_line_items`,
       params,
       options,
       {
@@ -877,7 +903,7 @@ export class QuoteResource extends StripeResource {
   ): ApiListPromise<LineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/quotes/${id}/line_items`,
+      `/v1/quotes/${encodeURIComponent(id)}/line_items`,
       params,
       options,
       {

--- a/src/resources/Radar/EarlyFraudWarnings.ts
+++ b/src/resources/Radar/EarlyFraudWarnings.ts
@@ -36,7 +36,7 @@ export class EarlyFraudWarningResource extends StripeResource {
   ): Promise<Response<EarlyFraudWarning>> {
     return this._makeRequest(
       'GET',
-      `/v1/radar/early_fraud_warnings/${id}`,
+      `/v1/radar/early_fraud_warnings/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Radar/ValueListItems.ts
+++ b/src/resources/Radar/ValueListItems.ts
@@ -15,7 +15,7 @@ export class ValueListItemResource extends StripeResource {
   ): Promise<Response<Radar.DeletedValueListItem>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/radar/value_list_items/${id}`,
+      `/v1/radar/value_list_items/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -30,7 +30,7 @@ export class ValueListItemResource extends StripeResource {
   ): Promise<Response<ValueListItem>> {
     return this._makeRequest(
       'GET',
-      `/v1/radar/value_list_items/${id}`,
+      `/v1/radar/value_list_items/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Radar/ValueLists.ts
+++ b/src/resources/Radar/ValueLists.ts
@@ -21,7 +21,7 @@ export class ValueListResource extends StripeResource {
   ): Promise<Response<Radar.DeletedValueList>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/radar/value_lists/${id}`,
+      `/v1/radar/value_lists/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -36,7 +36,7 @@ export class ValueListResource extends StripeResource {
   ): Promise<Response<ValueList>> {
     return this._makeRequest(
       'GET',
-      `/v1/radar/value_lists/${id}`,
+      `/v1/radar/value_lists/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -51,7 +51,7 @@ export class ValueListResource extends StripeResource {
   ): Promise<Response<ValueList>> {
     return this._makeRequest(
       'POST',
-      `/v1/radar/value_lists/${id}`,
+      `/v1/radar/value_lists/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Refunds.ts
+++ b/src/resources/Refunds.ts
@@ -55,7 +55,7 @@ export class RefundResource extends StripeResource {
   ): Promise<Response<Refund>> {
     return this._makeRequest(
       'GET',
-      `/v1/refunds/${id}`,
+      `/v1/refunds/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -72,7 +72,7 @@ export class RefundResource extends StripeResource {
   ): Promise<Response<Refund>> {
     return this._makeRequest(
       'POST',
-      `/v1/refunds/${id}`,
+      `/v1/refunds/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -89,7 +89,7 @@ export class RefundResource extends StripeResource {
   ): Promise<Response<Refund>> {
     return this._makeRequest(
       'POST',
-      `/v1/refunds/${id}/cancel`,
+      `/v1/refunds/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;

--- a/src/resources/Reporting/ReportRuns.ts
+++ b/src/resources/Reporting/ReportRuns.ts
@@ -47,7 +47,7 @@ export class ReportRunResource extends StripeResource {
   ): Promise<Response<ReportRun>> {
     return this._makeRequest(
       'GET',
-      `/v1/reporting/report_runs/${id}`,
+      `/v1/reporting/report_runs/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Reporting/ReportTypes.ts
+++ b/src/resources/Reporting/ReportTypes.ts
@@ -31,7 +31,7 @@ export class ReportTypeResource extends StripeResource {
   ): Promise<Response<ReportType>> {
     return this._makeRequest(
       'GET',
-      `/v1/reporting/report_types/${id}`,
+      `/v1/reporting/report_types/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Reviews.ts
+++ b/src/resources/Reviews.ts
@@ -28,7 +28,7 @@ export class ReviewResource extends StripeResource {
   ): Promise<Response<Review>> {
     return this._makeRequest(
       'GET',
-      `/v1/reviews/${id}`,
+      `/v1/reviews/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -43,7 +43,7 @@ export class ReviewResource extends StripeResource {
   ): Promise<Response<Review>> {
     return this._makeRequest(
       'POST',
-      `/v1/reviews/${id}/approve`,
+      `/v1/reviews/${encodeURIComponent(id)}/approve`,
       params,
       options
     ) as any;

--- a/src/resources/SetupIntents.ts
+++ b/src/resources/SetupIntents.ts
@@ -62,7 +62,7 @@ export class SetupIntentResource extends StripeResource {
   ): Promise<Response<SetupIntent>> {
     return this._makeRequest(
       'GET',
-      `/v1/setup_intents/${id}`,
+      `/v1/setup_intents/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -77,7 +77,7 @@ export class SetupIntentResource extends StripeResource {
   ): Promise<Response<SetupIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/setup_intents/${id}`,
+      `/v1/setup_intents/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -94,7 +94,7 @@ export class SetupIntentResource extends StripeResource {
   ): Promise<Response<SetupIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/setup_intents/${id}/cancel`,
+      `/v1/setup_intents/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;
@@ -122,7 +122,7 @@ export class SetupIntentResource extends StripeResource {
   ): Promise<Response<SetupIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/setup_intents/${id}/confirm`,
+      `/v1/setup_intents/${encodeURIComponent(id)}/confirm`,
       params,
       options
     ) as any;
@@ -137,7 +137,7 @@ export class SetupIntentResource extends StripeResource {
   ): Promise<Response<SetupIntent>> {
     return this._makeRequest(
       'POST',
-      `/v1/setup_intents/${id}/verify_microdeposits`,
+      `/v1/setup_intents/${encodeURIComponent(id)}/verify_microdeposits`,
       params,
       options
     ) as any;

--- a/src/resources/ShippingRates.ts
+++ b/src/resources/ShippingRates.ts
@@ -47,7 +47,7 @@ export class ShippingRateResource extends StripeResource {
   ): Promise<Response<ShippingRate>> {
     return this._makeRequest(
       'GET',
-      `/v1/shipping_rates/${id}`,
+      `/v1/shipping_rates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -62,7 +62,7 @@ export class ShippingRateResource extends StripeResource {
   ): Promise<Response<ShippingRate>> {
     return this._makeRequest(
       'POST',
-      `/v1/shipping_rates/${id}`,
+      `/v1/shipping_rates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Sigma/ScheduledQueryRuns.ts
+++ b/src/resources/Sigma/ScheduledQueryRuns.ts
@@ -33,7 +33,7 @@ export class ScheduledQueryRunResource extends StripeResource {
   ): Promise<Response<ScheduledQueryRun>> {
     return this._makeRequest(
       'GET',
-      `/v1/sigma/scheduled_query_runs/${id}`,
+      `/v1/sigma/scheduled_query_runs/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Sources.ts
+++ b/src/resources/Sources.ts
@@ -24,7 +24,7 @@ export class SourceResource extends StripeResource {
   ): Promise<Response<Source>> {
     return this._makeRequest(
       'GET',
-      `/v1/sources/${id}`,
+      `/v1/sources/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -41,7 +41,7 @@ export class SourceResource extends StripeResource {
   ): Promise<Response<Source>> {
     return this._makeRequest(
       'POST',
-      `/v1/sources/${id}`,
+      `/v1/sources/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -65,7 +65,7 @@ export class SourceResource extends StripeResource {
   ): Promise<Response<Source>> {
     return this._makeRequest(
       'POST',
-      `/v1/sources/${id}/verify`,
+      `/v1/sources/${encodeURIComponent(id)}/verify`,
       params,
       options
     ) as any;
@@ -80,7 +80,7 @@ export class SourceResource extends StripeResource {
   ): ApiListPromise<SourceTransaction> {
     return this._makeRequest(
       'GET',
-      `/v1/sources/${id}/source_transactions`,
+      `/v1/sources/${encodeURIComponent(id)}/source_transactions`,
       params,
       options,
       {

--- a/src/resources/SubscriptionItems.ts
+++ b/src/resources/SubscriptionItems.ts
@@ -25,7 +25,7 @@ export class SubscriptionItemResource extends StripeResource {
   ): Promise<Response<DeletedSubscriptionItem>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/subscription_items/${id}`,
+      `/v1/subscription_items/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -40,7 +40,7 @@ export class SubscriptionItemResource extends StripeResource {
   ): Promise<Response<SubscriptionItem>> {
     return this._makeRequest(
       'GET',
-      `/v1/subscription_items/${id}`,
+      `/v1/subscription_items/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -140,7 +140,7 @@ export class SubscriptionItemResource extends StripeResource {
   ): Promise<Response<SubscriptionItem>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscription_items/${id}`,
+      `/v1/subscription_items/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/SubscriptionSchedules.ts
+++ b/src/resources/SubscriptionSchedules.ts
@@ -109,7 +109,7 @@ export class SubscriptionScheduleResource extends StripeResource {
   ): Promise<Response<SubscriptionSchedule>> {
     return this._makeRequest(
       'GET',
-      `/v1/subscription_schedules/${id}`,
+      `/v1/subscription_schedules/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -124,7 +124,7 @@ export class SubscriptionScheduleResource extends StripeResource {
   ): Promise<Response<SubscriptionSchedule>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscription_schedules/${id}`,
+      `/v1/subscription_schedules/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -182,7 +182,7 @@ export class SubscriptionScheduleResource extends StripeResource {
   ): Promise<Response<SubscriptionSchedule>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscription_schedules/${id}/cancel`,
+      `/v1/subscription_schedules/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;
@@ -197,7 +197,7 @@ export class SubscriptionScheduleResource extends StripeResource {
   ): Promise<Response<SubscriptionSchedule>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscription_schedules/${id}/release`,
+      `/v1/subscription_schedules/${encodeURIComponent(id)}/release`,
       params,
       options
     ) as any;

--- a/src/resources/Subscriptions.ts
+++ b/src/resources/Subscriptions.ts
@@ -46,7 +46,7 @@ export class SubscriptionResource extends StripeResource {
   ): Promise<Response<Subscription>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/subscriptions/${id}`,
+      `/v1/subscriptions/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -159,7 +159,7 @@ export class SubscriptionResource extends StripeResource {
   ): Promise<Response<Subscription>> {
     return this._makeRequest(
       'GET',
-      `/v1/subscriptions/${id}`,
+      `/v1/subscriptions/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -292,7 +292,7 @@ export class SubscriptionResource extends StripeResource {
   ): Promise<Response<Subscription>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscriptions/${id}`,
+      `/v1/subscriptions/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -434,7 +434,7 @@ export class SubscriptionResource extends StripeResource {
   ): Promise<Response<DeletedDiscount>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/subscriptions/${id}/discount`,
+      `/v1/subscriptions/${encodeURIComponent(id)}/discount`,
       params,
       options
     ) as any;
@@ -829,7 +829,7 @@ export class SubscriptionResource extends StripeResource {
   ): Promise<Response<Subscription>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscriptions/${id}/migrate`,
+      `/v1/subscriptions/${encodeURIComponent(id)}/migrate`,
       params,
       options,
       {
@@ -942,7 +942,7 @@ export class SubscriptionResource extends StripeResource {
   ): Promise<Response<Subscription>> {
     return this._makeRequest(
       'POST',
-      `/v1/subscriptions/${id}/resume`,
+      `/v1/subscriptions/${encodeURIComponent(id)}/resume`,
       params,
       options,
       {

--- a/src/resources/Tax/Calculations.ts
+++ b/src/resources/Tax/Calculations.ts
@@ -21,7 +21,7 @@ export class CalculationResource extends StripeResource {
   ): Promise<Response<Calculation>> {
     return this._makeRequest(
       'GET',
-      `/v1/tax/calculations/${id}`,
+      `/v1/tax/calculations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -50,7 +50,7 @@ export class CalculationResource extends StripeResource {
   ): ApiListPromise<CalculationLineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/tax/calculations/${id}/line_items`,
+      `/v1/tax/calculations/${encodeURIComponent(id)}/line_items`,
       params,
       options,
       {

--- a/src/resources/Tax/Registrations.ts
+++ b/src/resources/Tax/Registrations.ts
@@ -40,7 +40,7 @@ export class RegistrationResource extends StripeResource {
   ): Promise<Response<Registration>> {
     return this._makeRequest(
       'GET',
-      `/v1/tax/registrations/${id}`,
+      `/v1/tax/registrations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -57,7 +57,7 @@ export class RegistrationResource extends StripeResource {
   ): Promise<Response<Registration>> {
     return this._makeRequest(
       'POST',
-      `/v1/tax/registrations/${id}`,
+      `/v1/tax/registrations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Tax/Transactions.ts
+++ b/src/resources/Tax/Transactions.ts
@@ -21,7 +21,7 @@ export class TransactionResource extends StripeResource {
   ): Promise<Response<Transaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/tax/transactions/${id}`,
+      `/v1/tax/transactions/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -64,7 +64,7 @@ export class TransactionResource extends StripeResource {
   ): ApiListPromise<TransactionLineItem> {
     return this._makeRequest(
       'GET',
-      `/v1/tax/transactions/${id}/line_items`,
+      `/v1/tax/transactions/${encodeURIComponent(id)}/line_items`,
       params,
       options,
       {

--- a/src/resources/TaxCodes.ts
+++ b/src/resources/TaxCodes.ts
@@ -26,7 +26,7 @@ export class TaxCodeResource extends StripeResource {
   ): Promise<Response<TaxCode>> {
     return this._makeRequest(
       'GET',
-      `/v1/tax_codes/${id}`,
+      `/v1/tax_codes/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/TaxIds.ts
+++ b/src/resources/TaxIds.ts
@@ -18,7 +18,7 @@ export class TaxIdResource extends StripeResource {
   ): Promise<Response<DeletedTaxId>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/tax_ids/${id}`,
+      `/v1/tax_ids/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -33,7 +33,7 @@ export class TaxIdResource extends StripeResource {
   ): Promise<Response<TaxId>> {
     return this._makeRequest(
       'GET',
-      `/v1/tax_ids/${id}`,
+      `/v1/tax_ids/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/TaxRates.ts
+++ b/src/resources/TaxRates.ts
@@ -41,7 +41,7 @@ export class TaxRateResource extends StripeResource {
   ): Promise<Response<TaxRate>> {
     return this._makeRequest(
       'GET',
-      `/v1/tax_rates/${id}`,
+      `/v1/tax_rates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -56,7 +56,7 @@ export class TaxRateResource extends StripeResource {
   ): Promise<Response<TaxRate>> {
     return this._makeRequest(
       'POST',
-      `/v1/tax_rates/${id}`,
+      `/v1/tax_rates/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Terminal/Configurations.ts
+++ b/src/resources/Terminal/Configurations.ts
@@ -16,7 +16,7 @@ export class ConfigurationResource extends StripeResource {
   ): Promise<Response<Terminal.DeletedConfiguration>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/terminal/configurations/${id}`,
+      `/v1/terminal/configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -31,7 +31,7 @@ export class ConfigurationResource extends StripeResource {
   ): Promise<Response<Configuration | Terminal.DeletedConfiguration>> {
     return this._makeRequest(
       'GET',
-      `/v1/terminal/configurations/${id}`,
+      `/v1/terminal/configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -46,7 +46,7 @@ export class ConfigurationResource extends StripeResource {
   ): Promise<Response<Configuration | Terminal.DeletedConfiguration>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/configurations/${id}`,
+      `/v1/terminal/configurations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Terminal/Locations.ts
+++ b/src/resources/Terminal/Locations.ts
@@ -23,7 +23,7 @@ export class LocationResource extends StripeResource {
   ): Promise<Response<Terminal.DeletedLocation>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/terminal/locations/${id}`,
+      `/v1/terminal/locations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -38,7 +38,7 @@ export class LocationResource extends StripeResource {
   ): Promise<Response<Location | Terminal.DeletedLocation>> {
     return this._makeRequest(
       'GET',
-      `/v1/terminal/locations/${id}`,
+      `/v1/terminal/locations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -53,7 +53,7 @@ export class LocationResource extends StripeResource {
   ): Promise<Response<Location | Terminal.DeletedLocation>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/locations/${id}`,
+      `/v1/terminal/locations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Terminal/Readers.ts
+++ b/src/resources/Terminal/Readers.ts
@@ -27,7 +27,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Terminal.DeletedReader>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/terminal/readers/${id}`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -42,7 +42,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader | Terminal.DeletedReader>> {
     return this._makeRequest(
       'GET',
-      `/v1/terminal/readers/${id}`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -57,7 +57,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader | Terminal.DeletedReader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -97,7 +97,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/cancel_action`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/cancel_action`,
       params,
       options
     ) as any;
@@ -112,7 +112,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/collect_inputs`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/collect_inputs`,
       params,
       options
     ) as any;
@@ -127,7 +127,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/collect_payment_method`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/collect_payment_method`,
       params,
       options
     ) as any;
@@ -142,7 +142,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/confirm_payment_intent`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/confirm_payment_intent`,
       params,
       options
     ) as any;
@@ -157,7 +157,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/process_payment_intent`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/process_payment_intent`,
       params,
       options
     ) as any;
@@ -172,7 +172,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/process_setup_intent`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/process_setup_intent`,
       params,
       options
     ) as any;
@@ -187,7 +187,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/refund_payment`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/refund_payment`,
       params,
       options
     ) as any;
@@ -202,7 +202,7 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/terminal/readers/${id}/set_reader_display`,
+      `/v1/terminal/readers/${encodeURIComponent(id)}/set_reader_display`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Customers.ts
+++ b/src/resources/TestHelpers/Customers.ts
@@ -15,7 +15,7 @@ export class CustomerResource extends StripeResource {
   ): Promise<Response<CustomerCashBalanceTransaction>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/customers/${id}/fund_cash_balance`,
+      `/v1/test_helpers/customers/${encodeURIComponent(id)}/fund_cash_balance`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Issuing/Authorizations.ts
+++ b/src/resources/TestHelpers/Issuing/Authorizations.ts
@@ -231,7 +231,9 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/authorizations/${id}/capture`,
+      `/v1/test_helpers/issuing/authorizations/${encodeURIComponent(
+        id
+      )}/capture`,
       params,
       options,
       {
@@ -463,7 +465,9 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/authorizations/${id}/expire`,
+      `/v1/test_helpers/issuing/authorizations/${encodeURIComponent(
+        id
+      )}/expire`,
       params,
       options,
       {
@@ -642,7 +646,9 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/authorizations/${id}/finalize_amount`,
+      `/v1/test_helpers/issuing/authorizations/${encodeURIComponent(
+        id
+      )}/finalize_amount`,
       params,
       options,
       {
@@ -858,7 +864,9 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/authorizations/${id}/fraud_challenges/respond`,
+      `/v1/test_helpers/issuing/authorizations/${encodeURIComponent(
+        id
+      )}/fraud_challenges/respond`,
       params,
       options,
       {
@@ -1037,7 +1045,9 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/authorizations/${id}/increment`,
+      `/v1/test_helpers/issuing/authorizations/${encodeURIComponent(
+        id
+      )}/increment`,
       params,
       options,
       {
@@ -1216,7 +1226,9 @@ export class AuthorizationResource extends StripeResource {
   ): Promise<Response<Authorization>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/authorizations/${id}/reverse`,
+      `/v1/test_helpers/issuing/authorizations/${encodeURIComponent(
+        id
+      )}/reverse`,
       params,
       options,
       {

--- a/src/resources/TestHelpers/Issuing/Cards.ts
+++ b/src/resources/TestHelpers/Issuing/Cards.ts
@@ -15,7 +15,9 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/cards/${id}/shipping/deliver`,
+      `/v1/test_helpers/issuing/cards/${encodeURIComponent(
+        id
+      )}/shipping/deliver`,
       params,
       options
     ) as any;
@@ -30,7 +32,7 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/cards/${id}/shipping/fail`,
+      `/v1/test_helpers/issuing/cards/${encodeURIComponent(id)}/shipping/fail`,
       params,
       options
     ) as any;
@@ -45,7 +47,9 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/cards/${id}/shipping/return`,
+      `/v1/test_helpers/issuing/cards/${encodeURIComponent(
+        id
+      )}/shipping/return`,
       params,
       options
     ) as any;
@@ -60,7 +64,7 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/cards/${id}/shipping/ship`,
+      `/v1/test_helpers/issuing/cards/${encodeURIComponent(id)}/shipping/ship`,
       params,
       options
     ) as any;
@@ -75,7 +79,9 @@ export class CardResource extends StripeResource {
   ): Promise<Response<Card>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/cards/${id}/shipping/submit`,
+      `/v1/test_helpers/issuing/cards/${encodeURIComponent(
+        id
+      )}/shipping/submit`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Issuing/PersonalizationDesigns.ts
+++ b/src/resources/TestHelpers/Issuing/PersonalizationDesigns.ts
@@ -15,7 +15,9 @@ export class PersonalizationDesignResource extends StripeResource {
   ): Promise<Response<PersonalizationDesign>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/personalization_designs/${id}/activate`,
+      `/v1/test_helpers/issuing/personalization_designs/${encodeURIComponent(
+        id
+      )}/activate`,
       params,
       options
     ) as any;
@@ -30,7 +32,9 @@ export class PersonalizationDesignResource extends StripeResource {
   ): Promise<Response<PersonalizationDesign>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/personalization_designs/${id}/deactivate`,
+      `/v1/test_helpers/issuing/personalization_designs/${encodeURIComponent(
+        id
+      )}/deactivate`,
       params,
       options
     ) as any;
@@ -45,7 +49,9 @@ export class PersonalizationDesignResource extends StripeResource {
   ): Promise<Response<PersonalizationDesign>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/personalization_designs/${id}/reject`,
+      `/v1/test_helpers/issuing/personalization_designs/${encodeURIComponent(
+        id
+      )}/reject`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Issuing/Transactions.ts
+++ b/src/resources/TestHelpers/Issuing/Transactions.ts
@@ -16,7 +16,7 @@ export class TransactionResource extends StripeResource {
   ): Promise<Response<Transaction>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/issuing/transactions/${id}/refund`,
+      `/v1/test_helpers/issuing/transactions/${encodeURIComponent(id)}/refund`,
       params,
       options,
       {

--- a/src/resources/TestHelpers/Refunds.ts
+++ b/src/resources/TestHelpers/Refunds.ts
@@ -15,7 +15,7 @@ export class RefundResource extends StripeResource {
   ): Promise<Response<Refund>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/refunds/${id}/expire`,
+      `/v1/test_helpers/refunds/${encodeURIComponent(id)}/expire`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Terminal/Readers.ts
+++ b/src/resources/TestHelpers/Terminal/Readers.ts
@@ -15,7 +15,9 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/terminal/readers/${id}/present_payment_method`,
+      `/v1/test_helpers/terminal/readers/${encodeURIComponent(
+        id
+      )}/present_payment_method`,
       params,
       options
     ) as any;
@@ -30,7 +32,9 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/terminal/readers/${id}/succeed_input_collection`,
+      `/v1/test_helpers/terminal/readers/${encodeURIComponent(
+        id
+      )}/succeed_input_collection`,
       params,
       options
     ) as any;
@@ -45,7 +49,9 @@ export class ReaderResource extends StripeResource {
   ): Promise<Response<Reader>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/terminal/readers/${id}/timeout_input_collection`,
+      `/v1/test_helpers/terminal/readers/${encodeURIComponent(
+        id
+      )}/timeout_input_collection`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/TestClocks.ts
+++ b/src/resources/TestHelpers/TestClocks.ts
@@ -15,7 +15,7 @@ export class TestClockResource extends StripeResource {
   ): Promise<Response<TestHelpers.DeletedTestClock>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/test_helpers/test_clocks/${id}`,
+      `/v1/test_helpers/test_clocks/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -30,7 +30,7 @@ export class TestClockResource extends StripeResource {
   ): Promise<Response<TestClock>> {
     return this._makeRequest(
       'GET',
-      `/v1/test_helpers/test_clocks/${id}`,
+      `/v1/test_helpers/test_clocks/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -76,7 +76,7 @@ export class TestClockResource extends StripeResource {
   ): Promise<Response<TestClock>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/test_clocks/${id}/advance`,
+      `/v1/test_helpers/test_clocks/${encodeURIComponent(id)}/advance`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Treasury/InboundTransfers.ts
+++ b/src/resources/TestHelpers/Treasury/InboundTransfers.ts
@@ -15,7 +15,9 @@ export class InboundTransferResource extends StripeResource {
   ): Promise<Response<InboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/inbound_transfers/${id}/fail`,
+      `/v1/test_helpers/treasury/inbound_transfers/${encodeURIComponent(
+        id
+      )}/fail`,
       params,
       options
     ) as any;
@@ -30,7 +32,9 @@ export class InboundTransferResource extends StripeResource {
   ): Promise<Response<InboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/inbound_transfers/${id}/return`,
+      `/v1/test_helpers/treasury/inbound_transfers/${encodeURIComponent(
+        id
+      )}/return`,
       params,
       options
     ) as any;
@@ -45,7 +49,9 @@ export class InboundTransferResource extends StripeResource {
   ): Promise<Response<InboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/inbound_transfers/${id}/succeed`,
+      `/v1/test_helpers/treasury/inbound_transfers/${encodeURIComponent(
+        id
+      )}/succeed`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Treasury/OutboundPayments.ts
+++ b/src/resources/TestHelpers/Treasury/OutboundPayments.ts
@@ -15,7 +15,7 @@ export class OutboundPaymentResource extends StripeResource {
   ): Promise<Response<OutboundPayment>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_payments/${id}`,
+      `/v1/test_helpers/treasury/outbound_payments/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -30,7 +30,9 @@ export class OutboundPaymentResource extends StripeResource {
   ): Promise<Response<OutboundPayment>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_payments/${id}/fail`,
+      `/v1/test_helpers/treasury/outbound_payments/${encodeURIComponent(
+        id
+      )}/fail`,
       params,
       options
     ) as any;
@@ -45,7 +47,9 @@ export class OutboundPaymentResource extends StripeResource {
   ): Promise<Response<OutboundPayment>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_payments/${id}/post`,
+      `/v1/test_helpers/treasury/outbound_payments/${encodeURIComponent(
+        id
+      )}/post`,
       params,
       options
     ) as any;
@@ -60,7 +64,9 @@ export class OutboundPaymentResource extends StripeResource {
   ): Promise<Response<OutboundPayment>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_payments/${id}/return`,
+      `/v1/test_helpers/treasury/outbound_payments/${encodeURIComponent(
+        id
+      )}/return`,
       params,
       options
     ) as any;

--- a/src/resources/TestHelpers/Treasury/OutboundTransfers.ts
+++ b/src/resources/TestHelpers/Treasury/OutboundTransfers.ts
@@ -15,7 +15,7 @@ export class OutboundTransferResource extends StripeResource {
   ): Promise<Response<OutboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_transfers/${id}`,
+      `/v1/test_helpers/treasury/outbound_transfers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -30,7 +30,9 @@ export class OutboundTransferResource extends StripeResource {
   ): Promise<Response<OutboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_transfers/${id}/fail`,
+      `/v1/test_helpers/treasury/outbound_transfers/${encodeURIComponent(
+        id
+      )}/fail`,
       params,
       options
     ) as any;
@@ -45,7 +47,9 @@ export class OutboundTransferResource extends StripeResource {
   ): Promise<Response<OutboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_transfers/${id}/post`,
+      `/v1/test_helpers/treasury/outbound_transfers/${encodeURIComponent(
+        id
+      )}/post`,
       params,
       options
     ) as any;
@@ -60,7 +64,9 @@ export class OutboundTransferResource extends StripeResource {
   ): Promise<Response<OutboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/test_helpers/treasury/outbound_transfers/${id}/return`,
+      `/v1/test_helpers/treasury/outbound_transfers/${encodeURIComponent(
+        id
+      )}/return`,
       params,
       options
     ) as any;

--- a/src/resources/Tokens.ts
+++ b/src/resources/Tokens.ts
@@ -20,7 +20,12 @@ export class TokenResource extends StripeResource {
     params?: TokenRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Token>> {
-    return this._makeRequest('GET', `/v1/tokens/${id}`, params, options) as any;
+    return this._makeRequest(
+      'GET',
+      `/v1/tokens/${encodeURIComponent(id)}`,
+      params,
+      options
+    ) as any;
   }
   /**
    * Creates a single-use token that represents a bank account's details.

--- a/src/resources/Topups.ts
+++ b/src/resources/Topups.ts
@@ -41,7 +41,12 @@ export class TopupResource extends StripeResource {
     params?: TopupRetrieveParams,
     options?: RequestOptions
   ): Promise<Response<Topup>> {
-    return this._makeRequest('GET', `/v1/topups/${id}`, params, options) as any;
+    return this._makeRequest(
+      'GET',
+      `/v1/topups/${encodeURIComponent(id)}`,
+      params,
+      options
+    ) as any;
   }
   /**
    * Updates the metadata of a top-up. Other top-up details are not editable by design.
@@ -53,7 +58,7 @@ export class TopupResource extends StripeResource {
   ): Promise<Response<Topup>> {
     return this._makeRequest(
       'POST',
-      `/v1/topups/${id}`,
+      `/v1/topups/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -68,7 +73,7 @@ export class TopupResource extends StripeResource {
   ): Promise<Response<Topup>> {
     return this._makeRequest(
       'POST',
-      `/v1/topups/${id}/cancel`,
+      `/v1/topups/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;

--- a/src/resources/Transfers.ts
+++ b/src/resources/Transfers.ts
@@ -45,7 +45,7 @@ export class TransferResource extends StripeResource {
   ): Promise<Response<Transfer>> {
     return this._makeRequest(
       'GET',
-      `/v1/transfers/${id}`,
+      `/v1/transfers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -62,7 +62,7 @@ export class TransferResource extends StripeResource {
   ): Promise<Response<Transfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/transfers/${id}`,
+      `/v1/transfers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -77,7 +77,7 @@ export class TransferResource extends StripeResource {
   ): ApiListPromise<TransferReversal> {
     return this._makeRequest(
       'GET',
-      `/v1/transfers/${id}/reversals`,
+      `/v1/transfers/${encodeURIComponent(id)}/reversals`,
       params,
       options,
       {
@@ -99,7 +99,7 @@ export class TransferResource extends StripeResource {
   ): Promise<Response<TransferReversal>> {
     return this._makeRequest(
       'POST',
-      `/v1/transfers/${id}/reversals`,
+      `/v1/transfers/${encodeURIComponent(id)}/reversals`,
       params,
       options
     ) as any;
@@ -115,7 +115,9 @@ export class TransferResource extends StripeResource {
   ): Promise<Response<TransferReversal>> {
     return this._makeRequest(
       'GET',
-      `/v1/transfers/${transferId}/reversals/${id}`,
+      `/v1/transfers/${encodeURIComponent(
+        transferId
+      )}/reversals/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -133,7 +135,9 @@ export class TransferResource extends StripeResource {
   ): Promise<Response<TransferReversal>> {
     return this._makeRequest(
       'POST',
-      `/v1/transfers/${transferId}/reversals/${id}`,
+      `/v1/transfers/${encodeURIComponent(
+        transferId
+      )}/reversals/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/CreditReversals.ts
+++ b/src/resources/Treasury/CreditReversals.ts
@@ -47,7 +47,7 @@ export class CreditReversalResource extends StripeResource {
   ): Promise<Response<CreditReversal>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/credit_reversals/${id}`,
+      `/v1/treasury/credit_reversals/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/DebitReversals.ts
+++ b/src/resources/Treasury/DebitReversals.ts
@@ -47,7 +47,7 @@ export class DebitReversalResource extends StripeResource {
   ): Promise<Response<DebitReversal>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/debit_reversals/${id}`,
+      `/v1/treasury/debit_reversals/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/FinancialAccounts.ts
+++ b/src/resources/Treasury/FinancialAccounts.ts
@@ -53,7 +53,7 @@ export class FinancialAccountResource extends StripeResource {
   ): Promise<Response<FinancialAccount>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/financial_accounts/${id}`,
+      `/v1/treasury/financial_accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -68,7 +68,7 @@ export class FinancialAccountResource extends StripeResource {
   ): Promise<Response<FinancialAccount>> {
     return this._makeRequest(
       'POST',
-      `/v1/treasury/financial_accounts/${id}`,
+      `/v1/treasury/financial_accounts/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -83,7 +83,7 @@ export class FinancialAccountResource extends StripeResource {
   ): Promise<Response<FinancialAccount>> {
     return this._makeRequest(
       'POST',
-      `/v1/treasury/financial_accounts/${id}/close`,
+      `/v1/treasury/financial_accounts/${encodeURIComponent(id)}/close`,
       params,
       options
     ) as any;
@@ -98,7 +98,7 @@ export class FinancialAccountResource extends StripeResource {
   ): Promise<Response<FinancialAccountFeatures>> {
     return this._makeRequest(
       'POST',
-      `/v1/treasury/financial_accounts/${id}/features`,
+      `/v1/treasury/financial_accounts/${encodeURIComponent(id)}/features`,
       params,
       options
     ) as any;
@@ -113,7 +113,7 @@ export class FinancialAccountResource extends StripeResource {
   ): Promise<Response<FinancialAccountFeatures>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/financial_accounts/${id}/features`,
+      `/v1/treasury/financial_accounts/${encodeURIComponent(id)}/features`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/InboundTransfers.ts
+++ b/src/resources/Treasury/InboundTransfers.ts
@@ -53,7 +53,7 @@ export class InboundTransferResource extends StripeResource {
   ): Promise<Response<InboundTransfer>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/inbound_transfers/${id}`,
+      `/v1/treasury/inbound_transfers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -68,7 +68,7 @@ export class InboundTransferResource extends StripeResource {
   ): Promise<Response<InboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/treasury/inbound_transfers/${id}/cancel`,
+      `/v1/treasury/inbound_transfers/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/OutboundPayments.ts
+++ b/src/resources/Treasury/OutboundPayments.ts
@@ -56,7 +56,7 @@ export class OutboundPaymentResource extends StripeResource {
   ): Promise<Response<OutboundPayment>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/outbound_payments/${id}`,
+      `/v1/treasury/outbound_payments/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -71,7 +71,7 @@ export class OutboundPaymentResource extends StripeResource {
   ): Promise<Response<OutboundPayment>> {
     return this._makeRequest(
       'POST',
-      `/v1/treasury/outbound_payments/${id}/cancel`,
+      `/v1/treasury/outbound_payments/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/OutboundTransfers.ts
+++ b/src/resources/Treasury/OutboundTransfers.ts
@@ -54,7 +54,7 @@ export class OutboundTransferResource extends StripeResource {
   ): Promise<Response<OutboundTransfer>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/outbound_transfers/${id}`,
+      `/v1/treasury/outbound_transfers/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -69,7 +69,7 @@ export class OutboundTransferResource extends StripeResource {
   ): Promise<Response<OutboundTransfer>> {
     return this._makeRequest(
       'POST',
-      `/v1/treasury/outbound_transfers/${id}/cancel`,
+      `/v1/treasury/outbound_transfers/${encodeURIComponent(id)}/cancel`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/ReceivedCredits.ts
+++ b/src/resources/Treasury/ReceivedCredits.ts
@@ -37,7 +37,7 @@ export class ReceivedCreditResource extends StripeResource {
   ): Promise<Response<ReceivedCredit>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/received_credits/${id}`,
+      `/v1/treasury/received_credits/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/ReceivedDebits.ts
+++ b/src/resources/Treasury/ReceivedDebits.ts
@@ -33,7 +33,7 @@ export class ReceivedDebitResource extends StripeResource {
   ): Promise<Response<ReceivedDebit>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/received_debits/${id}`,
+      `/v1/treasury/received_debits/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/Treasury/TransactionEntries.ts
+++ b/src/resources/Treasury/TransactionEntries.ts
@@ -238,7 +238,7 @@ export class TransactionEntryResource extends StripeResource {
   ): Promise<Response<TransactionEntry>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/transaction_entries/${id}`,
+      `/v1/treasury/transaction_entries/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/Treasury/Transactions.ts
+++ b/src/resources/Treasury/Transactions.ts
@@ -280,7 +280,7 @@ export class TransactionResource extends StripeResource {
   ): Promise<Response<Transaction>> {
     return this._makeRequest(
       'GET',
-      `/v1/treasury/transactions/${id}`,
+      `/v1/treasury/transactions/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/V2/Commerce/ProductCatalog/Imports.ts
+++ b/src/resources/V2/Commerce/ProductCatalog/Imports.ts
@@ -135,7 +135,7 @@ export class ImportResource extends StripeResource {
   ): Promise<Response<ProductCatalogImport>> {
     return this._makeRequest(
       'GET',
-      `/v2/commerce/product_catalog/imports/${id}`,
+      `/v2/commerce/product_catalog/imports/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/V2/Core/AccountTokens.ts
+++ b/src/resources/V2/Core/AccountTokens.ts
@@ -57,7 +57,7 @@ export class AccountTokenResource extends StripeResource {
   ): Promise<Response<AccountToken>> {
     return this._makeRequest(
       'GET',
-      `/v2/core/account_tokens/${id}`,
+      `/v2/core/account_tokens/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/V2/Core/Accounts.ts
+++ b/src/resources/V2/Core/Accounts.ts
@@ -122,7 +122,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'GET',
-      `/v2/core/accounts/${id}`,
+      `/v2/core/accounts/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -159,7 +159,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/accounts/${id}`,
+      `/v2/core/accounts/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -215,7 +215,7 @@ export class AccountResource extends StripeResource {
   ): Promise<Response<Account>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/accounts/${id}/close`,
+      `/v2/core/accounts/${encodeURIComponent(id)}/close`,
       params,
       options,
       {

--- a/src/resources/V2/Core/Accounts/PersonTokens.ts
+++ b/src/resources/V2/Core/Accounts/PersonTokens.ts
@@ -12,13 +12,13 @@ export class PersonTokenResource extends StripeResource {
    * @throws Stripe.RateLimitError
    */
   create(
-    id: string,
+    accountId: string,
     params?: V2.Core.Accounts.PersonTokenCreateParams,
     options?: RequestOptions
   ): Promise<Response<AccountPersonToken>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/accounts/${id}/person_tokens`,
+      `/v2/core/accounts/${encodeURIComponent(accountId)}/person_tokens`,
       params,
       options,
       {
@@ -46,7 +46,9 @@ export class PersonTokenResource extends StripeResource {
   ): Promise<Response<AccountPersonToken>> {
     return this._makeRequest(
       'GET',
-      `/v2/core/accounts/${accountId}/person_tokens/${id}`,
+      `/v2/core/accounts/${encodeURIComponent(
+        accountId
+      )}/person_tokens/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/src/resources/V2/Core/Accounts/Persons.ts
+++ b/src/resources/V2/Core/Accounts/Persons.ts
@@ -17,13 +17,13 @@ export class PersonResource extends StripeResource {
    * @throws Stripe.RateLimitError
    */
   list(
-    id: string,
+    accountId: string,
     params?: V2.Core.Accounts.PersonListParams,
     options?: RequestOptions
   ): V2ListPromise<AccountPerson> {
     return this._makeRequest(
       'GET',
-      `/v2/core/accounts/${id}/persons`,
+      `/v2/core/accounts/${encodeURIComponent(accountId)}/persons`,
       params,
       options,
       {
@@ -53,13 +53,13 @@ export class PersonResource extends StripeResource {
    * @throws Stripe.RateLimitError
    */
   create(
-    id: string,
+    accountId: string,
     params?: V2.Core.Accounts.PersonCreateParams,
     options?: RequestOptions
   ): Promise<Response<AccountPerson>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/accounts/${id}/persons`,
+      `/v2/core/accounts/${encodeURIComponent(accountId)}/persons`,
       params,
       options,
       {
@@ -96,7 +96,9 @@ export class PersonResource extends StripeResource {
   ): Promise<Response<DeletedObject>> {
     return this._makeRequest(
       'DELETE',
-      `/v2/core/accounts/${accountId}/persons/${id}`,
+      `/v2/core/accounts/${encodeURIComponent(
+        accountId
+      )}/persons/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -113,7 +115,9 @@ export class PersonResource extends StripeResource {
   ): Promise<Response<AccountPerson>> {
     return this._makeRequest(
       'GET',
-      `/v2/core/accounts/${accountId}/persons/${id}`,
+      `/v2/core/accounts/${encodeURIComponent(
+        accountId
+      )}/persons/${encodeURIComponent(id)}`,
       params,
       options,
       {
@@ -141,7 +145,9 @@ export class PersonResource extends StripeResource {
   ): Promise<Response<AccountPerson>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/accounts/${accountId}/persons/${id}`,
+      `/v2/core/accounts/${encodeURIComponent(
+        accountId
+      )}/persons/${encodeURIComponent(id)}`,
       params,
       options,
       {

--- a/src/resources/V2/Core/EventDestinations.ts
+++ b/src/resources/V2/Core/EventDestinations.ts
@@ -48,7 +48,7 @@ export class EventDestinationResource extends StripeResource {
   ): Promise<Response<DeletedObject>> {
     return this._makeRequest(
       'DELETE',
-      `/v2/core/event_destinations/${id}`,
+      `/v2/core/event_destinations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -63,7 +63,7 @@ export class EventDestinationResource extends StripeResource {
   ): Promise<Response<EventDestination>> {
     return this._makeRequest(
       'GET',
-      `/v2/core/event_destinations/${id}`,
+      `/v2/core/event_destinations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -78,7 +78,7 @@ export class EventDestinationResource extends StripeResource {
   ): Promise<Response<EventDestination>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/event_destinations/${id}`,
+      `/v2/core/event_destinations/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -93,7 +93,7 @@ export class EventDestinationResource extends StripeResource {
   ): Promise<Response<EventDestination>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/event_destinations/${id}/disable`,
+      `/v2/core/event_destinations/${encodeURIComponent(id)}/disable`,
       params,
       options
     ) as any;
@@ -108,7 +108,7 @@ export class EventDestinationResource extends StripeResource {
   ): Promise<Response<EventDestination>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/event_destinations/${id}/enable`,
+      `/v2/core/event_destinations/${encodeURIComponent(id)}/enable`,
       params,
       options
     ) as any;
@@ -123,7 +123,7 @@ export class EventDestinationResource extends StripeResource {
   ): Promise<Response<Event>> {
     return this._makeRequest(
       'POST',
-      `/v2/core/event_destinations/${id}/ping`,
+      `/v2/core/event_destinations/${encodeURIComponent(id)}/ping`,
       params,
       options
     ) as any;

--- a/src/resources/V2/Core/Events.ts
+++ b/src/resources/V2/Core/Events.ts
@@ -35,9 +35,15 @@ export class EventResource extends StripeResource {
     const transformResponseData = (response: any): any => {
       return this.addFetchRelatedObjectIfNeeded(response);
     };
-    return this._makeRequest('GET', `/v2/core/events/${id}`, params, options, {
-      transformResponseData: transformResponseData,
-    }) as any;
+    return this._makeRequest(
+      'GET',
+      `/v2/core/events/${encodeURIComponent(id)}`,
+      params,
+      options,
+      {
+        transformResponseData: transformResponseData,
+      }
+    ) as any;
   }
   /**
    * @private

--- a/src/resources/WebhookEndpoints.ts
+++ b/src/resources/WebhookEndpoints.ts
@@ -20,7 +20,7 @@ export class WebhookEndpointResource extends StripeResource {
   ): Promise<Response<DeletedWebhookEndpoint>> {
     return this._makeRequest(
       'DELETE',
-      `/v1/webhook_endpoints/${id}`,
+      `/v1/webhook_endpoints/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -35,7 +35,7 @@ export class WebhookEndpointResource extends StripeResource {
   ): Promise<Response<WebhookEndpoint>> {
     return this._makeRequest(
       'GET',
-      `/v1/webhook_endpoints/${id}`,
+      `/v1/webhook_endpoints/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;
@@ -50,7 +50,7 @@ export class WebhookEndpointResource extends StripeResource {
   ): Promise<Response<WebhookEndpoint>> {
     return this._makeRequest(
       'POST',
-      `/v1/webhook_endpoints/${id}`,
+      `/v1/webhook_endpoints/${encodeURIComponent(id)}`,
       params,
       options
     ) as any;

--- a/test/resources/Customers.spec.js
+++ b/test/resources/Customers.spec.js
@@ -470,4 +470,40 @@ describe('Customers Resource', () => {
       });
     });
   });
+
+  describe('Path parameter encoding', () => {
+    // these specific methods aren't important, just that they have 1+ path params
+    it('URL-encodes path separators in IDs', () => {
+      stripe.customers.retrieve('cus_123/sources');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/customers/cus_123%2Fsources',
+        headers: {},
+        data: null,
+        settings: {},
+      });
+    });
+
+    it('URL-encodes query metacharacters in IDs', () => {
+      stripe.customers.retrieve('cus_123?expand[]=sources');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/customers/cus_123%3Fexpand%5B%5D%3Dsources',
+        headers: {},
+        data: null,
+        settings: {},
+      });
+    });
+
+    it('URL-encodes both parent and child IDs in nested resources', () => {
+      stripe.customers.retrieveSource('cus/123', 'card?id');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/customers/cus%2F123/sources/card%3Fid',
+        headers: {},
+        data: null,
+        settings: {},
+      });
+    });
+  });
 });


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a regression introduced in https://github.com/stripe/stripe-node/pull/2645 (shipped in `v22.0.0`) where method params weren't encoded before being sent to Stripe. As a result, malicious user input could be used to redirect requests to unexpeted paths or to include more data than intended. For example:

```
stripe.customers.retrieve('cu_123/payment_methods/pm_456')
```

Would retrieve a payment method instead of the expected customer. Now that request will fail with a 400 error.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- codegen usage of the `encodeURIComponent` function for all path params
- add a test

### See Also
<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2486](https://go/j/RUN_DEVSDK-2486)