### PR TITLE
Pin `@types/node` to `~22.19` in CJS type test projects

### DIFF
--- a/testProjects/cjs-ts/package.json
+++ b/testProjects/cjs-ts/package.json
@@ -12,7 +12,7 @@
     "lint": "eslint . --ext .ts"
   },
   "devDependencies": {
-    "@types/node": "~22",
+    "@types/node": "~22.19",
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "eslint": "^8.33.0",

--- a/testProjects/types-cjs-node16/package.json
+++ b/testProjects/types-cjs-node16/package.json
@@ -7,7 +7,7 @@
     "stripe": "file:../../"
   },
   "devDependencies": {
-    "@types/node": "~22",
+    "@types/node": "~22.19",
     "typescript": "^5.9.3"
   }
 }

--- a/testProjects/types-cjs/package.json
+++ b/testProjects/types-cjs/package.json
@@ -10,7 +10,7 @@
     "runtestproject": "tsc && node typescriptTest.js"
   },
   "devDependencies": {
-    "@types/node": "~22",
+    "@types/node": "~22.19",
     "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
### Why?
`@types/node@22.20.0` introduced `web-globals/streams.d.ts` with circular
type references (`CompressionStream`, `DecompressionStream`) that TypeScript
5.9 now rejects with "referenced directly or indirectly in its own type
annotation." The lock files under `testProjects/` are gitignored, so CI
always installs fresh and picked up 22.20.0 the moment it was published
(June 20), causing the types test to fail on master.

### What?
- Tightens `"@types/node": "~22"` to `"~22.19"` in `testProjects/types-cjs/package.json` and `testProjects/types-cjs-node16/package.json`

This pins both projects to `22.19.x` (currently `22.19.21`) until `@types/node` fixes the upstream circular reference issue.

### See Also
https://github.com/stripe/stripe-node/actions/runs/27981091214/job/82811120409
