### PR TITLE
Fix `Stripe.ErrorType.StripeError` incorrectly being usable as a runtime class

### DIFF
--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -2593,6 +2593,105 @@ export declare namespace Stripe {
 
   export {StripeContext as StripeContextType};
   export {StripeRawError};
-  export import ErrorType = _Error;
+  // ErrorTypeNamespaces: The beginning of the section generated from our OpenAPI spec
+  export namespace ErrorType {
+    export type StripeError = InstanceType<typeof _Error.StripeError>;
+    export type StripeCardError = InstanceType<typeof _Error.StripeCardError>;
+    export type StripeInvalidRequestError = InstanceType<
+      typeof _Error.StripeInvalidRequestError
+    >;
+    export type StripeAPIError = InstanceType<typeof _Error.StripeAPIError>;
+    export type StripeAuthenticationError = InstanceType<
+      typeof _Error.StripeAuthenticationError
+    >;
+    export type StripePermissionError = InstanceType<
+      typeof _Error.StripePermissionError
+    >;
+    export type StripeRateLimitError = InstanceType<
+      typeof _Error.StripeRateLimitError
+    >;
+    export type StripeConnectionError = InstanceType<
+      typeof _Error.StripeConnectionError
+    >;
+    export type StripeSignatureVerificationError = InstanceType<
+      typeof _Error.StripeSignatureVerificationError
+    >;
+    export type StripeIdempotencyError = InstanceType<
+      typeof _Error.StripeIdempotencyError
+    >;
+    export type StripeOAuthError = InstanceType<typeof _Error.StripeOAuthError>;
+    export type StripeInvalidGrantError = InstanceType<
+      typeof _Error.StripeInvalidGrantError
+    >;
+    export type StripeInvalidClientError = InstanceType<
+      typeof _Error.StripeInvalidClientError
+    >;
+    export type StripeOAuthInvalidRequestError = InstanceType<
+      typeof _Error.StripeOAuthInvalidRequestError
+    >;
+    export type StripeInvalidScopeError = InstanceType<
+      typeof _Error.StripeInvalidScopeError
+    >;
+    export type StripeUnsupportedGrantTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedGrantTypeError
+    >;
+    export type StripeUnsupportedResponseTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedResponseTypeError
+    >;
+    export type RateLimitError = InstanceType<typeof _Error.RateLimitError>;
+    export type TemporarySessionExpiredError = InstanceType<
+      typeof _Error.TemporarySessionExpiredError
+    >;
+  }
+  export namespace errors {
+    export type StripeError = InstanceType<typeof _Error.StripeError>;
+    export type StripeCardError = InstanceType<typeof _Error.StripeCardError>;
+    export type StripeInvalidRequestError = InstanceType<
+      typeof _Error.StripeInvalidRequestError
+    >;
+    export type StripeAPIError = InstanceType<typeof _Error.StripeAPIError>;
+    export type StripeAuthenticationError = InstanceType<
+      typeof _Error.StripeAuthenticationError
+    >;
+    export type StripePermissionError = InstanceType<
+      typeof _Error.StripePermissionError
+    >;
+    export type StripeRateLimitError = InstanceType<
+      typeof _Error.StripeRateLimitError
+    >;
+    export type StripeConnectionError = InstanceType<
+      typeof _Error.StripeConnectionError
+    >;
+    export type StripeSignatureVerificationError = InstanceType<
+      typeof _Error.StripeSignatureVerificationError
+    >;
+    export type StripeIdempotencyError = InstanceType<
+      typeof _Error.StripeIdempotencyError
+    >;
+    export type StripeOAuthError = InstanceType<typeof _Error.StripeOAuthError>;
+    export type StripeInvalidGrantError = InstanceType<
+      typeof _Error.StripeInvalidGrantError
+    >;
+    export type StripeInvalidClientError = InstanceType<
+      typeof _Error.StripeInvalidClientError
+    >;
+    export type StripeOAuthInvalidRequestError = InstanceType<
+      typeof _Error.StripeOAuthInvalidRequestError
+    >;
+    export type StripeInvalidScopeError = InstanceType<
+      typeof _Error.StripeInvalidScopeError
+    >;
+    export type StripeUnsupportedGrantTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedGrantTypeError
+    >;
+    export type StripeUnsupportedResponseTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedResponseTypeError
+    >;
+    export type RateLimitError = InstanceType<typeof _Error.RateLimitError>;
+    export type TemporarySessionExpiredError = InstanceType<
+      typeof _Error.TemporarySessionExpiredError
+    >;
+  }
+  // ErrorTypeNamespaces: The end of the section generated from our OpenAPI spec
   export import Events = V2.Core.Events;
 }

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -2586,7 +2586,106 @@ export declare namespace Stripe {
 
   export {StripeContext as StripeContextType};
   export {StripeRawError};
-  export import ErrorType = _Error;
+  // ErrorTypeNamespaces: The beginning of the section generated from our OpenAPI spec
+  export namespace ErrorType {
+    export type StripeError = InstanceType<typeof _Error.StripeError>;
+    export type StripeCardError = InstanceType<typeof _Error.StripeCardError>;
+    export type StripeInvalidRequestError = InstanceType<
+      typeof _Error.StripeInvalidRequestError
+    >;
+    export type StripeAPIError = InstanceType<typeof _Error.StripeAPIError>;
+    export type StripeAuthenticationError = InstanceType<
+      typeof _Error.StripeAuthenticationError
+    >;
+    export type StripePermissionError = InstanceType<
+      typeof _Error.StripePermissionError
+    >;
+    export type StripeRateLimitError = InstanceType<
+      typeof _Error.StripeRateLimitError
+    >;
+    export type StripeConnectionError = InstanceType<
+      typeof _Error.StripeConnectionError
+    >;
+    export type StripeSignatureVerificationError = InstanceType<
+      typeof _Error.StripeSignatureVerificationError
+    >;
+    export type StripeIdempotencyError = InstanceType<
+      typeof _Error.StripeIdempotencyError
+    >;
+    export type StripeOAuthError = InstanceType<typeof _Error.StripeOAuthError>;
+    export type StripeInvalidGrantError = InstanceType<
+      typeof _Error.StripeInvalidGrantError
+    >;
+    export type StripeInvalidClientError = InstanceType<
+      typeof _Error.StripeInvalidClientError
+    >;
+    export type StripeOAuthInvalidRequestError = InstanceType<
+      typeof _Error.StripeOAuthInvalidRequestError
+    >;
+    export type StripeInvalidScopeError = InstanceType<
+      typeof _Error.StripeInvalidScopeError
+    >;
+    export type StripeUnsupportedGrantTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedGrantTypeError
+    >;
+    export type StripeUnsupportedResponseTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedResponseTypeError
+    >;
+    export type RateLimitError = InstanceType<typeof _Error.RateLimitError>;
+    export type TemporarySessionExpiredError = InstanceType<
+      typeof _Error.TemporarySessionExpiredError
+    >;
+  }
+  export namespace errors {
+    export type StripeError = InstanceType<typeof _Error.StripeError>;
+    export type StripeCardError = InstanceType<typeof _Error.StripeCardError>;
+    export type StripeInvalidRequestError = InstanceType<
+      typeof _Error.StripeInvalidRequestError
+    >;
+    export type StripeAPIError = InstanceType<typeof _Error.StripeAPIError>;
+    export type StripeAuthenticationError = InstanceType<
+      typeof _Error.StripeAuthenticationError
+    >;
+    export type StripePermissionError = InstanceType<
+      typeof _Error.StripePermissionError
+    >;
+    export type StripeRateLimitError = InstanceType<
+      typeof _Error.StripeRateLimitError
+    >;
+    export type StripeConnectionError = InstanceType<
+      typeof _Error.StripeConnectionError
+    >;
+    export type StripeSignatureVerificationError = InstanceType<
+      typeof _Error.StripeSignatureVerificationError
+    >;
+    export type StripeIdempotencyError = InstanceType<
+      typeof _Error.StripeIdempotencyError
+    >;
+    export type StripeOAuthError = InstanceType<typeof _Error.StripeOAuthError>;
+    export type StripeInvalidGrantError = InstanceType<
+      typeof _Error.StripeInvalidGrantError
+    >;
+    export type StripeInvalidClientError = InstanceType<
+      typeof _Error.StripeInvalidClientError
+    >;
+    export type StripeOAuthInvalidRequestError = InstanceType<
+      typeof _Error.StripeOAuthInvalidRequestError
+    >;
+    export type StripeInvalidScopeError = InstanceType<
+      typeof _Error.StripeInvalidScopeError
+    >;
+    export type StripeUnsupportedGrantTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedGrantTypeError
+    >;
+    export type StripeUnsupportedResponseTypeError = InstanceType<
+      typeof _Error.StripeUnsupportedResponseTypeError
+    >;
+    export type RateLimitError = InstanceType<typeof _Error.RateLimitError>;
+    export type TemporarySessionExpiredError = InstanceType<
+      typeof _Error.TemporarySessionExpiredError
+    >;
+  }
+  // ErrorTypeNamespaces: The end of the section generated from our OpenAPI spec
   export import Events = V2.Core.Events;
 }
 

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -271,6 +271,24 @@ const instanceofCheck2 = {} instanceof Stripe.errors.StripeAPIError;
 const instanceofCheck5 = {} instanceof stripe.errors.StripeError;
 const instanceofCheck6 = {} instanceof stripe.errors.StripeAPIError;
 
