### PR TITLE
Encode URI path params in `accounts.retrieve`

### DIFF
--- a/src/resources/Accounts.ts
+++ b/src/resources/Accounts.ts
@@ -52,7 +52,7 @@ export class AccountResource extends StripeResource {
     if (typeof id === 'string') {
       return this._makeRequest(
         'GET',
-        `/v1/accounts/${id}`,
+        `/v1/accounts/${encodeURIComponent(id)}`,
         params,
         options
       ) as any;

--- a/test/resources/Account.spec.js
+++ b/test/resources/Account.spec.js
@@ -76,6 +76,19 @@ describe('Account Resource', () => {
       });
     });
 
+    // GET /v1/accounts/:id uses an override instead of a normal generated method,
+    // so it gets its own test.
+    it('URL-encodes path separators in IDs', () => {
+      stripe.account.retrieve('acct_123/sources');
+      expect(stripe.LAST_REQUEST).to.deep.equal({
+        method: 'GET',
+        url: '/v1/accounts/acct_123%2Fsources',
+        headers: {},
+        data: null,
+        settings: {},
+      });
+    });
+
     it('Sends the correct request with secret key', () => {
       const key = 'sk_12345678901234567890123456789012';
       stripe.account.retrieve(null, undefined, {apiKey: key});


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Small follow up to https://github.com/stripe/stripe-node/pull/2750 to cover a method we missed. It was generated separately, so we missed it in the initial fix.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add `encodeURIComponent` call to `accounts.retrieve()`
- add test

### See Also
<!-- Include any links or additional information that help explain this change. -->