+// ErrorType namespace provides type-level access (DEVSDK-3141)
+let errorTypeCheck1: Stripe.ErrorType.StripeError;
+let errorTypeCheck2: Stripe.ErrorType.StripeCardError;
+let errorTypeCheck3: Stripe.ErrorType.StripeInvalidRequestError;
+
+// Stripe.errors and Stripe.ErrorType are interchangeable as types
+const errorTypeInterchangeable = (
+  e: Stripe.errors.StripeError
+): Stripe.ErrorType.StripeError => e;
+
+// instanceof narrows to the correct type
+const instanceofNarrowing = (e: unknown): Stripe.ErrorType.StripeError | null => {
+  if (e instanceof Stripe.errors.StripeError) {
+    return e;
+  }
+  return null;
+};
+
 stripe.files.create({
   purpose: 'dispute_evidence',
   file: {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Because of the way our errors were re-exported, Typescript allowed the use of `Stripe.ErrorType` in runtime code:

```ts
// passed `tsc`, but shouldn't:
if (error instanceof Stripe.ErrorType.StripeError) { 
  // ...
}
```

But at runtime, it would blow up:

```
16 |   if (error instanceof Stripe.ErrorType.StripeError) {
                                   ^
TypeError: undefined is not an object (evaluating 'Stripe.ErrorType.StripeError')
```

This was caused by the way we exported `ErrorType`. It was being described as a class by the type system, but was only usable as a type. To fix, we don't export it as a class in the type system anymore. There's no runtime impact of this, it's purely a types change

> Note: I _believe_ we don't need `ErrorType` any more at all. It was added to work around this bug, but given that `.errors` now works the way we expect (both as a type and as a value) we can probably drop it in the next major (filed as [DEVSDK-3165](https://go/j/DEVSDK-3165))

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- explicitly export a namespace of errors instead of the runtime module `_Error`

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-node/issues/2661
- [DEVSDK-3141](https://go/j/DEVSDK-3141)