### PR TITLE
fix: CJS companion namespace access for resource types at all depths

### DIFF
--- a/src/resources/Apps/Secrets.ts
+++ b/src/resources/Apps/Secrets.ts
@@ -100,25 +100,23 @@ export interface Secret {
    */
   payload?: string | null;
 
-  scope: Apps.Secret.Scope;
+  scope: Secret.Scope;
 }
-export namespace Apps {
-  export namespace Secret {
-    export interface Scope {
-      /**
-       * The secret scope type.
-       */
-      type: Scope.Type;
+export namespace Secret {
+  export interface Scope {
+    /**
+     * The secret scope type.
+     */
+    type: Scope.Type;
 
-      /**
-       * The user ID, if type is set to "user"
-       */
-      user?: string;
-    }
+    /**
+     * The user ID, if type is set to "user"
+     */
+    user?: string;
+  }
 
-    export namespace Scope {
-      export type Type = 'account' | 'user';
-    }
+  export namespace Scope {
+    export type Type = 'account' | 'user';
   }
 }
 export namespace Apps {

--- a/src/resources/Billing/Alerts.ts
+++ b/src/resources/Billing/Alerts.ts
@@ -117,7 +117,7 @@ export interface Alert {
   /**
    * Status of the alert. This can be active, inactive or archived.
    */
-  status: Billing.Alert.Status | null;
+  status: Alert.Status | null;
 
   /**
    * Title of the alert.
@@ -127,43 +127,41 @@ export interface Alert {
   /**
    * Encapsulates configuration of the alert to monitor usage on a specific [Billing Meter](https://docs.stripe.com/api/billing/meter).
    */
-  usage_threshold: Billing.Alert.UsageThreshold | null;
+  usage_threshold: Alert.UsageThreshold | null;
 }
-export namespace Billing {
-  export namespace Alert {
-    export type Status = 'active' | 'archived' | 'inactive';
+export namespace Alert {
+  export type Status = 'active' | 'archived' | 'inactive';
 
-    export interface UsageThreshold {
+  export interface UsageThreshold {
+    /**
+     * The filters allow limiting the scope of this usage alert. You can only specify up to one filter at this time.
+     */
+    filters: Array<UsageThreshold.Filter> | null;
+
+    /**
+     * The value at which this alert will trigger.
+     */
+    gte: number;
+
+    /**
+     * The [Billing Meter](https://docs.stripe.com/api/billing/meter) ID whose usage is monitored.
+     */
+    meter: string | Meter;
+
+    /**
+     * Defines how the alert will behave.
+     */
+    recurrence: 'one_time';
+  }
+
+  export namespace UsageThreshold {
+    export interface Filter {
       /**
-       * The filters allow limiting the scope of this usage alert. You can only specify up to one filter at this time.
+       * Limit the scope of the alert to this customer ID
        */
-      filters: Array<UsageThreshold.Filter> | null;
+      customer: string | Customer | null;
 
-      /**
-       * The value at which this alert will trigger.
-       */
-      gte: number;
-
-      /**
-       * The [Billing Meter](https://docs.stripe.com/api/billing/meter) ID whose usage is monitored.
-       */
-      meter: string | Meter;
-
-      /**
-       * Defines how the alert will behave.
-       */
-      recurrence: 'one_time';
-    }
-
-    export namespace UsageThreshold {
-      export interface Filter {
-        /**
-         * Limit the scope of the alert to this customer ID
-         */
-        customer: string | Customer | null;
-
-        type: 'customer';
-      }
+      type: 'customer';
     }
   }
 }

--- a/src/resources/Billing/CreditBalanceSummary.ts
+++ b/src/resources/Billing/CreditBalanceSummary.ts
@@ -29,7 +29,7 @@ export interface CreditBalanceSummary {
   /**
    * The billing credit balances. One entry per credit grant currency. If a customer only has credit grants in a single currency, then this will have a single balance entry.
    */
-  balances: Array<Billing.CreditBalanceSummary.Balance>;
+  balances: Array<CreditBalanceSummary.Balance>;
 
   /**
    * The customer the balance is for.
@@ -46,65 +46,63 @@ export interface CreditBalanceSummary {
    */
   livemode: boolean;
 }
-export namespace Billing {
-  export namespace CreditBalanceSummary {
-    export interface Balance {
-      available_balance: Balance.AvailableBalance;
+export namespace CreditBalanceSummary {
+  export interface Balance {
+    available_balance: Balance.AvailableBalance;
 
-      ledger_balance: Balance.LedgerBalance;
+    ledger_balance: Balance.LedgerBalance;
+  }
+
+  export namespace Balance {
+    export interface AvailableBalance {
+      /**
+       * The monetary amount.
+       */
+      monetary: AvailableBalance.Monetary | null;
+
+      /**
+       * The type of this amount. We currently only support `monetary` billing credits.
+       */
+      type: 'monetary';
     }
 
-    export namespace Balance {
-      export interface AvailableBalance {
+    export interface LedgerBalance {
+      /**
+       * The monetary amount.
+       */
+      monetary: LedgerBalance.Monetary | null;
+
+      /**
+       * The type of this amount. We currently only support `monetary` billing credits.
+       */
+      type: 'monetary';
+    }
+
+    export namespace AvailableBalance {
+      export interface Monetary {
         /**
-         * The monetary amount.
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
          */
-        monetary: AvailableBalance.Monetary | null;
+        currency: string;
 
         /**
-         * The type of this amount. We currently only support `monetary` billing credits.
+         * A positive integer representing the amount.
          */
-        type: 'monetary';
+        value: number;
       }
+    }
 
-      export interface LedgerBalance {
+    export namespace LedgerBalance {
+      export interface Monetary {
         /**
-         * The monetary amount.
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
          */
-        monetary: LedgerBalance.Monetary | null;
+        currency: string;
 
         /**
-         * The type of this amount. We currently only support `monetary` billing credits.
+         * A positive integer representing the amount.
          */
-        type: 'monetary';
-      }
-
-      export namespace AvailableBalance {
-        export interface Monetary {
-          /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-           */
-          currency: string;
-
-          /**
-           * A positive integer representing the amount.
-           */
-          value: number;
-        }
-      }
-
-      export namespace LedgerBalance {
-        export interface Monetary {
-          /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-           */
-          currency: string;
-
-          /**
-           * A positive integer representing the amount.
-           */
-          value: number;
-        }
+        value: number;
       }
     }
   }

--- a/src/resources/Billing/CreditBalanceTransactions.ts
+++ b/src/resources/Billing/CreditBalanceTransactions.ts
@@ -60,7 +60,7 @@ export interface CreditBalanceTransaction {
   /**
    * Credit details for this credit balance transaction. Only present if type is `credit`.
    */
-  credit: Billing.CreditBalanceTransaction.Credit | null;
+  credit: CreditBalanceTransaction.Credit | null;
 
   /**
    * The credit grant associated with this credit balance transaction.
@@ -70,7 +70,7 @@ export interface CreditBalanceTransaction {
   /**
    * Debit details for this credit balance transaction. Only present if type is `debit`.
    */
-  debit: Billing.CreditBalanceTransaction.Debit | null;
+  debit: CreditBalanceTransaction.Debit | null;
 
   /**
    * The effective time of this credit balance transaction.
@@ -90,126 +90,119 @@ export interface CreditBalanceTransaction {
   /**
    * The type of credit balance transaction (credit or debit).
    */
-  type: Billing.CreditBalanceTransaction.Type | null;
+  type: CreditBalanceTransaction.Type | null;
 }
-export namespace Billing {
-  export namespace CreditBalanceTransaction {
-    export interface Credit {
-      amount: Credit.Amount;
+export namespace CreditBalanceTransaction {
+  export interface Credit {
+    amount: Credit.Amount;
+
+    /**
+     * Details of the invoice to which the reinstated credits were originally applied. Only present if `type` is `credits_application_invoice_voided`.
+     */
+    credits_application_invoice_voided: Credit.CreditsApplicationInvoiceVoided | null;
+
+    /**
+     * The type of credit transaction.
+     */
+    type: Credit.Type;
+  }
+
+  export interface Debit {
+    amount: Debit.Amount;
+
+    /**
+     * Details of how the billing credits were applied to an invoice. Only present if `type` is `credits_applied`.
+     */
+    credits_applied: Debit.CreditsApplied | null;
+
+    /**
+     * The type of debit transaction.
+     */
+    type: Debit.Type;
+  }
+
+  export type Type = 'credit' | 'debit';
+
+  export namespace Credit {
+    export interface Amount {
+      /**
+       * The monetary amount.
+       */
+      monetary: Amount.Monetary | null;
 
       /**
-       * Details of the invoice to which the reinstated credits were originally applied. Only present if `type` is `credits_application_invoice_voided`.
+       * The type of this amount. We currently only support `monetary` billing credits.
        */
-      credits_application_invoice_voided: Credit.CreditsApplicationInvoiceVoided | null;
-
-      /**
-       * The type of credit transaction.
-       */
-      type: Credit.Type;
+      type: 'monetary';
     }
 
-    export interface Debit {
-      amount: Debit.Amount;
+    export interface CreditsApplicationInvoiceVoided {
+      /**
+       * The invoice to which the reinstated billing credits were originally applied.
+       */
+      invoice: string | Invoice;
 
       /**
-       * Details of how the billing credits were applied to an invoice. Only present if `type` is `credits_applied`.
+       * The invoice line item to which the reinstated billing credits were originally applied.
        */
-      credits_applied: Debit.CreditsApplied | null;
+      invoice_line_item: string;
+    }
+
+    export type Type = 'credits_application_invoice_voided' | 'credits_granted';
+
+    export namespace Amount {
+      export interface Monetary {
+        /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        currency: string;
+
+        /**
+         * A positive integer representing the amount.
+         */
+        value: number;
+      }
+    }
+  }
+
+  export namespace Debit {
+    export interface Amount {
+      /**
+       * The monetary amount.
+       */
+      monetary: Amount.Monetary | null;
 
       /**
-       * The type of debit transaction.
+       * The type of this amount. We currently only support `monetary` billing credits.
        */
-      type: Debit.Type;
+      type: 'monetary';
     }
 
-    export type Type = 'credit' | 'debit';
+    export interface CreditsApplied {
+      /**
+       * The invoice to which the billing credits were applied.
+       */
+      invoice: string | Invoice;
 
-    export namespace Credit {
-      export interface Amount {
-        /**
-         * The monetary amount.
-         */
-        monetary: Amount.Monetary | null;
-
-        /**
-         * The type of this amount. We currently only support `monetary` billing credits.
-         */
-        type: 'monetary';
-      }
-
-      export interface CreditsApplicationInvoiceVoided {
-        /**
-         * The invoice to which the reinstated billing credits were originally applied.
-         */
-        invoice: string | Invoice;
-
-        /**
-         * The invoice line item to which the reinstated billing credits were originally applied.
-         */
-        invoice_line_item: string;
-      }
-
-      export type Type =
-        | 'credits_application_invoice_voided'
-        | 'credits_granted';
-
-      export namespace Amount {
-        export interface Monetary {
-          /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-           */
-          currency: string;
-
-          /**
-           * A positive integer representing the amount.
-           */
-          value: number;
-        }
-      }
+      /**
+       * The invoice line item to which the billing credits were applied.
+       */
+      invoice_line_item: string;
     }
 
-    export namespace Debit {
-      export interface Amount {
-        /**
-         * The monetary amount.
-         */
-        monetary: Amount.Monetary | null;
+    export type Type = 'credits_applied' | 'credits_expired' | 'credits_voided';
 
+    export namespace Amount {
+      export interface Monetary {
         /**
-         * The type of this amount. We currently only support `monetary` billing credits.
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
          */
-        type: 'monetary';
-      }
-
-      export interface CreditsApplied {
-        /**
-         * The invoice to which the billing credits were applied.
-         */
-        invoice: string | Invoice;
+        currency: string;
 
         /**
-         * The invoice line item to which the billing credits were applied.
+         * A positive integer representing the amount.
          */
-        invoice_line_item: string;
-      }
-
-      export type Type =
-        | 'credits_applied'
-        | 'credits_expired'
-        | 'credits_voided';
-
-      export namespace Amount {
-        export interface Monetary {
-          /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-           */
-          currency: string;
-
-          /**
-           * A positive integer representing the amount.
-           */
-          value: number;
-        }
+        value: number;
       }
     }
   }

--- a/src/resources/Billing/CreditGrants.ts
+++ b/src/resources/Billing/CreditGrants.ts
@@ -115,14 +115,14 @@ export interface CreditGrant {
    */
   object: 'billing.credit_grant';
 
-  amount: Billing.CreditGrant.Amount;
+  amount: CreditGrant.Amount;
 
-  applicability_config: Billing.CreditGrant.ApplicabilityConfig;
+  applicability_config: CreditGrant.ApplicabilityConfig;
 
   /**
    * The category of this credit grant. This is for tracking purposes and isn't displayed to the customer.
    */
-  category: Billing.CreditGrant.Category;
+  category: CreditGrant.Category;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -184,60 +184,58 @@ export interface CreditGrant {
    */
   voided_at: number | null;
 }
-export namespace Billing {
-  export namespace CreditGrant {
-    export interface Amount {
+export namespace CreditGrant {
+  export interface Amount {
+    /**
+     * The monetary amount.
+     */
+    monetary: Amount.Monetary | null;
+
+    /**
+     * The type of this amount. We currently only support `monetary` billing credits.
+     */
+    type: 'monetary';
+  }
+
+  export interface ApplicabilityConfig {
+    scope: ApplicabilityConfig.Scope;
+  }
+
+  export type Category = 'paid' | 'promotional';
+
+  export namespace Amount {
+    export interface Monetary {
       /**
-       * The monetary amount.
+       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
        */
-      monetary: Amount.Monetary | null;
+      currency: string;
 
       /**
-       * The type of this amount. We currently only support `monetary` billing credits.
+       * A positive integer representing the amount.
        */
-      type: 'monetary';
+      value: number;
+    }
+  }
+
+  export namespace ApplicabilityConfig {
+    export interface Scope {
+      /**
+       * The price type that credit grants can apply to. We currently only support the `metered` price type. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them. Cannot be used in combination with `prices`.
+       */
+      price_type?: 'metered';
+
+      /**
+       * The prices that credit grants can apply to. We currently only support `metered` prices. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them. Cannot be used in combination with `price_type`.
+       */
+      prices?: Array<Scope.Price>;
     }
 
-    export interface ApplicabilityConfig {
-      scope: ApplicabilityConfig.Scope;
-    }
-
-    export type Category = 'paid' | 'promotional';
-
-    export namespace Amount {
-      export interface Monetary {
+    export namespace Scope {
+      export interface Price {
         /**
-         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         * Unique identifier for the object.
          */
-        currency: string;
-
-        /**
-         * A positive integer representing the amount.
-         */
-        value: number;
-      }
-    }
-
-    export namespace ApplicabilityConfig {
-      export interface Scope {
-        /**
-         * The price type that credit grants can apply to. We currently only support the `metered` price type. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them. Cannot be used in combination with `prices`.
-         */
-        price_type?: 'metered';
-
-        /**
-         * The prices that credit grants can apply to. We currently only support `metered` prices. This refers to prices that have a [Billing Meter](https://docs.stripe.com/api/billing/meter) attached to them. Cannot be used in combination with `price_type`.
-         */
-        prices?: Array<Scope.Price>;
-      }
-
-      export namespace Scope {
-        export interface Price {
-          /**
-           * Unique identifier for the object.
-           */
-          id: string | null;
-        }
+        id: string | null;
       }
     }
   }

--- a/src/resources/Billing/MeterEventAdjustments.ts
+++ b/src/resources/Billing/MeterEventAdjustments.ts
@@ -28,7 +28,7 @@ export interface MeterEventAdjustment {
   /**
    * Specifies which event to cancel.
    */
-  cancel: Billing.MeterEventAdjustment.Cancel | null;
+  cancel: MeterEventAdjustment.Cancel | null;
 
   /**
    * The name of the meter event. Corresponds with the `event_name` field on a meter.
@@ -43,24 +43,22 @@ export interface MeterEventAdjustment {
   /**
    * The meter event adjustment's status.
    */
-  status: Billing.MeterEventAdjustment.Status;
+  status: MeterEventAdjustment.Status;
 
   /**
    * Specifies whether to cancel a single event or a range of events for a time period. Time period cancellation is not supported yet.
    */
   type: 'cancel';
 }
-export namespace Billing {
-  export namespace MeterEventAdjustment {
-    export interface Cancel {
-      /**
-       * Unique identifier for the event.
-       */
-      identifier: string | null;
-    }
-
-    export type Status = 'complete' | 'pending';
+export namespace MeterEventAdjustment {
+  export interface Cancel {
+    /**
+     * Unique identifier for the event.
+     */
+    identifier: string | null;
   }
+
+  export type Status = 'complete' | 'pending';
 }
 export namespace Billing {
   export interface MeterEventAdjustmentCreateParams {

--- a/src/resources/Billing/Meters.ts
+++ b/src/resources/Billing/Meters.ts
@@ -126,9 +126,9 @@ export interface Meter {
    */
   created: number;
 
-  customer_mapping: Billing.Meter.CustomerMapping;
+  customer_mapping: Meter.CustomerMapping;
 
-  default_aggregation: Billing.Meter.DefaultAggregation;
+  default_aggregation: Meter.DefaultAggregation;
 
   /**
    * The meter's name.
@@ -143,7 +143,7 @@ export interface Meter {
   /**
    * The time window which meter events have been pre-aggregated for, if any.
    */
-  event_time_window: Billing.Meter.EventTimeWindow | null;
+  event_time_window: Meter.EventTimeWindow | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -153,59 +153,57 @@ export interface Meter {
   /**
    * The meter's status.
    */
-  status: Billing.Meter.Status;
+  status: Meter.Status;
 
-  status_transitions: Billing.Meter.StatusTransitions;
+  status_transitions: Meter.StatusTransitions;
 
   /**
    * Time at which the object was last updated. Measured in seconds since the Unix epoch.
    */
   updated: number;
 
-  value_settings: Billing.Meter.ValueSettings;
+  value_settings: Meter.ValueSettings;
 }
-export namespace Billing {
-  export namespace Meter {
-    export interface CustomerMapping {
-      /**
-       * The key in the meter event payload to use for mapping the event to a customer.
-       */
-      event_payload_key: string;
+export namespace Meter {
+  export interface CustomerMapping {
+    /**
+     * The key in the meter event payload to use for mapping the event to a customer.
+     */
+    event_payload_key: string;
 
-      /**
-       * The method for mapping a meter event to a customer.
-       */
-      type: 'by_id';
-    }
+    /**
+     * The method for mapping a meter event to a customer.
+     */
+    type: 'by_id';
+  }
 
-    export interface DefaultAggregation {
-      /**
-       * Specifies how events are aggregated.
-       */
-      formula: DefaultAggregation.Formula;
-    }
+  export interface DefaultAggregation {
+    /**
+     * Specifies how events are aggregated.
+     */
+    formula: DefaultAggregation.Formula;
+  }
 
-    export type EventTimeWindow = 'day' | 'hour';
+  export type EventTimeWindow = 'day' | 'hour';
 
-    export type Status = 'active' | 'inactive';
+  export type Status = 'active' | 'inactive';
 
-    export interface StatusTransitions {
-      /**
-       * The time the meter was deactivated, if any. Measured in seconds since Unix epoch.
-       */
-      deactivated_at: number | null;
-    }
+  export interface StatusTransitions {
+    /**
+     * The time the meter was deactivated, if any. Measured in seconds since Unix epoch.
+     */
+    deactivated_at: number | null;
+  }
 
-    export interface ValueSettings {
-      /**
-       * The key in the meter event payload to use as the value for this meter.
-       */
-      event_payload_key: string;
-    }
+  export interface ValueSettings {
+    /**
+     * The key in the meter event payload to use as the value for this meter.
+     */
+    event_payload_key: string;
+  }
 
-    export namespace DefaultAggregation {
-      export type Formula = 'count' | 'last' | 'sum';
-    }
+  export namespace DefaultAggregation {
+    export type Formula = 'count' | 'last' | 'sum';
   }
 }
 export namespace Billing {

--- a/src/resources/BillingPortal/Configurations.ts
+++ b/src/resources/BillingPortal/Configurations.ts
@@ -94,7 +94,7 @@ export interface Configuration {
    */
   application: string | Application | DeletedApplication | null;
 
-  business_profile: BillingPortal.Configuration.BusinessProfile;
+  business_profile: Configuration.BusinessProfile;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -106,7 +106,7 @@ export interface Configuration {
    */
   default_return_url: string | null;
 
-  features: BillingPortal.Configuration.Features;
+  features: Configuration.Features;
 
   /**
    * Whether the configuration is the default. If `true`, this configuration can be managed in the Dashboard and portal sessions will use this configuration unless it is overriden when creating the session.
@@ -118,7 +118,7 @@ export interface Configuration {
    */
   livemode: boolean;
 
-  login_page: BillingPortal.Configuration.LoginPage;
+  login_page: Configuration.LoginPage;
 
   /**
    * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -135,245 +135,243 @@ export interface Configuration {
    */
   updated: number;
 }
-export namespace BillingPortal {
-  export namespace Configuration {
-    export interface BusinessProfile {
+export namespace Configuration {
+  export interface BusinessProfile {
+    /**
+     * The messaging shown to customers in the portal.
+     */
+    headline: string | null;
+
+    /**
+     * A link to the business's publicly available privacy policy.
+     */
+    privacy_policy_url: string | null;
+
+    /**
+     * A link to the business's publicly available terms of service.
+     */
+    terms_of_service_url: string | null;
+  }
+
+  export interface Features {
+    customer_update: Features.CustomerUpdate;
+
+    invoice_history: Features.InvoiceHistory;
+
+    payment_method_update: Features.PaymentMethodUpdate;
+
+    subscription_cancel: Features.SubscriptionCancel;
+
+    subscription_update: Features.SubscriptionUpdate;
+  }
+
+  export interface LoginPage {
+    /**
+     * If `true`, a shareable `url` will be generated that will take your customers to a hosted login page for the customer portal.
+     *
+     * If `false`, the previously generated `url`, if any, will be deactivated.
+     */
+    enabled: boolean;
+
+    /**
+     * A shareable URL to the hosted portal login page. Your customers will be able to log in with their [email](https://docs.stripe.com/api/customers/object#customer_object-email) and receive a link to their customer portal.
+     */
+    url: string | null;
+  }
+
+  export namespace Features {
+    export interface CustomerUpdate {
       /**
-       * The messaging shown to customers in the portal.
+       * The types of customer updates that are supported. When empty, customers are not updateable.
        */
-      headline: string | null;
+      allowed_updates: Array<CustomerUpdate.AllowedUpdate>;
 
       /**
-       * A link to the business's publicly available privacy policy.
+       * Whether the feature is enabled.
        */
-      privacy_policy_url: string | null;
-
-      /**
-       * A link to the business's publicly available terms of service.
-       */
-      terms_of_service_url: string | null;
+      enabled: boolean;
     }
 
-    export interface Features {
-      customer_update: Features.CustomerUpdate;
-
-      invoice_history: Features.InvoiceHistory;
-
-      payment_method_update: Features.PaymentMethodUpdate;
-
-      subscription_cancel: Features.SubscriptionCancel;
-
-      subscription_update: Features.SubscriptionUpdate;
+    export interface InvoiceHistory {
+      /**
+       * Whether the feature is enabled.
+       */
+      enabled: boolean;
     }
 
-    export interface LoginPage {
+    export interface PaymentMethodUpdate {
       /**
-       * If `true`, a shareable `url` will be generated that will take your customers to a hosted login page for the customer portal.
-       *
-       * If `false`, the previously generated `url`, if any, will be deactivated.
+       * Whether the feature is enabled.
        */
       enabled: boolean;
 
       /**
-       * A shareable URL to the hosted portal login page. Your customers will be able to log in with their [email](https://docs.stripe.com/api/customers/object#customer_object-email) and receive a link to their customer portal.
+       * The [Payment Method Configuration](https://docs.stripe.com/api/payment_method_configurations) to use for this portal session. When specified, customers will be able to update their payment method to one of the options specified by the payment method configuration. If not set, the default payment method configuration is used.
        */
-      url: string | null;
+      payment_method_configuration: string | null;
     }
 
-    export namespace Features {
-      export interface CustomerUpdate {
-        /**
-         * The types of customer updates that are supported. When empty, customers are not updateable.
-         */
-        allowed_updates: Array<CustomerUpdate.AllowedUpdate>;
+    export interface SubscriptionCancel {
+      cancellation_reason: SubscriptionCancel.CancellationReason;
 
+      /**
+       * Whether the feature is enabled.
+       */
+      enabled: boolean;
+
+      /**
+       * Whether to cancel subscriptions immediately or at the end of the billing period.
+       */
+      mode: SubscriptionCancel.Mode;
+
+      /**
+       * Whether to create prorations when canceling subscriptions. Possible values are `none` and `create_prorations`.
+       */
+      proration_behavior: SubscriptionCancel.ProrationBehavior;
+    }
+
+    export interface SubscriptionUpdate {
+      /**
+       * Determines the value to use for the billing cycle anchor on subscription updates. Valid values are `now` or `unchanged`, and the default value is `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time (in UTC). For more information, see the billing cycle [documentation](https://docs.stripe.com/billing/subscriptions/billing-cycle).
+       */
+      billing_cycle_anchor: SubscriptionUpdate.BillingCycleAnchor | null;
+
+      /**
+       * The types of subscription updates that are supported for items listed in the `products` attribute. When empty, subscriptions are not updateable.
+       */
+      default_allowed_updates: Array<SubscriptionUpdate.DefaultAllowedUpdate>;
+
+      /**
+       * Whether the feature is enabled.
+       */
+      enabled: boolean;
+
+      /**
+       * The list of up to 10 products that support subscription updates.
+       */
+      products?: Array<SubscriptionUpdate.Product> | null;
+
+      /**
+       * Determines how to handle prorations resulting from subscription updates. Valid values are `none`, `create_prorations`, and `always_invoice`. Defaults to a value of `none` if you don't set it during creation.
+       */
+      proration_behavior: SubscriptionUpdate.ProrationBehavior;
+
+      schedule_at_period_end: SubscriptionUpdate.ScheduleAtPeriodEnd;
+
+      /**
+       * Determines how handle updates to trialing subscriptions. Valid values are `end_trial` and `continue_trial`. Defaults to a value of `end_trial` if you don't set it during creation.
+       */
+      trial_update_behavior: SubscriptionUpdate.TrialUpdateBehavior;
+    }
+
+    export namespace CustomerUpdate {
+      export type AllowedUpdate =
+        | 'address'
+        | 'email'
+        | 'name'
+        | 'phone'
+        | 'shipping'
+        | 'tax_id';
+    }
+
+    export namespace SubscriptionCancel {
+      export interface CancellationReason {
         /**
          * Whether the feature is enabled.
          */
         enabled: boolean;
+
+        /**
+         * Which cancellation reasons will be given as options to the customer.
+         */
+        options: Array<CancellationReason.Option>;
       }
 
-      export interface InvoiceHistory {
+      export type Mode = 'at_period_end' | 'immediately';
+
+      export type ProrationBehavior =
+        | 'always_invoice'
+        | 'create_prorations'
+        | 'none';
+
+      export namespace CancellationReason {
+        export type Option =
+          | 'customer_service'
+          | 'low_quality'
+          | 'missing_features'
+          | 'other'
+          | 'switched_service'
+          | 'too_complex'
+          | 'too_expensive'
+          | 'unused';
+      }
+    }
+
+    export namespace SubscriptionUpdate {
+      export type BillingCycleAnchor = 'now' | 'unchanged';
+
+      export type DefaultAllowedUpdate =
+        | 'price'
+        | 'promotion_code'
+        | 'quantity';
+
+      export interface Product {
+        adjustable_quantity: Product.AdjustableQuantity;
+
         /**
-         * Whether the feature is enabled.
+         * The list of price IDs which, when subscribed to, a subscription can be updated.
          */
-        enabled: boolean;
+        prices: Array<string>;
+
+        /**
+         * The product ID.
+         */
+        product: string;
       }
 
-      export interface PaymentMethodUpdate {
-        /**
-         * Whether the feature is enabled.
-         */
-        enabled: boolean;
+      export type ProrationBehavior =
+        | 'always_invoice'
+        | 'create_prorations'
+        | 'none';
 
+      export interface ScheduleAtPeriodEnd {
         /**
-         * The [Payment Method Configuration](https://docs.stripe.com/api/payment_method_configurations) to use for this portal session. When specified, customers will be able to update their payment method to one of the options specified by the payment method configuration. If not set, the default payment method configuration is used.
+         * List of conditions. When any condition is true, an update will be scheduled at the end of the current period.
          */
-        payment_method_configuration: string | null;
+        conditions: Array<ScheduleAtPeriodEnd.Condition>;
       }
 
-      export interface SubscriptionCancel {
-        cancellation_reason: SubscriptionCancel.CancellationReason;
+      export type TrialUpdateBehavior = 'continue_trial' | 'end_trial';
 
-        /**
-         * Whether the feature is enabled.
-         */
-        enabled: boolean;
-
-        /**
-         * Whether to cancel subscriptions immediately or at the end of the billing period.
-         */
-        mode: SubscriptionCancel.Mode;
-
-        /**
-         * Whether to create prorations when canceling subscriptions. Possible values are `none` and `create_prorations`.
-         */
-        proration_behavior: SubscriptionCancel.ProrationBehavior;
-      }
-
-      export interface SubscriptionUpdate {
-        /**
-         * Determines the value to use for the billing cycle anchor on subscription updates. Valid values are `now` or `unchanged`, and the default value is `unchanged`. Setting the value to `now` resets the subscription's billing cycle anchor to the current time (in UTC). For more information, see the billing cycle [documentation](https://docs.stripe.com/billing/subscriptions/billing-cycle).
-         */
-        billing_cycle_anchor: SubscriptionUpdate.BillingCycleAnchor | null;
-
-        /**
-         * The types of subscription updates that are supported for items listed in the `products` attribute. When empty, subscriptions are not updateable.
-         */
-        default_allowed_updates: Array<SubscriptionUpdate.DefaultAllowedUpdate>;
-
-        /**
-         * Whether the feature is enabled.
-         */
-        enabled: boolean;
-
-        /**
-         * The list of up to 10 products that support subscription updates.
-         */
-        products?: Array<SubscriptionUpdate.Product> | null;
-
-        /**
-         * Determines how to handle prorations resulting from subscription updates. Valid values are `none`, `create_prorations`, and `always_invoice`. Defaults to a value of `none` if you don't set it during creation.
-         */
-        proration_behavior: SubscriptionUpdate.ProrationBehavior;
-
-        schedule_at_period_end: SubscriptionUpdate.ScheduleAtPeriodEnd;
-
-        /**
-         * Determines how handle updates to trialing subscriptions. Valid values are `end_trial` and `continue_trial`. Defaults to a value of `end_trial` if you don't set it during creation.
-         */
-        trial_update_behavior: SubscriptionUpdate.TrialUpdateBehavior;
-      }
-
-      export namespace CustomerUpdate {
-        export type AllowedUpdate =
-          | 'address'
-          | 'email'
-          | 'name'
-          | 'phone'
-          | 'shipping'
-          | 'tax_id';
-      }
-
-      export namespace SubscriptionCancel {
-        export interface CancellationReason {
+      export namespace Product {
+        export interface AdjustableQuantity {
           /**
-           * Whether the feature is enabled.
+           * If true, the quantity can be adjusted to any non-negative integer.
            */
           enabled: boolean;
 
           /**
-           * Which cancellation reasons will be given as options to the customer.
+           * The maximum quantity that can be set for the product.
            */
-          options: Array<CancellationReason.Option>;
-        }
+          maximum: number | null;
 
-        export type Mode = 'at_period_end' | 'immediately';
-
-        export type ProrationBehavior =
-          | 'always_invoice'
-          | 'create_prorations'
-          | 'none';
-
-        export namespace CancellationReason {
-          export type Option =
-            | 'customer_service'
-            | 'low_quality'
-            | 'missing_features'
-            | 'other'
-            | 'switched_service'
-            | 'too_complex'
-            | 'too_expensive'
-            | 'unused';
+          /**
+           * The minimum quantity that can be set for the product.
+           */
+          minimum: number;
         }
       }
 
-      export namespace SubscriptionUpdate {
-        export type BillingCycleAnchor = 'now' | 'unchanged';
-
-        export type DefaultAllowedUpdate =
-          | 'price'
-          | 'promotion_code'
-          | 'quantity';
-
-        export interface Product {
-          adjustable_quantity: Product.AdjustableQuantity;
-
+      export namespace ScheduleAtPeriodEnd {
+        export interface Condition {
           /**
-           * The list of price IDs which, when subscribed to, a subscription can be updated.
+           * The type of condition.
            */
-          prices: Array<string>;
-
-          /**
-           * The product ID.
-           */
-          product: string;
+          type: Condition.Type;
         }
 
-        export type ProrationBehavior =
-          | 'always_invoice'
-          | 'create_prorations'
-          | 'none';
-
-        export interface ScheduleAtPeriodEnd {
-          /**
-           * List of conditions. When any condition is true, an update will be scheduled at the end of the current period.
-           */
-          conditions: Array<ScheduleAtPeriodEnd.Condition>;
-        }
-
-        export type TrialUpdateBehavior = 'continue_trial' | 'end_trial';
-
-        export namespace Product {
-          export interface AdjustableQuantity {
-            /**
-             * If true, the quantity can be adjusted to any non-negative integer.
-             */
-            enabled: boolean;
-
-            /**
-             * The maximum quantity that can be set for the product.
-             */
-            maximum: number | null;
-
-            /**
-             * The minimum quantity that can be set for the product.
-             */
-            minimum: number;
-          }
-        }
-
-        export namespace ScheduleAtPeriodEnd {
-          export interface Condition {
-            /**
-             * The type of condition.
-             */
-            type: Condition.Type;
-          }
-
-          export namespace Condition {
-            export type Type = 'decreasing_item_amount' | 'shortening_interval';
-          }
+        export namespace Condition {
+          export type Type = 'decreasing_item_amount' | 'shortening_interval';
         }
       }
     }

--- a/src/resources/BillingPortal/Sessions.ts
+++ b/src/resources/BillingPortal/Sessions.ts
@@ -54,7 +54,7 @@ export interface Session {
   /**
    * Information about a specific flow for the customer to go through. See the [docs](https://docs.stripe.com/customer-management/portal-deep-links) to learn more about using customer portal deep links and flows.
    */
-  flow: BillingPortal.Session.Flow | null;
+  flow: Session.Flow | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -64,7 +64,7 @@ export interface Session {
   /**
    * The IETF language tag of the locale Customer Portal is displayed in. If blank or auto, the customer's `preferred_locales` or browser's locale is used.
    */
-  locale: BillingPortal.Session.Locale | null;
+  locale: Session.Locale | null;
 
   /**
    * The account for which the session was created on behalf of. When specified, only subscriptions and invoices with this `on_behalf_of` account appear in the portal. For more information, see the [docs](https://docs.stripe.com/connect/separate-charges-and-transfers#settlement-merchant). Use the [Accounts API](https://docs.stripe.com/api/accounts/object#account_object-settings-branding) to modify the `on_behalf_of` account's branding settings, which the portal displays.
@@ -81,214 +81,209 @@ export interface Session {
    */
   url: string;
 }
-export namespace BillingPortal {
-  export namespace Session {
-    export interface Flow {
-      after_completion: Flow.AfterCompletion;
+export namespace Session {
+  export interface Flow {
+    after_completion: Flow.AfterCompletion;
+
+    /**
+     * Configuration when `flow.type=subscription_cancel`.
+     */
+    subscription_cancel: Flow.SubscriptionCancel | null;
+
+    /**
+     * Configuration when `flow.type=subscription_update`.
+     */
+    subscription_update: Flow.SubscriptionUpdate | null;
+
+    /**
+     * Configuration when `flow.type=subscription_update_confirm`.
+     */
+    subscription_update_confirm: Flow.SubscriptionUpdateConfirm | null;
+
+    /**
+     * Type of flow that the customer will go through.
+     */
+    type: Flow.Type;
+  }
+
+  export type Locale =
+    | 'auto'
+    | 'bg'
+    | 'cs'
+    | 'da'
+    | 'de'
+    | 'el'
+    | 'en'
+    | 'en-AU'
+    | 'en-CA'
+    | 'en-GB'
+    | 'en-IE'
+    | 'en-IN'
+    | 'en-NZ'
+    | 'en-SG'
+    | 'es'
+    | 'es-419'
+    | 'et'
+    | 'fi'
+    | 'fil'
+    | 'fr'
+    | 'fr-CA'
+    | 'hr'
+    | 'hu'
+    | 'id'
+    | 'it'
+    | 'ja'
+    | 'ko'
+    | 'lt'
+    | 'lv'
+    | 'ms'
+    | 'mt'
+    | 'nb'
+    | 'nl'
+    | 'pl'
+    | 'pt'
+    | 'pt-BR'
+    | 'ro'
+    | 'ru'
+    | 'sk'
+    | 'sl'
+    | 'sv'
+    | 'th'
+    | 'tr'
+    | 'vi'
+    | 'zh'
+    | 'zh-HK'
+    | 'zh-TW';
+
+  export namespace Flow {
+    export interface AfterCompletion {
+      /**
+       * Configuration when `after_completion.type=hosted_confirmation`.
+       */
+      hosted_confirmation: AfterCompletion.HostedConfirmation | null;
 
       /**
-       * Configuration when `flow.type=subscription_cancel`.
+       * Configuration when `after_completion.type=redirect`.
        */
-      subscription_cancel: Flow.SubscriptionCancel | null;
+      redirect: AfterCompletion.Redirect | null;
 
       /**
-       * Configuration when `flow.type=subscription_update`.
+       * The specified type of behavior after the flow is completed.
        */
-      subscription_update: Flow.SubscriptionUpdate | null;
-
-      /**
-       * Configuration when `flow.type=subscription_update_confirm`.
-       */
-      subscription_update_confirm: Flow.SubscriptionUpdateConfirm | null;
-
-      /**
-       * Type of flow that the customer will go through.
-       */
-      type: Flow.Type;
+      type: AfterCompletion.Type;
     }
 
-    export type Locale =
-      | 'auto'
-      | 'bg'
-      | 'cs'
-      | 'da'
-      | 'de'
-      | 'el'
-      | 'en'
-      | 'en-AU'
-      | 'en-CA'
-      | 'en-GB'
-      | 'en-IE'
-      | 'en-IN'
-      | 'en-NZ'
-      | 'en-SG'
-      | 'es'
-      | 'es-419'
-      | 'et'
-      | 'fi'
-      | 'fil'
-      | 'fr'
-      | 'fr-CA'
-      | 'hr'
-      | 'hu'
-      | 'id'
-      | 'it'
-      | 'ja'
-      | 'ko'
-      | 'lt'
-      | 'lv'
-      | 'ms'
-      | 'mt'
-      | 'nb'
-      | 'nl'
-      | 'pl'
-      | 'pt'
-      | 'pt-BR'
-      | 'ro'
-      | 'ru'
-      | 'sk'
-      | 'sl'
-      | 'sv'
-      | 'th'
-      | 'tr'
-      | 'vi'
-      | 'zh'
-      | 'zh-HK'
-      | 'zh-TW';
+    export interface SubscriptionCancel {
+      /**
+       * Specify a retention strategy to be used in the cancellation flow.
+       */
+      retention: SubscriptionCancel.Retention | null;
 
-    export namespace Flow {
-      export interface AfterCompletion {
-        /**
-         * Configuration when `after_completion.type=hosted_confirmation`.
-         */
-        hosted_confirmation: AfterCompletion.HostedConfirmation | null;
+      /**
+       * The ID of the subscription to be canceled.
+       */
+      subscription: string;
+    }
 
-        /**
-         * Configuration when `after_completion.type=redirect`.
-         */
-        redirect: AfterCompletion.Redirect | null;
+    export interface SubscriptionUpdate {
+      /**
+       * The ID of the subscription to be updated.
+       */
+      subscription: string;
+    }
 
+    export interface SubscriptionUpdateConfirm {
+      /**
+       * The coupon or promotion code to apply to this subscription update.
+       */
+      discounts: Array<SubscriptionUpdateConfirm.Discount> | null;
+
+      /**
+       * The [subscription item](https://docs.stripe.com/api/subscription_items) to be updated through this flow. Currently, only up to one may be specified and subscriptions with multiple items are not updatable.
+       */
+      items: Array<SubscriptionUpdateConfirm.Item>;
+
+      /**
+       * The ID of the subscription to be updated.
+       */
+      subscription: string;
+    }
+
+    export type Type =
+      | 'payment_method_update'
+      | 'subscription_cancel'
+      | 'subscription_update'
+      | 'subscription_update_confirm';
+
+    export namespace AfterCompletion {
+      export interface HostedConfirmation {
         /**
-         * The specified type of behavior after the flow is completed.
+         * A custom message to display to the customer after the flow is completed.
          */
-        type: AfterCompletion.Type;
+        custom_message: string | null;
       }
 
-      export interface SubscriptionCancel {
+      export interface Redirect {
         /**
-         * Specify a retention strategy to be used in the cancellation flow.
+         * The URL the customer will be redirected to after the flow is completed.
          */
-        retention: SubscriptionCancel.Retention | null;
-
-        /**
-         * The ID of the subscription to be canceled.
-         */
-        subscription: string;
+        return_url: string;
       }
 
-      export interface SubscriptionUpdate {
-        /**
-         * The ID of the subscription to be updated.
-         */
-        subscription: string;
-      }
+      export type Type = 'hosted_confirmation' | 'portal_homepage' | 'redirect';
+    }
 
-      export interface SubscriptionUpdateConfirm {
+    export namespace SubscriptionCancel {
+      export interface Retention {
         /**
-         * The coupon or promotion code to apply to this subscription update.
+         * Configuration when `retention.type=coupon_offer`.
          */
-        discounts: Array<SubscriptionUpdateConfirm.Discount> | null;
+        coupon_offer: Retention.CouponOffer | null;
 
         /**
-         * The [subscription item](https://docs.stripe.com/api/subscription_items) to be updated through this flow. Currently, only up to one may be specified and subscriptions with multiple items are not updatable.
+         * Type of retention strategy that will be used.
          */
-        items: Array<SubscriptionUpdateConfirm.Item>;
+        type: 'coupon_offer';
+      }
+
+      export namespace Retention {
+        export interface CouponOffer {
+          /**
+           * The ID of the coupon to be offered.
+           */
+          coupon: string;
+        }
+      }
+    }
+
+    export namespace SubscriptionUpdateConfirm {
+      export interface Discount {
+        /**
+         * The ID of the coupon to apply to this subscription update.
+         */
+        coupon: string | null;
 
         /**
-         * The ID of the subscription to be updated.
+         * The ID of a promotion code to apply to this subscription update.
          */
-        subscription: string;
+        promotion_code: string | null;
       }
 
-      export type Type =
-        | 'payment_method_update'
-        | 'subscription_cancel'
-        | 'subscription_update'
-        | 'subscription_update_confirm';
+      export interface Item {
+        /**
+         * The ID of the [subscription item](https://docs.stripe.com/api/subscriptions/object#subscription_object-items-data-id) to be updated.
+         */
+        id: string | null;
 
-      export namespace AfterCompletion {
-        export interface HostedConfirmation {
-          /**
-           * A custom message to display to the customer after the flow is completed.
-           */
-          custom_message: string | null;
-        }
+        /**
+         * The price the customer should subscribe to through this flow. The price must also be included in the configuration's [`features.subscription_update.products`](https://docs.stripe.com/api/customer_portal/configuration#portal_configuration_object-features-subscription_update-products).
+         */
+        price: string | null;
 
-        export interface Redirect {
-          /**
-           * The URL the customer will be redirected to after the flow is completed.
-           */
-          return_url: string;
-        }
-
-        export type Type =
-          | 'hosted_confirmation'
-          | 'portal_homepage'
-          | 'redirect';
-      }
-
-      export namespace SubscriptionCancel {
-        export interface Retention {
-          /**
-           * Configuration when `retention.type=coupon_offer`.
-           */
-          coupon_offer: Retention.CouponOffer | null;
-
-          /**
-           * Type of retention strategy that will be used.
-           */
-          type: 'coupon_offer';
-        }
-
-        export namespace Retention {
-          export interface CouponOffer {
-            /**
-             * The ID of the coupon to be offered.
-             */
-            coupon: string;
-          }
-        }
-      }
-
-      export namespace SubscriptionUpdateConfirm {
-        export interface Discount {
-          /**
-           * The ID of the coupon to apply to this subscription update.
-           */
-          coupon: string | null;
-
-          /**
-           * The ID of a promotion code to apply to this subscription update.
-           */
-          promotion_code: string | null;
-        }
-
-        export interface Item {
-          /**
-           * The ID of the [subscription item](https://docs.stripe.com/api/subscriptions/object#subscription_object-items-data-id) to be updated.
-           */
-          id: string | null;
-
-          /**
-           * The price the customer should subscribe to through this flow. The price must also be included in the configuration's [`features.subscription_update.products`](https://docs.stripe.com/api/customer_portal/configuration#portal_configuration_object-features-subscription_update-products).
-           */
-          price: string | null;
-
-          /**
-           * [Quantity](https://docs.stripe.com/subscriptions/quantities) for this item that the customer should subscribe to through this flow.
-           */
-          quantity?: number;
-        }
+        /**
+         * [Quantity](https://docs.stripe.com/subscriptions/quantities) for this item that the customer should subscribe to through this flow.
+         */
+        quantity?: number;
       }
     }
   }

--- a/src/resources/Checkout/Sessions.ts
+++ b/src/resources/Checkout/Sessions.ts
@@ -653,12 +653,12 @@ export interface Session {
   /**
    * Settings for price localization with [Adaptive Pricing](https://docs.stripe.com/payments/checkout/adaptive-pricing).
    */
-  adaptive_pricing: Checkout.Session.AdaptivePricing | null;
+  adaptive_pricing: Session.AdaptivePricing | null;
 
   /**
    * When set, provides configuration for actions to take if this Checkout Session expires.
    */
-  after_expiration: Checkout.Session.AfterExpiration | null;
+  after_expiration: Session.AfterExpiration | null;
 
   /**
    * Enables user redeemable promotion codes.
@@ -675,14 +675,14 @@ export interface Session {
    */
   amount_total: number | null;
 
-  automatic_tax: Checkout.Session.AutomaticTax;
+  automatic_tax: Session.AutomaticTax;
 
   /**
    * Describes whether Checkout should collect the customer's billing address. Defaults to `auto`.
    */
-  billing_address_collection: Checkout.Session.BillingAddressCollection | null;
+  billing_address_collection: Session.BillingAddressCollection | null;
 
-  branding_settings?: Checkout.Session.BrandingSettings;
+  branding_settings?: Session.BrandingSettings;
 
   /**
    * If set, Checkout displays a back button and customers will be directed to this URL if they decide to cancel payment and return to your website.
@@ -705,17 +705,17 @@ export interface Session {
   /**
    * Information about the customer collected within the Checkout Session.
    */
-  collected_information: Checkout.Session.CollectedInformation | null;
+  collected_information: Session.CollectedInformation | null;
 
   /**
    * Results of `consent_collection` for this session.
    */
-  consent: Checkout.Session.Consent | null;
+  consent: Session.Consent | null;
 
   /**
    * When set, provides configuration for the Checkout Session to gather active consent from customers.
    */
-  consent_collection: Checkout.Session.ConsentCollection | null;
+  consent_collection: Session.ConsentCollection | null;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -730,14 +730,14 @@ export interface Session {
   /**
    * Currency conversion details for [Adaptive Pricing](https://docs.stripe.com/payments/checkout/adaptive-pricing) sessions created before 2025-03-31.
    */
-  currency_conversion: Checkout.Session.CurrencyConversion | null;
+  currency_conversion: Session.CurrencyConversion | null;
 
   /**
    * Collect additional information from your customer using custom fields. Up to 3 fields are supported. You can't set this parameter if `ui_mode` is `custom`.
    */
-  custom_fields: Array<Checkout.Session.CustomField>;
+  custom_fields: Array<Session.CustomField>;
 
-  custom_text: Checkout.Session.CustomText;
+  custom_text: Session.CustomText;
 
   /**
    * The ID of the customer for this Session.
@@ -756,12 +756,12 @@ export interface Session {
   /**
    * Configure whether a Checkout Session creates a Customer when the Checkout Session completes.
    */
-  customer_creation: Checkout.Session.CustomerCreation | null;
+  customer_creation: Session.CustomerCreation | null;
 
   /**
    * The customer details including the customer's tax exempt status and the customer's tax IDs. Customer's address details are not present on Sessions in `setup` mode.
    */
-  customer_details: Checkout.Session.CustomerDetails | null;
+  customer_details: Session.CustomerDetails | null;
 
   /**
    * If provided, this value will be used when the Customer object is created.
@@ -775,7 +775,7 @@ export interface Session {
   /**
    * List of coupons and promotion codes attached to the Checkout Session.
    */
-  discounts: Array<Checkout.Session.Discount> | null;
+  discounts: Array<Session.Discount> | null;
 
   /**
    * A list of the types of payment methods (e.g., `card`) that should be excluded from this Checkout Session. This should only be used when payment methods for this Checkout Session are managed through the [Stripe Dashboard](https://dashboard.stripe.com/settings/payment_methods).
@@ -800,7 +800,7 @@ export interface Session {
   /**
    * Details on the state of invoice creation for the Checkout Session.
    */
-  invoice_creation: Checkout.Session.InvoiceCreation | null;
+  invoice_creation: Session.InvoiceCreation | null;
 
   /**
    * The line items purchased by the customer.
@@ -815,12 +815,12 @@ export interface Session {
   /**
    * The IETF language tag of the locale Checkout is displayed in. If blank or `auto`, the browser's locale is used.
    */
-  locale: Checkout.Session.Locale | null;
+  locale: Session.Locale | null;
 
   /**
    * Settings for Managed Payments for this Checkout Session and resulting [PaymentIntents](https://docs.stripe.com/api/payment_intents/object), [Invoices](https://docs.stripe.com/api/invoices/object), and [Subscriptions](https://docs.stripe.com/api/subscriptions/object).
    */
-  managed_payments: Checkout.Session.ManagedPayments | null;
+  managed_payments: Session.ManagedPayments | null;
 
   /**
    * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -830,19 +830,19 @@ export interface Session {
   /**
    * The mode of the Checkout Session.
    */
-  mode: Checkout.Session.Mode;
+  mode: Session.Mode;
 
-  name_collection?: Checkout.Session.NameCollection;
+  name_collection?: Session.NameCollection;
 
   /**
    * The optional items presented to the customer at checkout.
    */
-  optional_items?: Array<Checkout.Session.OptionalItem> | null;
+  optional_items?: Array<Session.OptionalItem> | null;
 
   /**
    * Where the user is coming from. This informs the optimizations that are applied to the session.
    */
-  origin_context: Checkout.Session.OriginContext | null;
+  origin_context: Session.OriginContext | null;
 
   /**
    * The ID of the PaymentIntent for Checkout Sessions in `payment` mode. You can't confirm or cancel the PaymentIntent for a Checkout Session. To cancel, [expire the Checkout Session](https://docs.stripe.com/api/checkout/sessions/expire) instead.
@@ -857,17 +857,17 @@ export interface Session {
   /**
    * Configure whether a Checkout Session should collect a payment method. Defaults to `always`.
    */
-  payment_method_collection: Checkout.Session.PaymentMethodCollection | null;
+  payment_method_collection: Session.PaymentMethodCollection | null;
 
   /**
    * Information about the payment method configuration used for this Checkout session if using dynamic payment methods.
    */
-  payment_method_configuration_details: Checkout.Session.PaymentMethodConfigurationDetails | null;
+  payment_method_configuration_details: Session.PaymentMethodConfigurationDetails | null;
 
   /**
    * Payment-method-specific configuration for the PaymentIntent or SetupIntent of this CheckoutSession.
    */
-  payment_method_options: Checkout.Session.PaymentMethodOptions | null;
+  payment_method_options: Session.PaymentMethodOptions | null;
 
   /**
    * A list of the types of payment methods (e.g. card) this Checkout
@@ -879,18 +879,18 @@ export interface Session {
    * The payment status of the Checkout Session, one of `paid`, `unpaid`, or `no_payment_required`.
    * You can use this value to decide when to fulfill your customer's order.
    */
-  payment_status: Checkout.Session.PaymentStatus;
+  payment_status: Session.PaymentStatus;
 
   /**
    * This property is used to set up permissions for various actions (e.g., update) on the CheckoutSession object.
    *
    * For specific permissions, please refer to their dedicated subsections, such as `permissions.update_shipping_details`.
    */
-  permissions: Checkout.Session.Permissions | null;
+  permissions: Session.Permissions | null;
 
-  phone_number_collection?: Checkout.Session.PhoneNumberCollection;
+  phone_number_collection?: Session.PhoneNumberCollection;
 
-  presentment_details?: Checkout.Session.PresentmentDetails;
+  presentment_details?: Session.PresentmentDetails;
 
   /**
    * The ID of the original expired Checkout Session that triggered the recovery flow.
@@ -900,7 +900,7 @@ export interface Session {
   /**
    * This parameter applies to `ui_mode: embedded_page`. Learn more about the [redirect behavior](https://docs.stripe.com/payments/checkout/custom-success-page?payment-ui=embedded-form) of embedded sessions. Defaults to `always`.
    */
-  redirect_on_completion?: Checkout.Session.RedirectOnCompletion;
+  redirect_on_completion?: Session.RedirectOnCompletion;
 
   /**
    * Applies to Checkout Sessions with `ui_mode: embedded_page` or `ui_mode: elements`. The URL to redirect your customer back to after they authenticate or cancel their payment on the payment method's app or site.
@@ -910,7 +910,7 @@ export interface Session {
   /**
    * Controls saved payment method settings for the session. Only available in `payment` and `subscription` mode.
    */
-  saved_payment_method_options: Checkout.Session.SavedPaymentMethodOptions | null;
+  saved_payment_method_options: Session.SavedPaymentMethodOptions | null;
 
   /**
    * The ID of the SetupIntent for Checkout Sessions in `setup` mode. You can't confirm or cancel the SetupIntent for a Checkout Session. To cancel, [expire the Checkout Session](https://docs.stripe.com/api/checkout/sessions/expire) instead.
@@ -920,29 +920,29 @@ export interface Session {
   /**
    * When set, provides configuration for Checkout to collect a shipping address from a customer.
    */
-  shipping_address_collection: Checkout.Session.ShippingAddressCollection | null;
+  shipping_address_collection: Session.ShippingAddressCollection | null;
 
   /**
    * The details of the customer cost of shipping, including the customer chosen ShippingRate.
    */
-  shipping_cost: Checkout.Session.ShippingCost | null;
+  shipping_cost: Session.ShippingCost | null;
 
   /**
    * The shipping rate options applied to this Session.
    */
-  shipping_options: Array<Checkout.Session.ShippingOption>;
+  shipping_options: Array<Session.ShippingOption>;
 
   /**
    * The status of the Checkout Session, one of `open`, `complete`, or `expired`.
    */
-  status: Checkout.Session.Status | null;
+  status: Session.Status | null;
 
   /**
    * Describes the type of transaction being performed by Checkout in order to customize
    * relevant text on the page, such as the submit button. `submit_type` can only be
    * specified on Checkout Sessions in `payment` mode. If blank or `auto`, `pay` is used.
    */
-  submit_type: Checkout.Session.SubmitType | null;
+  submit_type: Session.SubmitType | null;
 
   /**
    * The ID of the [Subscription](https://docs.stripe.com/api/subscriptions) for Checkout Sessions in `subscription` mode.
@@ -955,17 +955,17 @@ export interface Session {
    */
   success_url: string | null;
 
-  tax_id_collection?: Checkout.Session.TaxIdCollection;
+  tax_id_collection?: Session.TaxIdCollection;
 
   /**
    * Tax and discount details for the computed total amount.
    */
-  total_details: Checkout.Session.TotalDetails | null;
+  total_details: Session.TotalDetails | null;
 
   /**
    * The UI mode of the Session. Defaults to `hosted_page`.
    */
-  ui_mode: Checkout.Session.UiMode | null;
+  ui_mode: Session.UiMode | null;
 
   /**
    * The URL to the Checkout Session. Applies to Checkout Sessions with `ui_mode: hosted_page`. Redirect customers to this URL to take them to Checkout. If you're using [Custom Domains](https://docs.stripe.com/payments/checkout/custom-domains), the URL will use your subdomain. Otherwise, it'll use `checkout.stripe.com.`
@@ -976,610 +976,1017 @@ export interface Session {
   /**
    * Wallet-specific configuration for this Checkout Session.
    */
-  wallet_options: Checkout.Session.WalletOptions | null;
+  wallet_options: Session.WalletOptions | null;
 }
-export namespace Checkout {
-  export namespace Session {
-    export interface AdaptivePricing {
+export namespace Session {
+  export interface AdaptivePricing {
+    /**
+     * If enabled, Adaptive Pricing is available on [eligible sessions](https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing?payment-ui=stripe-hosted#restrictions).
+     */
+    enabled: boolean;
+  }
+
+  export interface AfterExpiration {
+    /**
+     * When set, configuration used to recover the Checkout Session on expiry.
+     */
+    recovery: AfterExpiration.Recovery | null;
+  }
+
+  export interface AutomaticTax {
+    /**
+     * Indicates whether automatic tax is enabled for the session
+     */
+    enabled: boolean;
+
+    /**
+     * The account that's liable for tax. If set, the business address and tax registrations required to perform the tax calculation are loaded from this account. The tax transaction is returned in the report of the connected account.
+     */
+    liability: AutomaticTax.Liability | null;
+
+    /**
+     * The tax provider powering automatic tax.
+     */
+    provider: string | null;
+
+    /**
+     * The status of the most recent automated tax calculation for this session.
+     */
+    status: AutomaticTax.Status | null;
+  }
+
+  export type BillingAddressCollection = 'auto' | 'required';
+
+  export interface BrandingSettings {
+    /**
+     * A hex color value starting with `#` representing the background color for the Checkout Session.
+     */
+    background_color: string;
+
+    /**
+     * The border style for the Checkout Session. Must be one of `rounded`, `rectangular`, or `pill`.
+     */
+    border_style: BrandingSettings.BorderStyle;
+
+    /**
+     * A hex color value starting with `#` representing the button color for the Checkout Session.
+     */
+    button_color: string;
+
+    /**
+     * The display name shown on the Checkout Session.
+     */
+    display_name: string;
+
+    /**
+     * The font family for the Checkout Session. Must be one of the [supported font families](https://docs.stripe.com/payments/checkout/customization/appearance?payment-ui=stripe-hosted#font-compatibility).
+     */
+    font_family: string;
+
+    /**
+     * The icon for the Checkout Session. You cannot set both `logo` and `icon`.
+     */
+    icon: BrandingSettings.Icon | null;
+
+    /**
+     * The logo for the Checkout Session. You cannot set both `logo` and `icon`.
+     */
+    logo: BrandingSettings.Logo | null;
+  }
+
+  export interface CollectedInformation {
+    /**
+     * Customer's business name for this Checkout Session
+     */
+    business_name: string | null;
+
+    /**
+     * Customer's individual name for this Checkout Session
+     */
+    individual_name: string | null;
+
+    /**
+     * Shipping information for this Checkout Session.
+     */
+    shipping_details: CollectedInformation.ShippingDetails | null;
+  }
+
+  export interface Consent {
+    /**
+     * If `opt_in`, the customer consents to receiving promotional communications
+     * from the merchant about this Checkout Session.
+     */
+    promotions: Consent.Promotions | null;
+
+    /**
+     * If `accepted`, the customer in this Checkout Session has agreed to the merchant's terms of service.
+     */
+    terms_of_service: 'accepted' | null;
+  }
+
+  export interface ConsentCollection {
+    /**
+     * If set to `hidden`, it will hide legal text related to the reuse of a payment method.
+     */
+    payment_method_reuse_agreement: ConsentCollection.PaymentMethodReuseAgreement | null;
+
+    /**
+     * If set to `auto`, enables the collection of customer consent for promotional communications. The Checkout
+     * Session will determine whether to display an option to opt into promotional communication
+     * from the merchant depending on the customer's locale. Only available to US merchants and US customers.
+     */
+    promotions: ConsentCollection.Promotions | null;
+
+    /**
+     * If set to `required`, it requires customers to accept the terms of service before being able to pay.
+     */
+    terms_of_service: ConsentCollection.TermsOfService | null;
+  }
+
+  export interface CurrencyConversion {
+    /**
+     * Total of all items in source currency before discounts or taxes are applied.
+     */
+    amount_subtotal: number;
+
+    /**
+     * Total of all items in source currency after discounts and taxes are applied.
+     */
+    amount_total: number;
+
+    /**
+     * Exchange rate used to convert source currency amounts to customer currency amounts
+     */
+    fx_rate: Decimal;
+
+    /**
+     * Creation currency of the CheckoutSession before localization
+     */
+    source_currency: string;
+  }
+
+  export interface CustomField {
+    dropdown?: CustomField.Dropdown;
+
+    /**
+     * String of your choice that your integration can use to reconcile this field. Must be unique to this field, alphanumeric, and up to 200 characters.
+     */
+    key: string;
+
+    label: CustomField.Label;
+
+    numeric?: CustomField.Numeric;
+
+    /**
+     * Whether the customer is required to complete the field before completing the Checkout Session. Defaults to `false`.
+     */
+    optional: boolean;
+
+    text?: CustomField.Text;
+
+    /**
+     * The type of the field.
+     */
+    type: CustomField.Type;
+  }
+
+  export interface CustomText {
+    /**
+     * Custom text that should be displayed after the payment confirmation button.
+     */
+    after_submit: CustomText.AfterSubmit | null;
+
+    /**
+     * Custom text that should be displayed alongside shipping address collection.
+     */
+    shipping_address: CustomText.ShippingAddress | null;
+
+    /**
+     * Custom text that should be displayed alongside the payment confirmation button.
+     */
+    submit: CustomText.Submit | null;
+
+    /**
+     * Custom text that should be displayed in place of the default terms of service agreement text.
+     */
+    terms_of_service_acceptance: CustomText.TermsOfServiceAcceptance | null;
+  }
+
+  export type CustomerCreation = 'always' | 'if_required';
+
+  export interface CustomerDetails {
+    /**
+     * The customer's address after a completed Checkout Session. Note: This property is populated only for sessions on or after March 30, 2022.
+     */
+    address: Address | null;
+
+    /**
+     * The customer's business name after a completed Checkout Session.
+     */
+    business_name: string | null;
+
+    /**
+     * The email associated with the Customer, if one exists, on the Checkout Session after a completed Checkout Session or at time of session expiry.
+     * Otherwise, if the customer has consented to promotional content, this value is the most recent valid email provided by the customer on the Checkout form.
+     */
+    email: string | null;
+
+    /**
+     * The customer's individual name after a completed Checkout Session.
+     */
+    individual_name: string | null;
+
+    /**
+     * The customer's name after a completed Checkout Session. Note: This property is populated only for sessions on or after March 30, 2022.
+     */
+    name: string | null;
+
+    /**
+     * The customer's phone number after a completed Checkout Session.
+     */
+    phone: string | null;
+
+    /**
+     * The customer's tax exempt status after a completed Checkout Session.
+     */
+    tax_exempt: CustomerDetails.TaxExempt | null;
+
+    /**
+     * The customer's tax IDs after a completed Checkout Session.
+     */
+    tax_ids: Array<CustomerDetails.TaxId> | null;
+  }
+
+  export interface Discount {
+    /**
+     * Coupon attached to the Checkout Session.
+     */
+    coupon: string | Coupon | null;
+
+    /**
+     * Promotion code attached to the Checkout Session.
+     */
+    promotion_code: string | PromotionCode | null;
+  }
+
+  export interface InvoiceCreation {
+    /**
+     * Indicates whether invoice creation is enabled for the Checkout Session.
+     */
+    enabled: boolean;
+
+    invoice_data: InvoiceCreation.InvoiceData;
+  }
+
+  export type Locale =
+    | 'auto'
+    | 'bg'
+    | 'cs'
+    | 'da'
+    | 'de'
+    | 'el'
+    | 'en'
+    | 'en-GB'
+    | 'es'
+    | 'es-419'
+    | 'et'
+    | 'fi'
+    | 'fil'
+    | 'fr'
+    | 'fr-CA'
+    | 'hr'
+    | 'hu'
+    | 'id'
+    | 'it'
+    | 'ja'
+    | 'ko'
+    | 'lt'
+    | 'lv'
+    | 'ms'
+    | 'mt'
+    | 'nb'
+    | 'nl'
+    | 'pl'
+    | 'pt'
+    | 'pt-BR'
+    | 'ro'
+    | 'ru'
+    | 'sk'
+    | 'sl'
+    | 'sv'
+    | 'th'
+    | 'tr'
+    | 'vi'
+    | 'zh'
+    | 'zh-HK'
+    | 'zh-TW';
+
+  export interface ManagedPayments {
+    /**
+     * Set to `true` to enable [Managed Payments](https://docs.stripe.com/payments/managed-payments), Stripe's merchant of record solution, for this session.
+     */
+    enabled: boolean;
+  }
+
+  export type Mode = 'payment' | 'setup' | 'subscription';
+
+  export interface NameCollection {
+    business?: NameCollection.Business;
+
+    individual?: NameCollection.Individual;
+  }
+
+  export interface OptionalItem {
+    adjustable_quantity: OptionalItem.AdjustableQuantity | null;
+
+    price: string;
+
+    quantity: number;
+  }
+
+  export type OriginContext = 'mobile_app' | 'web';
+
+  export type PaymentMethodCollection = 'always' | 'if_required';
+
+  export interface PaymentMethodConfigurationDetails {
+    /**
+     * ID of the payment method configuration used.
+     */
+    id: string;
+
+    /**
+     * ID of the parent payment method configuration used.
+     */
+    parent: string | null;
+  }
+
+  export interface PaymentMethodOptions {
+    acss_debit?: PaymentMethodOptions.AcssDebit;
+
+    affirm?: PaymentMethodOptions.Affirm;
+
+    afterpay_clearpay?: PaymentMethodOptions.AfterpayClearpay;
+
+    alipay?: PaymentMethodOptions.Alipay;
+
+    alma?: PaymentMethodOptions.Alma;
+
+    amazon_pay?: PaymentMethodOptions.AmazonPay;
+
+    au_becs_debit?: PaymentMethodOptions.AuBecsDebit;
+
+    bacs_debit?: PaymentMethodOptions.BacsDebit;
+
+    bancontact?: PaymentMethodOptions.Bancontact;
+
+    billie?: PaymentMethodOptions.Billie;
+
+    boleto?: PaymentMethodOptions.Boleto;
+
+    card?: PaymentMethodOptions.Card;
+
+    cashapp?: PaymentMethodOptions.Cashapp;
+
+    customer_balance?: PaymentMethodOptions.CustomerBalance;
+
+    eps?: PaymentMethodOptions.Eps;
+
+    fpx?: PaymentMethodOptions.Fpx;
+
+    giropay?: PaymentMethodOptions.Giropay;
+
+    grabpay?: PaymentMethodOptions.Grabpay;
+
+    ideal?: PaymentMethodOptions.Ideal;
+
+    kakao_pay?: PaymentMethodOptions.KakaoPay;
+
+    klarna?: PaymentMethodOptions.Klarna;
+
+    konbini?: PaymentMethodOptions.Konbini;
+
+    kr_card?: PaymentMethodOptions.KrCard;
+
+    link?: PaymentMethodOptions.Link;
+
+    mobilepay?: PaymentMethodOptions.Mobilepay;
+
+    multibanco?: PaymentMethodOptions.Multibanco;
+
+    naver_pay?: PaymentMethodOptions.NaverPay;
+
+    oxxo?: PaymentMethodOptions.Oxxo;
+
+    p24?: PaymentMethodOptions.P24;
+
+    payco?: PaymentMethodOptions.Payco;
+
+    paynow?: PaymentMethodOptions.Paynow;
+
+    paypal?: PaymentMethodOptions.Paypal;
+
+    payto?: PaymentMethodOptions.Payto;
+
+    pix?: PaymentMethodOptions.Pix;
+
+    revolut_pay?: PaymentMethodOptions.RevolutPay;
+
+    samsung_pay?: PaymentMethodOptions.SamsungPay;
+
+    satispay?: PaymentMethodOptions.Satispay;
+
+    scalapay?: PaymentMethodOptions.Scalapay;
+
+    sepa_debit?: PaymentMethodOptions.SepaDebit;
+
+    sofort?: PaymentMethodOptions.Sofort;
+
+    swish?: PaymentMethodOptions.Swish;
+
+    twint?: PaymentMethodOptions.Twint;
+
+    upi?: PaymentMethodOptions.Upi;
+
+    us_bank_account?: PaymentMethodOptions.UsBankAccount;
+  }
+
+  export type PaymentStatus = 'no_payment_required' | 'paid' | 'unpaid';
+
+  export interface Permissions {
+    /**
+     * Determines which entity is allowed to update the shipping details.
+     *
+     * Default is `client_only`. Stripe Checkout client will automatically update the shipping details. If set to `server_only`, only your server is allowed to update the shipping details.
+     *
+     * When set to `server_only`, you must add the onShippingDetailsChange event handler when initializing the Stripe Checkout client and manually update the shipping details from your server using the Stripe API.
+     */
+    update_shipping_details: Permissions.UpdateShippingDetails | null;
+  }
+
+  export interface PhoneNumberCollection {
+    /**
+     * Indicates whether phone number collection is enabled for the session
+     */
+    enabled: boolean;
+  }
+
+  export interface PresentmentDetails {
+    /**
+     * Amount intended to be collected by this payment, denominated in `presentment_currency`.
+     */
+    presentment_amount: number;
+
+    /**
+     * Currency presented to the customer during payment.
+     */
+    presentment_currency: string;
+  }
+
+  export type RedirectOnCompletion = 'always' | 'if_required' | 'never';
+
+  export interface SavedPaymentMethodOptions {
+    /**
+     * Uses the `allow_redisplay` value of each saved payment method to filter the set presented to a returning customer. By default, only saved payment methods with 'allow_redisplay: ‘always' are shown in Checkout.
+     */
+    allow_redisplay_filters: Array<
+      SavedPaymentMethodOptions.AllowRedisplayFilter
+    > | null;
+
+    /**
+     * Enable customers to choose if they wish to remove their saved payment methods. Disabled by default.
+     */
+    payment_method_remove: SavedPaymentMethodOptions.PaymentMethodRemove | null;
+
+    /**
+     * Enable customers to choose if they wish to save their payment method for future use. Disabled by default.
+     */
+    payment_method_save: SavedPaymentMethodOptions.PaymentMethodSave | null;
+  }
+
+  export interface ShippingAddressCollection {
+    /**
+     * An array of two-letter ISO country codes representing which countries Checkout should provide as options for
+     * shipping locations. Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SY, UM, VI`.
+     */
+    allowed_countries: Array<ShippingAddressCollection.AllowedCountry>;
+  }
+
+  export interface ShippingCost {
+    /**
+     * Total shipping cost before any discounts or taxes are applied.
+     */
+    amount_subtotal: number;
+
+    /**
+     * Total tax amount applied due to shipping costs. If no tax was applied, defaults to 0.
+     */
+    amount_tax: number;
+
+    /**
+     * Total shipping cost after discounts and taxes are applied.
+     */
+    amount_total: number;
+
+    /**
+     * The ID of the ShippingRate for this order.
+     */
+    shipping_rate: string | ShippingRate | null;
+
+    /**
+     * The taxes applied to the shipping rate.
+     */
+    taxes?: Array<ShippingCost.Tax>;
+  }
+
+  export interface ShippingOption {
+    /**
+     * A non-negative integer in cents representing how much to charge.
+     */
+    shipping_amount: number;
+
+    /**
+     * The shipping rate.
+     */
+    shipping_rate: string | ShippingRate;
+  }
+
+  export type Status = 'complete' | 'expired' | 'open';
+
+  export type SubmitType = 'auto' | 'book' | 'donate' | 'pay' | 'subscribe';
+
+  export interface TaxIdCollection {
+    /**
+     * Indicates whether tax ID collection is enabled for the session
+     */
+    enabled: boolean;
+
+    /**
+     * Indicates whether a tax ID is required on the payment page
+     */
+    required: TaxIdCollection.Required;
+  }
+
+  export interface TotalDetails {
+    /**
+     * This is the sum of all the discounts.
+     */
+    amount_discount: number;
+
+    /**
+     * This is the sum of all the shipping amounts.
+     */
+    amount_shipping: number | null;
+
+    /**
+     * This is the sum of all the tax amounts.
+     */
+    amount_tax: number;
+
+    breakdown?: TotalDetails.Breakdown;
+  }
+
+  export type UiMode = 'elements' | 'embedded_page' | 'form' | 'hosted_page';
+
+  export interface WalletOptions {
+    link?: WalletOptions.Link;
+  }
+
+  export namespace AfterExpiration {
+    export interface Recovery {
       /**
-       * If enabled, Adaptive Pricing is available on [eligible sessions](https://docs.stripe.com/payments/currencies/localize-prices/adaptive-pricing?payment-ui=stripe-hosted#restrictions).
+       * Enables user redeemable promotion codes on the recovered Checkout Sessions. Defaults to `false`
+       */
+      allow_promotion_codes: boolean;
+
+      /**
+       * If `true`, a recovery url will be generated to recover this Checkout Session if it
+       * expires before a transaction is completed. It will be attached to the
+       * Checkout Session object upon expiration.
        */
       enabled: boolean;
+
+      /**
+       * The timestamp at which the recovery URL will expire.
+       */
+      expires_at: number | null;
+
+      /**
+       * URL that creates a new Checkout Session when clicked that is a copy of this expired Checkout Session
+       */
+      url: string | null;
+    }
+  }
+
+  export namespace AutomaticTax {
+    export interface Liability {
+      /**
+       * The connected account being referenced when `type` is `account`.
+       */
+      account?: string | Account;
+
+      /**
+       * Type of the account referenced.
+       */
+      type: Liability.Type;
     }
 
-    export interface AfterExpiration {
+    export type Status = 'complete' | 'failed' | 'requires_location_inputs';
+
+    export namespace Liability {
+      export type Type = 'account' | 'self';
+    }
+  }
+
+  export namespace BrandingSettings {
+    export type BorderStyle = 'pill' | 'rectangular' | 'rounded';
+
+    export interface Icon {
       /**
-       * When set, configuration used to recover the Checkout Session on expiry.
+       * The ID of a [File upload](https://stripe.com/docs/api/files) representing the icon. Purpose must be `business_icon`. Required if `type` is `file` and disallowed otherwise.
        */
-      recovery: AfterExpiration.Recovery | null;
+      file?: string;
+
+      /**
+       * The type of image for the icon. Must be one of `file` or `url`.
+       */
+      type: Icon.Type;
+
+      /**
+       * The URL of the image. Present when `type` is `url`.
+       */
+      url?: string;
     }
 
-    export interface AutomaticTax {
+    export interface Logo {
       /**
-       * Indicates whether automatic tax is enabled for the session
+       * The ID of a [File upload](https://stripe.com/docs/api/files) representing the logo. Purpose must be `business_logo`. Required if `type` is `file` and disallowed otherwise.
        */
-      enabled: boolean;
+      file?: string;
 
       /**
-       * The account that's liable for tax. If set, the business address and tax registrations required to perform the tax calculation are loaded from this account. The tax transaction is returned in the report of the connected account.
+       * The type of image for the logo. Must be one of `file` or `url`.
        */
-      liability: AutomaticTax.Liability | null;
+      type: Logo.Type;
 
       /**
-       * The tax provider powering automatic tax.
+       * The URL of the image. Present when `type` is `url`.
        */
-      provider: string | null;
-
-      /**
-       * The status of the most recent automated tax calculation for this session.
-       */
-      status: AutomaticTax.Status | null;
+      url?: string;
     }
 
-    export type BillingAddressCollection = 'auto' | 'required';
-
-    export interface BrandingSettings {
-      /**
-       * A hex color value starting with `#` representing the background color for the Checkout Session.
-       */
-      background_color: string;
-
-      /**
-       * The border style for the Checkout Session. Must be one of `rounded`, `rectangular`, or `pill`.
-       */
-      border_style: BrandingSettings.BorderStyle;
-
-      /**
-       * A hex color value starting with `#` representing the button color for the Checkout Session.
-       */
-      button_color: string;
-
-      /**
-       * The display name shown on the Checkout Session.
-       */
-      display_name: string;
-
-      /**
-       * The font family for the Checkout Session. Must be one of the [supported font families](https://docs.stripe.com/payments/checkout/customization/appearance?payment-ui=stripe-hosted#font-compatibility).
-       */
-      font_family: string;
-
-      /**
-       * The icon for the Checkout Session. You cannot set both `logo` and `icon`.
-       */
-      icon: BrandingSettings.Icon | null;
-
-      /**
-       * The logo for the Checkout Session. You cannot set both `logo` and `icon`.
-       */
-      logo: BrandingSettings.Logo | null;
+    export namespace Icon {
+      export type Type = 'file' | 'url';
     }
 
-    export interface CollectedInformation {
-      /**
-       * Customer's business name for this Checkout Session
-       */
-      business_name: string | null;
-
-      /**
-       * Customer's individual name for this Checkout Session
-       */
-      individual_name: string | null;
-
-      /**
-       * Shipping information for this Checkout Session.
-       */
-      shipping_details: CollectedInformation.ShippingDetails | null;
+    export namespace Logo {
+      export type Type = 'file' | 'url';
     }
+  }
 
-    export interface Consent {
-      /**
-       * If `opt_in`, the customer consents to receiving promotional communications
-       * from the merchant about this Checkout Session.
-       */
-      promotions: Consent.Promotions | null;
+  export namespace CollectedInformation {
+    export interface ShippingDetails {
+      address: Address;
 
       /**
-       * If `accepted`, the customer in this Checkout Session has agreed to the merchant's terms of service.
+       * Customer name.
        */
-      terms_of_service: 'accepted' | null;
+      name: string;
     }
+  }
 
-    export interface ConsentCollection {
+  export namespace Consent {
+    export type Promotions = 'opt_in' | 'opt_out';
+  }
+
+  export namespace ConsentCollection {
+    export interface PaymentMethodReuseAgreement {
       /**
-       * If set to `hidden`, it will hide legal text related to the reuse of a payment method.
-       */
-      payment_method_reuse_agreement: ConsentCollection.PaymentMethodReuseAgreement | null;
-
-      /**
-       * If set to `auto`, enables the collection of customer consent for promotional communications. The Checkout
-       * Session will determine whether to display an option to opt into promotional communication
-       * from the merchant depending on the customer's locale. Only available to US merchants and US customers.
-       */
-      promotions: ConsentCollection.Promotions | null;
-
-      /**
-       * If set to `required`, it requires customers to accept the terms of service before being able to pay.
-       */
-      terms_of_service: ConsentCollection.TermsOfService | null;
-    }
-
-    export interface CurrencyConversion {
-      /**
-       * Total of all items in source currency before discounts or taxes are applied.
-       */
-      amount_subtotal: number;
-
-      /**
-       * Total of all items in source currency after discounts and taxes are applied.
-       */
-      amount_total: number;
-
-      /**
-       * Exchange rate used to convert source currency amounts to customer currency amounts
-       */
-      fx_rate: Decimal;
-
-      /**
-       * Creation currency of the CheckoutSession before localization
-       */
-      source_currency: string;
-    }
-
-    export interface CustomField {
-      dropdown?: CustomField.Dropdown;
-
-      /**
-       * String of your choice that your integration can use to reconcile this field. Must be unique to this field, alphanumeric, and up to 200 characters.
-       */
-      key: string;
-
-      label: CustomField.Label;
-
-      numeric?: CustomField.Numeric;
-
-      /**
-       * Whether the customer is required to complete the field before completing the Checkout Session. Defaults to `false`.
-       */
-      optional: boolean;
-
-      text?: CustomField.Text;
-
-      /**
-       * The type of the field.
-       */
-      type: CustomField.Type;
-    }
-
-    export interface CustomText {
-      /**
-       * Custom text that should be displayed after the payment confirmation button.
-       */
-      after_submit: CustomText.AfterSubmit | null;
-
-      /**
-       * Custom text that should be displayed alongside shipping address collection.
-       */
-      shipping_address: CustomText.ShippingAddress | null;
-
-      /**
-       * Custom text that should be displayed alongside the payment confirmation button.
-       */
-      submit: CustomText.Submit | null;
-
-      /**
-       * Custom text that should be displayed in place of the default terms of service agreement text.
-       */
-      terms_of_service_acceptance: CustomText.TermsOfServiceAcceptance | null;
-    }
-
-    export type CustomerCreation = 'always' | 'if_required';
-
-    export interface CustomerDetails {
-      /**
-       * The customer's address after a completed Checkout Session. Note: This property is populated only for sessions on or after March 30, 2022.
-       */
-      address: Address | null;
-
-      /**
-       * The customer's business name after a completed Checkout Session.
-       */
-      business_name: string | null;
-
-      /**
-       * The email associated with the Customer, if one exists, on the Checkout Session after a completed Checkout Session or at time of session expiry.
-       * Otherwise, if the customer has consented to promotional content, this value is the most recent valid email provided by the customer on the Checkout form.
-       */
-      email: string | null;
-
-      /**
-       * The customer's individual name after a completed Checkout Session.
-       */
-      individual_name: string | null;
-
-      /**
-       * The customer's name after a completed Checkout Session. Note: This property is populated only for sessions on or after March 30, 2022.
-       */
-      name: string | null;
-
-      /**
-       * The customer's phone number after a completed Checkout Session.
-       */
-      phone: string | null;
-
-      /**
-       * The customer's tax exempt status after a completed Checkout Session.
-       */
-      tax_exempt: CustomerDetails.TaxExempt | null;
-
-      /**
-       * The customer's tax IDs after a completed Checkout Session.
-       */
-      tax_ids: Array<CustomerDetails.TaxId> | null;
-    }
-
-    export interface Discount {
-      /**
-       * Coupon attached to the Checkout Session.
-       */
-      coupon: string | Coupon | null;
-
-      /**
-       * Promotion code attached to the Checkout Session.
-       */
-      promotion_code: string | PromotionCode | null;
-    }
-
-    export interface InvoiceCreation {
-      /**
-       * Indicates whether invoice creation is enabled for the Checkout Session.
-       */
-      enabled: boolean;
-
-      invoice_data: InvoiceCreation.InvoiceData;
-    }
-
-    export type Locale =
-      | 'auto'
-      | 'bg'
-      | 'cs'
-      | 'da'
-      | 'de'
-      | 'el'
-      | 'en'
-      | 'en-GB'
-      | 'es'
-      | 'es-419'
-      | 'et'
-      | 'fi'
-      | 'fil'
-      | 'fr'
-      | 'fr-CA'
-      | 'hr'
-      | 'hu'
-      | 'id'
-      | 'it'
-      | 'ja'
-      | 'ko'
-      | 'lt'
-      | 'lv'
-      | 'ms'
-      | 'mt'
-      | 'nb'
-      | 'nl'
-      | 'pl'
-      | 'pt'
-      | 'pt-BR'
-      | 'ro'
-      | 'ru'
-      | 'sk'
-      | 'sl'
-      | 'sv'
-      | 'th'
-      | 'tr'
-      | 'vi'
-      | 'zh'
-      | 'zh-HK'
-      | 'zh-TW';
-
-    export interface ManagedPayments {
-      /**
-       * Set to `true` to enable [Managed Payments](https://docs.stripe.com/payments/managed-payments), Stripe's merchant of record solution, for this session.
-       */
-      enabled: boolean;
-    }
-
-    export type Mode = 'payment' | 'setup' | 'subscription';
-
-    export interface NameCollection {
-      business?: NameCollection.Business;
-
-      individual?: NameCollection.Individual;
-    }
-
-    export interface OptionalItem {
-      adjustable_quantity: OptionalItem.AdjustableQuantity | null;
-
-      price: string;
-
-      quantity: number;
-    }
-
-    export type OriginContext = 'mobile_app' | 'web';
-
-    export type PaymentMethodCollection = 'always' | 'if_required';
-
-    export interface PaymentMethodConfigurationDetails {
-      /**
-       * ID of the payment method configuration used.
-       */
-      id: string;
-
-      /**
-       * ID of the parent payment method configuration used.
-       */
-      parent: string | null;
-    }
-
-    export interface PaymentMethodOptions {
-      acss_debit?: PaymentMethodOptions.AcssDebit;
-
-      affirm?: PaymentMethodOptions.Affirm;
-
-      afterpay_clearpay?: PaymentMethodOptions.AfterpayClearpay;
-
-      alipay?: PaymentMethodOptions.Alipay;
-
-      alma?: PaymentMethodOptions.Alma;
-
-      amazon_pay?: PaymentMethodOptions.AmazonPay;
-
-      au_becs_debit?: PaymentMethodOptions.AuBecsDebit;
-
-      bacs_debit?: PaymentMethodOptions.BacsDebit;
-
-      bancontact?: PaymentMethodOptions.Bancontact;
-
-      billie?: PaymentMethodOptions.Billie;
-
-      boleto?: PaymentMethodOptions.Boleto;
-
-      card?: PaymentMethodOptions.Card;
-
-      cashapp?: PaymentMethodOptions.Cashapp;
-
-      customer_balance?: PaymentMethodOptions.CustomerBalance;
-
-      eps?: PaymentMethodOptions.Eps;
-
-      fpx?: PaymentMethodOptions.Fpx;
-
-      giropay?: PaymentMethodOptions.Giropay;
-
-      grabpay?: PaymentMethodOptions.Grabpay;
-
-      ideal?: PaymentMethodOptions.Ideal;
-
-      kakao_pay?: PaymentMethodOptions.KakaoPay;
-
-      klarna?: PaymentMethodOptions.Klarna;
-
-      konbini?: PaymentMethodOptions.Konbini;
-
-      kr_card?: PaymentMethodOptions.KrCard;
-
-      link?: PaymentMethodOptions.Link;
-
-      mobilepay?: PaymentMethodOptions.Mobilepay;
-
-      multibanco?: PaymentMethodOptions.Multibanco;
-
-      naver_pay?: PaymentMethodOptions.NaverPay;
-
-      oxxo?: PaymentMethodOptions.Oxxo;
-
-      p24?: PaymentMethodOptions.P24;
-
-      payco?: PaymentMethodOptions.Payco;
-
-      paynow?: PaymentMethodOptions.Paynow;
-
-      paypal?: PaymentMethodOptions.Paypal;
-
-      payto?: PaymentMethodOptions.Payto;
-
-      pix?: PaymentMethodOptions.Pix;
-
-      revolut_pay?: PaymentMethodOptions.RevolutPay;
-
-      samsung_pay?: PaymentMethodOptions.SamsungPay;
-
-      satispay?: PaymentMethodOptions.Satispay;
-
-      scalapay?: PaymentMethodOptions.Scalapay;
-
-      sepa_debit?: PaymentMethodOptions.SepaDebit;
-
-      sofort?: PaymentMethodOptions.Sofort;
-
-      swish?: PaymentMethodOptions.Swish;
-
-      twint?: PaymentMethodOptions.Twint;
-
-      upi?: PaymentMethodOptions.Upi;
-
-      us_bank_account?: PaymentMethodOptions.UsBankAccount;
-    }
-
-    export type PaymentStatus = 'no_payment_required' | 'paid' | 'unpaid';
-
-    export interface Permissions {
-      /**
-       * Determines which entity is allowed to update the shipping details.
+       * Determines the position and visibility of the payment method reuse agreement in the UI. When set to `auto`, Stripe's defaults will be used.
        *
-       * Default is `client_only`. Stripe Checkout client will automatically update the shipping details. If set to `server_only`, only your server is allowed to update the shipping details.
-       *
-       * When set to `server_only`, you must add the onShippingDetailsChange event handler when initializing the Stripe Checkout client and manually update the shipping details from your server using the Stripe API.
+       * When set to `hidden`, the payment method reuse agreement text will always be hidden in the UI.
        */
-      update_shipping_details: Permissions.UpdateShippingDetails | null;
+      position: PaymentMethodReuseAgreement.Position;
     }
 
-    export interface PhoneNumberCollection {
+    export type Promotions = 'auto' | 'none';
+
+    export type TermsOfService = 'none' | 'required';
+
+    export namespace PaymentMethodReuseAgreement {
+      export type Position = 'auto' | 'hidden';
+    }
+  }
+
+  export namespace CustomerDetails {
+    export type TaxExempt = 'exempt' | 'none' | 'reverse';
+
+    export interface TaxId {
       /**
-       * Indicates whether phone number collection is enabled for the session
+       * The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `pl_nip`, `it_cf`, `fo_vat`, `gi_tin`, `py_ruc`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `lk_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `al_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, `ao_tin`, `bs_tin`, `bb_tin`, `cd_nif`, `mr_nif`, `me_pib`, `zw_tin`, `ba_tin`, `gn_nif`, `mk_vat`, `sr_fin`, `sn_ninea`, `am_tin`, `np_pan`, `tj_tin`, `ug_tin`, `zm_tin`, `kh_tin`, `aw_tin`, `az_tin`, `bd_bin`, `bj_ifu`, `et_tin`, `kg_tin`, `la_tin`, `cm_niu`, `cv_nif`, `bf_ifu`, or `unknown`
        */
-      enabled: boolean;
+      type: TaxId.Type;
+
+      /**
+       * The value of the tax ID.
+       */
+      value: string | null;
     }
 
-    export interface PresentmentDetails {
+    export namespace TaxId {
+      export type Type =
+        | 'ad_nrt'
+        | 'ae_trn'
+        | 'al_tin'
+        | 'am_tin'
+        | 'ao_tin'
+        | 'ar_cuit'
+        | 'au_abn'
+        | 'au_arn'
+        | 'aw_tin'
+        | 'az_tin'
+        | 'ba_tin'
+        | 'bb_tin'
+        | 'bd_bin'
+        | 'bf_ifu'
+        | 'bg_uic'
+        | 'bh_vat'
+        | 'bj_ifu'
+        | 'bo_tin'
+        | 'br_cnpj'
+        | 'br_cpf'
+        | 'bs_tin'
+        | 'by_tin'
+        | 'ca_bn'
+        | 'ca_gst_hst'
+        | 'ca_pst_bc'
+        | 'ca_pst_mb'
+        | 'ca_pst_sk'
+        | 'ca_qst'
+        | 'cd_nif'
+        | 'ch_uid'
+        | 'ch_vat'
+        | 'cl_tin'
+        | 'cm_niu'
+        | 'cn_tin'
+        | 'co_nit'
+        | 'cr_tin'
+        | 'cv_nif'
+        | 'de_stn'
+        | 'do_rcn'
+        | 'ec_ruc'
+        | 'eg_tin'
+        | 'es_cif'
+        | 'et_tin'
+        | 'eu_oss_vat'
+        | 'eu_vat'
+        | 'fo_vat'
+        | 'gb_vat'
+        | 'ge_vat'
+        | 'gi_tin'
+        | 'gn_nif'
+        | 'hk_br'
+        | 'hr_oib'
+        | 'hu_tin'
+        | 'id_npwp'
+        | 'il_vat'
+        | 'in_gst'
+        | 'is_vat'
+        | 'it_cf'
+        | 'jp_cn'
+        | 'jp_rn'
+        | 'jp_trn'
+        | 'ke_pin'
+        | 'kg_tin'
+        | 'kh_tin'
+        | 'kr_brn'
+        | 'kz_bin'
+        | 'la_tin'
+        | 'li_uid'
+        | 'li_vat'
+        | 'lk_vat'
+        | 'ma_vat'
+        | 'md_vat'
+        | 'me_pib'
+        | 'mk_vat'
+        | 'mr_nif'
+        | 'mx_rfc'
+        | 'my_frp'
+        | 'my_itn'
+        | 'my_sst'
+        | 'ng_tin'
+        | 'no_vat'
+        | 'no_voec'
+        | 'np_pan'
+        | 'nz_gst'
+        | 'om_vat'
+        | 'pe_ruc'
+        | 'ph_tin'
+        | 'pl_nip'
+        | 'py_ruc'
+        | 'ro_tin'
+        | 'rs_pib'
+        | 'ru_inn'
+        | 'ru_kpp'
+        | 'sa_vat'
+        | 'sg_gst'
+        | 'sg_uen'
+        | 'si_tin'
+        | 'sn_ninea'
+        | 'sr_fin'
+        | 'sv_nit'
+        | 'th_vat'
+        | 'tj_tin'
+        | 'tr_tin'
+        | 'tw_vat'
+        | 'tz_vat'
+        | 'ua_vat'
+        | 'ug_tin'
+        | 'unknown'
+        | 'us_ein'
+        | 'uy_ruc'
+        | 'uz_tin'
+        | 'uz_vat'
+        | 've_rif'
+        | 'vn_tin'
+        | 'za_vat'
+        | 'zm_tin'
+        | 'zw_tin';
+    }
+  }
+
+  export namespace CustomField {
+    export interface Dropdown {
       /**
-       * Amount intended to be collected by this payment, denominated in `presentment_currency`.
+       * The value that pre-fills on the payment page.
        */
-      presentment_amount: number;
+      default_value: string | null;
 
       /**
-       * Currency presented to the customer during payment.
+       * The options available for the customer to select. Up to 200 options allowed.
        */
-      presentment_currency: string;
+      options: Array<Dropdown.Option>;
+
+      /**
+       * The option selected by the customer. This will be the `value` for the option.
+       */
+      value: string | null;
     }
 
-    export type RedirectOnCompletion = 'always' | 'if_required' | 'never';
-
-    export interface SavedPaymentMethodOptions {
+    export interface Label {
       /**
-       * Uses the `allow_redisplay` value of each saved payment method to filter the set presented to a returning customer. By default, only saved payment methods with 'allow_redisplay: ‘always' are shown in Checkout.
+       * Custom text for the label, displayed to the customer. Up to 50 characters.
        */
-      allow_redisplay_filters: Array<
-        SavedPaymentMethodOptions.AllowRedisplayFilter
-      > | null;
+      custom: string | null;
 
       /**
-       * Enable customers to choose if they wish to remove their saved payment methods. Disabled by default.
+       * The type of the label.
        */
-      payment_method_remove: SavedPaymentMethodOptions.PaymentMethodRemove | null;
-
-      /**
-       * Enable customers to choose if they wish to save their payment method for future use. Disabled by default.
-       */
-      payment_method_save: SavedPaymentMethodOptions.PaymentMethodSave | null;
+      type: 'custom';
     }
 
-    export interface ShippingAddressCollection {
+    export interface Numeric {
       /**
-       * An array of two-letter ISO country codes representing which countries Checkout should provide as options for
-       * shipping locations. Unsupported country codes: `AS, CX, CC, CU, HM, IR, KP, MH, FM, NF, MP, PW, SY, UM, VI`.
+       * The value that pre-fills the field on the payment page.
        */
-      allowed_countries: Array<ShippingAddressCollection.AllowedCountry>;
+      default_value: string | null;
+
+      /**
+       * The maximum character length constraint for the customer's input.
+       */
+      maximum_length: number | null;
+
+      /**
+       * The minimum character length requirement for the customer's input.
+       */
+      minimum_length: number | null;
+
+      /**
+       * The value entered by the customer, containing only digits.
+       */
+      value: string | null;
     }
 
-    export interface ShippingCost {
+    export interface Text {
       /**
-       * Total shipping cost before any discounts or taxes are applied.
+       * The value that pre-fills the field on the payment page.
        */
-      amount_subtotal: number;
+      default_value: string | null;
 
       /**
-       * Total tax amount applied due to shipping costs. If no tax was applied, defaults to 0.
+       * The maximum character length constraint for the customer's input.
        */
-      amount_tax: number;
+      maximum_length: number | null;
 
       /**
-       * Total shipping cost after discounts and taxes are applied.
+       * The minimum character length requirement for the customer's input.
        */
-      amount_total: number;
+      minimum_length: number | null;
 
       /**
-       * The ID of the ShippingRate for this order.
+       * The value entered by the customer.
        */
-      shipping_rate: string | ShippingRate | null;
-
-      /**
-       * The taxes applied to the shipping rate.
-       */
-      taxes?: Array<ShippingCost.Tax>;
+      value: string | null;
     }
 
-    export interface ShippingOption {
-      /**
-       * A non-negative integer in cents representing how much to charge.
-       */
-      shipping_amount: number;
+    export type Type = 'dropdown' | 'numeric' | 'text';
 
-      /**
-       * The shipping rate.
-       */
-      shipping_rate: string | ShippingRate;
-    }
-
-    export type Status = 'complete' | 'expired' | 'open';
-
-    export type SubmitType = 'auto' | 'book' | 'donate' | 'pay' | 'subscribe';
-
-    export interface TaxIdCollection {
-      /**
-       * Indicates whether tax ID collection is enabled for the session
-       */
-      enabled: boolean;
-
-      /**
-       * Indicates whether a tax ID is required on the payment page
-       */
-      required: TaxIdCollection.Required;
-    }
-
-    export interface TotalDetails {
-      /**
-       * This is the sum of all the discounts.
-       */
-      amount_discount: number;
-
-      /**
-       * This is the sum of all the shipping amounts.
-       */
-      amount_shipping: number | null;
-
-      /**
-       * This is the sum of all the tax amounts.
-       */
-      amount_tax: number;
-
-      breakdown?: TotalDetails.Breakdown;
-    }
-
-    export type UiMode = 'elements' | 'embedded_page' | 'form' | 'hosted_page';
-
-    export interface WalletOptions {
-      link?: WalletOptions.Link;
-    }
-
-    export namespace AfterExpiration {
-      export interface Recovery {
+    export namespace Dropdown {
+      export interface Option {
         /**
-         * Enables user redeemable promotion codes on the recovered Checkout Sessions. Defaults to `false`
+         * The label for the option, displayed to the customer. Up to 100 characters.
          */
-        allow_promotion_codes: boolean;
+        label: string;
 
         /**
-         * If `true`, a recovery url will be generated to recover this Checkout Session if it
-         * expires before a transaction is completed. It will be attached to the
-         * Checkout Session object upon expiration.
+         * The value for this option, not displayed to the customer, used by your integration to reconcile the option selected by the customer. Must be unique to this option, alphanumeric, and up to 100 characters.
          */
-        enabled: boolean;
-
-        /**
-         * The timestamp at which the recovery URL will expire.
-         */
-        expires_at: number | null;
-
-        /**
-         * URL that creates a new Checkout Session when clicked that is a copy of this expired Checkout Session
-         */
-        url: string | null;
+        value: string;
       }
     }
+  }
 
-    export namespace AutomaticTax {
-      export interface Liability {
+  export namespace CustomText {
+    export interface AfterSubmit {
+      /**
+       * Text can be up to 1200 characters in length.
+       */
+      message: string;
+    }
+
+    export interface ShippingAddress {
+      /**
+       * Text can be up to 1200 characters in length.
+       */
+      message: string;
+    }
+
+    export interface Submit {
+      /**
+       * Text can be up to 1200 characters in length.
+       */
+      message: string;
+    }
+
+    export interface TermsOfServiceAcceptance {
+      /**
+       * Text can be up to 1200 characters in length.
+       */
+      message: string;
+    }
+  }
+
+  export namespace InvoiceCreation {
+    export interface InvoiceData {
+      /**
+       * The account tax IDs associated with the invoice.
+       */
+      account_tax_ids: Array<string | TaxId | DeletedTaxId> | null;
+
+      /**
+       * Custom fields displayed on the invoice.
+       */
+      custom_fields: Array<InvoiceData.CustomField> | null;
+
+      /**
+       * An arbitrary string attached to the object. Often useful for displaying to users.
+       */
+      description: string | null;
+
+      /**
+       * Footer displayed on the invoice.
+       */
+      footer: string | null;
+
+      /**
+       * The connected account that issues the invoice. The invoice is presented with the branding and support information of the specified account.
+       */
+      issuer: InvoiceData.Issuer | null;
+
+      /**
+       * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+       */
+      metadata: Metadata | null;
+
+      /**
+       * Options for invoice PDF rendering.
+       */
+      rendering_options: InvoiceData.RenderingOptions | null;
+    }
+
+    export namespace InvoiceData {
+      export interface CustomField {
+        /**
+         * The name of the custom field.
+         */
+        name: string;
+
+        /**
+         * The value of the custom field.
+         */
+        value: string;
+      }
+
+      export interface Issuer {
         /**
          * The connected account being referenced when `type` is `account`.
          */
@@ -1588,1863 +1995,1532 @@ export namespace Checkout {
         /**
          * Type of the account referenced.
          */
-        type: Liability.Type;
+        type: Issuer.Type;
       }
 
-      export type Status = 'complete' | 'failed' | 'requires_location_inputs';
+      export interface RenderingOptions {
+        /**
+         * How line-item prices and amounts will be displayed with respect to tax on invoice PDFs.
+         */
+        amount_tax_display: string | null;
 
-      export namespace Liability {
+        /**
+         * ID of the invoice rendering template to be used for the generated invoice.
+         */
+        template: string | null;
+      }
+
+      export namespace Issuer {
         export type Type = 'account' | 'self';
       }
     }
+  }
 
-    export namespace BrandingSettings {
-      export type BorderStyle = 'pill' | 'rectangular' | 'rounded';
+  export namespace NameCollection {
+    export interface Business {
+      /**
+       * Indicates whether business name collection is enabled for the session
+       */
+      enabled: boolean;
 
-      export interface Icon {
+      /**
+       * Whether the customer is required to complete the field before completing the Checkout Session. Defaults to `false`.
+       */
+      optional: boolean;
+    }
+
+    export interface Individual {
+      /**
+       * Indicates whether individual name collection is enabled for the session
+       */
+      enabled: boolean;
+
+      /**
+       * Whether the customer is required to complete the field before completing the Checkout Session. Defaults to `false`.
+       */
+      optional: boolean;
+    }
+  }
+
+  export namespace OptionalItem {
+    export interface AdjustableQuantity {
+      /**
+       * Set to true if the quantity can be adjusted to any non-negative integer.
+       */
+      enabled: boolean;
+
+      /**
+       * The maximum quantity of this item the customer can purchase. By default this value is 99. You can specify a value up to 999999.
+       */
+      maximum: number | null;
+
+      /**
+       * The minimum quantity of this item the customer must purchase, if they choose to purchase it. Because this item is optional, the customer will always be able to remove it from their order, even if the `minimum` configured here is greater than 0. By default this value is 0.
+       */
+      minimum: number | null;
+    }
+  }
+
+  export namespace PaymentMethodOptions {
+    export interface AcssDebit {
+      /**
+       * Currency supported by the bank account. Returned when the Session is in `setup` mode.
+       */
+      currency?: AcssDebit.Currency;
+
+      mandate_options?: AcssDebit.MandateOptions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: AcssDebit.SetupFutureUsage;
+
+      /**
+       * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
+       */
+      target_date?: string;
+
+      /**
+       * Bank account verification method. The default value is `automatic`.
+       */
+      verification_method?: AcssDebit.VerificationMethod;
+    }
+
+    export interface Affirm {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface AfterpayClearpay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Alipay {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Alma {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+    }
+
+    export interface AmazonPay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: AmazonPay.SetupFutureUsage;
+    }
+
+    export interface AuBecsDebit {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+
+      /**
+       * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
+       */
+      target_date?: string;
+    }
+
+    export interface BacsDebit {
+      mandate_options?: BacsDebit.MandateOptions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: BacsDebit.SetupFutureUsage;
+
+      /**
+       * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
+       */
+      target_date?: string;
+    }
+
+    export interface Bancontact {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Billie {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+    }
+
+    export interface Boleto {
+      /**
+       * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
+       */
+      expires_after_days: number;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Boleto.SetupFutureUsage;
+    }
+
+    export interface Card {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      installments?: Card.Installments;
+
+      /**
+       * Request ability to [capture beyond the standard authorization validity window](https://docs.stripe.com/payments/extended-authorization) for this CheckoutSession.
+       */
+      request_extended_authorization?: Card.RequestExtendedAuthorization;
+
+      /**
+       * Request ability to [increment the authorization](https://docs.stripe.com/payments/incremental-authorization) for this CheckoutSession.
+       */
+      request_incremental_authorization?: Card.RequestIncrementalAuthorization;
+
+      /**
+       * Request ability to make [multiple captures](https://docs.stripe.com/payments/multicapture) for this CheckoutSession.
+       */
+      request_multicapture?: Card.RequestMulticapture;
+
+      /**
+       * Request ability to [overcapture](https://docs.stripe.com/payments/overcapture) for this CheckoutSession.
+       */
+      request_overcapture?: Card.RequestOvercapture;
+
+      /**
+       * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://docs.stripe.com/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. If not provided, this value defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://docs.stripe.com/payments/3d-secure/authentication-flow#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
+       */
+      request_three_d_secure: Card.RequestThreeDSecure;
+
+      restrictions?: Card.Restrictions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Card.SetupFutureUsage;
+
+      /**
+       * Provides information about a card payment that customers see on their statements. Concatenated with the Kana prefix (shortened Kana descriptor) or Kana statement descriptor that's set on the account to form the complete statement descriptor. Maximum 22 characters. On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 22 characters.
+       */
+      statement_descriptor_suffix_kana?: string;
+
+      /**
+       * Provides information about a card payment that customers see on their statements. Concatenated with the Kanji prefix (shortened Kanji descriptor) or Kanji statement descriptor that's set on the account to form the complete statement descriptor. Maximum 17 characters. On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 17 characters.
+       */
+      statement_descriptor_suffix_kanji?: string;
+    }
+
+    export interface Cashapp {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface CustomerBalance {
+      bank_transfer?: CustomerBalance.BankTransfer;
+
+      /**
+       * The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
+       */
+      funding_type: 'bank_transfer' | null;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Eps {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Fpx {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Giropay {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Grabpay {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Ideal {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface KakaoPay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: KakaoPay.SetupFutureUsage;
+    }
+
+    export interface Klarna {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Klarna.SetupFutureUsage;
+    }
+
+    export interface Konbini {
+      /**
+       * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
+       */
+      expires_after_days: number | null;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface KrCard {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: KrCard.SetupFutureUsage;
+    }
+
+    export interface Link {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Link.SetupFutureUsage;
+    }
+
+    export interface Mobilepay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Multibanco {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface NaverPay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: NaverPay.SetupFutureUsage;
+    }
+
+    export interface Oxxo {
+      /**
+       * The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
+       */
+      expires_after_days: number;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface P24 {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Payco {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+    }
+
+    export interface Paynow {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Paypal {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Preferred locale of the PayPal checkout page that the customer is redirected to.
+       */
+      preferred_locale: string | null;
+
+      /**
+       * A reference of the PayPal transaction visible to customer which is mapped to PayPal's invoice ID. This must be a globally unique ID if you have configured in your PayPal settings to block multiple payments per invoice ID.
+       */
+      reference: string | null;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Paypal.SetupFutureUsage;
+    }
+
+    export interface Payto {
+      mandate_options?: Payto.MandateOptions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Payto.SetupFutureUsage;
+    }
+
+    export interface Pix {
+      /**
+       * Determines if the amount includes the IOF tax.
+       */
+      amount_includes_iof?: Pix.AmountIncludesIof;
+
+      /**
+       * The number of seconds after which Pix payment will expire.
+       */
+      expires_after_seconds: number | null;
+
+      mandate_options?: Pix.MandateOptions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Pix.SetupFutureUsage;
+    }
+
+    export interface RevolutPay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: RevolutPay.SetupFutureUsage;
+    }
+
+    export interface SamsungPay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+    }
+
+    export interface Satispay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+    }
+
+    export interface Scalapay {
+      /**
+       * Controls when the funds will be captured from the customer's account.
+       */
+      capture_method?: 'manual';
+    }
+
+    export interface SepaDebit {
+      mandate_options?: SepaDebit.MandateOptions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: SepaDebit.SetupFutureUsage;
+
+      /**
+       * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
+       */
+      target_date?: string;
+    }
+
+    export interface Sofort {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: 'none';
+    }
+
+    export interface Swish {
+      /**
+       * The order reference that will be displayed to customers in the Swish application. Defaults to the `id` of the Payment Intent.
+       */
+      reference: string | null;
+    }
+
+    export interface Twint {
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Twint.SetupFutureUsage;
+    }
+
+    export interface Upi {
+      mandate_options?: Upi.MandateOptions;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: Upi.SetupFutureUsage;
+    }
+
+    export interface UsBankAccount {
+      financial_connections?: UsBankAccount.FinancialConnections;
+
+      /**
+       * Indicates that you intend to make future payments with this PaymentIntent's payment method.
+       *
+       * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
+       *
+       * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
+       *
+       * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
+       */
+      setup_future_usage?: UsBankAccount.SetupFutureUsage;
+
+      /**
+       * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
+       */
+      target_date?: string;
+
+      /**
+       * Bank account verification method. The default value is `automatic`.
+       */
+      verification_method?: UsBankAccount.VerificationMethod;
+    }
+
+    export namespace AcssDebit {
+      export type Currency = 'cad' | 'usd';
+
+      export interface MandateOptions {
         /**
-         * The ID of a [File upload](https://stripe.com/docs/api/files) representing the icon. Purpose must be `business_icon`. Required if `type` is `file` and disallowed otherwise.
+         * A URL for custom mandate text
          */
-        file?: string;
+        custom_mandate_url?: string;
 
         /**
-         * The type of image for the icon. Must be one of `file` or `url`.
+         * List of Stripe products where this mandate can be selected automatically. Returned when the Session is in `setup` mode.
          */
-        type: Icon.Type;
+        default_for?: Array<MandateOptions.DefaultFor>;
 
         /**
-         * The URL of the image. Present when `type` is `url`.
+         * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
          */
-        url?: string;
+        interval_description: string | null;
+
+        /**
+         * Payment schedule for the mandate.
+         */
+        payment_schedule: MandateOptions.PaymentSchedule | null;
+
+        /**
+         * Transaction type of the mandate.
+         */
+        transaction_type: MandateOptions.TransactionType | null;
       }
 
-      export interface Logo {
-        /**
-         * The ID of a [File upload](https://stripe.com/docs/api/files) representing the logo. Purpose must be `business_logo`. Required if `type` is `file` and disallowed otherwise.
-         */
-        file?: string;
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
-        /**
-         * The type of image for the logo. Must be one of `file` or `url`.
-         */
-        type: Logo.Type;
+      export type VerificationMethod =
+        | 'automatic'
+        | 'instant'
+        | 'microdeposits';
 
-        /**
-         * The URL of the image. Present when `type` is `url`.
-         */
-        url?: string;
-      }
+      export namespace MandateOptions {
+        export type DefaultFor = 'invoice' | 'subscription';
 
-      export namespace Icon {
-        export type Type = 'file' | 'url';
-      }
+        export type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
 
-      export namespace Logo {
-        export type Type = 'file' | 'url';
+        export type TransactionType = 'business' | 'personal';
       }
     }
 
-    export namespace CollectedInformation {
-      export interface ShippingDetails {
-        address: Address;
+    export namespace AmazonPay {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
 
+    export namespace BacsDebit {
+      export interface MandateOptions {
         /**
-         * Customer name.
+         * Prefix used to generate the Mandate reference. Must be at most 12 characters long. Must consist of only uppercase letters, numbers, spaces, or the following special characters: '/', '_', '-', '&', '.'. Cannot begin with 'DDIC' or 'STRIPE'.
          */
-        name: string;
+        reference_prefix?: string;
+      }
+
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+    }
+
+    export namespace Boleto {
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+    }
+
+    export namespace Card {
+      export interface Installments {
+        /**
+         * Indicates if installments are enabled
+         */
+        enabled?: boolean;
+      }
+
+      export type RequestExtendedAuthorization = 'if_available' | 'never';
+
+      export type RequestIncrementalAuthorization = 'if_available' | 'never';
+
+      export type RequestMulticapture = 'if_available' | 'never';
+
+      export type RequestOvercapture = 'if_available' | 'never';
+
+      export type RequestThreeDSecure = 'any' | 'automatic' | 'challenge';
+
+      export interface Restrictions {
+        /**
+         * The card brands to block. If a customer enters or selects a card belonging to a blocked brand, they can't complete the payment.
+         */
+        brands_blocked?: Array<Restrictions.BrandsBlocked>;
+      }
+
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+
+      export namespace Restrictions {
+        export type BrandsBlocked =
+          | 'american_express'
+          | 'discover_global_network'
+          | 'mastercard'
+          | 'visa';
       }
     }
 
-    export namespace Consent {
-      export type Promotions = 'opt_in' | 'opt_out';
-    }
+    export namespace CustomerBalance {
+      export interface BankTransfer {
+        eu_bank_transfer?: BankTransfer.EuBankTransfer;
 
-    export namespace ConsentCollection {
-      export interface PaymentMethodReuseAgreement {
         /**
-         * Determines the position and visibility of the payment method reuse agreement in the UI. When set to `auto`, Stripe's defaults will be used.
+         * List of address types that should be returned in the financial_addresses response. If not specified, all valid types will be returned.
          *
-         * When set to `hidden`, the payment method reuse agreement text will always be hidden in the UI.
+         * Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
          */
-        position: PaymentMethodReuseAgreement.Position;
-      }
-
-      export type Promotions = 'auto' | 'none';
-
-      export type TermsOfService = 'none' | 'required';
-
-      export namespace PaymentMethodReuseAgreement {
-        export type Position = 'auto' | 'hidden';
-      }
-    }
-
-    export namespace CustomerDetails {
-      export type TaxExempt = 'exempt' | 'none' | 'reverse';
-
-      export interface TaxId {
-        /**
-         * The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `pl_nip`, `it_cf`, `fo_vat`, `gi_tin`, `py_ruc`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `lk_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `al_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, `ao_tin`, `bs_tin`, `bb_tin`, `cd_nif`, `mr_nif`, `me_pib`, `zw_tin`, `ba_tin`, `gn_nif`, `mk_vat`, `sr_fin`, `sn_ninea`, `am_tin`, `np_pan`, `tj_tin`, `ug_tin`, `zm_tin`, `kh_tin`, `aw_tin`, `az_tin`, `bd_bin`, `bj_ifu`, `et_tin`, `kg_tin`, `la_tin`, `cm_niu`, `cv_nif`, `bf_ifu`, or `unknown`
-         */
-        type: TaxId.Type;
+        requested_address_types?: Array<BankTransfer.RequestedAddressType>;
 
         /**
-         * The value of the tax ID.
+         * The bank transfer type that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
          */
-        value: string | null;
+        type: BankTransfer.Type | null;
       }
 
-      export namespace TaxId {
+      export namespace BankTransfer {
+        export interface EuBankTransfer {
+          /**
+           * The desired country code of the bank account information. Permitted values include: `DE`, `FR`, `IE`, or `NL`.
+           */
+          country: EuBankTransfer.Country;
+        }
+
+        export type RequestedAddressType =
+          | 'aba'
+          | 'iban'
+          | 'sepa'
+          | 'sort_code'
+          | 'spei'
+          | 'swift'
+          | 'zengin';
+
         export type Type =
-          | 'ad_nrt'
-          | 'ae_trn'
-          | 'al_tin'
-          | 'am_tin'
-          | 'ao_tin'
-          | 'ar_cuit'
-          | 'au_abn'
-          | 'au_arn'
-          | 'aw_tin'
-          | 'az_tin'
-          | 'ba_tin'
-          | 'bb_tin'
-          | 'bd_bin'
-          | 'bf_ifu'
-          | 'bg_uic'
-          | 'bh_vat'
-          | 'bj_ifu'
-          | 'bo_tin'
-          | 'br_cnpj'
-          | 'br_cpf'
-          | 'bs_tin'
-          | 'by_tin'
-          | 'ca_bn'
-          | 'ca_gst_hst'
-          | 'ca_pst_bc'
-          | 'ca_pst_mb'
-          | 'ca_pst_sk'
-          | 'ca_qst'
-          | 'cd_nif'
-          | 'ch_uid'
-          | 'ch_vat'
-          | 'cl_tin'
-          | 'cm_niu'
-          | 'cn_tin'
-          | 'co_nit'
-          | 'cr_tin'
-          | 'cv_nif'
-          | 'de_stn'
-          | 'do_rcn'
-          | 'ec_ruc'
-          | 'eg_tin'
-          | 'es_cif'
-          | 'et_tin'
-          | 'eu_oss_vat'
-          | 'eu_vat'
-          | 'fo_vat'
-          | 'gb_vat'
-          | 'ge_vat'
-          | 'gi_tin'
-          | 'gn_nif'
-          | 'hk_br'
-          | 'hr_oib'
-          | 'hu_tin'
-          | 'id_npwp'
-          | 'il_vat'
-          | 'in_gst'
-          | 'is_vat'
-          | 'it_cf'
-          | 'jp_cn'
-          | 'jp_rn'
-          | 'jp_trn'
-          | 'ke_pin'
-          | 'kg_tin'
-          | 'kh_tin'
-          | 'kr_brn'
-          | 'kz_bin'
-          | 'la_tin'
-          | 'li_uid'
-          | 'li_vat'
-          | 'lk_vat'
-          | 'ma_vat'
-          | 'md_vat'
-          | 'me_pib'
-          | 'mk_vat'
-          | 'mr_nif'
-          | 'mx_rfc'
-          | 'my_frp'
-          | 'my_itn'
-          | 'my_sst'
-          | 'ng_tin'
-          | 'no_vat'
-          | 'no_voec'
-          | 'np_pan'
-          | 'nz_gst'
-          | 'om_vat'
-          | 'pe_ruc'
-          | 'ph_tin'
-          | 'pl_nip'
-          | 'py_ruc'
-          | 'ro_tin'
-          | 'rs_pib'
-          | 'ru_inn'
-          | 'ru_kpp'
-          | 'sa_vat'
-          | 'sg_gst'
-          | 'sg_uen'
-          | 'si_tin'
-          | 'sn_ninea'
-          | 'sr_fin'
-          | 'sv_nit'
-          | 'th_vat'
-          | 'tj_tin'
-          | 'tr_tin'
-          | 'tw_vat'
-          | 'tz_vat'
-          | 'ua_vat'
-          | 'ug_tin'
-          | 'unknown'
-          | 'us_ein'
-          | 'uy_ruc'
-          | 'uz_tin'
-          | 'uz_vat'
-          | 've_rif'
-          | 'vn_tin'
-          | 'za_vat'
-          | 'zm_tin'
-          | 'zw_tin';
-      }
-    }
+          | 'eu_bank_transfer'
+          | 'gb_bank_transfer'
+          | 'jp_bank_transfer'
+          | 'mx_bank_transfer'
+          | 'us_bank_transfer';
 
-    export namespace CustomField {
-      export interface Dropdown {
-        /**
-         * The value that pre-fills on the payment page.
-         */
-        default_value: string | null;
-
-        /**
-         * The options available for the customer to select. Up to 200 options allowed.
-         */
-        options: Array<Dropdown.Option>;
-
-        /**
-         * The option selected by the customer. This will be the `value` for the option.
-         */
-        value: string | null;
-      }
-
-      export interface Label {
-        /**
-         * Custom text for the label, displayed to the customer. Up to 50 characters.
-         */
-        custom: string | null;
-
-        /**
-         * The type of the label.
-         */
-        type: 'custom';
-      }
-
-      export interface Numeric {
-        /**
-         * The value that pre-fills the field on the payment page.
-         */
-        default_value: string | null;
-
-        /**
-         * The maximum character length constraint for the customer's input.
-         */
-        maximum_length: number | null;
-
-        /**
-         * The minimum character length requirement for the customer's input.
-         */
-        minimum_length: number | null;
-
-        /**
-         * The value entered by the customer, containing only digits.
-         */
-        value: string | null;
-      }
-
-      export interface Text {
-        /**
-         * The value that pre-fills the field on the payment page.
-         */
-        default_value: string | null;
-
-        /**
-         * The maximum character length constraint for the customer's input.
-         */
-        maximum_length: number | null;
-
-        /**
-         * The minimum character length requirement for the customer's input.
-         */
-        minimum_length: number | null;
-
-        /**
-         * The value entered by the customer.
-         */
-        value: string | null;
-      }
-
-      export type Type = 'dropdown' | 'numeric' | 'text';
-
-      export namespace Dropdown {
-        export interface Option {
-          /**
-           * The label for the option, displayed to the customer. Up to 100 characters.
-           */
-          label: string;
-
-          /**
-           * The value for this option, not displayed to the customer, used by your integration to reconcile the option selected by the customer. Must be unique to this option, alphanumeric, and up to 100 characters.
-           */
-          value: string;
+        export namespace EuBankTransfer {
+          export type Country = 'BE' | 'DE' | 'ES' | 'FR' | 'IE' | 'NL';
         }
       }
     }
 
-    export namespace CustomText {
-      export interface AfterSubmit {
+    export namespace KakaoPay {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace Klarna {
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+    }
+
+    export namespace KrCard {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace Link {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace NaverPay {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace Paypal {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace Payto {
+      export interface MandateOptions {
         /**
-         * Text can be up to 1200 characters in length.
+         * Amount that will be collected. It is required when `amount_type` is `fixed`.
          */
-        message: string;
+        amount: number | null;
+
+        /**
+         * The type of amount that will be collected. The amount charged must be exact or up to the value of `amount` param for `fixed` or `maximum` type respectively. Defaults to `maximum`.
+         */
+        amount_type: MandateOptions.AmountType | null;
+
+        /**
+         * Date, in YYYY-MM-DD format, after which payments will not be collected. Defaults to no end date.
+         */
+        end_date: string | null;
+
+        /**
+         * The periodicity at which payments will be collected. Defaults to `adhoc`.
+         */
+        payment_schedule: MandateOptions.PaymentSchedule | null;
+
+        /**
+         * The number of payments that will be made during a payment period. Defaults to 1 except for when `payment_schedule` is `adhoc`. In that case, it defaults to no limit.
+         */
+        payments_per_period: number | null;
+
+        /**
+         * The purpose for which payments are made. Has a default value based on your merchant category code.
+         */
+        purpose: MandateOptions.Purpose | null;
+
+        /**
+         * Date, in YYYY-MM-DD format, from which payments will be collected. Defaults to confirmation time.
+         */
+        start_date: string | null;
       }
 
-      export interface ShippingAddress {
-        /**
-         * Text can be up to 1200 characters in length.
-         */
-        message: string;
-      }
+      export type SetupFutureUsage = 'none' | 'off_session';
 
-      export interface Submit {
-        /**
-         * Text can be up to 1200 characters in length.
-         */
-        message: string;
-      }
+      export namespace MandateOptions {
+        export type AmountType = 'fixed' | 'maximum';
 
-      export interface TermsOfServiceAcceptance {
-        /**
-         * Text can be up to 1200 characters in length.
-         */
-        message: string;
+        export type PaymentSchedule =
+          | 'adhoc'
+          | 'annual'
+          | 'daily'
+          | 'fortnightly'
+          | 'monthly'
+          | 'quarterly'
+          | 'semi_annual'
+          | 'weekly';
+
+        export type Purpose =
+          | 'dependant_support'
+          | 'government'
+          | 'loan'
+          | 'mortgage'
+          | 'other'
+          | 'pension'
+          | 'personal'
+          | 'retail'
+          | 'salary'
+          | 'tax'
+          | 'utility';
       }
     }
 
-    export namespace InvoiceCreation {
-      export interface InvoiceData {
+    export namespace Pix {
+      export type AmountIncludesIof = 'always' | 'never';
+
+      export interface MandateOptions {
         /**
-         * The account tax IDs associated with the invoice.
+         * Amount to be charged for future payments.
          */
-        account_tax_ids: Array<string | TaxId | DeletedTaxId> | null;
+        amount?: number;
 
         /**
-         * Custom fields displayed on the invoice.
+         * Determines if the amount includes the IOF tax.
          */
-        custom_fields: Array<InvoiceData.CustomField> | null;
+        amount_includes_iof?: MandateOptions.AmountIncludesIof;
 
         /**
-         * An arbitrary string attached to the object. Often useful for displaying to users.
+         * Type of amount.
+         */
+        amount_type?: MandateOptions.AmountType;
+
+        /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+         */
+        currency?: string;
+
+        /**
+         * Date when the mandate expires and no further payments will be charged, in `YYYY-MM-DD`.
+         */
+        end_date?: string;
+
+        /**
+         * Schedule at which the future payments will be charged.
+         */
+        payment_schedule?: MandateOptions.PaymentSchedule;
+
+        /**
+         * Subscription name displayed to buyers in their bank app.
+         */
+        reference?: string;
+
+        /**
+         * Start date of the mandate, in `YYYY-MM-DD`.
+         */
+        start_date?: string;
+      }
+
+      export type SetupFutureUsage = 'none' | 'off_session';
+
+      export namespace MandateOptions {
+        export type AmountIncludesIof = 'always' | 'never';
+
+        export type AmountType = 'fixed' | 'maximum';
+
+        export type PaymentSchedule =
+          | 'halfyearly'
+          | 'monthly'
+          | 'quarterly'
+          | 'weekly'
+          | 'yearly';
+      }
+    }
+
+    export namespace RevolutPay {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace SepaDebit {
+      export interface MandateOptions {
+        /**
+         * Prefix used to generate the Mandate reference. Must be at most 12 characters long. Must consist of only uppercase letters, numbers, spaces, or the following special characters: '/', '_', '-', '&', '.'. Cannot begin with 'STRIPE'.
+         */
+        reference_prefix?: string;
+      }
+
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
+    }
+
+    export namespace Twint {
+      export type SetupFutureUsage = 'none' | 'off_session';
+    }
+
+    export namespace Upi {
+      export interface MandateOptions {
+        /**
+         * Amount to be charged for future payments.
+         */
+        amount: number | null;
+
+        /**
+         * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
+         */
+        amount_type: MandateOptions.AmountType | null;
+
+        /**
+         * A description of the mandate or subscription that is meant to be displayed to the customer.
          */
         description: string | null;
 
         /**
-         * Footer displayed on the invoice.
+         * End date of the mandate or subscription.
          */
-        footer: string | null;
-
-        /**
-         * The connected account that issues the invoice. The invoice is presented with the branding and support information of the specified account.
-         */
-        issuer: InvoiceData.Issuer | null;
-
-        /**
-         * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
-         */
-        metadata: Metadata | null;
-
-        /**
-         * Options for invoice PDF rendering.
-         */
-        rendering_options: InvoiceData.RenderingOptions | null;
+        end_date: number | null;
       }
 
-      export namespace InvoiceData {
-        export interface CustomField {
-          /**
-           * The name of the custom field.
-           */
-          name: string;
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
-          /**
-           * The value of the custom field.
-           */
-          value: string;
-        }
-
-        export interface Issuer {
-          /**
-           * The connected account being referenced when `type` is `account`.
-           */
-          account?: string | Account;
-
-          /**
-           * Type of the account referenced.
-           */
-          type: Issuer.Type;
-        }
-
-        export interface RenderingOptions {
-          /**
-           * How line-item prices and amounts will be displayed with respect to tax on invoice PDFs.
-           */
-          amount_tax_display: string | null;
-
-          /**
-           * ID of the invoice rendering template to be used for the generated invoice.
-           */
-          template: string | null;
-        }
-
-        export namespace Issuer {
-          export type Type = 'account' | 'self';
-        }
+      export namespace MandateOptions {
+        export type AmountType = 'fixed' | 'maximum';
       }
     }
 
-    export namespace NameCollection {
-      export interface Business {
-        /**
-         * Indicates whether business name collection is enabled for the session
-         */
-        enabled: boolean;
+    export namespace UsBankAccount {
+      export interface FinancialConnections {
+        filters?: FinancialConnections.Filters;
 
         /**
-         * Whether the customer is required to complete the field before completing the Checkout Session. Defaults to `false`.
+         * The list of permissions to request. The `payment_method` permission must be included.
          */
-        optional: boolean;
+        permissions?: Array<FinancialConnections.Permission>;
+
+        /**
+         * Data features requested to be retrieved upon account creation.
+         */
+        prefetch: Array<FinancialConnections.Prefetch> | null;
+
+        /**
+         * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
+         */
+        return_url?: string;
       }
 
-      export interface Individual {
-        /**
-         * Indicates whether individual name collection is enabled for the session
-         */
-        enabled: boolean;
+      export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
 
-        /**
-         * Whether the customer is required to complete the field before completing the Checkout Session. Defaults to `false`.
-         */
-        optional: boolean;
-      }
-    }
+      export type VerificationMethod = 'automatic' | 'instant';
 
-    export namespace OptionalItem {
-      export interface AdjustableQuantity {
-        /**
-         * Set to true if the quantity can be adjusted to any non-negative integer.
-         */
-        enabled: boolean;
-
-        /**
-         * The maximum quantity of this item the customer can purchase. By default this value is 99. You can specify a value up to 999999.
-         */
-        maximum: number | null;
-
-        /**
-         * The minimum quantity of this item the customer must purchase, if they choose to purchase it. Because this item is optional, the customer will always be able to remove it from their order, even if the `minimum` configured here is greater than 0. By default this value is 0.
-         */
-        minimum: number | null;
-      }
-    }
-
-    export namespace PaymentMethodOptions {
-      export interface AcssDebit {
-        /**
-         * Currency supported by the bank account. Returned when the Session is in `setup` mode.
-         */
-        currency?: AcssDebit.Currency;
-
-        mandate_options?: AcssDebit.MandateOptions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: AcssDebit.SetupFutureUsage;
-
-        /**
-         * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
-         */
-        target_date?: string;
-
-        /**
-         * Bank account verification method. The default value is `automatic`.
-         */
-        verification_method?: AcssDebit.VerificationMethod;
-      }
-
-      export interface Affirm {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface AfterpayClearpay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Alipay {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Alma {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-      }
-
-      export interface AmazonPay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: AmazonPay.SetupFutureUsage;
-      }
-
-      export interface AuBecsDebit {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-
-        /**
-         * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
-         */
-        target_date?: string;
-      }
-
-      export interface BacsDebit {
-        mandate_options?: BacsDebit.MandateOptions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: BacsDebit.SetupFutureUsage;
-
-        /**
-         * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
-         */
-        target_date?: string;
-      }
-
-      export interface Bancontact {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Billie {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-      }
-
-      export interface Boleto {
-        /**
-         * The number of calendar days before a Boleto voucher expires. For example, if you create a Boleto voucher on Monday and you set expires_after_days to 2, the Boleto voucher will expire on Wednesday at 23:59 America/Sao_Paulo time.
-         */
-        expires_after_days: number;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Boleto.SetupFutureUsage;
-      }
-
-      export interface Card {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        installments?: Card.Installments;
-
-        /**
-         * Request ability to [capture beyond the standard authorization validity window](https://docs.stripe.com/payments/extended-authorization) for this CheckoutSession.
-         */
-        request_extended_authorization?: Card.RequestExtendedAuthorization;
-
-        /**
-         * Request ability to [increment the authorization](https://docs.stripe.com/payments/incremental-authorization) for this CheckoutSession.
-         */
-        request_incremental_authorization?: Card.RequestIncrementalAuthorization;
-
-        /**
-         * Request ability to make [multiple captures](https://docs.stripe.com/payments/multicapture) for this CheckoutSession.
-         */
-        request_multicapture?: Card.RequestMulticapture;
-
-        /**
-         * Request ability to [overcapture](https://docs.stripe.com/payments/overcapture) for this CheckoutSession.
-         */
-        request_overcapture?: Card.RequestOvercapture;
-
-        /**
-         * We strongly recommend that you rely on our SCA Engine to automatically prompt your customers for authentication based on risk level and [other requirements](https://docs.stripe.com/strong-customer-authentication). However, if you wish to request 3D Secure based on logic from your own fraud engine, provide this option. If not provided, this value defaults to `automatic`. Read our guide on [manually requesting 3D Secure](https://docs.stripe.com/payments/3d-secure/authentication-flow#manual-three-ds) for more information on how this configuration interacts with Radar and our SCA Engine.
-         */
-        request_three_d_secure: Card.RequestThreeDSecure;
-
-        restrictions?: Card.Restrictions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Card.SetupFutureUsage;
-
-        /**
-         * Provides information about a card payment that customers see on their statements. Concatenated with the Kana prefix (shortened Kana descriptor) or Kana statement descriptor that's set on the account to form the complete statement descriptor. Maximum 22 characters. On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 22 characters.
-         */
-        statement_descriptor_suffix_kana?: string;
-
-        /**
-         * Provides information about a card payment that customers see on their statements. Concatenated with the Kanji prefix (shortened Kanji descriptor) or Kanji statement descriptor that's set on the account to form the complete statement descriptor. Maximum 17 characters. On card statements, the *concatenation* of both prefix and suffix (including separators) will appear truncated to 17 characters.
-         */
-        statement_descriptor_suffix_kanji?: string;
-      }
-
-      export interface Cashapp {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface CustomerBalance {
-        bank_transfer?: CustomerBalance.BankTransfer;
-
-        /**
-         * The funding method type to be used when there are not enough funds in the customer balance. Permitted values include: `bank_transfer`.
-         */
-        funding_type: 'bank_transfer' | null;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Eps {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Fpx {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Giropay {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Grabpay {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Ideal {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface KakaoPay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: KakaoPay.SetupFutureUsage;
-      }
-
-      export interface Klarna {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Klarna.SetupFutureUsage;
-      }
-
-      export interface Konbini {
-        /**
-         * The number of calendar days (between 1 and 60) after which Konbini payment instructions will expire. For example, if a PaymentIntent is confirmed with Konbini and `expires_after_days` set to 2 on Monday JST, the instructions will expire on Wednesday 23:59:59 JST.
-         */
-        expires_after_days: number | null;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface KrCard {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: KrCard.SetupFutureUsage;
-      }
-
-      export interface Link {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Link.SetupFutureUsage;
-      }
-
-      export interface Mobilepay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Multibanco {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface NaverPay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: NaverPay.SetupFutureUsage;
-      }
-
-      export interface Oxxo {
-        /**
-         * The number of calendar days before an OXXO invoice expires. For example, if you create an OXXO invoice on Monday and you set expires_after_days to 2, the OXXO invoice will expire on Wednesday at 23:59 America/Mexico_City time.
-         */
-        expires_after_days: number;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface P24 {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Payco {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-      }
-
-      export interface Paynow {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Paypal {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Preferred locale of the PayPal checkout page that the customer is redirected to.
-         */
-        preferred_locale: string | null;
-
-        /**
-         * A reference of the PayPal transaction visible to customer which is mapped to PayPal's invoice ID. This must be a globally unique ID if you have configured in your PayPal settings to block multiple payments per invoice ID.
-         */
-        reference: string | null;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Paypal.SetupFutureUsage;
-      }
-
-      export interface Payto {
-        mandate_options?: Payto.MandateOptions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Payto.SetupFutureUsage;
-      }
-
-      export interface Pix {
-        /**
-         * Determines if the amount includes the IOF tax.
-         */
-        amount_includes_iof?: Pix.AmountIncludesIof;
-
-        /**
-         * The number of seconds after which Pix payment will expire.
-         */
-        expires_after_seconds: number | null;
-
-        mandate_options?: Pix.MandateOptions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Pix.SetupFutureUsage;
-      }
-
-      export interface RevolutPay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: RevolutPay.SetupFutureUsage;
-      }
-
-      export interface SamsungPay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-      }
-
-      export interface Satispay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-      }
-
-      export interface Scalapay {
-        /**
-         * Controls when the funds will be captured from the customer's account.
-         */
-        capture_method?: 'manual';
-      }
-
-      export interface SepaDebit {
-        mandate_options?: SepaDebit.MandateOptions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: SepaDebit.SetupFutureUsage;
-
-        /**
-         * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
-         */
-        target_date?: string;
-      }
-
-      export interface Sofort {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: 'none';
-      }
-
-      export interface Swish {
-        /**
-         * The order reference that will be displayed to customers in the Swish application. Defaults to the `id` of the Payment Intent.
-         */
-        reference: string | null;
-      }
-
-      export interface Twint {
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Twint.SetupFutureUsage;
-      }
-
-      export interface Upi {
-        mandate_options?: Upi.MandateOptions;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: Upi.SetupFutureUsage;
-      }
-
-      export interface UsBankAccount {
-        financial_connections?: UsBankAccount.FinancialConnections;
-
-        /**
-         * Indicates that you intend to make future payments with this PaymentIntent's payment method.
-         *
-         * If you provide a Customer with the PaymentIntent, you can use this parameter to [attach the payment method](https://docs.stripe.com/payments/save-during-payment) to the Customer after the PaymentIntent is confirmed and the customer completes any required actions. If you don't provide a Customer, you can still [attach](https://docs.stripe.com/api/payment_methods/attach) the payment method to a Customer after the transaction completes.
-         *
-         * If the payment method is `card_present` and isn't a digital wallet, Stripe creates and attaches a [generated_card](https://docs.stripe.com/api/charges/object#charge_object-payment_method_details-card_present-generated_card) payment method representing the card to the Customer instead.
-         *
-         * When processing card payments, Stripe uses `setup_future_usage` to help you comply with regional legislation and network rules, such as [SCA](https://docs.stripe.com/strong-customer-authentication).
-         */
-        setup_future_usage?: UsBankAccount.SetupFutureUsage;
-
-        /**
-         * Controls when Stripe will attempt to debit the funds from the customer's account. The date must be a string in YYYY-MM-DD format. The date must be in the future and between 3 and 15 calendar days from now.
-         */
-        target_date?: string;
-
-        /**
-         * Bank account verification method. The default value is `automatic`.
-         */
-        verification_method?: UsBankAccount.VerificationMethod;
-      }
-
-      export namespace AcssDebit {
-        export type Currency = 'cad' | 'usd';
-
-        export interface MandateOptions {
+      export namespace FinancialConnections {
+        export interface Filters {
           /**
-           * A URL for custom mandate text
+           * The account subcategories to use to filter for possible accounts to link. Valid subcategories are `checking` and `savings`.
            */
-          custom_mandate_url?: string;
-
-          /**
-           * List of Stripe products where this mandate can be selected automatically. Returned when the Session is in `setup` mode.
-           */
-          default_for?: Array<MandateOptions.DefaultFor>;
-
-          /**
-           * Description of the interval. Only required if the 'payment_schedule' parameter is 'interval' or 'combined'.
-           */
-          interval_description: string | null;
-
-          /**
-           * Payment schedule for the mandate.
-           */
-          payment_schedule: MandateOptions.PaymentSchedule | null;
-
-          /**
-           * Transaction type of the mandate.
-           */
-          transaction_type: MandateOptions.TransactionType | null;
+          account_subcategories?: Array<Filters.AccountSubcategory>;
         }
 
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-
-        export type VerificationMethod =
-          | 'automatic'
-          | 'instant'
-          | 'microdeposits';
-
-        export namespace MandateOptions {
-          export type DefaultFor = 'invoice' | 'subscription';
-
-          export type PaymentSchedule = 'combined' | 'interval' | 'sporadic';
-
-          export type TransactionType = 'business' | 'personal';
-        }
-      }
-
-      export namespace AmazonPay {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace BacsDebit {
-        export interface MandateOptions {
-          /**
-           * Prefix used to generate the Mandate reference. Must be at most 12 characters long. Must consist of only uppercase letters, numbers, spaces, or the following special characters: '/', '_', '-', '&', '.'. Cannot begin with 'DDIC' or 'STRIPE'.
-           */
-          reference_prefix?: string;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-      }
-
-      export namespace Boleto {
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-      }
-
-      export namespace Card {
-        export interface Installments {
-          /**
-           * Indicates if installments are enabled
-           */
-          enabled?: boolean;
-        }
-
-        export type RequestExtendedAuthorization = 'if_available' | 'never';
-
-        export type RequestIncrementalAuthorization = 'if_available' | 'never';
-
-        export type RequestMulticapture = 'if_available' | 'never';
-
-        export type RequestOvercapture = 'if_available' | 'never';
-
-        export type RequestThreeDSecure = 'any' | 'automatic' | 'challenge';
-
-        export interface Restrictions {
-          /**
-           * The card brands to block. If a customer enters or selects a card belonging to a blocked brand, they can't complete the payment.
-           */
-          brands_blocked?: Array<Restrictions.BrandsBlocked>;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-
-        export namespace Restrictions {
-          export type BrandsBlocked =
-            | 'american_express'
-            | 'discover_global_network'
-            | 'mastercard'
-            | 'visa';
-        }
-      }
-
-      export namespace CustomerBalance {
-        export interface BankTransfer {
-          eu_bank_transfer?: BankTransfer.EuBankTransfer;
-
-          /**
-           * List of address types that should be returned in the financial_addresses response. If not specified, all valid types will be returned.
-           *
-           * Permitted values include: `sort_code`, `zengin`, `iban`, or `spei`.
-           */
-          requested_address_types?: Array<BankTransfer.RequestedAddressType>;
-
-          /**
-           * The bank transfer type that this PaymentIntent is allowed to use for funding Permitted values include: `eu_bank_transfer`, `gb_bank_transfer`, `jp_bank_transfer`, `mx_bank_transfer`, or `us_bank_transfer`.
-           */
-          type: BankTransfer.Type | null;
-        }
-
-        export namespace BankTransfer {
-          export interface EuBankTransfer {
-            /**
-             * The desired country code of the bank account information. Permitted values include: `DE`, `FR`, `IE`, or `NL`.
-             */
-            country: EuBankTransfer.Country;
-          }
-
-          export type RequestedAddressType =
-            | 'aba'
-            | 'iban'
-            | 'sepa'
-            | 'sort_code'
-            | 'spei'
-            | 'swift'
-            | 'zengin';
-
-          export type Type =
-            | 'eu_bank_transfer'
-            | 'gb_bank_transfer'
-            | 'jp_bank_transfer'
-            | 'mx_bank_transfer'
-            | 'us_bank_transfer';
-
-          export namespace EuBankTransfer {
-            export type Country = 'BE' | 'DE' | 'ES' | 'FR' | 'IE' | 'NL';
-          }
-        }
-      }
-
-      export namespace KakaoPay {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace Klarna {
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-      }
-
-      export namespace KrCard {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace Link {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace NaverPay {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace Paypal {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace Payto {
-        export interface MandateOptions {
-          /**
-           * Amount that will be collected. It is required when `amount_type` is `fixed`.
-           */
-          amount: number | null;
-
-          /**
-           * The type of amount that will be collected. The amount charged must be exact or up to the value of `amount` param for `fixed` or `maximum` type respectively. Defaults to `maximum`.
-           */
-          amount_type: MandateOptions.AmountType | null;
-
-          /**
-           * Date, in YYYY-MM-DD format, after which payments will not be collected. Defaults to no end date.
-           */
-          end_date: string | null;
-
-          /**
-           * The periodicity at which payments will be collected. Defaults to `adhoc`.
-           */
-          payment_schedule: MandateOptions.PaymentSchedule | null;
-
-          /**
-           * The number of payments that will be made during a payment period. Defaults to 1 except for when `payment_schedule` is `adhoc`. In that case, it defaults to no limit.
-           */
-          payments_per_period: number | null;
-
-          /**
-           * The purpose for which payments are made. Has a default value based on your merchant category code.
-           */
-          purpose: MandateOptions.Purpose | null;
-
-          /**
-           * Date, in YYYY-MM-DD format, from which payments will be collected. Defaults to confirmation time.
-           */
-          start_date: string | null;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session';
-
-        export namespace MandateOptions {
-          export type AmountType = 'fixed' | 'maximum';
-
-          export type PaymentSchedule =
-            | 'adhoc'
-            | 'annual'
-            | 'daily'
-            | 'fortnightly'
-            | 'monthly'
-            | 'quarterly'
-            | 'semi_annual'
-            | 'weekly';
-
-          export type Purpose =
-            | 'dependant_support'
-            | 'government'
-            | 'loan'
-            | 'mortgage'
-            | 'other'
-            | 'pension'
-            | 'personal'
-            | 'retail'
-            | 'salary'
-            | 'tax'
-            | 'utility';
-        }
-      }
-
-      export namespace Pix {
-        export type AmountIncludesIof = 'always' | 'never';
-
-        export interface MandateOptions {
-          /**
-           * Amount to be charged for future payments.
-           */
-          amount?: number;
-
-          /**
-           * Determines if the amount includes the IOF tax.
-           */
-          amount_includes_iof?: MandateOptions.AmountIncludesIof;
-
-          /**
-           * Type of amount.
-           */
-          amount_type?: MandateOptions.AmountType;
-
-          /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
-           */
-          currency?: string;
-
-          /**
-           * Date when the mandate expires and no further payments will be charged, in `YYYY-MM-DD`.
-           */
-          end_date?: string;
-
-          /**
-           * Schedule at which the future payments will be charged.
-           */
-          payment_schedule?: MandateOptions.PaymentSchedule;
-
-          /**
-           * Subscription name displayed to buyers in their bank app.
-           */
-          reference?: string;
-
-          /**
-           * Start date of the mandate, in `YYYY-MM-DD`.
-           */
-          start_date?: string;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session';
-
-        export namespace MandateOptions {
-          export type AmountIncludesIof = 'always' | 'never';
-
-          export type AmountType = 'fixed' | 'maximum';
-
-          export type PaymentSchedule =
-            | 'halfyearly'
-            | 'monthly'
-            | 'quarterly'
-            | 'weekly'
-            | 'yearly';
-        }
-      }
-
-      export namespace RevolutPay {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace SepaDebit {
-        export interface MandateOptions {
-          /**
-           * Prefix used to generate the Mandate reference. Must be at most 12 characters long. Must consist of only uppercase letters, numbers, spaces, or the following special characters: '/', '_', '-', '&', '.'. Cannot begin with 'STRIPE'.
-           */
-          reference_prefix?: string;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-      }
-
-      export namespace Twint {
-        export type SetupFutureUsage = 'none' | 'off_session';
-      }
-
-      export namespace Upi {
-        export interface MandateOptions {
-          /**
-           * Amount to be charged for future payments.
-           */
-          amount: number | null;
-
-          /**
-           * One of `fixed` or `maximum`. If `fixed`, the `amount` param refers to the exact amount to be charged in future payments. If `maximum`, the amount charged can be up to the value passed for the `amount` param.
-           */
-          amount_type: MandateOptions.AmountType | null;
-
-          /**
-           * A description of the mandate or subscription that is meant to be displayed to the customer.
-           */
-          description: string | null;
-
-          /**
-           * End date of the mandate or subscription.
-           */
-          end_date: number | null;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-
-        export namespace MandateOptions {
-          export type AmountType = 'fixed' | 'maximum';
-        }
-      }
-
-      export namespace UsBankAccount {
-        export interface FinancialConnections {
-          filters?: FinancialConnections.Filters;
-
-          /**
-           * The list of permissions to request. The `payment_method` permission must be included.
-           */
-          permissions?: Array<FinancialConnections.Permission>;
-
-          /**
-           * Data features requested to be retrieved upon account creation.
-           */
-          prefetch: Array<FinancialConnections.Prefetch> | null;
-
-          /**
-           * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
-           */
-          return_url?: string;
-        }
-
-        export type SetupFutureUsage = 'none' | 'off_session' | 'on_session';
-
-        export type VerificationMethod = 'automatic' | 'instant';
-
-        export namespace FinancialConnections {
-          export interface Filters {
-            /**
-             * The account subcategories to use to filter for possible accounts to link. Valid subcategories are `checking` and `savings`.
-             */
-            account_subcategories?: Array<Filters.AccountSubcategory>;
-          }
-
-          export type Permission =
-            | 'balances'
-            | 'ownership'
-            | 'payment_method'
-            | 'transactions';
-
-          export type Prefetch = 'balances' | 'ownership' | 'transactions';
-
-          export namespace Filters {
-            export type AccountSubcategory = 'checking' | 'savings';
-          }
+        export type Permission =
+          | 'balances'
+          | 'ownership'
+          | 'payment_method'
+          | 'transactions';
+
+        export type Prefetch = 'balances' | 'ownership' | 'transactions';
+
+        export namespace Filters {
+          export type AccountSubcategory = 'checking' | 'savings';
         }
       }
     }
+  }
 
-    export namespace Permissions {
-      export type UpdateShippingDetails = 'client_only' | 'server_only';
+  export namespace Permissions {
+    export type UpdateShippingDetails = 'client_only' | 'server_only';
+  }
+
+  export namespace SavedPaymentMethodOptions {
+    export type AllowRedisplayFilter = 'always' | 'limited' | 'unspecified';
+
+    export type PaymentMethodRemove = 'disabled' | 'enabled';
+
+    export type PaymentMethodSave = 'disabled' | 'enabled';
+  }
+
+  export namespace ShippingAddressCollection {
+    export type AllowedCountry =
+      | 'AC'
+      | 'AD'
+      | 'AE'
+      | 'AF'
+      | 'AG'
+      | 'AI'
+      | 'AL'
+      | 'AM'
+      | 'AO'
+      | 'AQ'
+      | 'AR'
+      | 'AT'
+      | 'AU'
+      | 'AW'
+      | 'AX'
+      | 'AZ'
+      | 'BA'
+      | 'BB'
+      | 'BD'
+      | 'BE'
+      | 'BF'
+      | 'BG'
+      | 'BH'
+      | 'BI'
+      | 'BJ'
+      | 'BL'
+      | 'BM'
+      | 'BN'
+      | 'BO'
+      | 'BQ'
+      | 'BR'
+      | 'BS'
+      | 'BT'
+      | 'BV'
+      | 'BW'
+      | 'BY'
+      | 'BZ'
+      | 'CA'
+      | 'CD'
+      | 'CF'
+      | 'CG'
+      | 'CH'
+      | 'CI'
+      | 'CK'
+      | 'CL'
+      | 'CM'
+      | 'CN'
+      | 'CO'
+      | 'CR'
+      | 'CV'
+      | 'CW'
+      | 'CY'
+      | 'CZ'
+      | 'DE'
+      | 'DJ'
+      | 'DK'
+      | 'DM'
+      | 'DO'
+      | 'DZ'
+      | 'EC'
+      | 'EE'
+      | 'EG'
+      | 'EH'
+      | 'ER'
+      | 'ES'
+      | 'ET'
+      | 'FI'
+      | 'FJ'
+      | 'FK'
+      | 'FO'
+      | 'FR'
+      | 'GA'
+      | 'GB'
+      | 'GD'
+      | 'GE'
+      | 'GF'
+      | 'GG'
+      | 'GH'
+      | 'GI'
+      | 'GL'
+      | 'GM'
+      | 'GN'
+      | 'GP'
+      | 'GQ'
+      | 'GR'
+      | 'GS'
+      | 'GT'
+      | 'GU'
+      | 'GW'
+      | 'GY'
+      | 'HK'
+      | 'HN'
+      | 'HR'
+      | 'HT'
+      | 'HU'
+      | 'ID'
+      | 'IE'
+      | 'IL'
+      | 'IM'
+      | 'IN'
+      | 'IO'
+      | 'IQ'
+      | 'IS'
+      | 'IT'
+      | 'JE'
+      | 'JM'
+      | 'JO'
+      | 'JP'
+      | 'KE'
+      | 'KG'
+      | 'KH'
+      | 'KI'
+      | 'KM'
+      | 'KN'
+      | 'KR'
+      | 'KW'
+      | 'KY'
+      | 'KZ'
+      | 'LA'
+      | 'LB'
+      | 'LC'
+      | 'LI'
+      | 'LK'
+      | 'LR'
+      | 'LS'
+      | 'LT'
+      | 'LU'
+      | 'LV'
+      | 'LY'
+      | 'MA'
+      | 'MC'
+      | 'MD'
+      | 'ME'
+      | 'MF'
+      | 'MG'
+      | 'MK'
+      | 'ML'
+      | 'MM'
+      | 'MN'
+      | 'MO'
+      | 'MQ'
+      | 'MR'
+      | 'MS'
+      | 'MT'
+      | 'MU'
+      | 'MV'
+      | 'MW'
+      | 'MX'
+      | 'MY'
+      | 'MZ'
+      | 'NA'
+      | 'NC'
+      | 'NE'
+      | 'NG'
+      | 'NI'
+      | 'NL'
+      | 'NO'
+      | 'NP'
+      | 'NR'
+      | 'NU'
+      | 'NZ'
+      | 'OM'
+      | 'PA'
+      | 'PE'
+      | 'PF'
+      | 'PG'
+      | 'PH'
+      | 'PK'
+      | 'PL'
+      | 'PM'
+      | 'PN'
+      | 'PR'
+      | 'PS'
+      | 'PT'
+      | 'PY'
+      | 'QA'
+      | 'RE'
+      | 'RO'
+      | 'RS'
+      | 'RU'
+      | 'RW'
+      | 'SA'
+      | 'SB'
+      | 'SC'
+      | 'SD'
+      | 'SE'
+      | 'SG'
+      | 'SH'
+      | 'SI'
+      | 'SJ'
+      | 'SK'
+      | 'SL'
+      | 'SM'
+      | 'SN'
+      | 'SO'
+      | 'SR'
+      | 'SS'
+      | 'ST'
+      | 'SV'
+      | 'SX'
+      | 'SZ'
+      | 'TA'
+      | 'TC'
+      | 'TD'
+      | 'TF'
+      | 'TG'
+      | 'TH'
+      | 'TJ'
+      | 'TK'
+      | 'TL'
+      | 'TM'
+      | 'TN'
+      | 'TO'
+      | 'TR'
+      | 'TT'
+      | 'TV'
+      | 'TW'
+      | 'TZ'
+      | 'UA'
+      | 'UG'
+      | 'US'
+      | 'UY'
+      | 'UZ'
+      | 'VA'
+      | 'VC'
+      | 'VE'
+      | 'VG'
+      | 'VN'
+      | 'VU'
+      | 'WF'
+      | 'WS'
+      | 'XK'
+      | 'YE'
+      | 'YT'
+      | 'ZA'
+      | 'ZM'
+      | 'ZW'
+      | 'ZZ';
+  }
+
+  export namespace ShippingCost {
+    export interface Tax {
+      /**
+       * Amount of tax applied for this rate.
+       */
+      amount: number;
+
+      /**
+       * Tax rates can be applied to [invoices](https://docs.stripe.com/invoicing/taxes/tax-rates), [subscriptions](https://docs.stripe.com/billing/taxes/tax-rates) and [Checkout Sessions](https://docs.stripe.com/payments/checkout/use-manual-tax-rates) to collect tax.
+       *
+       * Related guide: [Tax rates](https://docs.stripe.com/billing/taxes/tax-rates)
+       */
+      rate: TaxRate;
+
+      /**
+       * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
+       */
+      taxability_reason: Tax.TaxabilityReason | null;
+
+      /**
+       * The amount on which tax is calculated, in cents (or local equivalent).
+       */
+      taxable_amount: number | null;
     }
 
-    export namespace SavedPaymentMethodOptions {
-      export type AllowRedisplayFilter = 'always' | 'limited' | 'unspecified';
+    export namespace Tax {
+      export type TaxabilityReason =
+        | 'customer_exempt'
+        | 'not_collecting'
+        | 'not_subject_to_tax'
+        | 'not_supported'
+        | 'portion_product_exempt'
+        | 'portion_reduced_rated'
+        | 'portion_standard_rated'
+        | 'product_exempt'
+        | 'product_exempt_holiday'
+        | 'proportionally_rated'
+        | 'reduced_rated'
+        | 'reverse_charge'
+        | 'standard_rated'
+        | 'taxable_basis_reduced'
+        | 'zero_rated';
+    }
+  }
 
-      export type PaymentMethodRemove = 'disabled' | 'enabled';
+  export namespace TaxIdCollection {
+    export type Required = 'if_supported' | 'never';
+  }
 
-      export type PaymentMethodSave = 'disabled' | 'enabled';
+  export namespace TotalDetails {
+    export interface Breakdown {
+      /**
+       * The aggregated discounts.
+       */
+      discounts: Array<Breakdown.Discount>;
+
+      /**
+       * The aggregated tax amounts by rate.
+       */
+      taxes: Array<Breakdown.Tax>;
     }
 
-    export namespace ShippingAddressCollection {
-      export type AllowedCountry =
-        | 'AC'
-        | 'AD'
-        | 'AE'
-        | 'AF'
-        | 'AG'
-        | 'AI'
-        | 'AL'
-        | 'AM'
-        | 'AO'
-        | 'AQ'
-        | 'AR'
-        | 'AT'
-        | 'AU'
-        | 'AW'
-        | 'AX'
-        | 'AZ'
-        | 'BA'
-        | 'BB'
-        | 'BD'
-        | 'BE'
-        | 'BF'
-        | 'BG'
-        | 'BH'
-        | 'BI'
-        | 'BJ'
-        | 'BL'
-        | 'BM'
-        | 'BN'
-        | 'BO'
-        | 'BQ'
-        | 'BR'
-        | 'BS'
-        | 'BT'
-        | 'BV'
-        | 'BW'
-        | 'BY'
-        | 'BZ'
-        | 'CA'
-        | 'CD'
-        | 'CF'
-        | 'CG'
-        | 'CH'
-        | 'CI'
-        | 'CK'
-        | 'CL'
-        | 'CM'
-        | 'CN'
-        | 'CO'
-        | 'CR'
-        | 'CV'
-        | 'CW'
-        | 'CY'
-        | 'CZ'
-        | 'DE'
-        | 'DJ'
-        | 'DK'
-        | 'DM'
-        | 'DO'
-        | 'DZ'
-        | 'EC'
-        | 'EE'
-        | 'EG'
-        | 'EH'
-        | 'ER'
-        | 'ES'
-        | 'ET'
-        | 'FI'
-        | 'FJ'
-        | 'FK'
-        | 'FO'
-        | 'FR'
-        | 'GA'
-        | 'GB'
-        | 'GD'
-        | 'GE'
-        | 'GF'
-        | 'GG'
-        | 'GH'
-        | 'GI'
-        | 'GL'
-        | 'GM'
-        | 'GN'
-        | 'GP'
-        | 'GQ'
-        | 'GR'
-        | 'GS'
-        | 'GT'
-        | 'GU'
-        | 'GW'
-        | 'GY'
-        | 'HK'
-        | 'HN'
-        | 'HR'
-        | 'HT'
-        | 'HU'
-        | 'ID'
-        | 'IE'
-        | 'IL'
-        | 'IM'
-        | 'IN'
-        | 'IO'
-        | 'IQ'
-        | 'IS'
-        | 'IT'
-        | 'JE'
-        | 'JM'
-        | 'JO'
-        | 'JP'
-        | 'KE'
-        | 'KG'
-        | 'KH'
-        | 'KI'
-        | 'KM'
-        | 'KN'
-        | 'KR'
-        | 'KW'
-        | 'KY'
-        | 'KZ'
-        | 'LA'
-        | 'LB'
-        | 'LC'
-        | 'LI'
-        | 'LK'
-        | 'LR'
-        | 'LS'
-        | 'LT'
-        | 'LU'
-        | 'LV'
-        | 'LY'
-        | 'MA'
-        | 'MC'
-        | 'MD'
-        | 'ME'
-        | 'MF'
-        | 'MG'
-        | 'MK'
-        | 'ML'
-        | 'MM'
-        | 'MN'
-        | 'MO'
-        | 'MQ'
-        | 'MR'
-        | 'MS'
-        | 'MT'
-        | 'MU'
-        | 'MV'
-        | 'MW'
-        | 'MX'
-        | 'MY'
-        | 'MZ'
-        | 'NA'
-        | 'NC'
-        | 'NE'
-        | 'NG'
-        | 'NI'
-        | 'NL'
-        | 'NO'
-        | 'NP'
-        | 'NR'
-        | 'NU'
-        | 'NZ'
-        | 'OM'
-        | 'PA'
-        | 'PE'
-        | 'PF'
-        | 'PG'
-        | 'PH'
-        | 'PK'
-        | 'PL'
-        | 'PM'
-        | 'PN'
-        | 'PR'
-        | 'PS'
-        | 'PT'
-        | 'PY'
-        | 'QA'
-        | 'RE'
-        | 'RO'
-        | 'RS'
-        | 'RU'
-        | 'RW'
-        | 'SA'
-        | 'SB'
-        | 'SC'
-        | 'SD'
-        | 'SE'
-        | 'SG'
-        | 'SH'
-        | 'SI'
-        | 'SJ'
-        | 'SK'
-        | 'SL'
-        | 'SM'
-        | 'SN'
-        | 'SO'
-        | 'SR'
-        | 'SS'
-        | 'ST'
-        | 'SV'
-        | 'SX'
-        | 'SZ'
-        | 'TA'
-        | 'TC'
-        | 'TD'
-        | 'TF'
-        | 'TG'
-        | 'TH'
-        | 'TJ'
-        | 'TK'
-        | 'TL'
-        | 'TM'
-        | 'TN'
-        | 'TO'
-        | 'TR'
-        | 'TT'
-        | 'TV'
-        | 'TW'
-        | 'TZ'
-        | 'UA'
-        | 'UG'
-        | 'US'
-        | 'UY'
-        | 'UZ'
-        | 'VA'
-        | 'VC'
-        | 'VE'
-        | 'VG'
-        | 'VN'
-        | 'VU'
-        | 'WF'
-        | 'WS'
-        | 'XK'
-        | 'YE'
-        | 'YT'
-        | 'ZA'
-        | 'ZM'
-        | 'ZW'
-        | 'ZZ';
-    }
+    export namespace Breakdown {
+      export interface Discount {
+        /**
+         * The amount discounted.
+         */
+        amount: number;
 
-    export namespace ShippingCost {
+        /**
+         * A discount represents the actual application of a [coupon](https://api.stripe.com#coupons) or [promotion code](https://api.stripe.com#promotion_codes).
+         * It contains information about when the discount began, when it will end, and what it is applied to.
+         *
+         * Related guide: [Applying discounts to subscriptions](https://docs.stripe.com/billing/subscriptions/discounts)
+         */
+        discount: _Discount;
+      }
+
       export interface Tax {
         /**
          * Amount of tax applied for this rate.
@@ -3488,96 +3564,18 @@ export namespace Checkout {
           | 'zero_rated';
       }
     }
+  }
 
-    export namespace TaxIdCollection {
-      export type Required = 'if_supported' | 'never';
+  export namespace WalletOptions {
+    export interface Link {
+      /**
+       * Describes whether Checkout should display Link. Defaults to `auto`.
+       */
+      display?: Link.Display;
     }
 
-    export namespace TotalDetails {
-      export interface Breakdown {
-        /**
-         * The aggregated discounts.
-         */
-        discounts: Array<Breakdown.Discount>;
-
-        /**
-         * The aggregated tax amounts by rate.
-         */
-        taxes: Array<Breakdown.Tax>;
-      }
-
-      export namespace Breakdown {
-        export interface Discount {
-          /**
-           * The amount discounted.
-           */
-          amount: number;
-
-          /**
-           * A discount represents the actual application of a [coupon](https://api.stripe.com#coupons) or [promotion code](https://api.stripe.com#promotion_codes).
-           * It contains information about when the discount began, when it will end, and what it is applied to.
-           *
-           * Related guide: [Applying discounts to subscriptions](https://docs.stripe.com/billing/subscriptions/discounts)
-           */
-          discount: _Discount;
-        }
-
-        export interface Tax {
-          /**
-           * Amount of tax applied for this rate.
-           */
-          amount: number;
-
-          /**
-           * Tax rates can be applied to [invoices](https://docs.stripe.com/invoicing/taxes/tax-rates), [subscriptions](https://docs.stripe.com/billing/taxes/tax-rates) and [Checkout Sessions](https://docs.stripe.com/payments/checkout/use-manual-tax-rates) to collect tax.
-           *
-           * Related guide: [Tax rates](https://docs.stripe.com/billing/taxes/tax-rates)
-           */
-          rate: TaxRate;
-
-          /**
-           * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
-           */
-          taxability_reason: Tax.TaxabilityReason | null;
-
-          /**
-           * The amount on which tax is calculated, in cents (or local equivalent).
-           */
-          taxable_amount: number | null;
-        }
-
-        export namespace Tax {
-          export type TaxabilityReason =
-            | 'customer_exempt'
-            | 'not_collecting'
-            | 'not_subject_to_tax'
-            | 'not_supported'
-            | 'portion_product_exempt'
-            | 'portion_reduced_rated'
-            | 'portion_standard_rated'
-            | 'product_exempt'
-            | 'product_exempt_holiday'
-            | 'proportionally_rated'
-            | 'reduced_rated'
-            | 'reverse_charge'
-            | 'standard_rated'
-            | 'taxable_basis_reduced'
-            | 'zero_rated';
-        }
-      }
-    }
-
-    export namespace WalletOptions {
-      export interface Link {
-        /**
-         * Describes whether Checkout should display Link. Defaults to `auto`.
-         */
-        display?: Link.Display;
-      }
-
-      export namespace Link {
-        export type Display = 'auto' | 'never';
-      }
+    export namespace Link {
+      export type Display = 'auto' | 'never';
     }
   }
 }

--- a/src/resources/Climate/Orders.ts
+++ b/src/resources/Climate/Orders.ts
@@ -149,7 +149,7 @@ export interface Order {
    */
   amount_total: number;
 
-  beneficiary?: Climate.Order.Beneficiary;
+  beneficiary?: Order.Beneficiary;
 
   /**
    * Time at which the order was canceled. Measured in seconds since the Unix epoch.
@@ -159,7 +159,7 @@ export interface Order {
   /**
    * Reason for the cancellation of this order.
    */
-  cancellation_reason: Climate.Order.CancellationReason | null;
+  cancellation_reason: Order.CancellationReason | null;
 
   /**
    * For delivered orders, a URL to a delivery certificate for the order.
@@ -194,7 +194,7 @@ export interface Order {
   /**
    * Details about the delivery of carbon removal for this order.
    */
-  delivery_details: Array<Climate.Order.DeliveryDetail>;
+  delivery_details: Array<Order.DeliveryDetail>;
 
   /**
    * The year this order is expected to be delivered.
@@ -229,83 +229,81 @@ export interface Order {
   /**
    * The current status of this order.
    */
-  status: Climate.Order.Status;
+  status: Order.Status;
 }
-export namespace Climate {
-  export namespace Order {
-    export interface Beneficiary {
+export namespace Order {
+  export interface Beneficiary {
+    /**
+     * Publicly displayable name for the end beneficiary of carbon removal.
+     */
+    public_name: string;
+  }
+
+  export type CancellationReason =
+    | 'expired'
+    | 'product_unavailable'
+    | 'requested';
+
+  export interface DeliveryDetail {
+    /**
+     * Time at which the delivery occurred. Measured in seconds since the Unix epoch.
+     */
+    delivered_at: number;
+
+    /**
+     * Specific location of this delivery.
+     */
+    location: DeliveryDetail.Location | null;
+
+    /**
+     * Quantity of carbon removal supplied by this delivery.
+     */
+    metric_tons: string;
+
+    /**
+     * Once retired, a URL to the registry entry for the tons from this delivery.
+     */
+    registry_url: string | null;
+
+    /**
+     * A supplier of carbon removal.
+     */
+    supplier: Supplier;
+  }
+
+  export type Status =
+    | 'awaiting_funds'
+    | 'canceled'
+    | 'confirmed'
+    | 'delivered'
+    | 'open';
+
+  export namespace DeliveryDetail {
+    export interface Location {
       /**
-       * Publicly displayable name for the end beneficiary of carbon removal.
+       * The city where the supplier is located.
        */
-      public_name: string;
-    }
-
-    export type CancellationReason =
-      | 'expired'
-      | 'product_unavailable'
-      | 'requested';
-
-    export interface DeliveryDetail {
-      /**
-       * Time at which the delivery occurred. Measured in seconds since the Unix epoch.
-       */
-      delivered_at: number;
+      city: string | null;
 
       /**
-       * Specific location of this delivery.
+       * Two-letter ISO code representing the country where the supplier is located.
        */
-      location: DeliveryDetail.Location | null;
+      country: string;
 
       /**
-       * Quantity of carbon removal supplied by this delivery.
+       * The geographic latitude where the supplier is located.
        */
-      metric_tons: string;
+      latitude: number | null;
 
       /**
-       * Once retired, a URL to the registry entry for the tons from this delivery.
+       * The geographic longitude where the supplier is located.
        */
-      registry_url: string | null;
+      longitude: number | null;
 
       /**
-       * A supplier of carbon removal.
+       * The state/county/province/region where the supplier is located.
        */
-      supplier: Supplier;
-    }
-
-    export type Status =
-      | 'awaiting_funds'
-      | 'canceled'
-      | 'confirmed'
-      | 'delivered'
-      | 'open';
-
-    export namespace DeliveryDetail {
-      export interface Location {
-        /**
-         * The city where the supplier is located.
-         */
-        city: string | null;
-
-        /**
-         * Two-letter ISO code representing the country where the supplier is located.
-         */
-        country: string;
-
-        /**
-         * The geographic latitude where the supplier is located.
-         */
-        latitude: number | null;
-
-        /**
-         * The geographic longitude where the supplier is located.
-         */
-        longitude: number | null;
-
-        /**
-         * The state/county/province/region where the supplier is located.
-         */
-        region: string | null;
-      }
+      region: string | null;
     }
   }
 }

--- a/src/resources/Climate/Products.ts
+++ b/src/resources/Climate/Products.ts
@@ -73,7 +73,7 @@ export interface Product {
    * Current prices for a metric ton of carbon removal in a currency's smallest unit.
    */
   current_prices_per_metric_ton: {
-    [key: string]: Climate.Product.CurrentPricesPerMetricTon;
+    [key: string]: Product.CurrentPricesPerMetricTon;
   };
 
   /**
@@ -101,24 +101,22 @@ export interface Product {
    */
   suppliers: Array<Supplier>;
 }
-export namespace Climate {
-  export namespace Product {
-    export interface CurrentPricesPerMetricTon {
-      /**
-       * Fees for one metric ton of carbon removal in the currency's smallest unit.
-       */
-      amount_fees: number;
+export namespace Product {
+  export interface CurrentPricesPerMetricTon {
+    /**
+     * Fees for one metric ton of carbon removal in the currency's smallest unit.
+     */
+    amount_fees: number;
 
-      /**
-       * Subtotal for one metric ton of carbon removal (excluding fees) in the currency's smallest unit.
-       */
-      amount_subtotal: number;
+    /**
+     * Subtotal for one metric ton of carbon removal (excluding fees) in the currency's smallest unit.
+     */
+    amount_subtotal: number;
 
-      /**
-       * Total for one metric ton of carbon removal (including fees) in the currency's smallest unit.
-       */
-      amount_total: number;
-    }
+    /**
+     * Total for one metric ton of carbon removal (including fees) in the currency's smallest unit.
+     */
+    amount_total: number;
   }
 }
 export namespace Climate {

--- a/src/resources/Climate/Suppliers.ts
+++ b/src/resources/Climate/Suppliers.ts
@@ -56,7 +56,7 @@ export interface Supplier {
   /**
    * The locations in which this supplier operates.
    */
-  locations: Array<Climate.Supplier.Location>;
+  locations: Array<Supplier.Location>;
 
   /**
    * Name of this carbon removal supplier.
@@ -66,43 +66,41 @@ export interface Supplier {
   /**
    * The scientific pathway used for carbon removal.
    */
-  removal_pathway: Climate.Supplier.RemovalPathway;
+  removal_pathway: Supplier.RemovalPathway;
 }
-export namespace Climate {
-  export namespace Supplier {
-    export interface Location {
-      /**
-       * The city where the supplier is located.
-       */
-      city: string | null;
+export namespace Supplier {
+  export interface Location {
+    /**
+     * The city where the supplier is located.
+     */
+    city: string | null;
 
-      /**
-       * Two-letter ISO code representing the country where the supplier is located.
-       */
-      country: string;
+    /**
+     * Two-letter ISO code representing the country where the supplier is located.
+     */
+    country: string;
 
-      /**
-       * The geographic latitude where the supplier is located.
-       */
-      latitude: number | null;
+    /**
+     * The geographic latitude where the supplier is located.
+     */
+    latitude: number | null;
 
-      /**
-       * The geographic longitude where the supplier is located.
-       */
-      longitude: number | null;
+    /**
+     * The geographic longitude where the supplier is located.
+     */
+    longitude: number | null;
 
-      /**
-       * The state/county/province/region where the supplier is located.
-       */
-      region: string | null;
-    }
-
-    export type RemovalPathway =
-      | 'biomass_carbon_removal_and_storage'
-      | 'direct_air_capture'
-      | 'enhanced_weathering'
-      | 'marine_carbon_removal';
+    /**
+     * The state/county/province/region where the supplier is located.
+     */
+    region: string | null;
   }
+
+  export type RemovalPathway =
+    | 'biomass_carbon_removal_and_storage'
+    | 'direct_air_capture'
+    | 'enhanced_weathering'
+    | 'marine_carbon_removal';
 }
 export namespace Climate {
   export interface SupplierRetrieveParams {

--- a/src/resources/FinancialConnections/Accounts.ts
+++ b/src/resources/FinancialConnections/Accounts.ts
@@ -135,27 +135,27 @@ export interface Account {
   /**
    * The account holder that this account belongs to.
    */
-  account_holder: FinancialConnections.Account.AccountHolder | null;
+  account_holder: Account.AccountHolder | null;
 
   /**
    * Details about the account numbers.
    */
-  account_numbers: Array<FinancialConnections.Account.AccountNumber> | null;
+  account_numbers: Array<Account.AccountNumber> | null;
 
   /**
    * The most recent information about the account's balance.
    */
-  balance: FinancialConnections.Account.Balance | null;
+  balance: Account.Balance | null;
 
   /**
    * The state of the most recent attempt to refresh the account balance.
    */
-  balance_refresh: FinancialConnections.Account.BalanceRefresh | null;
+  balance_refresh: Account.BalanceRefresh | null;
 
   /**
    * The type of the account. Account category is further divided in `subcategory`.
    */
-  category: FinancialConnections.Account.Category;
+  category: Account.Category;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -190,17 +190,17 @@ export interface Account {
   /**
    * The state of the most recent attempt to refresh the account owners.
    */
-  ownership_refresh: FinancialConnections.Account.OwnershipRefresh | null;
+  ownership_refresh: Account.OwnershipRefresh | null;
 
   /**
    * The list of permissions granted by this account.
    */
-  permissions: Array<FinancialConnections.Account.Permission> | null;
+  permissions: Array<Account.Permission> | null;
 
   /**
    * The status of the link to the account.
    */
-  status: FinancialConnections.Account.Status;
+  status: Account.Status;
 
   /**
    * If `category` is `cash`, one of:
@@ -218,7 +218,7 @@ export interface Account {
    *
    * If `category` is `investment` or `other`, this will be `other`.
    */
-  subcategory: FinancialConnections.Account.Subcategory;
+  subcategory: Account.Subcategory;
 
   /**
    * The list of data refresh subscriptions requested on this account.
@@ -228,214 +228,208 @@ export interface Account {
   /**
    * The [PaymentMethod type](https://docs.stripe.com/api/payment_methods/object#payment_method_object-type)(s) that can be created from this account.
    */
-  supported_payment_method_types: Array<
-    FinancialConnections.Account.SupportedPaymentMethodType
-  >;
+  supported_payment_method_types: Array<Account.SupportedPaymentMethodType>;
 
   /**
    * The state of the most recent attempt to refresh the account transactions.
    */
-  transaction_refresh: FinancialConnections.Account.TransactionRefresh | null;
+  transaction_refresh: Account.TransactionRefresh | null;
 }
-export namespace FinancialConnections {
-  export namespace Account {
-    export interface AccountHolder {
+export namespace Account {
+  export interface AccountHolder {
+    /**
+     * The ID of the Stripe account that this account belongs to. Only available when `account_holder.type` is `account`.
+     */
+    account?: string | Account;
+
+    /**
+     * The ID for an Account representing a customer that this account belongs to. Only available when `account_holder.type` is `customer`.
+     */
+    customer?: string | Customer;
+
+    customer_account?: string;
+
+    /**
+     * Type of account holder that this account belongs to.
+     */
+    type: AccountHolder.Type;
+  }
+
+  export interface AccountNumber {
+    /**
+     * When the account number is expected to expire, if applicable.
+     */
+    expected_expiry_date: number | null;
+
+    /**
+     * The type of account number associated with the account.
+     */
+    identifier_type: AccountNumber.IdentifierType;
+
+    /**
+     * Whether the account number is currently active and usable for transactions.
+     */
+    status: AccountNumber.Status;
+
+    /**
+     * The payment networks that the account number can be used for.
+     */
+    supported_networks: Array<'ach'>;
+  }
+
+  export interface Balance {
+    /**
+     * The time that the external institution calculated this balance. Measured in seconds since the Unix epoch.
+     */
+    as_of: number;
+
+    cash?: Balance.Cash;
+
+    credit?: Balance.Credit;
+
+    /**
+     * The balances owed to (or by) the account holder, before subtracting any outbound pending transactions or adding any inbound pending transactions.
+     *
+     * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+     *
+     * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
+     */
+    current: {
+      [key: string]: number;
+    };
+
+    /**
+     * The `type` of the balance. An additional hash is included on the balance with a name matching this value.
+     */
+    type: Balance.Type;
+  }
+
+  export interface BalanceRefresh {
+    /**
+     * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
+     */
+    last_attempted_at: number;
+
+    /**
+     * Time at which the next balance refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
+     */
+    next_refresh_available_at: number | null;
+
+    /**
+     * The status of the last refresh attempt.
+     */
+    status: BalanceRefresh.Status;
+  }
+
+  export type Category = 'cash' | 'credit' | 'investment' | 'other';
+
+  export interface OwnershipRefresh {
+    /**
+     * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
+     */
+    last_attempted_at: number;
+
+    /**
+     * Time at which the next ownership refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
+     */
+    next_refresh_available_at: number | null;
+
+    /**
+     * The status of the last refresh attempt.
+     */
+    status: OwnershipRefresh.Status;
+  }
+
+  export type Permission =
+    | 'balances'
+    | 'ownership'
+    | 'payment_method'
+    | 'transactions';
+
+  export type Status = 'active' | 'disconnected' | 'inactive';
+
+  export type Subcategory =
+    | 'checking'
+    | 'credit_card'
+    | 'line_of_credit'
+    | 'mortgage'
+    | 'other'
+    | 'savings';
+
+  export type SupportedPaymentMethodType = 'link' | 'us_bank_account';
+
+  export interface TransactionRefresh {
+    /**
+     * Unique identifier for the object.
+     */
+    id: string;
+
+    /**
+     * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
+     */
+    last_attempted_at: number;
+
+    /**
+     * Time at which the next transaction refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
+     */
+    next_refresh_available_at: number | null;
+
+    /**
+     * The status of the last refresh attempt.
+     */
+    status: TransactionRefresh.Status;
+  }
+
+  export namespace AccountHolder {
+    export type Type = 'account' | 'customer';
+  }
+
+  export namespace AccountNumber {
+    export type IdentifierType = 'account_number' | 'tokenized_account_number';
+
+    export type Status = 'deactivated' | 'transactable';
+  }
+
+  export namespace Balance {
+    export interface Cash {
       /**
-       * The ID of the Stripe account that this account belongs to. Only available when `account_holder.type` is `account`.
-       */
-      account?: string | Account;
-
-      /**
-       * The ID for an Account representing a customer that this account belongs to. Only available when `account_holder.type` is `customer`.
-       */
-      customer?: string | Customer;
-
-      customer_account?: string;
-
-      /**
-       * Type of account holder that this account belongs to.
-       */
-      type: AccountHolder.Type;
-    }
-
-    export interface AccountNumber {
-      /**
-       * When the account number is expected to expire, if applicable.
-       */
-      expected_expiry_date: number | null;
-
-      /**
-       * The type of account number associated with the account.
-       */
-      identifier_type: AccountNumber.IdentifierType;
-
-      /**
-       * Whether the account number is currently active and usable for transactions.
-       */
-      status: AccountNumber.Status;
-
-      /**
-       * The payment networks that the account number can be used for.
-       */
-      supported_networks: Array<'ach'>;
-    }
-
-    export interface Balance {
-      /**
-       * The time that the external institution calculated this balance. Measured in seconds since the Unix epoch.
-       */
-      as_of: number;
-
-      cash?: Balance.Cash;
-
-      credit?: Balance.Credit;
-
-      /**
-       * The balances owed to (or by) the account holder, before subtracting any outbound pending transactions or adding any inbound pending transactions.
+       * The funds available to the account holder. Typically this is the current balance after subtracting any outbound pending transactions and adding any inbound pending transactions.
        *
        * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
        *
        * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
        */
-      current: {
+      available: {
         [key: string]: number;
-      };
-
-      /**
-       * The `type` of the balance. An additional hash is included on the balance with a name matching this value.
-       */
-      type: Balance.Type;
+      } | null;
     }
 
-    export interface BalanceRefresh {
+    export interface Credit {
       /**
-       * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
+       * The credit that has been used by the account holder.
+       *
+       * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
+       *
+       * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
        */
-      last_attempted_at: number;
-
-      /**
-       * Time at which the next balance refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-       */
-      next_refresh_available_at: number | null;
-
-      /**
-       * The status of the last refresh attempt.
-       */
-      status: BalanceRefresh.Status;
+      used: {
+        [key: string]: number;
+      } | null;
     }
 
-    export type Category = 'cash' | 'credit' | 'investment' | 'other';
+    export type Type = 'cash' | 'credit';
+  }
 
-    export interface OwnershipRefresh {
-      /**
-       * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
-       */
-      last_attempted_at: number;
+  export namespace BalanceRefresh {
+    export type Status = 'failed' | 'pending' | 'succeeded';
+  }
 
-      /**
-       * Time at which the next ownership refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-       */
-      next_refresh_available_at: number | null;
+  export namespace OwnershipRefresh {
+    export type Status = 'failed' | 'pending' | 'succeeded';
+  }
 
-      /**
-       * The status of the last refresh attempt.
-       */
-      status: OwnershipRefresh.Status;
-    }
-
-    export type Permission =
-      | 'balances'
-      | 'ownership'
-      | 'payment_method'
-      | 'transactions';
-
-    export type Status = 'active' | 'disconnected' | 'inactive';
-
-    export type Subcategory =
-      | 'checking'
-      | 'credit_card'
-      | 'line_of_credit'
-      | 'mortgage'
-      | 'other'
-      | 'savings';
-
-    export type SupportedPaymentMethodType = 'link' | 'us_bank_account';
-
-    export interface TransactionRefresh {
-      /**
-       * Unique identifier for the object.
-       */
-      id: string;
-
-      /**
-       * The time at which the last refresh attempt was initiated. Measured in seconds since the Unix epoch.
-       */
-      last_attempted_at: number;
-
-      /**
-       * Time at which the next transaction refresh can be initiated. This value will be `null` when `status` is `pending`. Measured in seconds since the Unix epoch.
-       */
-      next_refresh_available_at: number | null;
-
-      /**
-       * The status of the last refresh attempt.
-       */
-      status: TransactionRefresh.Status;
-    }
-
-    export namespace AccountHolder {
-      export type Type = 'account' | 'customer';
-    }
-
-    export namespace AccountNumber {
-      export type IdentifierType =
-        | 'account_number'
-        | 'tokenized_account_number';
-
-      export type Status = 'deactivated' | 'transactable';
-    }
-
-    export namespace Balance {
-      export interface Cash {
-        /**
-         * The funds available to the account holder. Typically this is the current balance after subtracting any outbound pending transactions and adding any inbound pending transactions.
-         *
-         * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
-         *
-         * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
-         */
-        available: {
-          [key: string]: number;
-        } | null;
-      }
-
-      export interface Credit {
-        /**
-         * The credit that has been used by the account holder.
-         *
-         * Each key is a three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
-         *
-         * Each value is a integer amount. A positive amount indicates money owed to the account holder. A negative amount indicates money owed by the account holder.
-         */
-        used: {
-          [key: string]: number;
-        } | null;
-      }
-
-      export type Type = 'cash' | 'credit';
-    }
-
-    export namespace BalanceRefresh {
-      export type Status = 'failed' | 'pending' | 'succeeded';
-    }
-
-    export namespace OwnershipRefresh {
-      export type Status = 'failed' | 'pending' | 'succeeded';
-    }
-
-    export namespace TransactionRefresh {
-      export type Status = 'failed' | 'pending' | 'succeeded';
-    }
+  export namespace TransactionRefresh {
+    export type Status = 'failed' | 'pending' | 'succeeded';
   }
 }
 export namespace FinancialConnections {

--- a/src/resources/FinancialConnections/Sessions.ts
+++ b/src/resources/FinancialConnections/Sessions.ts
@@ -50,7 +50,7 @@ export interface Session {
   /**
    * The account holder for whom accounts are collected in this session.
    */
-  account_holder: FinancialConnections.Session.AccountHolder | null;
+  account_holder: Session.AccountHolder | null;
 
   /**
    * The accounts that were collected as part of this Session.
@@ -62,7 +62,7 @@ export interface Session {
    */
   client_secret: string | null;
 
-  filters?: FinancialConnections.Session.Filters;
+  filters?: Session.Filters;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -72,71 +72,69 @@ export interface Session {
   /**
    * Permissions requested for accounts collected during this session.
    */
-  permissions: Array<FinancialConnections.Session.Permission>;
+  permissions: Array<Session.Permission>;
 
   /**
    * Data features requested to be retrieved upon account creation.
    */
-  prefetch: Array<FinancialConnections.Session.Prefetch> | null;
+  prefetch: Array<Session.Prefetch> | null;
 
   /**
    * For webview integrations only. Upon completing OAuth login in the native browser, the user will be redirected to this URL to return to your app.
    */
   return_url?: string;
 }
-export namespace FinancialConnections {
-  export namespace Session {
-    export interface AccountHolder {
-      /**
-       * The ID of the Stripe account that this account belongs to. Only available when `account_holder.type` is `account`.
-       */
-      account?: string | Account;
+export namespace Session {
+  export interface AccountHolder {
+    /**
+     * The ID of the Stripe account that this account belongs to. Only available when `account_holder.type` is `account`.
+     */
+    account?: string | Account;
 
-      /**
-       * The ID for an Account representing a customer that this account belongs to. Only available when `account_holder.type` is `customer`.
-       */
-      customer?: string | Customer;
+    /**
+     * The ID for an Account representing a customer that this account belongs to. Only available when `account_holder.type` is `customer`.
+     */
+    customer?: string | Customer;
 
-      customer_account?: string;
+    customer_account?: string;
 
-      /**
-       * Type of account holder that this account belongs to.
-       */
-      type: AccountHolder.Type;
-    }
+    /**
+     * Type of account holder that this account belongs to.
+     */
+    type: AccountHolder.Type;
+  }
 
-    export interface Filters {
-      /**
-       * Restricts the Session to subcategories of accounts that can be linked. Valid subcategories are: `checking`, `savings`, `mortgage`, `line_of_credit`, `credit_card`.
-       */
-      account_subcategories: Array<Filters.AccountSubcategory> | null;
+  export interface Filters {
+    /**
+     * Restricts the Session to subcategories of accounts that can be linked. Valid subcategories are: `checking`, `savings`, `mortgage`, `line_of_credit`, `credit_card`.
+     */
+    account_subcategories: Array<Filters.AccountSubcategory> | null;
 
-      /**
-       * List of countries from which to filter accounts.
-       */
-      countries: Array<string> | null;
-    }
+    /**
+     * List of countries from which to filter accounts.
+     */
+    countries: Array<string> | null;
+  }
 
-    export type Permission =
-      | 'balances'
-      | 'ownership'
-      | 'payment_method'
-      | 'transactions';
+  export type Permission =
+    | 'balances'
+    | 'ownership'
+    | 'payment_method'
+    | 'transactions';
 
-    export type Prefetch = 'balances' | 'ownership' | 'transactions';
+  export type Prefetch = 'balances' | 'ownership' | 'transactions';
 
-    export namespace AccountHolder {
-      export type Type = 'account' | 'customer';
-    }
+  export namespace AccountHolder {
+    export type Type = 'account' | 'customer';
+  }
 
-    export namespace Filters {
-      export type AccountSubcategory =
-        | 'checking'
-        | 'credit_card'
-        | 'line_of_credit'
-        | 'mortgage'
-        | 'savings';
-    }
+  export namespace Filters {
+    export type AccountSubcategory =
+      | 'checking'
+      | 'credit_card'
+      | 'line_of_credit'
+      | 'mortgage'
+      | 'savings';
   }
 }
 export namespace FinancialConnections {

--- a/src/resources/FinancialConnections/Transactions.ts
+++ b/src/resources/FinancialConnections/Transactions.ts
@@ -77,9 +77,9 @@ export interface Transaction {
   /**
    * The status of the transaction.
    */
-  status: FinancialConnections.Transaction.Status;
+  status: Transaction.Status;
 
-  status_transitions: FinancialConnections.Transaction.StatusTransitions;
+  status_transitions: Transaction.StatusTransitions;
 
   /**
    * Time at which the transaction was transacted. Measured in seconds since the Unix epoch.
@@ -96,21 +96,19 @@ export interface Transaction {
    */
   updated: number;
 }
-export namespace FinancialConnections {
-  export namespace Transaction {
-    export type Status = 'pending' | 'posted' | 'void';
+export namespace Transaction {
+  export type Status = 'pending' | 'posted' | 'void';
 
-    export interface StatusTransitions {
-      /**
-       * Time at which this transaction posted. Measured in seconds since the Unix epoch.
-       */
-      posted_at: number | null;
+  export interface StatusTransitions {
+    /**
+     * Time at which this transaction posted. Measured in seconds since the Unix epoch.
+     */
+    posted_at: number | null;
 
-      /**
-       * Time at which this transaction was voided. Measured in seconds since the Unix epoch.
-       */
-      void_at: number | null;
-    }
+    /**
+     * Time at which this transaction was voided. Measured in seconds since the Unix epoch.
+     */
+    void_at: number | null;
   }
 }
 export namespace FinancialConnections {

--- a/src/resources/Forwarding/Requests.ts
+++ b/src/resources/Forwarding/Requests.ts
@@ -91,109 +91,107 @@ export interface Request {
   /**
    * The field kinds to be replaced in the forwarded request.
    */
-  replacements: Array<Forwarding.Request.Replacement>;
+  replacements: Array<Request.Replacement>;
 
   /**
    * Context about the request from Stripe's servers to the destination endpoint.
    */
-  request_context: Forwarding.Request.RequestContext | null;
+  request_context: Request.RequestContext | null;
 
   /**
    * The request that was sent to the destination endpoint. We redact any sensitive fields.
    */
-  request_details: Forwarding.Request.RequestDetails | null;
+  request_details: Request.RequestDetails | null;
 
   /**
    * The response that the destination endpoint returned to us. We redact any sensitive fields.
    */
-  response_details: Forwarding.Request.ResponseDetails | null;
+  response_details: Request.ResponseDetails | null;
 
   /**
    * The destination URL for the forwarded request. Must be supported by the config.
    */
   url: string | null;
 }
-export namespace Forwarding {
-  export namespace Request {
-    export type Replacement =
-      | 'card_cvc'
-      | 'card_expiry'
-      | 'card_number'
-      | 'cardholder_name'
-      | 'request_signature';
+export namespace Request {
+  export type Replacement =
+    | 'card_cvc'
+    | 'card_expiry'
+    | 'card_number'
+    | 'cardholder_name'
+    | 'request_signature';
 
-    export interface RequestContext {
+  export interface RequestContext {
+    /**
+     * The time it took in milliseconds for the destination endpoint to respond.
+     */
+    destination_duration: number;
+
+    /**
+     * The IP address of the destination.
+     */
+    destination_ip_address: string;
+  }
+
+  export interface RequestDetails {
+    /**
+     * The body payload to send to the destination endpoint.
+     */
+    body: string;
+
+    /**
+     * The headers to include in the forwarded request. Can be omitted if no additional headers (excluding Stripe-generated ones such as the Content-Type header) should be included.
+     */
+    headers: Array<RequestDetails.Header>;
+
+    /**
+     * The HTTP method used to call the destination endpoint.
+     */
+    http_method: 'POST';
+  }
+
+  export interface ResponseDetails {
+    /**
+     * The response body from the destination endpoint to Stripe.
+     */
+    body: string;
+
+    /**
+     * HTTP headers that the destination endpoint returned.
+     */
+    headers: Array<ResponseDetails.Header>;
+
+    /**
+     * The HTTP status code that the destination endpoint returned.
+     */
+    status: number;
+  }
+
+  export namespace RequestDetails {
+    export interface Header {
       /**
-       * The time it took in milliseconds for the destination endpoint to respond.
+       * The header name.
        */
-      destination_duration: number;
+      name: string;
 
       /**
-       * The IP address of the destination.
+       * The header value.
        */
-      destination_ip_address: string;
+      value: string;
     }
+  }
 
-    export interface RequestDetails {
+  export namespace ResponseDetails {
+    export interface Header {
       /**
-       * The body payload to send to the destination endpoint.
+       * The header name.
        */
-      body: string;
-
-      /**
-       * The headers to include in the forwarded request. Can be omitted if no additional headers (excluding Stripe-generated ones such as the Content-Type header) should be included.
-       */
-      headers: Array<RequestDetails.Header>;
+      name: string;
 
       /**
-       * The HTTP method used to call the destination endpoint.
+       * The header value.
        */
-      http_method: 'POST';
-    }
-
-    export interface ResponseDetails {
-      /**
-       * The response body from the destination endpoint to Stripe.
-       */
-      body: string;
-
-      /**
-       * HTTP headers that the destination endpoint returned.
-       */
-      headers: Array<ResponseDetails.Header>;
-
-      /**
-       * The HTTP status code that the destination endpoint returned.
-       */
-      status: number;
-    }
-
-    export namespace RequestDetails {
-      export interface Header {
-        /**
-         * The header name.
-         */
-        name: string;
-
-        /**
-         * The header value.
-         */
-        value: string;
-      }
-    }
-
-    export namespace ResponseDetails {
-      export interface Header {
-        /**
-         * The header name.
-         */
-        name: string;
-
-        /**
-         * The header value.
-         */
-        value: string;
-      }
+      value: string;
     }
   }
 }

--- a/src/resources/Identity/VerificationReports.ts
+++ b/src/resources/Identity/VerificationReports.ts
@@ -62,39 +62,39 @@ export interface VerificationReport {
   /**
    * Result from a document check
    */
-  document?: Identity.VerificationReport.Document;
+  document?: VerificationReport.Document;
 
   /**
    * Result from a email check
    */
-  email?: Identity.VerificationReport.Email;
+  email?: VerificationReport.Email;
 
   /**
    * Result from an id_number check
    */
-  id_number?: Identity.VerificationReport.IdNumber;
+  id_number?: VerificationReport.IdNumber;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
    */
   livemode: boolean;
 
-  options?: Identity.VerificationReport.Options;
+  options?: VerificationReport.Options;
 
   /**
    * Result from a phone check
    */
-  phone?: Identity.VerificationReport.Phone;
+  phone?: VerificationReport.Phone;
 
   /**
    * Result from a selfie check
    */
-  selfie?: Identity.VerificationReport.Selfie;
+  selfie?: VerificationReport.Selfie;
 
   /**
    * Type of report.
    */
-  type: Identity.VerificationReport.Type;
+  type: VerificationReport.Type;
 
   /**
    * The configuration token of a verification flow from the dashboard.
@@ -106,402 +106,400 @@ export interface VerificationReport {
    */
   verification_session: string | null;
 }
-export namespace Identity {
-  export namespace VerificationReport {
+export namespace VerificationReport {
+  export interface Document {
+    /**
+     * Address as it appears in the document.
+     */
+    address: Address | null;
+
+    /**
+     * Date of birth as it appears in the document.
+     */
+    dob?: Document.Dob | null;
+
+    /**
+     * Details on the verification error. Present when status is `unverified`.
+     */
+    error: Document.Error | null;
+
+    /**
+     * Expiration date of the document.
+     */
+    expiration_date?: Document.ExpirationDate | null;
+
+    /**
+     * Array of [File](https://docs.stripe.com/api/files) ids containing images for this document.
+     */
+    files: Array<string> | null;
+
+    /**
+     * First name as it appears in the document.
+     */
+    first_name: string | null;
+
+    /**
+     * Issued date of the document.
+     */
+    issued_date: Document.IssuedDate | null;
+
+    /**
+     * Issuing country of the document.
+     */
+    issuing_country: string | null;
+
+    /**
+     * Last name as it appears in the document.
+     */
+    last_name: string | null;
+
+    /**
+     * Document ID number.
+     */
+    number?: string | null;
+
+    /**
+     * Sex of the person in the document.
+     */
+    sex?: Document.Sex | null;
+
+    /**
+     * Status of this `document` check.
+     */
+    status: Document.Status;
+
+    /**
+     * Type of the document.
+     */
+    type: Document.Type | null;
+
+    /**
+     * Place of birth as it appears in the document.
+     */
+    unparsed_place_of_birth?: string | null;
+
+    /**
+     * Sex as it appears in the document.
+     */
+    unparsed_sex?: string | null;
+  }
+
+  export interface Email {
+    /**
+     * Email to be verified.
+     */
+    email: string | null;
+
+    /**
+     * Details on the verification error. Present when status is `unverified`.
+     */
+    error: Email.Error | null;
+
+    /**
+     * Status of this `email` check.
+     */
+    status: Email.Status;
+  }
+
+  export interface IdNumber {
+    /**
+     * Date of birth.
+     */
+    dob?: IdNumber.Dob | null;
+
+    /**
+     * Details on the verification error. Present when status is `unverified`.
+     */
+    error: IdNumber.Error | null;
+
+    /**
+     * First name.
+     */
+    first_name: string | null;
+
+    /**
+     * ID number. When `id_number_type` is `us_ssn`, only the last 4 digits are present.
+     */
+    id_number?: string | null;
+
+    /**
+     * Type of ID number.
+     */
+    id_number_type: IdNumber.IdNumberType | null;
+
+    /**
+     * Last name.
+     */
+    last_name: string | null;
+
+    /**
+     * Status of this `id_number` check.
+     */
+    status: IdNumber.Status;
+  }
+
+  export interface Options {
+    document?: Options.Document;
+
+    id_number?: Options.IdNumber;
+  }
+
+  export interface Phone {
+    /**
+     * Details on the verification error. Present when status is `unverified`.
+     */
+    error: Phone.Error | null;
+
+    /**
+     * Phone to be verified.
+     */
+    phone: string | null;
+
+    /**
+     * Status of this `phone` check.
+     */
+    status: Phone.Status;
+  }
+
+  export interface Selfie {
+    /**
+     * ID of the [File](https://docs.stripe.com/api/files) holding the image of the identity document used in this check.
+     */
+    document: string | null;
+
+    /**
+     * Details on the verification error. Present when status is `unverified`.
+     */
+    error: Selfie.Error | null;
+
+    /**
+     * ID of the [File](https://docs.stripe.com/api/files) holding the image of the selfie used in this check.
+     */
+    selfie: string | null;
+
+    /**
+     * Status of this `selfie` check.
+     */
+    status: Selfie.Status;
+  }
+
+  export type Type = 'document' | 'id_number' | 'verification_flow';
+
+  export namespace Document {
+    export interface Dob {
+      /**
+       * Numerical day between 1 and 31.
+       */
+      day: number | null;
+
+      /**
+       * Numerical month between 1 and 12.
+       */
+      month: number | null;
+
+      /**
+       * The four-digit year.
+       */
+      year: number | null;
+    }
+
+    export interface Error {
+      /**
+       * A short machine-readable string giving the reason for the verification failure.
+       */
+      code: Error.Code | null;
+
+      /**
+       * A human-readable message giving the reason for the failure. These messages can be shown to your users.
+       */
+      reason: string | null;
+    }
+
+    export interface ExpirationDate {
+      /**
+       * Numerical day between 1 and 31.
+       */
+      day: number | null;
+
+      /**
+       * Numerical month between 1 and 12.
+       */
+      month: number | null;
+
+      /**
+       * The four-digit year.
+       */
+      year: number | null;
+    }
+
+    export interface IssuedDate {
+      /**
+       * Numerical day between 1 and 31.
+       */
+      day: number | null;
+
+      /**
+       * Numerical month between 1 and 12.
+       */
+      month: number | null;
+
+      /**
+       * The four-digit year.
+       */
+      year: number | null;
+    }
+
+    export type Sex = '[redacted]' | 'female' | 'male' | 'unknown';
+
+    export type Status = 'unverified' | 'verified';
+
+    export type Type = 'driving_license' | 'id_card' | 'passport';
+
+    export namespace Error {
+      export type Code =
+        | 'document_expired'
+        | 'document_type_not_supported'
+        | 'document_unverified_other';
+    }
+  }
+
+  export namespace Email {
+    export interface Error {
+      /**
+       * A short machine-readable string giving the reason for the verification failure.
+       */
+      code: Error.Code | null;
+
+      /**
+       * A human-readable message giving the reason for the failure. These messages can be shown to your users.
+       */
+      reason: string | null;
+    }
+
+    export type Status = 'unverified' | 'verified';
+
+    export namespace Error {
+      export type Code =
+        | 'email_unverified_other'
+        | 'email_verification_declined';
+    }
+  }
+
+  export namespace IdNumber {
+    export interface Dob {
+      /**
+       * Numerical day between 1 and 31.
+       */
+      day: number | null;
+
+      /**
+       * Numerical month between 1 and 12.
+       */
+      month: number | null;
+
+      /**
+       * The four-digit year.
+       */
+      year: number | null;
+    }
+
+    export interface Error {
+      /**
+       * A short machine-readable string giving the reason for the verification failure.
+       */
+      code: Error.Code | null;
+
+      /**
+       * A human-readable message giving the reason for the failure. These messages can be shown to your users.
+       */
+      reason: string | null;
+    }
+
+    export type IdNumberType = 'br_cpf' | 'sg_nric' | 'us_ssn';
+
+    export type Status = 'unverified' | 'verified';
+
+    export namespace Error {
+      export type Code =
+        | 'id_number_insufficient_document_data'
+        | 'id_number_mismatch'
+        | 'id_number_unverified_other';
+    }
+  }
+
+  export namespace Options {
     export interface Document {
       /**
-       * Address as it appears in the document.
+       * Array of strings of allowed identity document types. If the provided identity document isn't one of the allowed types, the verification check will fail with a document_type_not_allowed error code.
        */
-      address: Address | null;
+      allowed_types?: Array<Document.AllowedType>;
 
       /**
-       * Date of birth as it appears in the document.
+       * Collect an ID number and perform an [ID number check](https://docs.stripe.com/identity/verification-checks?type=id-number) with the document's extracted name and date of birth.
        */
-      dob?: Document.Dob | null;
+      require_id_number?: boolean;
 
       /**
-       * Details on the verification error. Present when status is `unverified`.
+       * Disable image uploads, identity document images have to be captured using the device's camera.
        */
-      error: Document.Error | null;
+      require_live_capture?: boolean;
 
       /**
-       * Expiration date of the document.
+       * Capture a face image and perform a [selfie check](https://docs.stripe.com/identity/verification-checks?type=selfie) comparing a photo ID and a picture of your user's face. [Learn more](https://docs.stripe.com/identity/selfie).
        */
-      expiration_date?: Document.ExpirationDate | null;
-
-      /**
-       * Array of [File](https://docs.stripe.com/api/files) ids containing images for this document.
-       */
-      files: Array<string> | null;
-
-      /**
-       * First name as it appears in the document.
-       */
-      first_name: string | null;
-
-      /**
-       * Issued date of the document.
-       */
-      issued_date: Document.IssuedDate | null;
-
-      /**
-       * Issuing country of the document.
-       */
-      issuing_country: string | null;
-
-      /**
-       * Last name as it appears in the document.
-       */
-      last_name: string | null;
-
-      /**
-       * Document ID number.
-       */
-      number?: string | null;
-
-      /**
-       * Sex of the person in the document.
-       */
-      sex?: Document.Sex | null;
-
-      /**
-       * Status of this `document` check.
-       */
-      status: Document.Status;
-
-      /**
-       * Type of the document.
-       */
-      type: Document.Type | null;
-
-      /**
-       * Place of birth as it appears in the document.
-       */
-      unparsed_place_of_birth?: string | null;
-
-      /**
-       * Sex as it appears in the document.
-       */
-      unparsed_sex?: string | null;
+      require_matching_selfie?: boolean;
     }
 
-    export interface Email {
-      /**
-       * Email to be verified.
-       */
-      email: string | null;
-
-      /**
-       * Details on the verification error. Present when status is `unverified`.
-       */
-      error: Email.Error | null;
-
-      /**
-       * Status of this `email` check.
-       */
-      status: Email.Status;
-    }
-
-    export interface IdNumber {
-      /**
-       * Date of birth.
-       */
-      dob?: IdNumber.Dob | null;
-
-      /**
-       * Details on the verification error. Present when status is `unverified`.
-       */
-      error: IdNumber.Error | null;
-
-      /**
-       * First name.
-       */
-      first_name: string | null;
-
-      /**
-       * ID number. When `id_number_type` is `us_ssn`, only the last 4 digits are present.
-       */
-      id_number?: string | null;
-
-      /**
-       * Type of ID number.
-       */
-      id_number_type: IdNumber.IdNumberType | null;
-
-      /**
-       * Last name.
-       */
-      last_name: string | null;
-
-      /**
-       * Status of this `id_number` check.
-       */
-      status: IdNumber.Status;
-    }
-
-    export interface Options {
-      document?: Options.Document;
-
-      id_number?: Options.IdNumber;
-    }
-
-    export interface Phone {
-      /**
-       * Details on the verification error. Present when status is `unverified`.
-       */
-      error: Phone.Error | null;
-
-      /**
-       * Phone to be verified.
-       */
-      phone: string | null;
-
-      /**
-       * Status of this `phone` check.
-       */
-      status: Phone.Status;
-    }
-
-    export interface Selfie {
-      /**
-       * ID of the [File](https://docs.stripe.com/api/files) holding the image of the identity document used in this check.
-       */
-      document: string | null;
-
-      /**
-       * Details on the verification error. Present when status is `unverified`.
-       */
-      error: Selfie.Error | null;
-
-      /**
-       * ID of the [File](https://docs.stripe.com/api/files) holding the image of the selfie used in this check.
-       */
-      selfie: string | null;
-
-      /**
-       * Status of this `selfie` check.
-       */
-      status: Selfie.Status;
-    }
-
-    export type Type = 'document' | 'id_number' | 'verification_flow';
+    export interface IdNumber {}
 
     export namespace Document {
-      export interface Dob {
-        /**
-         * Numerical day between 1 and 31.
-         */
-        day: number | null;
+      export type AllowedType = 'driving_license' | 'id_card' | 'passport';
+    }
+  }
 
-        /**
-         * Numerical month between 1 and 12.
-         */
-        month: number | null;
+  export namespace Phone {
+    export interface Error {
+      /**
+       * A short machine-readable string giving the reason for the verification failure.
+       */
+      code: Error.Code | null;
 
-        /**
-         * The four-digit year.
-         */
-        year: number | null;
-      }
-
-      export interface Error {
-        /**
-         * A short machine-readable string giving the reason for the verification failure.
-         */
-        code: Error.Code | null;
-
-        /**
-         * A human-readable message giving the reason for the failure. These messages can be shown to your users.
-         */
-        reason: string | null;
-      }
-
-      export interface ExpirationDate {
-        /**
-         * Numerical day between 1 and 31.
-         */
-        day: number | null;
-
-        /**
-         * Numerical month between 1 and 12.
-         */
-        month: number | null;
-
-        /**
-         * The four-digit year.
-         */
-        year: number | null;
-      }
-
-      export interface IssuedDate {
-        /**
-         * Numerical day between 1 and 31.
-         */
-        day: number | null;
-
-        /**
-         * Numerical month between 1 and 12.
-         */
-        month: number | null;
-
-        /**
-         * The four-digit year.
-         */
-        year: number | null;
-      }
-
-      export type Sex = '[redacted]' | 'female' | 'male' | 'unknown';
-
-      export type Status = 'unverified' | 'verified';
-
-      export type Type = 'driving_license' | 'id_card' | 'passport';
-
-      export namespace Error {
-        export type Code =
-          | 'document_expired'
-          | 'document_type_not_supported'
-          | 'document_unverified_other';
-      }
+      /**
+       * A human-readable message giving the reason for the failure. These messages can be shown to your users.
+       */
+      reason: string | null;
     }
 
-    export namespace Email {
-      export interface Error {
-        /**
-         * A short machine-readable string giving the reason for the verification failure.
-         */
-        code: Error.Code | null;
+    export type Status = 'unverified' | 'verified';
 
-        /**
-         * A human-readable message giving the reason for the failure. These messages can be shown to your users.
-         */
-        reason: string | null;
-      }
+    export namespace Error {
+      export type Code =
+        | 'phone_unverified_other'
+        | 'phone_verification_declined';
+    }
+  }
 
-      export type Status = 'unverified' | 'verified';
+  export namespace Selfie {
+    export interface Error {
+      /**
+       * A short machine-readable string giving the reason for the verification failure.
+       */
+      code: Error.Code | null;
 
-      export namespace Error {
-        export type Code =
-          | 'email_unverified_other'
-          | 'email_verification_declined';
-      }
+      /**
+       * A human-readable message giving the reason for the failure. These messages can be shown to your users.
+       */
+      reason: string | null;
     }
 
-    export namespace IdNumber {
-      export interface Dob {
-        /**
-         * Numerical day between 1 and 31.
-         */
-        day: number | null;
+    export type Status = 'unverified' | 'verified';
 
-        /**
-         * Numerical month between 1 and 12.
-         */
-        month: number | null;
-
-        /**
-         * The four-digit year.
-         */
-        year: number | null;
-      }
-
-      export interface Error {
-        /**
-         * A short machine-readable string giving the reason for the verification failure.
-         */
-        code: Error.Code | null;
-
-        /**
-         * A human-readable message giving the reason for the failure. These messages can be shown to your users.
-         */
-        reason: string | null;
-      }
-
-      export type IdNumberType = 'br_cpf' | 'sg_nric' | 'us_ssn';
-
-      export type Status = 'unverified' | 'verified';
-
-      export namespace Error {
-        export type Code =
-          | 'id_number_insufficient_document_data'
-          | 'id_number_mismatch'
-          | 'id_number_unverified_other';
-      }
-    }
-
-    export namespace Options {
-      export interface Document {
-        /**
-         * Array of strings of allowed identity document types. If the provided identity document isn't one of the allowed types, the verification check will fail with a document_type_not_allowed error code.
-         */
-        allowed_types?: Array<Document.AllowedType>;
-
-        /**
-         * Collect an ID number and perform an [ID number check](https://docs.stripe.com/identity/verification-checks?type=id-number) with the document's extracted name and date of birth.
-         */
-        require_id_number?: boolean;
-
-        /**
-         * Disable image uploads, identity document images have to be captured using the device's camera.
-         */
-        require_live_capture?: boolean;
-
-        /**
-         * Capture a face image and perform a [selfie check](https://docs.stripe.com/identity/verification-checks?type=selfie) comparing a photo ID and a picture of your user's face. [Learn more](https://docs.stripe.com/identity/selfie).
-         */
-        require_matching_selfie?: boolean;
-      }
-
-      export interface IdNumber {}
-
-      export namespace Document {
-        export type AllowedType = 'driving_license' | 'id_card' | 'passport';
-      }
-    }
-
-    export namespace Phone {
-      export interface Error {
-        /**
-         * A short machine-readable string giving the reason for the verification failure.
-         */
-        code: Error.Code | null;
-
-        /**
-         * A human-readable message giving the reason for the failure. These messages can be shown to your users.
-         */
-        reason: string | null;
-      }
-
-      export type Status = 'unverified' | 'verified';
-
-      export namespace Error {
-        export type Code =
-          | 'phone_unverified_other'
-          | 'phone_verification_declined';
-      }
-    }
-
-    export namespace Selfie {
-      export interface Error {
-        /**
-         * A short machine-readable string giving the reason for the verification failure.
-         */
-        code: Error.Code | null;
-
-        /**
-         * A human-readable message giving the reason for the failure. These messages can be shown to your users.
-         */
-        reason: string | null;
-      }
-
-      export type Status = 'unverified' | 'verified';
-
-      export namespace Error {
-        export type Code =
-          | 'selfie_document_missing_photo'
-          | 'selfie_face_mismatch'
-          | 'selfie_manipulated'
-          | 'selfie_unverified_other';
-      }
+    export namespace Error {
+      export type Code =
+        | 'selfie_document_missing_photo'
+        | 'selfie_face_mismatch'
+        | 'selfie_manipulated'
+        | 'selfie_unverified_other';
     }
   }
 }

--- a/src/resources/Identity/VerificationSessions.ts
+++ b/src/resources/Identity/VerificationSessions.ts
@@ -166,7 +166,7 @@ export interface VerificationSession {
   /**
    * If present, this property tells you the last error encountered when processing the verification.
    */
-  last_error: Identity.VerificationSession.LastError | null;
+  last_error: VerificationSession.LastError | null;
 
   /**
    * ID of the most recent VerificationReport. [Learn more about accessing detailed verification results.](https://docs.stripe.com/identity/verification-sessions#results)
@@ -186,17 +186,17 @@ export interface VerificationSession {
   /**
    * A set of options for the session's verification checks.
    */
-  options: Identity.VerificationSession.Options | null;
+  options: VerificationSession.Options | null;
 
   /**
    * Details provided about the user being verified. These details may be shown to the user.
    */
-  provided_details?: Identity.VerificationSession.ProvidedDetails | null;
+  provided_details?: VerificationSession.ProvidedDetails | null;
 
   /**
    * Redaction status of this VerificationSession. If the VerificationSession is not redacted, this field will be null.
    */
-  redaction: Identity.VerificationSession.Redaction | null;
+  redaction: VerificationSession.Redaction | null;
 
   /**
    * Customer ID
@@ -208,17 +208,17 @@ export interface VerificationSession {
    */
   related_customer_account: string | null;
 
-  related_person?: Identity.VerificationSession.RelatedPerson;
+  related_person?: VerificationSession.RelatedPerson;
 
   /**
    * Status of this VerificationSession. [Learn more about the lifecycle of sessions](https://docs.stripe.com/identity/how-sessions-work).
    */
-  status: Identity.VerificationSession.Status;
+  status: VerificationSession.Status;
 
   /**
    * The type of [verification check](https://docs.stripe.com/identity/verification-checks) to be performed.
    */
-  type: Identity.VerificationSession.Type;
+  type: VerificationSession.Type;
 
   /**
    * The short-lived URL that you use to redirect a user to Stripe to submit their identity information. This URL expires after 48 hours and can only be used once. Don't store it, log it, send it in emails or expose it to anyone other than the user. Refer to our docs on [verifying identity documents](https://docs.stripe.com/identity/verify-identity-documents?platform=web&type=redirect) to learn how to redirect users to Stripe.
@@ -233,241 +233,239 @@ export interface VerificationSession {
   /**
    * The user's verified data.
    */
-  verified_outputs?: Identity.VerificationSession.VerifiedOutputs | null;
+  verified_outputs?: VerificationSession.VerifiedOutputs | null;
 }
-export namespace Identity {
-  export namespace VerificationSession {
-    export interface LastError {
+export namespace VerificationSession {
+  export interface LastError {
+    /**
+     * A short machine-readable string giving the reason for the verification or user-session failure.
+     */
+    code: LastError.Code | null;
+
+    /**
+     * A message that explains the reason for verification or user-session failure.
+     */
+    reason: string | null;
+  }
+
+  export interface Options {
+    document?: Options.Document;
+
+    email?: Options.Email;
+
+    id_number?: Options.IdNumber;
+
+    matching?: Options.Matching;
+
+    phone?: Options.Phone;
+  }
+
+  export interface ProvidedDetails {
+    /**
+     * Email of user being verified
+     */
+    email?: string;
+
+    /**
+     * Phone number of user being verified
+     */
+    phone?: string;
+  }
+
+  export interface Redaction {
+    /**
+     * Indicates whether this object and its related objects have been redacted or not.
+     */
+    status: Redaction.Status;
+  }
+
+  export interface RelatedPerson {
+    /**
+     * Token referencing the associated Account of the related Person resource.
+     */
+    account: string;
+
+    /**
+     * Token referencing the related Person resource.
+     */
+    person: string;
+  }
+
+  export type Status =
+    | 'canceled'
+    | 'processing'
+    | 'requires_input'
+    | 'verified';
+
+  export type Type = 'document' | 'id_number' | 'verification_flow';
+
+  export interface VerifiedOutputs {
+    /**
+     * The user's verified address.
+     */
+    address: Address | null;
+
+    /**
+     * The user's verified date of birth.
+     */
+    dob?: VerifiedOutputs.Dob | null;
+
+    /**
+     * The user's verified email address
+     */
+    email: string | null;
+
+    /**
+     * The user's verified first name.
+     */
+    first_name: string | null;
+
+    /**
+     * The user's verified id number.
+     */
+    id_number?: string | null;
+
+    /**
+     * The user's verified id number type.
+     */
+    id_number_type: VerifiedOutputs.IdNumberType | null;
+
+    /**
+     * The user's verified last name.
+     */
+    last_name: string | null;
+
+    /**
+     * The user's verified phone number
+     */
+    phone: string | null;
+
+    /**
+     * The user's verified sex.
+     */
+    sex?: VerifiedOutputs.Sex | null;
+
+    /**
+     * The user's verified place of birth as it appears in the document.
+     */
+    unparsed_place_of_birth?: string | null;
+
+    /**
+     * The user's verified sex as it appears in the document.
+     */
+    unparsed_sex?: string | null;
+  }
+
+  export namespace LastError {
+    export type Code =
+      | 'abandoned'
+      | 'consent_declined'
+      | 'country_not_supported'
+      | 'device_not_supported'
+      | 'document_expired'
+      | 'document_type_not_supported'
+      | 'document_unverified_other'
+      | 'email_unverified_other'
+      | 'email_verification_declined'
+      | 'id_number_insufficient_document_data'
+      | 'id_number_mismatch'
+      | 'id_number_unverified_other'
+      | 'phone_unverified_other'
+      | 'phone_verification_declined'
+      | 'selfie_document_missing_photo'
+      | 'selfie_face_mismatch'
+      | 'selfie_manipulated'
+      | 'selfie_unverified_other'
+      | 'under_supported_age';
+  }
+
+  export namespace Options {
+    export interface Document {
       /**
-       * A short machine-readable string giving the reason for the verification or user-session failure.
+       * Array of strings of allowed identity document types. If the provided identity document isn't one of the allowed types, the verification check will fail with a document_type_not_allowed error code.
        */
-      code: LastError.Code | null;
+      allowed_types?: Array<Document.AllowedType>;
 
       /**
-       * A message that explains the reason for verification or user-session failure.
+       * Collect an ID number and perform an [ID number check](https://docs.stripe.com/identity/verification-checks?type=id-number) with the document's extracted name and date of birth.
        */
-      reason: string | null;
+      require_id_number?: boolean;
+
+      /**
+       * Disable image uploads, identity document images have to be captured using the device's camera.
+       */
+      require_live_capture?: boolean;
+
+      /**
+       * Capture a face image and perform a [selfie check](https://docs.stripe.com/identity/verification-checks?type=selfie) comparing a photo ID and a picture of your user's face. [Learn more](https://docs.stripe.com/identity/selfie).
+       */
+      require_matching_selfie?: boolean;
     }
 
-    export interface Options {
-      document?: Options.Document;
-
-      email?: Options.Email;
-
-      id_number?: Options.IdNumber;
-
-      matching?: Options.Matching;
-
-      phone?: Options.Phone;
+    export interface Email {
+      /**
+       * Request one time password verification of `provided_details.email`.
+       */
+      require_verification?: boolean;
     }
 
-    export interface ProvidedDetails {
+    export interface IdNumber {}
+
+    export interface Matching {
       /**
-       * Email of user being verified
+       * Strictness of the DOB matching policy to apply.
        */
-      email?: string;
+      dob?: Matching.Dob;
 
       /**
-       * Phone number of user being verified
+       * Strictness of the name matching policy to apply.
        */
-      phone?: string;
+      name?: Matching.Name;
     }
 
-    export interface Redaction {
+    export interface Phone {
       /**
-       * Indicates whether this object and its related objects have been redacted or not.
+       * Request one time password verification of `provided_details.phone`.
        */
-      status: Redaction.Status;
+      require_verification?: boolean;
     }
 
-    export interface RelatedPerson {
-      /**
-       * Token referencing the associated Account of the related Person resource.
-       */
-      account: string;
-
-      /**
-       * Token referencing the related Person resource.
-       */
-      person: string;
+    export namespace Document {
+      export type AllowedType = 'driving_license' | 'id_card' | 'passport';
     }
 
-    export type Status =
-      | 'canceled'
-      | 'processing'
-      | 'requires_input'
-      | 'verified';
+    export namespace Matching {
+      export type Dob = 'none' | 'similar';
 
-    export type Type = 'document' | 'id_number' | 'verification_flow';
+      export type Name = 'none' | 'similar';
+    }
+  }
 
-    export interface VerifiedOutputs {
+  export namespace Redaction {
+    export type Status = 'processing' | 'redacted';
+  }
+
+  export namespace VerifiedOutputs {
+    export interface Dob {
       /**
-       * The user's verified address.
+       * Numerical day between 1 and 31.
        */
-      address: Address | null;
-
-      /**
-       * The user's verified date of birth.
-       */
-      dob?: VerifiedOutputs.Dob | null;
-
-      /**
-       * The user's verified email address
-       */
-      email: string | null;
+      day: number | null;
 
       /**
-       * The user's verified first name.
+       * Numerical month between 1 and 12.
        */
-      first_name: string | null;
+      month: number | null;
 
       /**
-       * The user's verified id number.
+       * The four-digit year.
        */
-      id_number?: string | null;
-
-      /**
-       * The user's verified id number type.
-       */
-      id_number_type: VerifiedOutputs.IdNumberType | null;
-
-      /**
-       * The user's verified last name.
-       */
-      last_name: string | null;
-
-      /**
-       * The user's verified phone number
-       */
-      phone: string | null;
-
-      /**
-       * The user's verified sex.
-       */
-      sex?: VerifiedOutputs.Sex | null;
-
-      /**
-       * The user's verified place of birth as it appears in the document.
-       */
-      unparsed_place_of_birth?: string | null;
-
-      /**
-       * The user's verified sex as it appears in the document.
-       */
-      unparsed_sex?: string | null;
+      year: number | null;
     }
 
-    export namespace LastError {
-      export type Code =
-        | 'abandoned'
-        | 'consent_declined'
-        | 'country_not_supported'
-        | 'device_not_supported'
-        | 'document_expired'
-        | 'document_type_not_supported'
-        | 'document_unverified_other'
-        | 'email_unverified_other'
-        | 'email_verification_declined'
-        | 'id_number_insufficient_document_data'
-        | 'id_number_mismatch'
-        | 'id_number_unverified_other'
-        | 'phone_unverified_other'
-        | 'phone_verification_declined'
-        | 'selfie_document_missing_photo'
-        | 'selfie_face_mismatch'
-        | 'selfie_manipulated'
-        | 'selfie_unverified_other'
-        | 'under_supported_age';
-    }
+    export type IdNumberType = 'br_cpf' | 'sg_nric' | 'us_ssn';
 
-    export namespace Options {
-      export interface Document {
-        /**
-         * Array of strings of allowed identity document types. If the provided identity document isn't one of the allowed types, the verification check will fail with a document_type_not_allowed error code.
-         */
-        allowed_types?: Array<Document.AllowedType>;
-
-        /**
-         * Collect an ID number and perform an [ID number check](https://docs.stripe.com/identity/verification-checks?type=id-number) with the document's extracted name and date of birth.
-         */
-        require_id_number?: boolean;
-
-        /**
-         * Disable image uploads, identity document images have to be captured using the device's camera.
-         */
-        require_live_capture?: boolean;
-
-        /**
-         * Capture a face image and perform a [selfie check](https://docs.stripe.com/identity/verification-checks?type=selfie) comparing a photo ID and a picture of your user's face. [Learn more](https://docs.stripe.com/identity/selfie).
-         */
-        require_matching_selfie?: boolean;
-      }
-
-      export interface Email {
-        /**
-         * Request one time password verification of `provided_details.email`.
-         */
-        require_verification?: boolean;
-      }
-
-      export interface IdNumber {}
-
-      export interface Matching {
-        /**
-         * Strictness of the DOB matching policy to apply.
-         */
-        dob?: Matching.Dob;
-
-        /**
-         * Strictness of the name matching policy to apply.
-         */
-        name?: Matching.Name;
-      }
-
-      export interface Phone {
-        /**
-         * Request one time password verification of `provided_details.phone`.
-         */
-        require_verification?: boolean;
-      }
-
-      export namespace Document {
-        export type AllowedType = 'driving_license' | 'id_card' | 'passport';
-      }
-
-      export namespace Matching {
-        export type Dob = 'none' | 'similar';
-
-        export type Name = 'none' | 'similar';
-      }
-    }
-
-    export namespace Redaction {
-      export type Status = 'processing' | 'redacted';
-    }
-
-    export namespace VerifiedOutputs {
-      export interface Dob {
-        /**
-         * Numerical day between 1 and 31.
-         */
-        day: number | null;
-
-        /**
-         * Numerical month between 1 and 12.
-         */
-        month: number | null;
-
-        /**
-         * The four-digit year.
-         */
-        year: number | null;
-      }
-
-      export type IdNumberType = 'br_cpf' | 'sg_nric' | 'us_ssn';
-
-      export type Sex = '[redacted]' | 'female' | 'male' | 'unknown';
-    }
+    export type Sex = '[redacted]' | 'female' | 'male' | 'unknown';
   }
 }
 export namespace Identity {

--- a/src/resources/Issuing/Authorizations.ts
+++ b/src/resources/Issuing/Authorizations.ts
@@ -952,7 +952,7 @@ export interface Authorization {
   /**
    * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
    */
-  amount_details: Issuing.Authorization.AmountDetails | null;
+  amount_details: Authorization.AmountDetails | null;
 
   /**
    * Whether the authorization has been approved.
@@ -962,7 +962,7 @@ export interface Authorization {
   /**
    * How the card details were provided.
    */
-  authorization_method: Issuing.Authorization.AuthorizationMethod;
+  authorization_method: Authorization.AuthorizationMethod;
 
   /**
    * List of balance transactions associated with this authorization.
@@ -977,7 +977,7 @@ export interface Authorization {
   /**
    * Whether the card was present at the point of sale for the authorization.
    */
-  card_presence: Issuing.Authorization.CardPresence | null;
+  card_presence: Authorization.CardPresence | null;
 
   /**
    * The cardholder to whom this authorization belongs.
@@ -997,17 +997,17 @@ export interface Authorization {
   /**
    * Fleet-specific information for authorizations using Fleet cards.
    */
-  fleet: Issuing.Authorization.Fleet | null;
+  fleet: Authorization.Fleet | null;
 
   /**
    * Fraud challenges sent to the cardholder, if this authorization was declined for fraud risk reasons.
    */
-  fraud_challenges?: Array<Issuing.Authorization.FraudChallenge> | null;
+  fraud_challenges?: Array<Authorization.FraudChallenge> | null;
 
   /**
    * Information about fuel that was purchased with this transaction. Typically this information is received from the merchant after the authorization has been approved and the fuel dispensed.
    */
-  fuel: Issuing.Authorization.Fuel | null;
+  fuel: Authorization.Fuel | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -1024,7 +1024,7 @@ export interface Authorization {
    */
   merchant_currency: string;
 
-  merchant_data: Issuing.Authorization.MerchantData;
+  merchant_data: Authorization.MerchantData;
 
   /**
    * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -1034,22 +1034,22 @@ export interface Authorization {
   /**
    * Details about the authorization, such as identifiers, set by the card network.
    */
-  network_data: Issuing.Authorization.NetworkData | null;
+  network_data: Authorization.NetworkData | null;
 
   /**
    * The pending authorization request. This field will only be non-null during an `issuing_authorization.request` webhook.
    */
-  pending_request: Issuing.Authorization.PendingRequest | null;
+  pending_request: Authorization.PendingRequest | null;
 
   /**
    * History of every time a `pending_request` authorization was approved/declined, either by you directly or by Stripe (e.g. based on your spending_controls). If the merchant changes the authorization by performing an incremental authorization, you can look at this field to see the previous requests for the authorization. This field can be helpful in determining why a given authorization was approved/declined.
    */
-  request_history: Array<Issuing.Authorization.RequestHistory>;
+  request_history: Array<Authorization.RequestHistory>;
 
   /**
    * The current status of the authorization in its lifecycle.
    */
-  status: Issuing.Authorization.Status;
+  status: Authorization.Status;
 
   /**
    * [Token](https://docs.stripe.com/api/issuing/tokens/object) object used for this authorization. If a network token was not used for this authorization, this field will be null.
@@ -1064,9 +1064,9 @@ export interface Authorization {
   /**
    * [Treasury](https://docs.stripe.com/api/treasury) details related to this authorization if it was created on a [FinancialAccount](https://docs.stripe.com/api/treasury/financial_accounts).
    */
-  treasury?: Issuing.Authorization.Treasury | null;
+  treasury?: Authorization.Treasury | null;
 
-  verification_data: Issuing.Authorization.VerificationData;
+  verification_data: Authorization.VerificationData;
 
   /**
    * Whether the authorization bypassed fraud risk checks because the cardholder has previously completed a fraud challenge on a similar high-risk authorization from the same merchant.
@@ -1078,8 +1078,460 @@ export interface Authorization {
    */
   wallet: string | null;
 }
-export namespace Issuing {
-  export namespace Authorization {
+export namespace Authorization {
+  export interface AmountDetails {
+    /**
+     * The fee charged by the ATM for the cash withdrawal.
+     */
+    atm_fee: number | null;
+
+    /**
+     * The amount of cash requested by the cardholder.
+     */
+    cashback_amount: number | null;
+  }
+
+  export type AuthorizationMethod =
+    | 'chip'
+    | 'contactless'
+    | 'keyed_in'
+    | 'online'
+    | 'swipe';
+
+  export type CardPresence = 'not_present' | 'present';
+
+  export interface Fleet {
+    /**
+     * Answers to prompts presented to the cardholder at the point of sale. Prompted fields vary depending on the configuration of your physical fleet cards. Typical points of sale support only numeric entry.
+     */
+    cardholder_prompt_data: Fleet.CardholderPromptData | null;
+
+    /**
+     * The type of purchase.
+     */
+    purchase_type: Fleet.PurchaseType | null;
+
+    /**
+     * More information about the total amount. Typically this information is received from the merchant after the authorization has been approved and the fuel dispensed. This information is not guaranteed to be accurate as some merchants may provide unreliable data.
+     */
+    reported_breakdown: Fleet.ReportedBreakdown | null;
+
+    /**
+     * The type of fuel service.
+     */
+    service_type: Fleet.ServiceType | null;
+  }
+
+  export interface FraudChallenge {
+    /**
+     * The method by which the fraud challenge was delivered to the cardholder.
+     */
+    channel: 'sms';
+
+    /**
+     * The status of the fraud challenge.
+     */
+    status: FraudChallenge.Status;
+
+    /**
+     * If the challenge is not deliverable, the reason why.
+     */
+    undeliverable_reason: FraudChallenge.UndeliverableReason | null;
+  }
+
+  export interface Fuel {
+    /**
+     * [Conexxus Payment System Product Code](https://www.conexxus.org/conexxus-payment-system-product-codes) identifying the primary fuel product purchased.
+     */
+    industry_product_code: string | null;
+
+    /**
+     * The quantity of `unit`s of fuel that was dispensed, represented as a decimal string with at most 12 decimal places.
+     */
+    quantity_decimal: Decimal | null;
+
+    /**
+     * The type of fuel that was purchased.
+     */
+    type: Fuel.Type | null;
+
+    /**
+     * The units for `quantity_decimal`.
+     */
+    unit: Fuel.Unit | null;
+
+    /**
+     * The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
+     */
+    unit_cost_decimal: Decimal | null;
+  }
+
+  export interface MerchantData {
+    /**
+     * A categorization of the seller's type of business. See our [merchant categories guide](https://docs.stripe.com/issuing/merchant-categories) for a list of possible values.
+     */
+    category: string;
+
+    /**
+     * The merchant category code for the seller's business
+     */
+    category_code: string;
+
+    /**
+     * City where the seller is located
+     */
+    city: string | null;
+
+    /**
+     * Country where the seller is located
+     */
+    country: string | null;
+
+    /**
+     * Name of the seller
+     */
+    name: string | null;
+
+    /**
+     * Identifier assigned to the seller by the card network. Different card networks may assign different network_id fields to the same merchant.
+     */
+    network_id: string;
+
+    /**
+     * Postal code where the seller is located
+     */
+    postal_code: string | null;
+
+    /**
+     * State where the seller is located
+     */
+    state: string | null;
+
+    /**
+     * The seller's tax identification number. Currently populated for French merchants only.
+     */
+    tax_id: string | null;
+
+    /**
+     * An ID assigned by the seller to the location of the sale.
+     */
+    terminal_id: string | null;
+
+    /**
+     * URL provided by the merchant on a 3DS request
+     */
+    url: string | null;
+  }
+
+  export interface NetworkData {
+    /**
+     * Identifier assigned to the acquirer by the card network. Sometimes this value is not provided by the network; in this case, the value will be `null`.
+     */
+    acquiring_institution_id: string | null;
+
+    /**
+     * The System Trace Audit Number (STAN) is a 6-digit identifier assigned by the acquirer. Prefer `network_data.transaction_id` if present, unless you have special requirements.
+     */
+    system_trace_audit_number: string | null;
+
+    /**
+     * Unique identifier for the authorization assigned by the card network used to match subsequent messages, disputes, and transactions.
+     */
+    transaction_id: string | null;
+  }
+
+  export interface PendingRequest {
+    /**
+     * The additional amount Stripe will hold if the authorization is approved, in the card's [currency](https://docs.stripe.com/api#issuing_authorization_object-pending-request-currency) and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+     */
+    amount: number;
+
+    /**
+     * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+     */
+    amount_details: PendingRequest.AmountDetails | null;
+
+    /**
+     * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+     */
+    currency: string;
+
+    /**
+     * If set `true`, you may provide [amount](https://docs.stripe.com/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization.
+     */
+    is_amount_controllable: boolean;
+
+    /**
+     * The amount the merchant is requesting to be authorized in the `merchant_currency`. The amount is in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+     */
+    merchant_amount: number;
+
+    /**
+     * The local currency the merchant is requesting to authorize.
+     */
+    merchant_currency: string;
+
+    /**
+     * The card network's estimate of the likelihood that an authorization is fraudulent. Takes on values between 1 and 99.
+     */
+    network_risk_score: number | null;
+  }
+
+  export interface RequestHistory {
+    /**
+     * The `pending_request.amount` at the time of the request, presented in your card's currency and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
+     */
+    amount: number;
+
+    /**
+     * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+     */
+    amount_details: RequestHistory.AmountDetails | null;
+
+    /**
+     * Whether this request was approved.
+     */
+    approved: boolean;
+
+    /**
+     * A code created by Stripe which is shared with the merchant to validate the authorization. This field will be populated if the authorization message was approved. The code typically starts with the letter "S", followed by a six-digit number. For example, "S498162". Please note that the code is not guaranteed to be unique across authorizations.
+     */
+    authorization_code: string | null;
+
+    /**
+     * Time at which the object was created. Measured in seconds since the Unix epoch.
+     */
+    created: number;
+
+    /**
+     * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+     */
+    currency: string;
+
+    /**
+     * The `pending_request.merchant_amount` at the time of the request, presented in the `merchant_currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+     */
+    merchant_amount: number;
+
+    /**
+     * The currency that was collected by the merchant and presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+     */
+    merchant_currency: string;
+
+    /**
+     * The card network's estimate of the likelihood that an authorization is fraudulent. Takes on values between 1 and 99.
+     */
+    network_risk_score: number | null;
+
+    /**
+     * When an authorization is approved or declined by you or by Stripe, this field provides additional detail on the reason for the outcome.
+     */
+    reason: RequestHistory.Reason;
+
+    /**
+     * If the `request_history.reason` is `webhook_error` because the direct webhook response is invalid (for example, parsing errors or missing parameters), we surface a more detailed error message via this field.
+     */
+    reason_message: string | null;
+
+    /**
+     * Time when the card network received an authorization request from the acquirer in UTC. Referred to by networks as transmission time.
+     */
+    requested_at: number | null;
+  }
+
+  export type Status = 'closed' | 'expired' | 'pending' | 'reversed';
+
+  export interface Treasury {
+    /**
+     * The array of [ReceivedCredits](https://docs.stripe.com/api/treasury/received_credits) associated with this authorization
+     */
+    received_credits: Array<string>;
+
+    /**
+     * The array of [ReceivedDebits](https://docs.stripe.com/api/treasury/received_debits) associated with this authorization
+     */
+    received_debits: Array<string>;
+
+    /**
+     * The Treasury [Transaction](https://docs.stripe.com/api/treasury/transactions) associated with this authorization
+     */
+    transaction: string | null;
+  }
+
+  export interface VerificationData {
+    /**
+     * Whether the cardholder provided an address first line and if it matched the cardholder's `billing.address.line1`.
+     */
+    address_line1_check: VerificationData.AddressLine1Check;
+
+    /**
+     * Whether the cardholder provided a postal code and if it matched the cardholder's `billing.address.postal_code`.
+     */
+    address_postal_code_check: VerificationData.AddressPostalCodeCheck;
+
+    /**
+     * The exemption applied to this authorization.
+     */
+    authentication_exemption: VerificationData.AuthenticationExemption | null;
+
+    /**
+     * Whether the cardholder provided a CVC and if it matched Stripe's record.
+     */
+    cvc_check: VerificationData.CvcCheck;
+
+    /**
+     * Whether the cardholder provided an expiry date and if it matched Stripe's record.
+     */
+    expiry_check: VerificationData.ExpiryCheck;
+
+    /**
+     * The postal code submitted as part of the authorization used for postal code verification.
+     */
+    postal_code: string | null;
+
+    /**
+     * 3D Secure details.
+     */
+    three_d_secure: VerificationData.ThreeDSecure | null;
+  }
+
+  export namespace Fleet {
+    export interface CardholderPromptData {
+      /**
+       * [Deprecated] An alphanumeric ID, though typical point of sales only support numeric entry. The card program can be configured to prompt for a vehicle ID, driver ID, or generic ID.
+       * @deprecated
+       */
+      alphanumeric_id: string | null;
+
+      /**
+       * Driver ID.
+       */
+      driver_id: string | null;
+
+      /**
+       * Odometer reading.
+       */
+      odometer: number | null;
+
+      /**
+       * An alphanumeric ID. This field is used when a vehicle ID, driver ID, or generic ID is entered by the cardholder, but the merchant or card network did not specify the prompt type.
+       */
+      unspecified_id: string | null;
+
+      /**
+       * User ID.
+       */
+      user_id: string | null;
+
+      /**
+       * Vehicle number.
+       */
+      vehicle_number: string | null;
+    }
+
+    export type PurchaseType =
+      | 'fuel_and_non_fuel_purchase'
+      | 'fuel_purchase'
+      | 'non_fuel_purchase';
+
+    export interface ReportedBreakdown {
+      /**
+       * Breakdown of fuel portion of the purchase.
+       */
+      fuel: ReportedBreakdown.Fuel | null;
+
+      /**
+       * Breakdown of non-fuel portion of the purchase.
+       */
+      non_fuel: ReportedBreakdown.NonFuel | null;
+
+      /**
+       * Information about tax included in this transaction.
+       */
+      tax: ReportedBreakdown.Tax | null;
+    }
+
+    export type ServiceType =
+      | 'full_service'
+      | 'non_fuel_transaction'
+      | 'self_service';
+
+    export namespace ReportedBreakdown {
+      export interface Fuel {
+        /**
+         * Gross fuel amount that should equal Fuel Quantity multiplied by Fuel Unit Cost, inclusive of taxes.
+         */
+        gross_amount_decimal: Decimal | null;
+      }
+
+      export interface NonFuel {
+        /**
+         * Gross non-fuel amount that should equal the sum of the line items, inclusive of taxes.
+         */
+        gross_amount_decimal: Decimal | null;
+      }
+
+      export interface Tax {
+        /**
+         * Amount of state or provincial Sales Tax included in the transaction amount. `null` if not reported by merchant or not subject to tax.
+         */
+        local_amount_decimal: Decimal | null;
+
+        /**
+         * Amount of national Sales Tax or VAT included in the transaction amount. `null` if not reported by merchant or not subject to tax.
+         */
+        national_amount_decimal: Decimal | null;
+      }
+    }
+  }
+
+  export namespace FraudChallenge {
+    export type Status =
+      | 'expired'
+      | 'pending'
+      | 'rejected'
+      | 'undeliverable'
+      | 'verified';
+
+    export type UndeliverableReason =
+      | 'no_phone_number'
+      | 'unsupported_phone_number';
+  }
+
+  export namespace Fuel {
+    export type Type =
+      | 'diesel'
+      | 'other'
+      | 'unleaded_plus'
+      | 'unleaded_regular'
+      | 'unleaded_super';
+
+    export type Unit =
+      | 'charging_minute'
+      | 'imperial_gallon'
+      | 'kilogram'
+      | 'kilowatt_hour'
+      | 'liter'
+      | 'other'
+      | 'pound'
+      | 'us_gallon';
+  }
+
+  export namespace PendingRequest {
+    export interface AmountDetails {
+      /**
+       * The fee charged by the ATM for the cash withdrawal.
+       */
+      atm_fee: number | null;
+
+      /**
+       * The amount of cash requested by the cardholder.
+       */
+      cashback_amount: number | null;
+    }
+  }
+
+  export namespace RequestHistory {
     export interface AmountDetails {
       /**
        * The fee charged by the ATM for the cash withdrawal.
@@ -1092,529 +1544,72 @@ export namespace Issuing {
       cashback_amount: number | null;
     }
 
-    export type AuthorizationMethod =
-      | 'chip'
-      | 'contactless'
-      | 'keyed_in'
-      | 'online'
-      | 'swipe';
+    export type Reason =
+      | 'account_disabled'
+      | 'card_active'
+      | 'card_canceled'
+      | 'card_expired'
+      | 'card_inactive'
+      | 'cardholder_blocked'
+      | 'cardholder_inactive'
+      | 'cardholder_verification_required'
+      | 'insecure_authorization_method'
+      | 'insufficient_funds'
+      | 'network_fallback'
+      | 'not_allowed'
+      | 'pin_blocked'
+      | 'spending_controls'
+      | 'suspected_fraud'
+      | 'verification_failed'
+      | 'webhook_approved'
+      | 'webhook_declined'
+      | 'webhook_error'
+      | 'webhook_timeout';
+  }
 
-    export type CardPresence = 'not_present' | 'present';
+  export namespace VerificationData {
+    export type AddressLine1Check = 'match' | 'mismatch' | 'not_provided';
 
-    export interface Fleet {
+    export type AddressPostalCodeCheck = 'match' | 'mismatch' | 'not_provided';
+
+    export interface AuthenticationExemption {
       /**
-       * Answers to prompts presented to the cardholder at the point of sale. Prompted fields vary depending on the configuration of your physical fleet cards. Typical points of sale support only numeric entry.
+       * The entity that requested the exemption, either the acquiring merchant or the Issuing user.
        */
-      cardholder_prompt_data: Fleet.CardholderPromptData | null;
+      claimed_by: AuthenticationExemption.ClaimedBy;
 
       /**
-       * The type of purchase.
+       * The specific exemption claimed for this authorization.
        */
-      purchase_type: Fleet.PurchaseType | null;
-
-      /**
-       * More information about the total amount. Typically this information is received from the merchant after the authorization has been approved and the fuel dispensed. This information is not guaranteed to be accurate as some merchants may provide unreliable data.
-       */
-      reported_breakdown: Fleet.ReportedBreakdown | null;
-
-      /**
-       * The type of fuel service.
-       */
-      service_type: Fleet.ServiceType | null;
+      type: AuthenticationExemption.Type;
     }
 
-    export interface FraudChallenge {
-      /**
-       * The method by which the fraud challenge was delivered to the cardholder.
-       */
-      channel: 'sms';
+    export type CvcCheck = 'match' | 'mismatch' | 'not_provided';
 
-      /**
-       * The status of the fraud challenge.
-       */
-      status: FraudChallenge.Status;
+    export type ExpiryCheck = 'match' | 'mismatch' | 'not_provided';
 
+    export interface ThreeDSecure {
       /**
-       * If the challenge is not deliverable, the reason why.
+       * The outcome of the 3D Secure authentication request.
        */
-      undeliverable_reason: FraudChallenge.UndeliverableReason | null;
+      result: ThreeDSecure.Result;
     }
 
-    export interface Fuel {
-      /**
-       * [Conexxus Payment System Product Code](https://www.conexxus.org/conexxus-payment-system-product-codes) identifying the primary fuel product purchased.
-       */
-      industry_product_code: string | null;
+    export namespace AuthenticationExemption {
+      export type ClaimedBy = 'acquirer' | 'issuer';
 
-      /**
-       * The quantity of `unit`s of fuel that was dispensed, represented as a decimal string with at most 12 decimal places.
-       */
-      quantity_decimal: Decimal | null;
-
-      /**
-       * The type of fuel that was purchased.
-       */
-      type: Fuel.Type | null;
-
-      /**
-       * The units for `quantity_decimal`.
-       */
-      unit: Fuel.Unit | null;
-
-      /**
-       * The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
-       */
-      unit_cost_decimal: Decimal | null;
-    }
-
-    export interface MerchantData {
-      /**
-       * A categorization of the seller's type of business. See our [merchant categories guide](https://docs.stripe.com/issuing/merchant-categories) for a list of possible values.
-       */
-      category: string;
-
-      /**
-       * The merchant category code for the seller's business
-       */
-      category_code: string;
-
-      /**
-       * City where the seller is located
-       */
-      city: string | null;
-
-      /**
-       * Country where the seller is located
-       */
-      country: string | null;
-
-      /**
-       * Name of the seller
-       */
-      name: string | null;
-
-      /**
-       * Identifier assigned to the seller by the card network. Different card networks may assign different network_id fields to the same merchant.
-       */
-      network_id: string;
-
-      /**
-       * Postal code where the seller is located
-       */
-      postal_code: string | null;
-
-      /**
-       * State where the seller is located
-       */
-      state: string | null;
-
-      /**
-       * The seller's tax identification number. Currently populated for French merchants only.
-       */
-      tax_id: string | null;
-
-      /**
-       * An ID assigned by the seller to the location of the sale.
-       */
-      terminal_id: string | null;
-
-      /**
-       * URL provided by the merchant on a 3DS request
-       */
-      url: string | null;
-    }
-
-    export interface NetworkData {
-      /**
-       * Identifier assigned to the acquirer by the card network. Sometimes this value is not provided by the network; in this case, the value will be `null`.
-       */
-      acquiring_institution_id: string | null;
-
-      /**
-       * The System Trace Audit Number (STAN) is a 6-digit identifier assigned by the acquirer. Prefer `network_data.transaction_id` if present, unless you have special requirements.
-       */
-      system_trace_audit_number: string | null;
-
-      /**
-       * Unique identifier for the authorization assigned by the card network used to match subsequent messages, disputes, and transactions.
-       */
-      transaction_id: string | null;
-    }
-
-    export interface PendingRequest {
-      /**
-       * The additional amount Stripe will hold if the authorization is approved, in the card's [currency](https://docs.stripe.com/api#issuing_authorization_object-pending-request-currency) and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-       */
-      amount: number;
-
-      /**
-       * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-       */
-      amount_details: PendingRequest.AmountDetails | null;
-
-      /**
-       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-       */
-      currency: string;
-
-      /**
-       * If set `true`, you may provide [amount](https://docs.stripe.com/api/issuing/authorizations/approve#approve_issuing_authorization-amount) to control how much to hold for the authorization.
-       */
-      is_amount_controllable: boolean;
-
-      /**
-       * The amount the merchant is requesting to be authorized in the `merchant_currency`. The amount is in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-       */
-      merchant_amount: number;
-
-      /**
-       * The local currency the merchant is requesting to authorize.
-       */
-      merchant_currency: string;
-
-      /**
-       * The card network's estimate of the likelihood that an authorization is fraudulent. Takes on values between 1 and 99.
-       */
-      network_risk_score: number | null;
-    }
-
-    export interface RequestHistory {
-      /**
-       * The `pending_request.amount` at the time of the request, presented in your card's currency and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal). Stripe held this amount from your account to fund the authorization if the request was approved.
-       */
-      amount: number;
-
-      /**
-       * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-       */
-      amount_details: RequestHistory.AmountDetails | null;
-
-      /**
-       * Whether this request was approved.
-       */
-      approved: boolean;
-
-      /**
-       * A code created by Stripe which is shared with the merchant to validate the authorization. This field will be populated if the authorization message was approved. The code typically starts with the letter "S", followed by a six-digit number. For example, "S498162". Please note that the code is not guaranteed to be unique across authorizations.
-       */
-      authorization_code: string | null;
-
-      /**
-       * Time at which the object was created. Measured in seconds since the Unix epoch.
-       */
-      created: number;
-
-      /**
-       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-       */
-      currency: string;
-
-      /**
-       * The `pending_request.merchant_amount` at the time of the request, presented in the `merchant_currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-       */
-      merchant_amount: number;
-
-      /**
-       * The currency that was collected by the merchant and presented to the cardholder for the authorization. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-       */
-      merchant_currency: string;
-
-      /**
-       * The card network's estimate of the likelihood that an authorization is fraudulent. Takes on values between 1 and 99.
-       */
-      network_risk_score: number | null;
-
-      /**
-       * When an authorization is approved or declined by you or by Stripe, this field provides additional detail on the reason for the outcome.
-       */
-      reason: RequestHistory.Reason;
-
-      /**
-       * If the `request_history.reason` is `webhook_error` because the direct webhook response is invalid (for example, parsing errors or missing parameters), we surface a more detailed error message via this field.
-       */
-      reason_message: string | null;
-
-      /**
-       * Time when the card network received an authorization request from the acquirer in UTC. Referred to by networks as transmission time.
-       */
-      requested_at: number | null;
-    }
-
-    export type Status = 'closed' | 'expired' | 'pending' | 'reversed';
-
-    export interface Treasury {
-      /**
-       * The array of [ReceivedCredits](https://docs.stripe.com/api/treasury/received_credits) associated with this authorization
-       */
-      received_credits: Array<string>;
-
-      /**
-       * The array of [ReceivedDebits](https://docs.stripe.com/api/treasury/received_debits) associated with this authorization
-       */
-      received_debits: Array<string>;
-
-      /**
-       * The Treasury [Transaction](https://docs.stripe.com/api/treasury/transactions) associated with this authorization
-       */
-      transaction: string | null;
-    }
-
-    export interface VerificationData {
-      /**
-       * Whether the cardholder provided an address first line and if it matched the cardholder's `billing.address.line1`.
-       */
-      address_line1_check: VerificationData.AddressLine1Check;
-
-      /**
-       * Whether the cardholder provided a postal code and if it matched the cardholder's `billing.address.postal_code`.
-       */
-      address_postal_code_check: VerificationData.AddressPostalCodeCheck;
-
-      /**
-       * The exemption applied to this authorization.
-       */
-      authentication_exemption: VerificationData.AuthenticationExemption | null;
-
-      /**
-       * Whether the cardholder provided a CVC and if it matched Stripe's record.
-       */
-      cvc_check: VerificationData.CvcCheck;
-
-      /**
-       * Whether the cardholder provided an expiry date and if it matched Stripe's record.
-       */
-      expiry_check: VerificationData.ExpiryCheck;
-
-      /**
-       * The postal code submitted as part of the authorization used for postal code verification.
-       */
-      postal_code: string | null;
-
-      /**
-       * 3D Secure details.
-       */
-      three_d_secure: VerificationData.ThreeDSecure | null;
-    }
-
-    export namespace Fleet {
-      export interface CardholderPromptData {
-        /**
-         * [Deprecated] An alphanumeric ID, though typical point of sales only support numeric entry. The card program can be configured to prompt for a vehicle ID, driver ID, or generic ID.
-         * @deprecated
-         */
-        alphanumeric_id: string | null;
-
-        /**
-         * Driver ID.
-         */
-        driver_id: string | null;
-
-        /**
-         * Odometer reading.
-         */
-        odometer: number | null;
-
-        /**
-         * An alphanumeric ID. This field is used when a vehicle ID, driver ID, or generic ID is entered by the cardholder, but the merchant or card network did not specify the prompt type.
-         */
-        unspecified_id: string | null;
-
-        /**
-         * User ID.
-         */
-        user_id: string | null;
-
-        /**
-         * Vehicle number.
-         */
-        vehicle_number: string | null;
-      }
-
-      export type PurchaseType =
-        | 'fuel_and_non_fuel_purchase'
-        | 'fuel_purchase'
-        | 'non_fuel_purchase';
-
-      export interface ReportedBreakdown {
-        /**
-         * Breakdown of fuel portion of the purchase.
-         */
-        fuel: ReportedBreakdown.Fuel | null;
-
-        /**
-         * Breakdown of non-fuel portion of the purchase.
-         */
-        non_fuel: ReportedBreakdown.NonFuel | null;
-
-        /**
-         * Information about tax included in this transaction.
-         */
-        tax: ReportedBreakdown.Tax | null;
-      }
-
-      export type ServiceType =
-        | 'full_service'
-        | 'non_fuel_transaction'
-        | 'self_service';
-
-      export namespace ReportedBreakdown {
-        export interface Fuel {
-          /**
-           * Gross fuel amount that should equal Fuel Quantity multiplied by Fuel Unit Cost, inclusive of taxes.
-           */
-          gross_amount_decimal: Decimal | null;
-        }
-
-        export interface NonFuel {
-          /**
-           * Gross non-fuel amount that should equal the sum of the line items, inclusive of taxes.
-           */
-          gross_amount_decimal: Decimal | null;
-        }
-
-        export interface Tax {
-          /**
-           * Amount of state or provincial Sales Tax included in the transaction amount. `null` if not reported by merchant or not subject to tax.
-           */
-          local_amount_decimal: Decimal | null;
-
-          /**
-           * Amount of national Sales Tax or VAT included in the transaction amount. `null` if not reported by merchant or not subject to tax.
-           */
-          national_amount_decimal: Decimal | null;
-        }
-      }
-    }
-
-    export namespace FraudChallenge {
-      export type Status =
-        | 'expired'
-        | 'pending'
-        | 'rejected'
-        | 'undeliverable'
-        | 'verified';
-
-      export type UndeliverableReason =
-        | 'no_phone_number'
-        | 'unsupported_phone_number';
-    }
-
-    export namespace Fuel {
       export type Type =
-        | 'diesel'
-        | 'other'
-        | 'unleaded_plus'
-        | 'unleaded_regular'
-        | 'unleaded_super';
-
-      export type Unit =
-        | 'charging_minute'
-        | 'imperial_gallon'
-        | 'kilogram'
-        | 'kilowatt_hour'
-        | 'liter'
-        | 'other'
-        | 'pound'
-        | 'us_gallon';
+        | 'low_value_transaction'
+        | 'transaction_risk_analysis'
+        | 'unknown';
     }
 
-    export namespace PendingRequest {
-      export interface AmountDetails {
-        /**
-         * The fee charged by the ATM for the cash withdrawal.
-         */
-        atm_fee: number | null;
-
-        /**
-         * The amount of cash requested by the cardholder.
-         */
-        cashback_amount: number | null;
-      }
-    }
-
-    export namespace RequestHistory {
-      export interface AmountDetails {
-        /**
-         * The fee charged by the ATM for the cash withdrawal.
-         */
-        atm_fee: number | null;
-
-        /**
-         * The amount of cash requested by the cardholder.
-         */
-        cashback_amount: number | null;
-      }
-
-      export type Reason =
-        | 'account_disabled'
-        | 'card_active'
-        | 'card_canceled'
-        | 'card_expired'
-        | 'card_inactive'
-        | 'cardholder_blocked'
-        | 'cardholder_inactive'
-        | 'cardholder_verification_required'
-        | 'insecure_authorization_method'
-        | 'insufficient_funds'
-        | 'network_fallback'
-        | 'not_allowed'
-        | 'pin_blocked'
-        | 'spending_controls'
-        | 'suspected_fraud'
-        | 'verification_failed'
-        | 'webhook_approved'
-        | 'webhook_declined'
-        | 'webhook_error'
-        | 'webhook_timeout';
-    }
-
-    export namespace VerificationData {
-      export type AddressLine1Check = 'match' | 'mismatch' | 'not_provided';
-
-      export type AddressPostalCodeCheck =
-        | 'match'
-        | 'mismatch'
-        | 'not_provided';
-
-      export interface AuthenticationExemption {
-        /**
-         * The entity that requested the exemption, either the acquiring merchant or the Issuing user.
-         */
-        claimed_by: AuthenticationExemption.ClaimedBy;
-
-        /**
-         * The specific exemption claimed for this authorization.
-         */
-        type: AuthenticationExemption.Type;
-      }
-
-      export type CvcCheck = 'match' | 'mismatch' | 'not_provided';
-
-      export type ExpiryCheck = 'match' | 'mismatch' | 'not_provided';
-
-      export interface ThreeDSecure {
-        /**
-         * The outcome of the 3D Secure authentication request.
-         */
-        result: ThreeDSecure.Result;
-      }
-
-      export namespace AuthenticationExemption {
-        export type ClaimedBy = 'acquirer' | 'issuer';
-
-        export type Type =
-          | 'low_value_transaction'
-          | 'transaction_risk_analysis'
-          | 'unknown';
-      }
-
-      export namespace ThreeDSecure {
-        export type Result =
-          | 'attempt_acknowledged'
-          | 'authenticated'
-          | 'failed'
-          | 'required';
-      }
+    export namespace ThreeDSecure {
+      export type Result =
+        | 'attempt_acknowledged'
+        | 'authenticated'
+        | 'failed'
+        | 'required';
     }
   }
 }

--- a/src/resources/Issuing/Cardholders.ts
+++ b/src/resources/Issuing/Cardholders.ts
@@ -86,12 +86,12 @@ export interface Cardholder {
    */
   object: 'issuing.cardholder';
 
-  billing: Issuing.Cardholder.Billing;
+  billing: Cardholder.Billing;
 
   /**
    * Additional information about a `company` cardholder.
    */
-  company: Issuing.Cardholder.Company | null;
+  company: Cardholder.Company | null;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -106,7 +106,7 @@ export interface Cardholder {
   /**
    * Additional information about an `individual` cardholder.
    */
-  individual: Issuing.Cardholder.Individual | null;
+  individual: Cardholder.Individual | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -132,218 +132,827 @@ export interface Cardholder {
    * The cardholder's preferred locales (languages), ordered by preference. Locales can be `da`, `de`, `en`, `es`, `fr`, `it`, `pl`, or `sv`.
    *  This changes the language of the [3D Secure flow](https://docs.stripe.com/issuing/3d-secure) and one-time password messages sent to the cardholder.
    */
-  preferred_locales: Array<Issuing.Cardholder.PreferredLocale> | null;
+  preferred_locales: Array<Cardholder.PreferredLocale> | null;
 
-  requirements: Issuing.Cardholder.Requirements;
+  requirements: Cardholder.Requirements;
 
   /**
    * Rules that control spending across this cardholder's cards. Refer to our [documentation](https://docs.stripe.com/issuing/controls/spending-controls) for more details.
    */
-  spending_controls: Issuing.Cardholder.SpendingControls | null;
+  spending_controls: Cardholder.SpendingControls | null;
 
   /**
    * Specifies whether to permit authorizations on this cardholder's cards.
    */
-  status: Issuing.Cardholder.Status;
+  status: Cardholder.Status;
 
   /**
    * One of `individual` or `company`. See [Choose a cardholder type](https://docs.stripe.com/issuing/other/choose-cardholder) for more details.
    */
-  type: Issuing.Cardholder.Type;
+  type: Cardholder.Type;
 }
-export namespace Issuing {
-  export namespace Cardholder {
-    export interface Billing {
-      address: Address;
+export namespace Cardholder {
+  export interface Billing {
+    address: Address;
+  }
+
+  export interface Company {
+    /**
+     * Whether the company's business ID number was provided.
+     */
+    tax_id_provided: boolean;
+  }
+
+  export interface Individual {
+    /**
+     * Information related to the card_issuing program for this cardholder.
+     */
+    card_issuing?: Individual.CardIssuing | null;
+
+    /**
+     * The date of birth of this cardholder.
+     */
+    dob: Individual.Dob | null;
+
+    /**
+     * The first name of this cardholder. Required before activating Cards. This field cannot contain any numbers, special characters (except periods, commas, hyphens, spaces and apostrophes) or non-latin letters.
+     */
+    first_name: string | null;
+
+    /**
+     * The last name of this cardholder. Required before activating Cards. This field cannot contain any numbers, special characters (except periods, commas, hyphens, spaces and apostrophes) or non-latin letters.
+     */
+    last_name: string | null;
+
+    /**
+     * Government-issued ID document for this cardholder.
+     */
+    verification: Individual.Verification | null;
+  }
+
+  export type PreferredLocale = 'de' | 'en' | 'es' | 'fr' | 'it';
+
+  export interface Requirements {
+    /**
+     * If `disabled_reason` is present, all cards will decline authorizations with `cardholder_verification_required` reason.
+     */
+    disabled_reason: Requirements.DisabledReason | null;
+
+    /**
+     * Array of fields that need to be collected in order to verify and re-enable the cardholder.
+     */
+    past_due: Array<Requirements.PastDue> | null;
+  }
+
+  export interface SpendingControls {
+    /**
+     * Array of card presence statuses from which authorizations will be allowed. Possible options are `present`, `not_present`. All other statuses will be blocked. Cannot be set with `blocked_card_presences`. Provide an empty value to unset this control.
+     */
+    allowed_card_presences: Array<SpendingControls.AllowedCardPresence> | null;
+
+    /**
+     * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
+     */
+    allowed_categories: Array<SpendingControls.AllowedCategory> | null;
+
+    /**
+     * Array of strings containing representing countries from which authorizations will be allowed. Authorizations from merchants in all other countries will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `blocked_merchant_countries`. Provide an empty value to unset this control.
+     */
+    allowed_merchant_countries: Array<string> | null;
+
+    /**
+     * Array of card presence statuses from which authorizations will be declined. Possible options are `present`, `not_present`. Cannot be set with `allowed_card_presences`. Provide an empty value to unset this control.
+     */
+    blocked_card_presences: Array<SpendingControls.BlockedCardPresence> | null;
+
+    /**
+     * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
+     */
+    blocked_categories: Array<SpendingControls.BlockedCategory> | null;
+
+    /**
+     * Array of strings containing representing countries from which authorizations will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `allowed_merchant_countries`. Provide an empty value to unset this control.
+     */
+    blocked_merchant_countries: Array<string> | null;
+
+    /**
+     * Limit spending with amount-based rules that apply across this cardholder's cards.
+     */
+    spending_limits: Array<SpendingControls.SpendingLimit> | null;
+
+    /**
+     * Currency of the amounts within `spending_limits`.
+     */
+    spending_limits_currency: string | null;
+  }
+
+  export type Status = 'active' | 'blocked' | 'inactive';
+
+  export type Type = 'company' | 'individual';
+
+  export namespace Individual {
+    export interface CardIssuing {
+      /**
+       * Information about cardholder acceptance of Celtic [Authorized User Terms](https://stripe.com/docs/issuing/cards#accept-authorized-user-terms). Required for cards backed by a Celtic program.
+       */
+      user_terms_acceptance: CardIssuing.UserTermsAcceptance | null;
     }
 
-    export interface Company {
+    export interface Dob {
       /**
-       * Whether the company's business ID number was provided.
+       * The day of birth, between 1 and 31.
        */
-      tax_id_provided: boolean;
+      day: number | null;
+
+      /**
+       * The month of birth, between 1 and 12.
+       */
+      month: number | null;
+
+      /**
+       * The four-digit year of birth.
+       */
+      year: number | null;
     }
 
-    export interface Individual {
+    export interface Verification {
       /**
-       * Information related to the card_issuing program for this cardholder.
+       * An identifying document, either a passport or local ID card.
        */
-      card_issuing?: Individual.CardIssuing | null;
-
-      /**
-       * The date of birth of this cardholder.
-       */
-      dob: Individual.Dob | null;
-
-      /**
-       * The first name of this cardholder. Required before activating Cards. This field cannot contain any numbers, special characters (except periods, commas, hyphens, spaces and apostrophes) or non-latin letters.
-       */
-      first_name: string | null;
-
-      /**
-       * The last name of this cardholder. Required before activating Cards. This field cannot contain any numbers, special characters (except periods, commas, hyphens, spaces and apostrophes) or non-latin letters.
-       */
-      last_name: string | null;
-
-      /**
-       * Government-issued ID document for this cardholder.
-       */
-      verification: Individual.Verification | null;
+      document: Verification.Document | null;
     }
 
-    export type PreferredLocale = 'de' | 'en' | 'es' | 'fr' | 'it';
-
-    export interface Requirements {
-      /**
-       * If `disabled_reason` is present, all cards will decline authorizations with `cardholder_verification_required` reason.
-       */
-      disabled_reason: Requirements.DisabledReason | null;
-
-      /**
-       * Array of fields that need to be collected in order to verify and re-enable the cardholder.
-       */
-      past_due: Array<Requirements.PastDue> | null;
-    }
-
-    export interface SpendingControls {
-      /**
-       * Array of card presence statuses from which authorizations will be allowed. Possible options are `present`, `not_present`. All other statuses will be blocked. Cannot be set with `blocked_card_presences`. Provide an empty value to unset this control.
-       */
-      allowed_card_presences: Array<
-        SpendingControls.AllowedCardPresence
-      > | null;
-
-      /**
-       * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
-       */
-      allowed_categories: Array<SpendingControls.AllowedCategory> | null;
-
-      /**
-       * Array of strings containing representing countries from which authorizations will be allowed. Authorizations from merchants in all other countries will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `blocked_merchant_countries`. Provide an empty value to unset this control.
-       */
-      allowed_merchant_countries: Array<string> | null;
-
-      /**
-       * Array of card presence statuses from which authorizations will be declined. Possible options are `present`, `not_present`. Cannot be set with `allowed_card_presences`. Provide an empty value to unset this control.
-       */
-      blocked_card_presences: Array<
-        SpendingControls.BlockedCardPresence
-      > | null;
-
-      /**
-       * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
-       */
-      blocked_categories: Array<SpendingControls.BlockedCategory> | null;
-
-      /**
-       * Array of strings containing representing countries from which authorizations will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `allowed_merchant_countries`. Provide an empty value to unset this control.
-       */
-      blocked_merchant_countries: Array<string> | null;
-
-      /**
-       * Limit spending with amount-based rules that apply across this cardholder's cards.
-       */
-      spending_limits: Array<SpendingControls.SpendingLimit> | null;
-
-      /**
-       * Currency of the amounts within `spending_limits`.
-       */
-      spending_limits_currency: string | null;
-    }
-
-    export type Status = 'active' | 'blocked' | 'inactive';
-
-    export type Type = 'company' | 'individual';
-
-    export namespace Individual {
-      export interface CardIssuing {
+    export namespace CardIssuing {
+      export interface UserTermsAcceptance {
         /**
-         * Information about cardholder acceptance of Celtic [Authorized User Terms](https://stripe.com/docs/issuing/cards#accept-authorized-user-terms). Required for cards backed by a Celtic program.
+         * The Unix timestamp marking when the cardholder accepted the Authorized User Terms.
          */
-        user_terms_acceptance: CardIssuing.UserTermsAcceptance | null;
-      }
-
-      export interface Dob {
-        /**
-         * The day of birth, between 1 and 31.
-         */
-        day: number | null;
+        date: number | null;
 
         /**
-         * The month of birth, between 1 and 12.
+         * The IP address from which the cardholder accepted the Authorized User Terms.
          */
-        month: number | null;
+        ip: string | null;
 
         /**
-         * The four-digit year of birth.
+         * The user agent of the browser from which the cardholder accepted the Authorized User Terms.
          */
-        year: number | null;
-      }
-
-      export interface Verification {
-        /**
-         * An identifying document, either a passport or local ID card.
-         */
-        document: Verification.Document | null;
-      }
-
-      export namespace CardIssuing {
-        export interface UserTermsAcceptance {
-          /**
-           * The Unix timestamp marking when the cardholder accepted the Authorized User Terms.
-           */
-          date: number | null;
-
-          /**
-           * The IP address from which the cardholder accepted the Authorized User Terms.
-           */
-          ip: string | null;
-
-          /**
-           * The user agent of the browser from which the cardholder accepted the Authorized User Terms.
-           */
-          user_agent: string | null;
-        }
-      }
-
-      export namespace Verification {
-        export interface Document {
-          /**
-           * The back of a document returned by a [file upload](https://api.stripe.com#create_file) with a `purpose` value of `identity_document`.
-           */
-          back: string | File | null;
-
-          /**
-           * The front of a document returned by a [file upload](https://api.stripe.com#create_file) with a `purpose` value of `identity_document`.
-           */
-          front: string | File | null;
-        }
+        user_agent: string | null;
       }
     }
 
-    export namespace Requirements {
-      export type DisabledReason =
-        | 'listed'
-        | 'rejected.listed'
-        | 'requirements.past_due'
-        | 'under_review';
+    export namespace Verification {
+      export interface Document {
+        /**
+         * The back of a document returned by a [file upload](https://api.stripe.com#create_file) with a `purpose` value of `identity_document`.
+         */
+        back: string | File | null;
 
-      export type PastDue =
-        | 'company.tax_id'
-        | 'individual.card_issuing.user_terms_acceptance.date'
-        | 'individual.card_issuing.user_terms_acceptance.ip'
-        | 'individual.dob.day'
-        | 'individual.dob.month'
-        | 'individual.dob.year'
-        | 'individual.first_name'
-        | 'individual.last_name'
-        | 'individual.verification.document';
+        /**
+         * The front of a document returned by a [file upload](https://api.stripe.com#create_file) with a `purpose` value of `identity_document`.
+         */
+        front: string | File | null;
+      }
+    }
+  }
+
+  export namespace Requirements {
+    export type DisabledReason =
+      | 'listed'
+      | 'rejected.listed'
+      | 'requirements.past_due'
+      | 'under_review';
+
+    export type PastDue =
+      | 'company.tax_id'
+      | 'individual.card_issuing.user_terms_acceptance.date'
+      | 'individual.card_issuing.user_terms_acceptance.ip'
+      | 'individual.dob.day'
+      | 'individual.dob.month'
+      | 'individual.dob.year'
+      | 'individual.first_name'
+      | 'individual.last_name'
+      | 'individual.verification.document';
+  }
+
+  export namespace SpendingControls {
+    export type AllowedCardPresence = 'not_present' | 'present';
+
+    export type AllowedCategory =
+      | 'ac_refrigeration_repair'
+      | 'accounting_bookkeeping_services'
+      | 'advertising_services'
+      | 'agricultural_cooperative'
+      | 'airlines_air_carriers'
+      | 'airports_flying_fields'
+      | 'ambulance_services'
+      | 'amusement_parks_carnivals'
+      | 'antique_reproductions'
+      | 'antique_shops'
+      | 'aquariums'
+      | 'architectural_surveying_services'
+      | 'art_dealers_and_galleries'
+      | 'artists_supply_and_craft_shops'
+      | 'auto_and_home_supply_stores'
+      | 'auto_body_repair_shops'
+      | 'auto_paint_shops'
+      | 'auto_service_shops'
+      | 'automated_cash_disburse'
+      | 'automated_fuel_dispensers'
+      | 'automobile_associations'
+      | 'automotive_parts_and_accessories_stores'
+      | 'automotive_tire_stores'
+      | 'bail_and_bond_payments'
+      | 'bakeries'
+      | 'bands_orchestras'
+      | 'barber_and_beauty_shops'
+      | 'betting_casino_gambling'
+      | 'bicycle_shops'
+      | 'billiard_pool_establishments'
+      | 'boat_dealers'
+      | 'boat_rentals_and_leases'
+      | 'book_stores'
+      | 'books_periodicals_and_newspapers'
+      | 'bowling_alleys'
+      | 'bus_lines'
+      | 'business_secretarial_schools'
+      | 'buying_shopping_services'
+      | 'cable_satellite_and_other_pay_television_and_radio'
+      | 'camera_and_photographic_supply_stores'
+      | 'candy_nut_and_confectionery_stores'
+      | 'car_and_truck_dealers_new_used'
+      | 'car_and_truck_dealers_used_only'
+      | 'car_rental_agencies'
+      | 'car_washes'
+      | 'carpentry_services'
+      | 'carpet_upholstery_cleaning'
+      | 'caterers'
+      | 'charitable_and_social_service_organizations_fundraising'
+      | 'chemicals_and_allied_products'
+      | 'child_care_services'
+      | 'childrens_and_infants_wear_stores'
+      | 'chiropodists_podiatrists'
+      | 'chiropractors'
+      | 'cigar_stores_and_stands'
+      | 'civic_social_fraternal_associations'
+      | 'cleaning_and_maintenance'
+      | 'clothing_rental'
+      | 'colleges_universities'
+      | 'commercial_equipment'
+      | 'commercial_footwear'
+      | 'commercial_photography_art_and_graphics'
+      | 'commuter_transport_and_ferries'
+      | 'computer_network_services'
+      | 'computer_programming'
+      | 'computer_repair'
+      | 'computer_software_stores'
+      | 'computers_peripherals_and_software'
+      | 'concrete_work_services'
+      | 'construction_materials'
+      | 'consulting_public_relations'
+      | 'correspondence_schools'
+      | 'cosmetic_stores'
+      | 'counseling_services'
+      | 'country_clubs'
+      | 'courier_services'
+      | 'court_costs'
+      | 'credit_reporting_agencies'
+      | 'cruise_lines'
+      | 'dairy_products_stores'
+      | 'dance_hall_studios_schools'
+      | 'dating_escort_services'
+      | 'dentists_orthodontists'
+      | 'department_stores'
+      | 'detective_agencies'
+      | 'digital_goods_applications'
+      | 'digital_goods_games'
+      | 'digital_goods_large_volume'
+      | 'digital_goods_media'
+      | 'direct_marketing_catalog_merchant'
+      | 'direct_marketing_combination_catalog_and_retail_merchant'
+      | 'direct_marketing_inbound_telemarketing'
+      | 'direct_marketing_insurance_services'
+      | 'direct_marketing_other'
+      | 'direct_marketing_outbound_telemarketing'
+      | 'direct_marketing_subscription'
+      | 'direct_marketing_travel'
+      | 'discount_stores'
+      | 'doctors'
+      | 'door_to_door_sales'
+      | 'drapery_window_covering_and_upholstery_stores'
+      | 'drinking_places'
+      | 'drug_stores_and_pharmacies'
+      | 'drugs_drug_proprietaries_and_druggist_sundries'
+      | 'dry_cleaners'
+      | 'durable_goods'
+      | 'duty_free_stores'
+      | 'eating_places_restaurants'
+      | 'educational_services'
+      | 'electric_razor_stores'
+      | 'electric_vehicle_charging'
+      | 'electrical_parts_and_equipment'
+      | 'electrical_services'
+      | 'electronics_repair_shops'
+      | 'electronics_stores'
+      | 'elementary_secondary_schools'
+      | 'emergency_services_gcas_visa_use_only'
+      | 'employment_temp_agencies'
+      | 'equipment_rental'
+      | 'exterminating_services'
+      | 'family_clothing_stores'
+      | 'fast_food_restaurants'
+      | 'financial_institutions'
+      | 'fines_government_administrative_entities'
+      | 'fireplace_fireplace_screens_and_accessories_stores'
+      | 'floor_covering_stores'
+      | 'florists'
+      | 'florists_supplies_nursery_stock_and_flowers'
+      | 'freezer_and_locker_meat_provisioners'
+      | 'fuel_dealers_non_automotive'
+      | 'funeral_services_crematories'
+      | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
+      | 'furniture_repair_refinishing'
+      | 'furriers_and_fur_shops'
+      | 'general_services'
+      | 'gift_card_novelty_and_souvenir_shops'
+      | 'glass_paint_and_wallpaper_stores'
+      | 'glassware_crystal_stores'
+      | 'golf_courses_public'
+      | 'government_licensed_horse_dog_racing_us_region_only'
+      | 'government_licensed_online_casions_online_gambling_us_region_only'
+      | 'government_owned_lotteries_non_us_region'
+      | 'government_owned_lotteries_us_region_only'
+      | 'government_services'
+      | 'grocery_stores_supermarkets'
+      | 'hardware_equipment_and_supplies'
+      | 'hardware_stores'
+      | 'health_and_beauty_spas'
+      | 'hearing_aids_sales_and_supplies'
+      | 'heating_plumbing_a_c'
+      | 'hobby_toy_and_game_shops'
+      | 'home_supply_warehouse_stores'
+      | 'hospitals'
+      | 'hotels_motels_and_resorts'
+      | 'household_appliance_stores'
+      | 'industrial_supplies'
+      | 'information_retrieval_services'
+      | 'insurance_default'
+      | 'insurance_underwriting_premiums'
+      | 'intra_company_purchases'
+      | 'jewelry_stores_watches_clocks_and_silverware_stores'
+      | 'landscaping_services'
+      | 'laundries'
+      | 'laundry_cleaning_services'
+      | 'legal_services_attorneys'
+      | 'luggage_and_leather_goods_stores'
+      | 'lumber_building_materials_stores'
+      | 'manual_cash_disburse'
+      | 'marinas_service_and_supplies'
+      | 'marketplaces'
+      | 'masonry_stonework_and_plaster'
+      | 'massage_parlors'
+      | 'medical_and_dental_labs'
+      | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
+      | 'medical_services'
+      | 'membership_organizations'
+      | 'mens_and_boys_clothing_and_accessories_stores'
+      | 'mens_womens_clothing_stores'
+      | 'metal_service_centers'
+      | 'miscellaneous'
+      | 'miscellaneous_apparel_and_accessory_shops'
+      | 'miscellaneous_auto_dealers'
+      | 'miscellaneous_business_services'
+      | 'miscellaneous_food_stores'
+      | 'miscellaneous_general_merchandise'
+      | 'miscellaneous_general_services'
+      | 'miscellaneous_home_furnishing_specialty_stores'
+      | 'miscellaneous_publishing_and_printing'
+      | 'miscellaneous_recreation_services'
+      | 'miscellaneous_repair_shops'
+      | 'miscellaneous_specialty_retail'
+      | 'mobile_home_dealers'
+      | 'motion_picture_theaters'
+      | 'motor_freight_carriers_and_trucking'
+      | 'motor_homes_dealers'
+      | 'motor_vehicle_supplies_and_new_parts'
+      | 'motorcycle_shops_and_dealers'
+      | 'motorcycle_shops_dealers'
+      | 'music_stores_musical_instruments_pianos_and_sheet_music'
+      | 'news_dealers_and_newsstands'
+      | 'non_fi_money_orders'
+      | 'non_fi_stored_value_card_purchase_load'
+      | 'nondurable_goods'
+      | 'nurseries_lawn_and_garden_supply_stores'
+      | 'nursing_personal_care'
+      | 'office_and_commercial_furniture'
+      | 'opticians_eyeglasses'
+      | 'optometrists_ophthalmologist'
+      | 'orthopedic_goods_prosthetic_devices'
+      | 'osteopaths'
+      | 'package_stores_beer_wine_and_liquor'
+      | 'paints_varnishes_and_supplies'
+      | 'parking_lots_garages'
+      | 'passenger_railways'
+      | 'pawn_shops'
+      | 'pet_shops_pet_food_and_supplies'
+      | 'petroleum_and_petroleum_products'
+      | 'photo_developing'
+      | 'photographic_photocopy_microfilm_equipment_and_supplies'
+      | 'photographic_studios'
+      | 'picture_video_production'
+      | 'piece_goods_notions_and_other_dry_goods'
+      | 'plumbing_heating_equipment_and_supplies'
+      | 'political_organizations'
+      | 'postal_services_government_only'
+      | 'precious_stones_and_metals_watches_and_jewelry'
+      | 'professional_services'
+      | 'public_warehousing_and_storage'
+      | 'quick_copy_repro_and_blueprint'
+      | 'railroads'
+      | 'real_estate_agents_and_managers_rentals'
+      | 'record_stores'
+      | 'recreational_vehicle_rentals'
+      | 'religious_goods_stores'
+      | 'religious_organizations'
+      | 'roofing_siding_sheet_metal'
+      | 'secretarial_support_services'
+      | 'security_brokers_dealers'
+      | 'service_stations'
+      | 'sewing_needlework_fabric_and_piece_goods_stores'
+      | 'shoe_repair_hat_cleaning'
+      | 'shoe_stores'
+      | 'small_appliance_repair'
+      | 'snowmobile_dealers'
+      | 'special_trade_services'
+      | 'specialty_cleaning'
+      | 'sporting_goods_stores'
+      | 'sporting_recreation_camps'
+      | 'sports_and_riding_apparel_stores'
+      | 'sports_clubs_fields'
+      | 'stamp_and_coin_stores'
+      | 'stationary_office_supplies_printing_and_writing_paper'
+      | 'stationery_stores_office_and_school_supply_stores'
+      | 'swimming_pools_sales'
+      | 't_ui_travel_germany'
+      | 'tailors_alterations'
+      | 'tax_payments_government_agencies'
+      | 'tax_preparation_services'
+      | 'taxicabs_limousines'
+      | 'telecommunication_equipment_and_telephone_sales'
+      | 'telecommunication_services'
+      | 'telegraph_services'
+      | 'tent_and_awning_shops'
+      | 'testing_laboratories'
+      | 'theatrical_ticket_agencies'
+      | 'timeshares'
+      | 'tire_retreading_and_repair'
+      | 'tolls_bridge_fees'
+      | 'tourist_attractions_and_exhibits'
+      | 'towing_services'
+      | 'trailer_parks_campgrounds'
+      | 'transportation_services'
+      | 'travel_agencies_tour_operators'
+      | 'truck_stop_iteration'
+      | 'truck_utility_trailer_rentals'
+      | 'typesetting_plate_making_and_related_services'
+      | 'typewriter_stores'
+      | 'u_s_federal_government_agencies_or_departments'
+      | 'uniforms_commercial_clothing'
+      | 'used_merchandise_and_secondhand_stores'
+      | 'utilities'
+      | 'variety_stores'
+      | 'veterinary_services'
+      | 'video_amusement_game_supplies'
+      | 'video_game_arcades'
+      | 'video_tape_rental_stores'
+      | 'vocational_trade_schools'
+      | 'watch_jewelry_repair'
+      | 'welding_repair'
+      | 'wholesale_clubs'
+      | 'wig_and_toupee_stores'
+      | 'wires_money_orders'
+      | 'womens_accessory_and_specialty_shops'
+      | 'womens_ready_to_wear_stores'
+      | 'wrecking_and_salvage_yards';
+
+    export type BlockedCardPresence = 'not_present' | 'present';
+
+    export type BlockedCategory =
+      | 'ac_refrigeration_repair'
+      | 'accounting_bookkeeping_services'
+      | 'advertising_services'
+      | 'agricultural_cooperative'
+      | 'airlines_air_carriers'
+      | 'airports_flying_fields'
+      | 'ambulance_services'
+      | 'amusement_parks_carnivals'
+      | 'antique_reproductions'
+      | 'antique_shops'
+      | 'aquariums'
+      | 'architectural_surveying_services'
+      | 'art_dealers_and_galleries'
+      | 'artists_supply_and_craft_shops'
+      | 'auto_and_home_supply_stores'
+      | 'auto_body_repair_shops'
+      | 'auto_paint_shops'
+      | 'auto_service_shops'
+      | 'automated_cash_disburse'
+      | 'automated_fuel_dispensers'
+      | 'automobile_associations'
+      | 'automotive_parts_and_accessories_stores'
+      | 'automotive_tire_stores'
+      | 'bail_and_bond_payments'
+      | 'bakeries'
+      | 'bands_orchestras'
+      | 'barber_and_beauty_shops'
+      | 'betting_casino_gambling'
+      | 'bicycle_shops'
+      | 'billiard_pool_establishments'
+      | 'boat_dealers'
+      | 'boat_rentals_and_leases'
+      | 'book_stores'
+      | 'books_periodicals_and_newspapers'
+      | 'bowling_alleys'
+      | 'bus_lines'
+      | 'business_secretarial_schools'
+      | 'buying_shopping_services'
+      | 'cable_satellite_and_other_pay_television_and_radio'
+      | 'camera_and_photographic_supply_stores'
+      | 'candy_nut_and_confectionery_stores'
+      | 'car_and_truck_dealers_new_used'
+      | 'car_and_truck_dealers_used_only'
+      | 'car_rental_agencies'
+      | 'car_washes'
+      | 'carpentry_services'
+      | 'carpet_upholstery_cleaning'
+      | 'caterers'
+      | 'charitable_and_social_service_organizations_fundraising'
+      | 'chemicals_and_allied_products'
+      | 'child_care_services'
+      | 'childrens_and_infants_wear_stores'
+      | 'chiropodists_podiatrists'
+      | 'chiropractors'
+      | 'cigar_stores_and_stands'
+      | 'civic_social_fraternal_associations'
+      | 'cleaning_and_maintenance'
+      | 'clothing_rental'
+      | 'colleges_universities'
+      | 'commercial_equipment'
+      | 'commercial_footwear'
+      | 'commercial_photography_art_and_graphics'
+      | 'commuter_transport_and_ferries'
+      | 'computer_network_services'
+      | 'computer_programming'
+      | 'computer_repair'
+      | 'computer_software_stores'
+      | 'computers_peripherals_and_software'
+      | 'concrete_work_services'
+      | 'construction_materials'
+      | 'consulting_public_relations'
+      | 'correspondence_schools'
+      | 'cosmetic_stores'
+      | 'counseling_services'
+      | 'country_clubs'
+      | 'courier_services'
+      | 'court_costs'
+      | 'credit_reporting_agencies'
+      | 'cruise_lines'
+      | 'dairy_products_stores'
+      | 'dance_hall_studios_schools'
+      | 'dating_escort_services'
+      | 'dentists_orthodontists'
+      | 'department_stores'
+      | 'detective_agencies'
+      | 'digital_goods_applications'
+      | 'digital_goods_games'
+      | 'digital_goods_large_volume'
+      | 'digital_goods_media'
+      | 'direct_marketing_catalog_merchant'
+      | 'direct_marketing_combination_catalog_and_retail_merchant'
+      | 'direct_marketing_inbound_telemarketing'
+      | 'direct_marketing_insurance_services'
+      | 'direct_marketing_other'
+      | 'direct_marketing_outbound_telemarketing'
+      | 'direct_marketing_subscription'
+      | 'direct_marketing_travel'
+      | 'discount_stores'
+      | 'doctors'
+      | 'door_to_door_sales'
+      | 'drapery_window_covering_and_upholstery_stores'
+      | 'drinking_places'
+      | 'drug_stores_and_pharmacies'
+      | 'drugs_drug_proprietaries_and_druggist_sundries'
+      | 'dry_cleaners'
+      | 'durable_goods'
+      | 'duty_free_stores'
+      | 'eating_places_restaurants'
+      | 'educational_services'
+      | 'electric_razor_stores'
+      | 'electric_vehicle_charging'
+      | 'electrical_parts_and_equipment'
+      | 'electrical_services'
+      | 'electronics_repair_shops'
+      | 'electronics_stores'
+      | 'elementary_secondary_schools'
+      | 'emergency_services_gcas_visa_use_only'
+      | 'employment_temp_agencies'
+      | 'equipment_rental'
+      | 'exterminating_services'
+      | 'family_clothing_stores'
+      | 'fast_food_restaurants'
+      | 'financial_institutions'
+      | 'fines_government_administrative_entities'
+      | 'fireplace_fireplace_screens_and_accessories_stores'
+      | 'floor_covering_stores'
+      | 'florists'
+      | 'florists_supplies_nursery_stock_and_flowers'
+      | 'freezer_and_locker_meat_provisioners'
+      | 'fuel_dealers_non_automotive'
+      | 'funeral_services_crematories'
+      | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
+      | 'furniture_repair_refinishing'
+      | 'furriers_and_fur_shops'
+      | 'general_services'
+      | 'gift_card_novelty_and_souvenir_shops'
+      | 'glass_paint_and_wallpaper_stores'
+      | 'glassware_crystal_stores'
+      | 'golf_courses_public'
+      | 'government_licensed_horse_dog_racing_us_region_only'
+      | 'government_licensed_online_casions_online_gambling_us_region_only'
+      | 'government_owned_lotteries_non_us_region'
+      | 'government_owned_lotteries_us_region_only'
+      | 'government_services'
+      | 'grocery_stores_supermarkets'
+      | 'hardware_equipment_and_supplies'
+      | 'hardware_stores'
+      | 'health_and_beauty_spas'
+      | 'hearing_aids_sales_and_supplies'
+      | 'heating_plumbing_a_c'
+      | 'hobby_toy_and_game_shops'
+      | 'home_supply_warehouse_stores'
+      | 'hospitals'
+      | 'hotels_motels_and_resorts'
+      | 'household_appliance_stores'
+      | 'industrial_supplies'
+      | 'information_retrieval_services'
+      | 'insurance_default'
+      | 'insurance_underwriting_premiums'
+      | 'intra_company_purchases'
+      | 'jewelry_stores_watches_clocks_and_silverware_stores'
+      | 'landscaping_services'
+      | 'laundries'
+      | 'laundry_cleaning_services'
+      | 'legal_services_attorneys'
+      | 'luggage_and_leather_goods_stores'
+      | 'lumber_building_materials_stores'
+      | 'manual_cash_disburse'
+      | 'marinas_service_and_supplies'
+      | 'marketplaces'
+      | 'masonry_stonework_and_plaster'
+      | 'massage_parlors'
+      | 'medical_and_dental_labs'
+      | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
+      | 'medical_services'
+      | 'membership_organizations'
+      | 'mens_and_boys_clothing_and_accessories_stores'
+      | 'mens_womens_clothing_stores'
+      | 'metal_service_centers'
+      | 'miscellaneous'
+      | 'miscellaneous_apparel_and_accessory_shops'
+      | 'miscellaneous_auto_dealers'
+      | 'miscellaneous_business_services'
+      | 'miscellaneous_food_stores'
+      | 'miscellaneous_general_merchandise'
+      | 'miscellaneous_general_services'
+      | 'miscellaneous_home_furnishing_specialty_stores'
+      | 'miscellaneous_publishing_and_printing'
+      | 'miscellaneous_recreation_services'
+      | 'miscellaneous_repair_shops'
+      | 'miscellaneous_specialty_retail'
+      | 'mobile_home_dealers'
+      | 'motion_picture_theaters'
+      | 'motor_freight_carriers_and_trucking'
+      | 'motor_homes_dealers'
+      | 'motor_vehicle_supplies_and_new_parts'
+      | 'motorcycle_shops_and_dealers'
+      | 'motorcycle_shops_dealers'
+      | 'music_stores_musical_instruments_pianos_and_sheet_music'
+      | 'news_dealers_and_newsstands'
+      | 'non_fi_money_orders'
+      | 'non_fi_stored_value_card_purchase_load'
+      | 'nondurable_goods'
+      | 'nurseries_lawn_and_garden_supply_stores'
+      | 'nursing_personal_care'
+      | 'office_and_commercial_furniture'
+      | 'opticians_eyeglasses'
+      | 'optometrists_ophthalmologist'
+      | 'orthopedic_goods_prosthetic_devices'
+      | 'osteopaths'
+      | 'package_stores_beer_wine_and_liquor'
+      | 'paints_varnishes_and_supplies'
+      | 'parking_lots_garages'
+      | 'passenger_railways'
+      | 'pawn_shops'
+      | 'pet_shops_pet_food_and_supplies'
+      | 'petroleum_and_petroleum_products'
+      | 'photo_developing'
+      | 'photographic_photocopy_microfilm_equipment_and_supplies'
+      | 'photographic_studios'
+      | 'picture_video_production'
+      | 'piece_goods_notions_and_other_dry_goods'
+      | 'plumbing_heating_equipment_and_supplies'
+      | 'political_organizations'
+      | 'postal_services_government_only'
+      | 'precious_stones_and_metals_watches_and_jewelry'
+      | 'professional_services'
+      | 'public_warehousing_and_storage'
+      | 'quick_copy_repro_and_blueprint'
+      | 'railroads'
+      | 'real_estate_agents_and_managers_rentals'
+      | 'record_stores'
+      | 'recreational_vehicle_rentals'
+      | 'religious_goods_stores'
+      | 'religious_organizations'
+      | 'roofing_siding_sheet_metal'
+      | 'secretarial_support_services'
+      | 'security_brokers_dealers'
+      | 'service_stations'
+      | 'sewing_needlework_fabric_and_piece_goods_stores'
+      | 'shoe_repair_hat_cleaning'
+      | 'shoe_stores'
+      | 'small_appliance_repair'
+      | 'snowmobile_dealers'
+      | 'special_trade_services'
+      | 'specialty_cleaning'
+      | 'sporting_goods_stores'
+      | 'sporting_recreation_camps'
+      | 'sports_and_riding_apparel_stores'
+      | 'sports_clubs_fields'
+      | 'stamp_and_coin_stores'
+      | 'stationary_office_supplies_printing_and_writing_paper'
+      | 'stationery_stores_office_and_school_supply_stores'
+      | 'swimming_pools_sales'
+      | 't_ui_travel_germany'
+      | 'tailors_alterations'
+      | 'tax_payments_government_agencies'
+      | 'tax_preparation_services'
+      | 'taxicabs_limousines'
+      | 'telecommunication_equipment_and_telephone_sales'
+      | 'telecommunication_services'
+      | 'telegraph_services'
+      | 'tent_and_awning_shops'
+      | 'testing_laboratories'
+      | 'theatrical_ticket_agencies'
+      | 'timeshares'
+      | 'tire_retreading_and_repair'
+      | 'tolls_bridge_fees'
+      | 'tourist_attractions_and_exhibits'
+      | 'towing_services'
+      | 'trailer_parks_campgrounds'
+      | 'transportation_services'
+      | 'travel_agencies_tour_operators'
+      | 'truck_stop_iteration'
+      | 'truck_utility_trailer_rentals'
+      | 'typesetting_plate_making_and_related_services'
+      | 'typewriter_stores'
+      | 'u_s_federal_government_agencies_or_departments'
+      | 'uniforms_commercial_clothing'
+      | 'used_merchandise_and_secondhand_stores'
+      | 'utilities'
+      | 'variety_stores'
+      | 'veterinary_services'
+      | 'video_amusement_game_supplies'
+      | 'video_game_arcades'
+      | 'video_tape_rental_stores'
+      | 'vocational_trade_schools'
+      | 'watch_jewelry_repair'
+      | 'welding_repair'
+      | 'wholesale_clubs'
+      | 'wig_and_toupee_stores'
+      | 'wires_money_orders'
+      | 'womens_accessory_and_specialty_shops'
+      | 'womens_ready_to_wear_stores'
+      | 'wrecking_and_salvage_yards';
+
+    export interface SpendingLimit {
+      /**
+       * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+       */
+      amount: number;
+
+      /**
+       * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
+       */
+      categories: Array<SpendingLimit.Category> | null;
+
+      /**
+       * Interval (or event) to which the amount applies.
+       */
+      interval: SpendingLimit.Interval;
     }
 
-    export namespace SpendingControls {
-      export type AllowedCardPresence = 'not_present' | 'present';
-
-      export type AllowedCategory =
+    export namespace SpendingLimit {
+      export type Category =
         | 'ac_refrigeration_repair'
         | 'accounting_bookkeeping_services'
         | 'advertising_services'
@@ -640,628 +1249,13 @@ export namespace Issuing {
         | 'womens_ready_to_wear_stores'
         | 'wrecking_and_salvage_yards';
 
-      export type BlockedCardPresence = 'not_present' | 'present';
-
-      export type BlockedCategory =
-        | 'ac_refrigeration_repair'
-        | 'accounting_bookkeeping_services'
-        | 'advertising_services'
-        | 'agricultural_cooperative'
-        | 'airlines_air_carriers'
-        | 'airports_flying_fields'
-        | 'ambulance_services'
-        | 'amusement_parks_carnivals'
-        | 'antique_reproductions'
-        | 'antique_shops'
-        | 'aquariums'
-        | 'architectural_surveying_services'
-        | 'art_dealers_and_galleries'
-        | 'artists_supply_and_craft_shops'
-        | 'auto_and_home_supply_stores'
-        | 'auto_body_repair_shops'
-        | 'auto_paint_shops'
-        | 'auto_service_shops'
-        | 'automated_cash_disburse'
-        | 'automated_fuel_dispensers'
-        | 'automobile_associations'
-        | 'automotive_parts_and_accessories_stores'
-        | 'automotive_tire_stores'
-        | 'bail_and_bond_payments'
-        | 'bakeries'
-        | 'bands_orchestras'
-        | 'barber_and_beauty_shops'
-        | 'betting_casino_gambling'
-        | 'bicycle_shops'
-        | 'billiard_pool_establishments'
-        | 'boat_dealers'
-        | 'boat_rentals_and_leases'
-        | 'book_stores'
-        | 'books_periodicals_and_newspapers'
-        | 'bowling_alleys'
-        | 'bus_lines'
-        | 'business_secretarial_schools'
-        | 'buying_shopping_services'
-        | 'cable_satellite_and_other_pay_television_and_radio'
-        | 'camera_and_photographic_supply_stores'
-        | 'candy_nut_and_confectionery_stores'
-        | 'car_and_truck_dealers_new_used'
-        | 'car_and_truck_dealers_used_only'
-        | 'car_rental_agencies'
-        | 'car_washes'
-        | 'carpentry_services'
-        | 'carpet_upholstery_cleaning'
-        | 'caterers'
-        | 'charitable_and_social_service_organizations_fundraising'
-        | 'chemicals_and_allied_products'
-        | 'child_care_services'
-        | 'childrens_and_infants_wear_stores'
-        | 'chiropodists_podiatrists'
-        | 'chiropractors'
-        | 'cigar_stores_and_stands'
-        | 'civic_social_fraternal_associations'
-        | 'cleaning_and_maintenance'
-        | 'clothing_rental'
-        | 'colleges_universities'
-        | 'commercial_equipment'
-        | 'commercial_footwear'
-        | 'commercial_photography_art_and_graphics'
-        | 'commuter_transport_and_ferries'
-        | 'computer_network_services'
-        | 'computer_programming'
-        | 'computer_repair'
-        | 'computer_software_stores'
-        | 'computers_peripherals_and_software'
-        | 'concrete_work_services'
-        | 'construction_materials'
-        | 'consulting_public_relations'
-        | 'correspondence_schools'
-        | 'cosmetic_stores'
-        | 'counseling_services'
-        | 'country_clubs'
-        | 'courier_services'
-        | 'court_costs'
-        | 'credit_reporting_agencies'
-        | 'cruise_lines'
-        | 'dairy_products_stores'
-        | 'dance_hall_studios_schools'
-        | 'dating_escort_services'
-        | 'dentists_orthodontists'
-        | 'department_stores'
-        | 'detective_agencies'
-        | 'digital_goods_applications'
-        | 'digital_goods_games'
-        | 'digital_goods_large_volume'
-        | 'digital_goods_media'
-        | 'direct_marketing_catalog_merchant'
-        | 'direct_marketing_combination_catalog_and_retail_merchant'
-        | 'direct_marketing_inbound_telemarketing'
-        | 'direct_marketing_insurance_services'
-        | 'direct_marketing_other'
-        | 'direct_marketing_outbound_telemarketing'
-        | 'direct_marketing_subscription'
-        | 'direct_marketing_travel'
-        | 'discount_stores'
-        | 'doctors'
-        | 'door_to_door_sales'
-        | 'drapery_window_covering_and_upholstery_stores'
-        | 'drinking_places'
-        | 'drug_stores_and_pharmacies'
-        | 'drugs_drug_proprietaries_and_druggist_sundries'
-        | 'dry_cleaners'
-        | 'durable_goods'
-        | 'duty_free_stores'
-        | 'eating_places_restaurants'
-        | 'educational_services'
-        | 'electric_razor_stores'
-        | 'electric_vehicle_charging'
-        | 'electrical_parts_and_equipment'
-        | 'electrical_services'
-        | 'electronics_repair_shops'
-        | 'electronics_stores'
-        | 'elementary_secondary_schools'
-        | 'emergency_services_gcas_visa_use_only'
-        | 'employment_temp_agencies'
-        | 'equipment_rental'
-        | 'exterminating_services'
-        | 'family_clothing_stores'
-        | 'fast_food_restaurants'
-        | 'financial_institutions'
-        | 'fines_government_administrative_entities'
-        | 'fireplace_fireplace_screens_and_accessories_stores'
-        | 'floor_covering_stores'
-        | 'florists'
-        | 'florists_supplies_nursery_stock_and_flowers'
-        | 'freezer_and_locker_meat_provisioners'
-        | 'fuel_dealers_non_automotive'
-        | 'funeral_services_crematories'
-        | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
-        | 'furniture_repair_refinishing'
-        | 'furriers_and_fur_shops'
-        | 'general_services'
-        | 'gift_card_novelty_and_souvenir_shops'
-        | 'glass_paint_and_wallpaper_stores'
-        | 'glassware_crystal_stores'
-        | 'golf_courses_public'
-        | 'government_licensed_horse_dog_racing_us_region_only'
-        | 'government_licensed_online_casions_online_gambling_us_region_only'
-        | 'government_owned_lotteries_non_us_region'
-        | 'government_owned_lotteries_us_region_only'
-        | 'government_services'
-        | 'grocery_stores_supermarkets'
-        | 'hardware_equipment_and_supplies'
-        | 'hardware_stores'
-        | 'health_and_beauty_spas'
-        | 'hearing_aids_sales_and_supplies'
-        | 'heating_plumbing_a_c'
-        | 'hobby_toy_and_game_shops'
-        | 'home_supply_warehouse_stores'
-        | 'hospitals'
-        | 'hotels_motels_and_resorts'
-        | 'household_appliance_stores'
-        | 'industrial_supplies'
-        | 'information_retrieval_services'
-        | 'insurance_default'
-        | 'insurance_underwriting_premiums'
-        | 'intra_company_purchases'
-        | 'jewelry_stores_watches_clocks_and_silverware_stores'
-        | 'landscaping_services'
-        | 'laundries'
-        | 'laundry_cleaning_services'
-        | 'legal_services_attorneys'
-        | 'luggage_and_leather_goods_stores'
-        | 'lumber_building_materials_stores'
-        | 'manual_cash_disburse'
-        | 'marinas_service_and_supplies'
-        | 'marketplaces'
-        | 'masonry_stonework_and_plaster'
-        | 'massage_parlors'
-        | 'medical_and_dental_labs'
-        | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
-        | 'medical_services'
-        | 'membership_organizations'
-        | 'mens_and_boys_clothing_and_accessories_stores'
-        | 'mens_womens_clothing_stores'
-        | 'metal_service_centers'
-        | 'miscellaneous'
-        | 'miscellaneous_apparel_and_accessory_shops'
-        | 'miscellaneous_auto_dealers'
-        | 'miscellaneous_business_services'
-        | 'miscellaneous_food_stores'
-        | 'miscellaneous_general_merchandise'
-        | 'miscellaneous_general_services'
-        | 'miscellaneous_home_furnishing_specialty_stores'
-        | 'miscellaneous_publishing_and_printing'
-        | 'miscellaneous_recreation_services'
-        | 'miscellaneous_repair_shops'
-        | 'miscellaneous_specialty_retail'
-        | 'mobile_home_dealers'
-        | 'motion_picture_theaters'
-        | 'motor_freight_carriers_and_trucking'
-        | 'motor_homes_dealers'
-        | 'motor_vehicle_supplies_and_new_parts'
-        | 'motorcycle_shops_and_dealers'
-        | 'motorcycle_shops_dealers'
-        | 'music_stores_musical_instruments_pianos_and_sheet_music'
-        | 'news_dealers_and_newsstands'
-        | 'non_fi_money_orders'
-        | 'non_fi_stored_value_card_purchase_load'
-        | 'nondurable_goods'
-        | 'nurseries_lawn_and_garden_supply_stores'
-        | 'nursing_personal_care'
-        | 'office_and_commercial_furniture'
-        | 'opticians_eyeglasses'
-        | 'optometrists_ophthalmologist'
-        | 'orthopedic_goods_prosthetic_devices'
-        | 'osteopaths'
-        | 'package_stores_beer_wine_and_liquor'
-        | 'paints_varnishes_and_supplies'
-        | 'parking_lots_garages'
-        | 'passenger_railways'
-        | 'pawn_shops'
-        | 'pet_shops_pet_food_and_supplies'
-        | 'petroleum_and_petroleum_products'
-        | 'photo_developing'
-        | 'photographic_photocopy_microfilm_equipment_and_supplies'
-        | 'photographic_studios'
-        | 'picture_video_production'
-        | 'piece_goods_notions_and_other_dry_goods'
-        | 'plumbing_heating_equipment_and_supplies'
-        | 'political_organizations'
-        | 'postal_services_government_only'
-        | 'precious_stones_and_metals_watches_and_jewelry'
-        | 'professional_services'
-        | 'public_warehousing_and_storage'
-        | 'quick_copy_repro_and_blueprint'
-        | 'railroads'
-        | 'real_estate_agents_and_managers_rentals'
-        | 'record_stores'
-        | 'recreational_vehicle_rentals'
-        | 'religious_goods_stores'
-        | 'religious_organizations'
-        | 'roofing_siding_sheet_metal'
-        | 'secretarial_support_services'
-        | 'security_brokers_dealers'
-        | 'service_stations'
-        | 'sewing_needlework_fabric_and_piece_goods_stores'
-        | 'shoe_repair_hat_cleaning'
-        | 'shoe_stores'
-        | 'small_appliance_repair'
-        | 'snowmobile_dealers'
-        | 'special_trade_services'
-        | 'specialty_cleaning'
-        | 'sporting_goods_stores'
-        | 'sporting_recreation_camps'
-        | 'sports_and_riding_apparel_stores'
-        | 'sports_clubs_fields'
-        | 'stamp_and_coin_stores'
-        | 'stationary_office_supplies_printing_and_writing_paper'
-        | 'stationery_stores_office_and_school_supply_stores'
-        | 'swimming_pools_sales'
-        | 't_ui_travel_germany'
-        | 'tailors_alterations'
-        | 'tax_payments_government_agencies'
-        | 'tax_preparation_services'
-        | 'taxicabs_limousines'
-        | 'telecommunication_equipment_and_telephone_sales'
-        | 'telecommunication_services'
-        | 'telegraph_services'
-        | 'tent_and_awning_shops'
-        | 'testing_laboratories'
-        | 'theatrical_ticket_agencies'
-        | 'timeshares'
-        | 'tire_retreading_and_repair'
-        | 'tolls_bridge_fees'
-        | 'tourist_attractions_and_exhibits'
-        | 'towing_services'
-        | 'trailer_parks_campgrounds'
-        | 'transportation_services'
-        | 'travel_agencies_tour_operators'
-        | 'truck_stop_iteration'
-        | 'truck_utility_trailer_rentals'
-        | 'typesetting_plate_making_and_related_services'
-        | 'typewriter_stores'
-        | 'u_s_federal_government_agencies_or_departments'
-        | 'uniforms_commercial_clothing'
-        | 'used_merchandise_and_secondhand_stores'
-        | 'utilities'
-        | 'variety_stores'
-        | 'veterinary_services'
-        | 'video_amusement_game_supplies'
-        | 'video_game_arcades'
-        | 'video_tape_rental_stores'
-        | 'vocational_trade_schools'
-        | 'watch_jewelry_repair'
-        | 'welding_repair'
-        | 'wholesale_clubs'
-        | 'wig_and_toupee_stores'
-        | 'wires_money_orders'
-        | 'womens_accessory_and_specialty_shops'
-        | 'womens_ready_to_wear_stores'
-        | 'wrecking_and_salvage_yards';
-
-      export interface SpendingLimit {
-        /**
-         * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-         */
-        amount: number;
-
-        /**
-         * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
-         */
-        categories: Array<SpendingLimit.Category> | null;
-
-        /**
-         * Interval (or event) to which the amount applies.
-         */
-        interval: SpendingLimit.Interval;
-      }
-
-      export namespace SpendingLimit {
-        export type Category =
-          | 'ac_refrigeration_repair'
-          | 'accounting_bookkeeping_services'
-          | 'advertising_services'
-          | 'agricultural_cooperative'
-          | 'airlines_air_carriers'
-          | 'airports_flying_fields'
-          | 'ambulance_services'
-          | 'amusement_parks_carnivals'
-          | 'antique_reproductions'
-          | 'antique_shops'
-          | 'aquariums'
-          | 'architectural_surveying_services'
-          | 'art_dealers_and_galleries'
-          | 'artists_supply_and_craft_shops'
-          | 'auto_and_home_supply_stores'
-          | 'auto_body_repair_shops'
-          | 'auto_paint_shops'
-          | 'auto_service_shops'
-          | 'automated_cash_disburse'
-          | 'automated_fuel_dispensers'
-          | 'automobile_associations'
-          | 'automotive_parts_and_accessories_stores'
-          | 'automotive_tire_stores'
-          | 'bail_and_bond_payments'
-          | 'bakeries'
-          | 'bands_orchestras'
-          | 'barber_and_beauty_shops'
-          | 'betting_casino_gambling'
-          | 'bicycle_shops'
-          | 'billiard_pool_establishments'
-          | 'boat_dealers'
-          | 'boat_rentals_and_leases'
-          | 'book_stores'
-          | 'books_periodicals_and_newspapers'
-          | 'bowling_alleys'
-          | 'bus_lines'
-          | 'business_secretarial_schools'
-          | 'buying_shopping_services'
-          | 'cable_satellite_and_other_pay_television_and_radio'
-          | 'camera_and_photographic_supply_stores'
-          | 'candy_nut_and_confectionery_stores'
-          | 'car_and_truck_dealers_new_used'
-          | 'car_and_truck_dealers_used_only'
-          | 'car_rental_agencies'
-          | 'car_washes'
-          | 'carpentry_services'
-          | 'carpet_upholstery_cleaning'
-          | 'caterers'
-          | 'charitable_and_social_service_organizations_fundraising'
-          | 'chemicals_and_allied_products'
-          | 'child_care_services'
-          | 'childrens_and_infants_wear_stores'
-          | 'chiropodists_podiatrists'
-          | 'chiropractors'
-          | 'cigar_stores_and_stands'
-          | 'civic_social_fraternal_associations'
-          | 'cleaning_and_maintenance'
-          | 'clothing_rental'
-          | 'colleges_universities'
-          | 'commercial_equipment'
-          | 'commercial_footwear'
-          | 'commercial_photography_art_and_graphics'
-          | 'commuter_transport_and_ferries'
-          | 'computer_network_services'
-          | 'computer_programming'
-          | 'computer_repair'
-          | 'computer_software_stores'
-          | 'computers_peripherals_and_software'
-          | 'concrete_work_services'
-          | 'construction_materials'
-          | 'consulting_public_relations'
-          | 'correspondence_schools'
-          | 'cosmetic_stores'
-          | 'counseling_services'
-          | 'country_clubs'
-          | 'courier_services'
-          | 'court_costs'
-          | 'credit_reporting_agencies'
-          | 'cruise_lines'
-          | 'dairy_products_stores'
-          | 'dance_hall_studios_schools'
-          | 'dating_escort_services'
-          | 'dentists_orthodontists'
-          | 'department_stores'
-          | 'detective_agencies'
-          | 'digital_goods_applications'
-          | 'digital_goods_games'
-          | 'digital_goods_large_volume'
-          | 'digital_goods_media'
-          | 'direct_marketing_catalog_merchant'
-          | 'direct_marketing_combination_catalog_and_retail_merchant'
-          | 'direct_marketing_inbound_telemarketing'
-          | 'direct_marketing_insurance_services'
-          | 'direct_marketing_other'
-          | 'direct_marketing_outbound_telemarketing'
-          | 'direct_marketing_subscription'
-          | 'direct_marketing_travel'
-          | 'discount_stores'
-          | 'doctors'
-          | 'door_to_door_sales'
-          | 'drapery_window_covering_and_upholstery_stores'
-          | 'drinking_places'
-          | 'drug_stores_and_pharmacies'
-          | 'drugs_drug_proprietaries_and_druggist_sundries'
-          | 'dry_cleaners'
-          | 'durable_goods'
-          | 'duty_free_stores'
-          | 'eating_places_restaurants'
-          | 'educational_services'
-          | 'electric_razor_stores'
-          | 'electric_vehicle_charging'
-          | 'electrical_parts_and_equipment'
-          | 'electrical_services'
-          | 'electronics_repair_shops'
-          | 'electronics_stores'
-          | 'elementary_secondary_schools'
-          | 'emergency_services_gcas_visa_use_only'
-          | 'employment_temp_agencies'
-          | 'equipment_rental'
-          | 'exterminating_services'
-          | 'family_clothing_stores'
-          | 'fast_food_restaurants'
-          | 'financial_institutions'
-          | 'fines_government_administrative_entities'
-          | 'fireplace_fireplace_screens_and_accessories_stores'
-          | 'floor_covering_stores'
-          | 'florists'
-          | 'florists_supplies_nursery_stock_and_flowers'
-          | 'freezer_and_locker_meat_provisioners'
-          | 'fuel_dealers_non_automotive'
-          | 'funeral_services_crematories'
-          | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
-          | 'furniture_repair_refinishing'
-          | 'furriers_and_fur_shops'
-          | 'general_services'
-          | 'gift_card_novelty_and_souvenir_shops'
-          | 'glass_paint_and_wallpaper_stores'
-          | 'glassware_crystal_stores'
-          | 'golf_courses_public'
-          | 'government_licensed_horse_dog_racing_us_region_only'
-          | 'government_licensed_online_casions_online_gambling_us_region_only'
-          | 'government_owned_lotteries_non_us_region'
-          | 'government_owned_lotteries_us_region_only'
-          | 'government_services'
-          | 'grocery_stores_supermarkets'
-          | 'hardware_equipment_and_supplies'
-          | 'hardware_stores'
-          | 'health_and_beauty_spas'
-          | 'hearing_aids_sales_and_supplies'
-          | 'heating_plumbing_a_c'
-          | 'hobby_toy_and_game_shops'
-          | 'home_supply_warehouse_stores'
-          | 'hospitals'
-          | 'hotels_motels_and_resorts'
-          | 'household_appliance_stores'
-          | 'industrial_supplies'
-          | 'information_retrieval_services'
-          | 'insurance_default'
-          | 'insurance_underwriting_premiums'
-          | 'intra_company_purchases'
-          | 'jewelry_stores_watches_clocks_and_silverware_stores'
-          | 'landscaping_services'
-          | 'laundries'
-          | 'laundry_cleaning_services'
-          | 'legal_services_attorneys'
-          | 'luggage_and_leather_goods_stores'
-          | 'lumber_building_materials_stores'
-          | 'manual_cash_disburse'
-          | 'marinas_service_and_supplies'
-          | 'marketplaces'
-          | 'masonry_stonework_and_plaster'
-          | 'massage_parlors'
-          | 'medical_and_dental_labs'
-          | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
-          | 'medical_services'
-          | 'membership_organizations'
-          | 'mens_and_boys_clothing_and_accessories_stores'
-          | 'mens_womens_clothing_stores'
-          | 'metal_service_centers'
-          | 'miscellaneous'
-          | 'miscellaneous_apparel_and_accessory_shops'
-          | 'miscellaneous_auto_dealers'
-          | 'miscellaneous_business_services'
-          | 'miscellaneous_food_stores'
-          | 'miscellaneous_general_merchandise'
-          | 'miscellaneous_general_services'
-          | 'miscellaneous_home_furnishing_specialty_stores'
-          | 'miscellaneous_publishing_and_printing'
-          | 'miscellaneous_recreation_services'
-          | 'miscellaneous_repair_shops'
-          | 'miscellaneous_specialty_retail'
-          | 'mobile_home_dealers'
-          | 'motion_picture_theaters'
-          | 'motor_freight_carriers_and_trucking'
-          | 'motor_homes_dealers'
-          | 'motor_vehicle_supplies_and_new_parts'
-          | 'motorcycle_shops_and_dealers'
-          | 'motorcycle_shops_dealers'
-          | 'music_stores_musical_instruments_pianos_and_sheet_music'
-          | 'news_dealers_and_newsstands'
-          | 'non_fi_money_orders'
-          | 'non_fi_stored_value_card_purchase_load'
-          | 'nondurable_goods'
-          | 'nurseries_lawn_and_garden_supply_stores'
-          | 'nursing_personal_care'
-          | 'office_and_commercial_furniture'
-          | 'opticians_eyeglasses'
-          | 'optometrists_ophthalmologist'
-          | 'orthopedic_goods_prosthetic_devices'
-          | 'osteopaths'
-          | 'package_stores_beer_wine_and_liquor'
-          | 'paints_varnishes_and_supplies'
-          | 'parking_lots_garages'
-          | 'passenger_railways'
-          | 'pawn_shops'
-          | 'pet_shops_pet_food_and_supplies'
-          | 'petroleum_and_petroleum_products'
-          | 'photo_developing'
-          | 'photographic_photocopy_microfilm_equipment_and_supplies'
-          | 'photographic_studios'
-          | 'picture_video_production'
-          | 'piece_goods_notions_and_other_dry_goods'
-          | 'plumbing_heating_equipment_and_supplies'
-          | 'political_organizations'
-          | 'postal_services_government_only'
-          | 'precious_stones_and_metals_watches_and_jewelry'
-          | 'professional_services'
-          | 'public_warehousing_and_storage'
-          | 'quick_copy_repro_and_blueprint'
-          | 'railroads'
-          | 'real_estate_agents_and_managers_rentals'
-          | 'record_stores'
-          | 'recreational_vehicle_rentals'
-          | 'religious_goods_stores'
-          | 'religious_organizations'
-          | 'roofing_siding_sheet_metal'
-          | 'secretarial_support_services'
-          | 'security_brokers_dealers'
-          | 'service_stations'
-          | 'sewing_needlework_fabric_and_piece_goods_stores'
-          | 'shoe_repair_hat_cleaning'
-          | 'shoe_stores'
-          | 'small_appliance_repair'
-          | 'snowmobile_dealers'
-          | 'special_trade_services'
-          | 'specialty_cleaning'
-          | 'sporting_goods_stores'
-          | 'sporting_recreation_camps'
-          | 'sports_and_riding_apparel_stores'
-          | 'sports_clubs_fields'
-          | 'stamp_and_coin_stores'
-          | 'stationary_office_supplies_printing_and_writing_paper'
-          | 'stationery_stores_office_and_school_supply_stores'
-          | 'swimming_pools_sales'
-          | 't_ui_travel_germany'
-          | 'tailors_alterations'
-          | 'tax_payments_government_agencies'
-          | 'tax_preparation_services'
-          | 'taxicabs_limousines'
-          | 'telecommunication_equipment_and_telephone_sales'
-          | 'telecommunication_services'
-          | 'telegraph_services'
-          | 'tent_and_awning_shops'
-          | 'testing_laboratories'
-          | 'theatrical_ticket_agencies'
-          | 'timeshares'
-          | 'tire_retreading_and_repair'
-          | 'tolls_bridge_fees'
-          | 'tourist_attractions_and_exhibits'
-          | 'towing_services'
-          | 'trailer_parks_campgrounds'
-          | 'transportation_services'
-          | 'travel_agencies_tour_operators'
-          | 'truck_stop_iteration'
-          | 'truck_utility_trailer_rentals'
-          | 'typesetting_plate_making_and_related_services'
-          | 'typewriter_stores'
-          | 'u_s_federal_government_agencies_or_departments'
-          | 'uniforms_commercial_clothing'
-          | 'used_merchandise_and_secondhand_stores'
-          | 'utilities'
-          | 'variety_stores'
-          | 'veterinary_services'
-          | 'video_amusement_game_supplies'
-          | 'video_game_arcades'
-          | 'video_tape_rental_stores'
-          | 'vocational_trade_schools'
-          | 'watch_jewelry_repair'
-          | 'welding_repair'
-          | 'wholesale_clubs'
-          | 'wig_and_toupee_stores'
-          | 'wires_money_orders'
-          | 'womens_accessory_and_specialty_shops'
-          | 'womens_ready_to_wear_stores'
-          | 'wrecking_and_salvage_yards';
-
-        export type Interval =
-          | 'all_time'
-          | 'daily'
-          | 'monthly'
-          | 'per_authorization'
-          | 'weekly'
-          | 'yearly';
-      }
+      export type Interval =
+        | 'all_time'
+        | 'daily'
+        | 'monthly'
+        | 'per_authorization'
+        | 'weekly'
+        | 'yearly';
     }
   }
 }

--- a/src/resources/Issuing/Cards.ts
+++ b/src/resources/Issuing/Cards.ts
@@ -89,7 +89,7 @@ export interface Card {
   /**
    * The reason why the card was canceled.
    */
-  cancellation_reason: Issuing.Card.CancellationReason | null;
+  cancellation_reason: Card.CancellationReason | null;
 
   /**
    * An Issuing `Cardholder` object represents an individual or business entity who is [issued](https://docs.stripe.com/issuing) cards.
@@ -136,12 +136,12 @@ export interface Card {
   /**
    * Stripe's assessment of whether this card's details have been compromised. If this property isn't null, cancel and reissue the card to prevent fraudulent activity risk.
    */
-  latest_fraud_warning: Issuing.Card.LatestFraudWarning | null;
+  latest_fraud_warning: Card.LatestFraudWarning | null;
 
   /**
    * Rules that control the lifecycle of this card, such as automatic cancellation. Refer to our [documentation](https://docs.stripe.com/issuing/controls/lifecycle-controls) for more details.
    */
-  lifecycle_controls: Issuing.Card.LifecycleControls | null;
+  lifecycle_controls: Card.LifecycleControls | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -176,7 +176,7 @@ export interface Card {
   /**
    * The reason why the previous card needed to be replaced.
    */
-  replacement_reason: Issuing.Card.ReplacementReason | null;
+  replacement_reason: Card.ReplacementReason | null;
 
   /**
    * Text separate from cardholder name, printed on the card.
@@ -186,255 +186,864 @@ export interface Card {
   /**
    * Where and how the card will be shipped.
    */
-  shipping: Issuing.Card.Shipping | null;
+  shipping: Card.Shipping | null;
 
-  spending_controls: Issuing.Card.SpendingControls;
+  spending_controls: Card.SpendingControls;
 
   /**
    * Whether authorizations can be approved on this card. May be blocked from activating cards depending on past-due Cardholder requirements. Defaults to `inactive`.
    */
-  status: Issuing.Card.Status;
+  status: Card.Status;
 
   /**
    * The type of the card.
    */
-  type: Issuing.Card.Type;
+  type: Card.Type;
 
   /**
    * Information relating to digital wallets (like Apple Pay and Google Pay).
    */
-  wallets: Issuing.Card.Wallets | null;
+  wallets: Card.Wallets | null;
 }
-export namespace Issuing {
-  export namespace Card {
-    export type CancellationReason =
-      | 'design_rejected'
-      | 'fulfillment_error'
-      | 'lost'
-      | 'stolen';
+export namespace Card {
+  export type CancellationReason =
+    | 'design_rejected'
+    | 'fulfillment_error'
+    | 'lost'
+    | 'stolen';
 
-    export interface LatestFraudWarning {
+  export interface LatestFraudWarning {
+    /**
+     * Timestamp of the most recent fraud warning.
+     */
+    started_at: number | null;
+
+    /**
+     * The type of fraud warning that most recently took place on this card. This field updates with every new fraud warning, so the value changes over time. If populated, cancel and reissue the card.
+     */
+    type: LatestFraudWarning.Type | null;
+  }
+
+  export interface LifecycleControls {
+    cancel_after: LifecycleControls.CancelAfter;
+  }
+
+  export type ReplacementReason =
+    | 'damaged'
+    | 'expired'
+    | 'fulfillment_error'
+    | 'lost'
+    | 'stolen';
+
+  export interface Shipping {
+    address: Address;
+
+    /**
+     * Address validation details for the shipment.
+     */
+    address_validation: Shipping.AddressValidation | null;
+
+    /**
+     * The delivery company that shipped a card.
+     */
+    carrier: Shipping.Carrier | null;
+
+    /**
+     * Additional information that may be required for clearing customs.
+     */
+    customs: Shipping.Customs | null;
+
+    /**
+     * A unix timestamp representing a best estimate of when the card will be delivered.
+     */
+    eta: number | null;
+
+    /**
+     * Recipient name.
+     */
+    name: string;
+
+    /**
+     * The phone number of the receiver of the shipment. Our courier partners will use this number to contact you in the event of card delivery issues. For individual shipments to the EU/UK, if this field is empty, we will provide them with the phone number provided when the cardholder was initially created.
+     */
+    phone_number: string | null;
+
+    /**
+     * Whether a signature is required for card delivery. This feature is only supported for US users. Standard shipping service does not support signature on delivery. The default value for standard shipping service is false and for express and priority services is true.
+     */
+    require_signature: boolean | null;
+
+    /**
+     * Shipment service, such as `standard` or `express`.
+     */
+    service: Shipping.Service;
+
+    /**
+     * The delivery status of the card.
+     */
+    status: Shipping.Status | null;
+
+    /**
+     * A tracking number for a card shipment.
+     */
+    tracking_number: string | null;
+
+    /**
+     * A link to the shipping carrier's site where you can view detailed information about a card shipment.
+     */
+    tracking_url: string | null;
+
+    /**
+     * Packaging options.
+     */
+    type: Shipping.Type;
+  }
+
+  export interface SpendingControls {
+    /**
+     * Array of card presence statuses from which authorizations will be allowed. Possible options are `present`, `not_present`. All other statuses will be blocked. Cannot be set with `blocked_card_presences`. Provide an empty value to unset this control.
+     */
+    allowed_card_presences: Array<SpendingControls.AllowedCardPresence> | null;
+
+    /**
+     * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
+     */
+    allowed_categories: Array<SpendingControls.AllowedCategory> | null;
+
+    /**
+     * Array of strings containing representing countries from which authorizations will be allowed. Authorizations from merchants in all other countries will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `blocked_merchant_countries`. Provide an empty value to unset this control.
+     */
+    allowed_merchant_countries: Array<string> | null;
+
+    /**
+     * Array of card presence statuses from which authorizations will be declined. Possible options are `present`, `not_present`. Cannot be set with `allowed_card_presences`. Provide an empty value to unset this control.
+     */
+    blocked_card_presences: Array<SpendingControls.BlockedCardPresence> | null;
+
+    /**
+     * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
+     */
+    blocked_categories: Array<SpendingControls.BlockedCategory> | null;
+
+    /**
+     * Array of strings containing representing countries from which authorizations will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `allowed_merchant_countries`. Provide an empty value to unset this control.
+     */
+    blocked_merchant_countries: Array<string> | null;
+
+    /**
+     * Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
+     */
+    spending_limits: Array<SpendingControls.SpendingLimit> | null;
+
+    /**
+     * Currency of the amounts within `spending_limits`. Always the same as the currency of the card.
+     */
+    spending_limits_currency: string | null;
+  }
+
+  export type Status = 'active' | 'canceled' | 'inactive';
+
+  export type Type = 'physical' | 'virtual';
+
+  export interface Wallets {
+    apple_pay: Wallets.ApplePay;
+
+    google_pay: Wallets.GooglePay;
+
+    /**
+     * Unique identifier for a card used with digital wallets
+     */
+    primary_account_identifier: string | null;
+  }
+
+  export namespace LatestFraudWarning {
+    export type Type =
+      | 'card_testing_exposure'
+      | 'fraud_dispute_filed'
+      | 'third_party_reported'
+      | 'user_indicated_fraud';
+  }
+
+  export namespace LifecycleControls {
+    export interface CancelAfter {
       /**
-       * Timestamp of the most recent fraud warning.
+       * The card is automatically cancelled when it makes this number of non-zero payment authorizations and transactions. The count includes penny authorizations, but doesn't include non-payment actions, such as authorization advice.
        */
-      started_at: number | null;
+      payment_count: number;
+    }
+  }
+
+  export namespace Shipping {
+    export interface AddressValidation {
+      /**
+       * The address validation capabilities to use.
+       */
+      mode: AddressValidation.Mode;
 
       /**
-       * The type of fraud warning that most recently took place on this card. This field updates with every new fraud warning, so the value changes over time. If populated, cancel and reissue the card.
+       * The normalized shipping address.
        */
-      type: LatestFraudWarning.Type | null;
+      normalized_address: Address | null;
+
+      /**
+       * The validation result for the shipping address.
+       */
+      result: AddressValidation.Result | null;
     }
 
-    export interface LifecycleControls {
-      cancel_after: LifecycleControls.CancelAfter;
+    export type Carrier = 'dhl' | 'fedex' | 'royal_mail' | 'usps';
+
+    export interface Customs {
+      /**
+       * A registration number used for customs in Europe. See [https://www.gov.uk/eori](https://www.gov.uk/eori) for the UK and [https://ec.europa.eu/taxation_customs/business/customs-procedures-import-and-export/customs-procedures/economic-operators-registration-and-identification-number-eori_en](https://ec.europa.eu/taxation_customs/business/customs-procedures-import-and-export/customs-procedures/economic-operators-registration-and-identification-number-eori_en) for the EU.
+       */
+      eori_number: string | null;
     }
 
-    export type ReplacementReason =
-      | 'damaged'
-      | 'expired'
-      | 'fulfillment_error'
-      | 'lost'
-      | 'stolen';
+    export type Service = 'express' | 'priority' | 'standard';
 
-    export interface Shipping {
-      address: Address;
+    export type Status =
+      | 'canceled'
+      | 'delivered'
+      | 'failure'
+      | 'pending'
+      | 'returned'
+      | 'shipped'
+      | 'submitted';
+
+    export type Type = 'bulk' | 'individual';
+
+    export namespace AddressValidation {
+      export type Mode =
+        | 'disabled'
+        | 'normalization_only'
+        | 'validation_and_normalization';
+
+      export type Result =
+        | 'indeterminate'
+        | 'likely_deliverable'
+        | 'likely_undeliverable';
+    }
+  }
+
+  export namespace SpendingControls {
+    export type AllowedCardPresence = 'not_present' | 'present';
+
+    export type AllowedCategory =
+      | 'ac_refrigeration_repair'
+      | 'accounting_bookkeeping_services'
+      | 'advertising_services'
+      | 'agricultural_cooperative'
+      | 'airlines_air_carriers'
+      | 'airports_flying_fields'
+      | 'ambulance_services'
+      | 'amusement_parks_carnivals'
+      | 'antique_reproductions'
+      | 'antique_shops'
+      | 'aquariums'
+      | 'architectural_surveying_services'
+      | 'art_dealers_and_galleries'
+      | 'artists_supply_and_craft_shops'
+      | 'auto_and_home_supply_stores'
+      | 'auto_body_repair_shops'
+      | 'auto_paint_shops'
+      | 'auto_service_shops'
+      | 'automated_cash_disburse'
+      | 'automated_fuel_dispensers'
+      | 'automobile_associations'
+      | 'automotive_parts_and_accessories_stores'
+      | 'automotive_tire_stores'
+      | 'bail_and_bond_payments'
+      | 'bakeries'
+      | 'bands_orchestras'
+      | 'barber_and_beauty_shops'
+      | 'betting_casino_gambling'
+      | 'bicycle_shops'
+      | 'billiard_pool_establishments'
+      | 'boat_dealers'
+      | 'boat_rentals_and_leases'
+      | 'book_stores'
+      | 'books_periodicals_and_newspapers'
+      | 'bowling_alleys'
+      | 'bus_lines'
+      | 'business_secretarial_schools'
+      | 'buying_shopping_services'
+      | 'cable_satellite_and_other_pay_television_and_radio'
+      | 'camera_and_photographic_supply_stores'
+      | 'candy_nut_and_confectionery_stores'
+      | 'car_and_truck_dealers_new_used'
+      | 'car_and_truck_dealers_used_only'
+      | 'car_rental_agencies'
+      | 'car_washes'
+      | 'carpentry_services'
+      | 'carpet_upholstery_cleaning'
+      | 'caterers'
+      | 'charitable_and_social_service_organizations_fundraising'
+      | 'chemicals_and_allied_products'
+      | 'child_care_services'
+      | 'childrens_and_infants_wear_stores'
+      | 'chiropodists_podiatrists'
+      | 'chiropractors'
+      | 'cigar_stores_and_stands'
+      | 'civic_social_fraternal_associations'
+      | 'cleaning_and_maintenance'
+      | 'clothing_rental'
+      | 'colleges_universities'
+      | 'commercial_equipment'
+      | 'commercial_footwear'
+      | 'commercial_photography_art_and_graphics'
+      | 'commuter_transport_and_ferries'
+      | 'computer_network_services'
+      | 'computer_programming'
+      | 'computer_repair'
+      | 'computer_software_stores'
+      | 'computers_peripherals_and_software'
+      | 'concrete_work_services'
+      | 'construction_materials'
+      | 'consulting_public_relations'
+      | 'correspondence_schools'
+      | 'cosmetic_stores'
+      | 'counseling_services'
+      | 'country_clubs'
+      | 'courier_services'
+      | 'court_costs'
+      | 'credit_reporting_agencies'
+      | 'cruise_lines'
+      | 'dairy_products_stores'
+      | 'dance_hall_studios_schools'
+      | 'dating_escort_services'
+      | 'dentists_orthodontists'
+      | 'department_stores'
+      | 'detective_agencies'
+      | 'digital_goods_applications'
+      | 'digital_goods_games'
+      | 'digital_goods_large_volume'
+      | 'digital_goods_media'
+      | 'direct_marketing_catalog_merchant'
+      | 'direct_marketing_combination_catalog_and_retail_merchant'
+      | 'direct_marketing_inbound_telemarketing'
+      | 'direct_marketing_insurance_services'
+      | 'direct_marketing_other'
+      | 'direct_marketing_outbound_telemarketing'
+      | 'direct_marketing_subscription'
+      | 'direct_marketing_travel'
+      | 'discount_stores'
+      | 'doctors'
+      | 'door_to_door_sales'
+      | 'drapery_window_covering_and_upholstery_stores'
+      | 'drinking_places'
+      | 'drug_stores_and_pharmacies'
+      | 'drugs_drug_proprietaries_and_druggist_sundries'
+      | 'dry_cleaners'
+      | 'durable_goods'
+      | 'duty_free_stores'
+      | 'eating_places_restaurants'
+      | 'educational_services'
+      | 'electric_razor_stores'
+      | 'electric_vehicle_charging'
+      | 'electrical_parts_and_equipment'
+      | 'electrical_services'
+      | 'electronics_repair_shops'
+      | 'electronics_stores'
+      | 'elementary_secondary_schools'
+      | 'emergency_services_gcas_visa_use_only'
+      | 'employment_temp_agencies'
+      | 'equipment_rental'
+      | 'exterminating_services'
+      | 'family_clothing_stores'
+      | 'fast_food_restaurants'
+      | 'financial_institutions'
+      | 'fines_government_administrative_entities'
+      | 'fireplace_fireplace_screens_and_accessories_stores'
+      | 'floor_covering_stores'
+      | 'florists'
+      | 'florists_supplies_nursery_stock_and_flowers'
+      | 'freezer_and_locker_meat_provisioners'
+      | 'fuel_dealers_non_automotive'
+      | 'funeral_services_crematories'
+      | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
+      | 'furniture_repair_refinishing'
+      | 'furriers_and_fur_shops'
+      | 'general_services'
+      | 'gift_card_novelty_and_souvenir_shops'
+      | 'glass_paint_and_wallpaper_stores'
+      | 'glassware_crystal_stores'
+      | 'golf_courses_public'
+      | 'government_licensed_horse_dog_racing_us_region_only'
+      | 'government_licensed_online_casions_online_gambling_us_region_only'
+      | 'government_owned_lotteries_non_us_region'
+      | 'government_owned_lotteries_us_region_only'
+      | 'government_services'
+      | 'grocery_stores_supermarkets'
+      | 'hardware_equipment_and_supplies'
+      | 'hardware_stores'
+      | 'health_and_beauty_spas'
+      | 'hearing_aids_sales_and_supplies'
+      | 'heating_plumbing_a_c'
+      | 'hobby_toy_and_game_shops'
+      | 'home_supply_warehouse_stores'
+      | 'hospitals'
+      | 'hotels_motels_and_resorts'
+      | 'household_appliance_stores'
+      | 'industrial_supplies'
+      | 'information_retrieval_services'
+      | 'insurance_default'
+      | 'insurance_underwriting_premiums'
+      | 'intra_company_purchases'
+      | 'jewelry_stores_watches_clocks_and_silverware_stores'
+      | 'landscaping_services'
+      | 'laundries'
+      | 'laundry_cleaning_services'
+      | 'legal_services_attorneys'
+      | 'luggage_and_leather_goods_stores'
+      | 'lumber_building_materials_stores'
+      | 'manual_cash_disburse'
+      | 'marinas_service_and_supplies'
+      | 'marketplaces'
+      | 'masonry_stonework_and_plaster'
+      | 'massage_parlors'
+      | 'medical_and_dental_labs'
+      | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
+      | 'medical_services'
+      | 'membership_organizations'
+      | 'mens_and_boys_clothing_and_accessories_stores'
+      | 'mens_womens_clothing_stores'
+      | 'metal_service_centers'
+      | 'miscellaneous'
+      | 'miscellaneous_apparel_and_accessory_shops'
+      | 'miscellaneous_auto_dealers'
+      | 'miscellaneous_business_services'
+      | 'miscellaneous_food_stores'
+      | 'miscellaneous_general_merchandise'
+      | 'miscellaneous_general_services'
+      | 'miscellaneous_home_furnishing_specialty_stores'
+      | 'miscellaneous_publishing_and_printing'
+      | 'miscellaneous_recreation_services'
+      | 'miscellaneous_repair_shops'
+      | 'miscellaneous_specialty_retail'
+      | 'mobile_home_dealers'
+      | 'motion_picture_theaters'
+      | 'motor_freight_carriers_and_trucking'
+      | 'motor_homes_dealers'
+      | 'motor_vehicle_supplies_and_new_parts'
+      | 'motorcycle_shops_and_dealers'
+      | 'motorcycle_shops_dealers'
+      | 'music_stores_musical_instruments_pianos_and_sheet_music'
+      | 'news_dealers_and_newsstands'
+      | 'non_fi_money_orders'
+      | 'non_fi_stored_value_card_purchase_load'
+      | 'nondurable_goods'
+      | 'nurseries_lawn_and_garden_supply_stores'
+      | 'nursing_personal_care'
+      | 'office_and_commercial_furniture'
+      | 'opticians_eyeglasses'
+      | 'optometrists_ophthalmologist'
+      | 'orthopedic_goods_prosthetic_devices'
+      | 'osteopaths'
+      | 'package_stores_beer_wine_and_liquor'
+      | 'paints_varnishes_and_supplies'
+      | 'parking_lots_garages'
+      | 'passenger_railways'
+      | 'pawn_shops'
+      | 'pet_shops_pet_food_and_supplies'
+      | 'petroleum_and_petroleum_products'
+      | 'photo_developing'
+      | 'photographic_photocopy_microfilm_equipment_and_supplies'
+      | 'photographic_studios'
+      | 'picture_video_production'
+      | 'piece_goods_notions_and_other_dry_goods'
+      | 'plumbing_heating_equipment_and_supplies'
+      | 'political_organizations'
+      | 'postal_services_government_only'
+      | 'precious_stones_and_metals_watches_and_jewelry'
+      | 'professional_services'
+      | 'public_warehousing_and_storage'
+      | 'quick_copy_repro_and_blueprint'
+      | 'railroads'
+      | 'real_estate_agents_and_managers_rentals'
+      | 'record_stores'
+      | 'recreational_vehicle_rentals'
+      | 'religious_goods_stores'
+      | 'religious_organizations'
+      | 'roofing_siding_sheet_metal'
+      | 'secretarial_support_services'
+      | 'security_brokers_dealers'
+      | 'service_stations'
+      | 'sewing_needlework_fabric_and_piece_goods_stores'
+      | 'shoe_repair_hat_cleaning'
+      | 'shoe_stores'
+      | 'small_appliance_repair'
+      | 'snowmobile_dealers'
+      | 'special_trade_services'
+      | 'specialty_cleaning'
+      | 'sporting_goods_stores'
+      | 'sporting_recreation_camps'
+      | 'sports_and_riding_apparel_stores'
+      | 'sports_clubs_fields'
+      | 'stamp_and_coin_stores'
+      | 'stationary_office_supplies_printing_and_writing_paper'
+      | 'stationery_stores_office_and_school_supply_stores'
+      | 'swimming_pools_sales'
+      | 't_ui_travel_germany'
+      | 'tailors_alterations'
+      | 'tax_payments_government_agencies'
+      | 'tax_preparation_services'
+      | 'taxicabs_limousines'
+      | 'telecommunication_equipment_and_telephone_sales'
+      | 'telecommunication_services'
+      | 'telegraph_services'
+      | 'tent_and_awning_shops'
+      | 'testing_laboratories'
+      | 'theatrical_ticket_agencies'
+      | 'timeshares'
+      | 'tire_retreading_and_repair'
+      | 'tolls_bridge_fees'
+      | 'tourist_attractions_and_exhibits'
+      | 'towing_services'
+      | 'trailer_parks_campgrounds'
+      | 'transportation_services'
+      | 'travel_agencies_tour_operators'
+      | 'truck_stop_iteration'
+      | 'truck_utility_trailer_rentals'
+      | 'typesetting_plate_making_and_related_services'
+      | 'typewriter_stores'
+      | 'u_s_federal_government_agencies_or_departments'
+      | 'uniforms_commercial_clothing'
+      | 'used_merchandise_and_secondhand_stores'
+      | 'utilities'
+      | 'variety_stores'
+      | 'veterinary_services'
+      | 'video_amusement_game_supplies'
+      | 'video_game_arcades'
+      | 'video_tape_rental_stores'
+      | 'vocational_trade_schools'
+      | 'watch_jewelry_repair'
+      | 'welding_repair'
+      | 'wholesale_clubs'
+      | 'wig_and_toupee_stores'
+      | 'wires_money_orders'
+      | 'womens_accessory_and_specialty_shops'
+      | 'womens_ready_to_wear_stores'
+      | 'wrecking_and_salvage_yards';
+
+    export type BlockedCardPresence = 'not_present' | 'present';
+
+    export type BlockedCategory =
+      | 'ac_refrigeration_repair'
+      | 'accounting_bookkeeping_services'
+      | 'advertising_services'
+      | 'agricultural_cooperative'
+      | 'airlines_air_carriers'
+      | 'airports_flying_fields'
+      | 'ambulance_services'
+      | 'amusement_parks_carnivals'
+      | 'antique_reproductions'
+      | 'antique_shops'
+      | 'aquariums'
+      | 'architectural_surveying_services'
+      | 'art_dealers_and_galleries'
+      | 'artists_supply_and_craft_shops'
+      | 'auto_and_home_supply_stores'
+      | 'auto_body_repair_shops'
+      | 'auto_paint_shops'
+      | 'auto_service_shops'
+      | 'automated_cash_disburse'
+      | 'automated_fuel_dispensers'
+      | 'automobile_associations'
+      | 'automotive_parts_and_accessories_stores'
+      | 'automotive_tire_stores'
+      | 'bail_and_bond_payments'
+      | 'bakeries'
+      | 'bands_orchestras'
+      | 'barber_and_beauty_shops'
+      | 'betting_casino_gambling'
+      | 'bicycle_shops'
+      | 'billiard_pool_establishments'
+      | 'boat_dealers'
+      | 'boat_rentals_and_leases'
+      | 'book_stores'
+      | 'books_periodicals_and_newspapers'
+      | 'bowling_alleys'
+      | 'bus_lines'
+      | 'business_secretarial_schools'
+      | 'buying_shopping_services'
+      | 'cable_satellite_and_other_pay_television_and_radio'
+      | 'camera_and_photographic_supply_stores'
+      | 'candy_nut_and_confectionery_stores'
+      | 'car_and_truck_dealers_new_used'
+      | 'car_and_truck_dealers_used_only'
+      | 'car_rental_agencies'
+      | 'car_washes'
+      | 'carpentry_services'
+      | 'carpet_upholstery_cleaning'
+      | 'caterers'
+      | 'charitable_and_social_service_organizations_fundraising'
+      | 'chemicals_and_allied_products'
+      | 'child_care_services'
+      | 'childrens_and_infants_wear_stores'
+      | 'chiropodists_podiatrists'
+      | 'chiropractors'
+      | 'cigar_stores_and_stands'
+      | 'civic_social_fraternal_associations'
+      | 'cleaning_and_maintenance'
+      | 'clothing_rental'
+      | 'colleges_universities'
+      | 'commercial_equipment'
+      | 'commercial_footwear'
+      | 'commercial_photography_art_and_graphics'
+      | 'commuter_transport_and_ferries'
+      | 'computer_network_services'
+      | 'computer_programming'
+      | 'computer_repair'
+      | 'computer_software_stores'
+      | 'computers_peripherals_and_software'
+      | 'concrete_work_services'
+      | 'construction_materials'
+      | 'consulting_public_relations'
+      | 'correspondence_schools'
+      | 'cosmetic_stores'
+      | 'counseling_services'
+      | 'country_clubs'
+      | 'courier_services'
+      | 'court_costs'
+      | 'credit_reporting_agencies'
+      | 'cruise_lines'
+      | 'dairy_products_stores'
+      | 'dance_hall_studios_schools'
+      | 'dating_escort_services'
+      | 'dentists_orthodontists'
+      | 'department_stores'
+      | 'detective_agencies'
+      | 'digital_goods_applications'
+      | 'digital_goods_games'
+      | 'digital_goods_large_volume'
+      | 'digital_goods_media'
+      | 'direct_marketing_catalog_merchant'
+      | 'direct_marketing_combination_catalog_and_retail_merchant'
+      | 'direct_marketing_inbound_telemarketing'
+      | 'direct_marketing_insurance_services'
+      | 'direct_marketing_other'
+      | 'direct_marketing_outbound_telemarketing'
+      | 'direct_marketing_subscription'
+      | 'direct_marketing_travel'
+      | 'discount_stores'
+      | 'doctors'
+      | 'door_to_door_sales'
+      | 'drapery_window_covering_and_upholstery_stores'
+      | 'drinking_places'
+      | 'drug_stores_and_pharmacies'
+      | 'drugs_drug_proprietaries_and_druggist_sundries'
+      | 'dry_cleaners'
+      | 'durable_goods'
+      | 'duty_free_stores'
+      | 'eating_places_restaurants'
+      | 'educational_services'
+      | 'electric_razor_stores'
+      | 'electric_vehicle_charging'
+      | 'electrical_parts_and_equipment'
+      | 'electrical_services'
+      | 'electronics_repair_shops'
+      | 'electronics_stores'
+      | 'elementary_secondary_schools'
+      | 'emergency_services_gcas_visa_use_only'
+      | 'employment_temp_agencies'
+      | 'equipment_rental'
+      | 'exterminating_services'
+      | 'family_clothing_stores'
+      | 'fast_food_restaurants'
+      | 'financial_institutions'
+      | 'fines_government_administrative_entities'
+      | 'fireplace_fireplace_screens_and_accessories_stores'
+      | 'floor_covering_stores'
+      | 'florists'
+      | 'florists_supplies_nursery_stock_and_flowers'
+      | 'freezer_and_locker_meat_provisioners'
+      | 'fuel_dealers_non_automotive'
+      | 'funeral_services_crematories'
+      | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
+      | 'furniture_repair_refinishing'
+      | 'furriers_and_fur_shops'
+      | 'general_services'
+      | 'gift_card_novelty_and_souvenir_shops'
+      | 'glass_paint_and_wallpaper_stores'
+      | 'glassware_crystal_stores'
+      | 'golf_courses_public'
+      | 'government_licensed_horse_dog_racing_us_region_only'
+      | 'government_licensed_online_casions_online_gambling_us_region_only'
+      | 'government_owned_lotteries_non_us_region'
+      | 'government_owned_lotteries_us_region_only'
+      | 'government_services'
+      | 'grocery_stores_supermarkets'
+      | 'hardware_equipment_and_supplies'
+      | 'hardware_stores'
+      | 'health_and_beauty_spas'
+      | 'hearing_aids_sales_and_supplies'
+      | 'heating_plumbing_a_c'
+      | 'hobby_toy_and_game_shops'
+      | 'home_supply_warehouse_stores'
+      | 'hospitals'
+      | 'hotels_motels_and_resorts'
+      | 'household_appliance_stores'
+      | 'industrial_supplies'
+      | 'information_retrieval_services'
+      | 'insurance_default'
+      | 'insurance_underwriting_premiums'
+      | 'intra_company_purchases'
+      | 'jewelry_stores_watches_clocks_and_silverware_stores'
+      | 'landscaping_services'
+      | 'laundries'
+      | 'laundry_cleaning_services'
+      | 'legal_services_attorneys'
+      | 'luggage_and_leather_goods_stores'
+      | 'lumber_building_materials_stores'
+      | 'manual_cash_disburse'
+      | 'marinas_service_and_supplies'
+      | 'marketplaces'
+      | 'masonry_stonework_and_plaster'
+      | 'massage_parlors'
+      | 'medical_and_dental_labs'
+      | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
+      | 'medical_services'
+      | 'membership_organizations'
+      | 'mens_and_boys_clothing_and_accessories_stores'
+      | 'mens_womens_clothing_stores'
+      | 'metal_service_centers'
+      | 'miscellaneous'
+      | 'miscellaneous_apparel_and_accessory_shops'
+      | 'miscellaneous_auto_dealers'
+      | 'miscellaneous_business_services'
+      | 'miscellaneous_food_stores'
+      | 'miscellaneous_general_merchandise'
+      | 'miscellaneous_general_services'
+      | 'miscellaneous_home_furnishing_specialty_stores'
+      | 'miscellaneous_publishing_and_printing'
+      | 'miscellaneous_recreation_services'
+      | 'miscellaneous_repair_shops'
+      | 'miscellaneous_specialty_retail'
+      | 'mobile_home_dealers'
+      | 'motion_picture_theaters'
+      | 'motor_freight_carriers_and_trucking'
+      | 'motor_homes_dealers'
+      | 'motor_vehicle_supplies_and_new_parts'
+      | 'motorcycle_shops_and_dealers'
+      | 'motorcycle_shops_dealers'
+      | 'music_stores_musical_instruments_pianos_and_sheet_music'
+      | 'news_dealers_and_newsstands'
+      | 'non_fi_money_orders'
+      | 'non_fi_stored_value_card_purchase_load'
+      | 'nondurable_goods'
+      | 'nurseries_lawn_and_garden_supply_stores'
+      | 'nursing_personal_care'
+      | 'office_and_commercial_furniture'
+      | 'opticians_eyeglasses'
+      | 'optometrists_ophthalmologist'
+      | 'orthopedic_goods_prosthetic_devices'
+      | 'osteopaths'
+      | 'package_stores_beer_wine_and_liquor'
+      | 'paints_varnishes_and_supplies'
+      | 'parking_lots_garages'
+      | 'passenger_railways'
+      | 'pawn_shops'
+      | 'pet_shops_pet_food_and_supplies'
+      | 'petroleum_and_petroleum_products'
+      | 'photo_developing'
+      | 'photographic_photocopy_microfilm_equipment_and_supplies'
+      | 'photographic_studios'
+      | 'picture_video_production'
+      | 'piece_goods_notions_and_other_dry_goods'
+      | 'plumbing_heating_equipment_and_supplies'
+      | 'political_organizations'
+      | 'postal_services_government_only'
+      | 'precious_stones_and_metals_watches_and_jewelry'
+      | 'professional_services'
+      | 'public_warehousing_and_storage'
+      | 'quick_copy_repro_and_blueprint'
+      | 'railroads'
+      | 'real_estate_agents_and_managers_rentals'
+      | 'record_stores'
+      | 'recreational_vehicle_rentals'
+      | 'religious_goods_stores'
+      | 'religious_organizations'
+      | 'roofing_siding_sheet_metal'
+      | 'secretarial_support_services'
+      | 'security_brokers_dealers'
+      | 'service_stations'
+      | 'sewing_needlework_fabric_and_piece_goods_stores'
+      | 'shoe_repair_hat_cleaning'
+      | 'shoe_stores'
+      | 'small_appliance_repair'
+      | 'snowmobile_dealers'
+      | 'special_trade_services'
+      | 'specialty_cleaning'
+      | 'sporting_goods_stores'
+      | 'sporting_recreation_camps'
+      | 'sports_and_riding_apparel_stores'
+      | 'sports_clubs_fields'
+      | 'stamp_and_coin_stores'
+      | 'stationary_office_supplies_printing_and_writing_paper'
+      | 'stationery_stores_office_and_school_supply_stores'
+      | 'swimming_pools_sales'
+      | 't_ui_travel_germany'
+      | 'tailors_alterations'
+      | 'tax_payments_government_agencies'
+      | 'tax_preparation_services'
+      | 'taxicabs_limousines'
+      | 'telecommunication_equipment_and_telephone_sales'
+      | 'telecommunication_services'
+      | 'telegraph_services'
+      | 'tent_and_awning_shops'
+      | 'testing_laboratories'
+      | 'theatrical_ticket_agencies'
+      | 'timeshares'
+      | 'tire_retreading_and_repair'
+      | 'tolls_bridge_fees'
+      | 'tourist_attractions_and_exhibits'
+      | 'towing_services'
+      | 'trailer_parks_campgrounds'
+      | 'transportation_services'
+      | 'travel_agencies_tour_operators'
+      | 'truck_stop_iteration'
+      | 'truck_utility_trailer_rentals'
+      | 'typesetting_plate_making_and_related_services'
+      | 'typewriter_stores'
+      | 'u_s_federal_government_agencies_or_departments'
+      | 'uniforms_commercial_clothing'
+      | 'used_merchandise_and_secondhand_stores'
+      | 'utilities'
+      | 'variety_stores'
+      | 'veterinary_services'
+      | 'video_amusement_game_supplies'
+      | 'video_game_arcades'
+      | 'video_tape_rental_stores'
+      | 'vocational_trade_schools'
+      | 'watch_jewelry_repair'
+      | 'welding_repair'
+      | 'wholesale_clubs'
+      | 'wig_and_toupee_stores'
+      | 'wires_money_orders'
+      | 'womens_accessory_and_specialty_shops'
+      | 'womens_ready_to_wear_stores'
+      | 'wrecking_and_salvage_yards';
+
+    export interface SpendingLimit {
+      /**
+       * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+       */
+      amount: number;
 
       /**
-       * Address validation details for the shipment.
+       * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
        */
-      address_validation: Shipping.AddressValidation | null;
+      categories: Array<SpendingLimit.Category> | null;
 
       /**
-       * The delivery company that shipped a card.
+       * Interval (or event) to which the amount applies.
        */
-      carrier: Shipping.Carrier | null;
-
-      /**
-       * Additional information that may be required for clearing customs.
-       */
-      customs: Shipping.Customs | null;
-
-      /**
-       * A unix timestamp representing a best estimate of when the card will be delivered.
-       */
-      eta: number | null;
-
-      /**
-       * Recipient name.
-       */
-      name: string;
-
-      /**
-       * The phone number of the receiver of the shipment. Our courier partners will use this number to contact you in the event of card delivery issues. For individual shipments to the EU/UK, if this field is empty, we will provide them with the phone number provided when the cardholder was initially created.
-       */
-      phone_number: string | null;
-
-      /**
-       * Whether a signature is required for card delivery. This feature is only supported for US users. Standard shipping service does not support signature on delivery. The default value for standard shipping service is false and for express and priority services is true.
-       */
-      require_signature: boolean | null;
-
-      /**
-       * Shipment service, such as `standard` or `express`.
-       */
-      service: Shipping.Service;
-
-      /**
-       * The delivery status of the card.
-       */
-      status: Shipping.Status | null;
-
-      /**
-       * A tracking number for a card shipment.
-       */
-      tracking_number: string | null;
-
-      /**
-       * A link to the shipping carrier's site where you can view detailed information about a card shipment.
-       */
-      tracking_url: string | null;
-
-      /**
-       * Packaging options.
-       */
-      type: Shipping.Type;
+      interval: SpendingLimit.Interval;
     }
 
-    export interface SpendingControls {
-      /**
-       * Array of card presence statuses from which authorizations will be allowed. Possible options are `present`, `not_present`. All other statuses will be blocked. Cannot be set with `blocked_card_presences`. Provide an empty value to unset this control.
-       */
-      allowed_card_presences: Array<
-        SpendingControls.AllowedCardPresence
-      > | null;
-
-      /**
-       * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to allow. All other categories will be blocked. Cannot be set with `blocked_categories`.
-       */
-      allowed_categories: Array<SpendingControls.AllowedCategory> | null;
-
-      /**
-       * Array of strings containing representing countries from which authorizations will be allowed. Authorizations from merchants in all other countries will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `blocked_merchant_countries`. Provide an empty value to unset this control.
-       */
-      allowed_merchant_countries: Array<string> | null;
-
-      /**
-       * Array of card presence statuses from which authorizations will be declined. Possible options are `present`, `not_present`. Cannot be set with `allowed_card_presences`. Provide an empty value to unset this control.
-       */
-      blocked_card_presences: Array<
-        SpendingControls.BlockedCardPresence
-      > | null;
-
-      /**
-       * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) of authorizations to decline. All other categories will be allowed. Cannot be set with `allowed_categories`.
-       */
-      blocked_categories: Array<SpendingControls.BlockedCategory> | null;
-
-      /**
-       * Array of strings containing representing countries from which authorizations will be declined. Country codes should be ISO 3166 alpha-2 country codes (e.g. `US`). Cannot be set with `allowed_merchant_countries`. Provide an empty value to unset this control.
-       */
-      blocked_merchant_countries: Array<string> | null;
-
-      /**
-       * Limit spending with amount-based rules that apply across any cards this card replaced (i.e., its `replacement_for` card and _that_ card's `replacement_for` card, up the chain).
-       */
-      spending_limits: Array<SpendingControls.SpendingLimit> | null;
-
-      /**
-       * Currency of the amounts within `spending_limits`. Always the same as the currency of the card.
-       */
-      spending_limits_currency: string | null;
-    }
-
-    export type Status = 'active' | 'canceled' | 'inactive';
-
-    export type Type = 'physical' | 'virtual';
-
-    export interface Wallets {
-      apple_pay: Wallets.ApplePay;
-
-      google_pay: Wallets.GooglePay;
-
-      /**
-       * Unique identifier for a card used with digital wallets
-       */
-      primary_account_identifier: string | null;
-    }
-
-    export namespace LatestFraudWarning {
-      export type Type =
-        | 'card_testing_exposure'
-        | 'fraud_dispute_filed'
-        | 'third_party_reported'
-        | 'user_indicated_fraud';
-    }
-
-    export namespace LifecycleControls {
-      export interface CancelAfter {
-        /**
-         * The card is automatically cancelled when it makes this number of non-zero payment authorizations and transactions. The count includes penny authorizations, but doesn't include non-payment actions, such as authorization advice.
-         */
-        payment_count: number;
-      }
-    }
-
-    export namespace Shipping {
-      export interface AddressValidation {
-        /**
-         * The address validation capabilities to use.
-         */
-        mode: AddressValidation.Mode;
-
-        /**
-         * The normalized shipping address.
-         */
-        normalized_address: Address | null;
-
-        /**
-         * The validation result for the shipping address.
-         */
-        result: AddressValidation.Result | null;
-      }
-
-      export type Carrier = 'dhl' | 'fedex' | 'royal_mail' | 'usps';
-
-      export interface Customs {
-        /**
-         * A registration number used for customs in Europe. See [https://www.gov.uk/eori](https://www.gov.uk/eori) for the UK and [https://ec.europa.eu/taxation_customs/business/customs-procedures-import-and-export/customs-procedures/economic-operators-registration-and-identification-number-eori_en](https://ec.europa.eu/taxation_customs/business/customs-procedures-import-and-export/customs-procedures/economic-operators-registration-and-identification-number-eori_en) for the EU.
-         */
-        eori_number: string | null;
-      }
-
-      export type Service = 'express' | 'priority' | 'standard';
-
-      export type Status =
-        | 'canceled'
-        | 'delivered'
-        | 'failure'
-        | 'pending'
-        | 'returned'
-        | 'shipped'
-        | 'submitted';
-
-      export type Type = 'bulk' | 'individual';
-
-      export namespace AddressValidation {
-        export type Mode =
-          | 'disabled'
-          | 'normalization_only'
-          | 'validation_and_normalization';
-
-        export type Result =
-          | 'indeterminate'
-          | 'likely_deliverable'
-          | 'likely_undeliverable';
-      }
-    }
-
-    export namespace SpendingControls {
-      export type AllowedCardPresence = 'not_present' | 'present';
-
-      export type AllowedCategory =
+    export namespace SpendingLimit {
+      export type Category =
         | 'ac_refrigeration_repair'
         | 'accounting_bookkeeping_services'
         | 'advertising_services'
@@ -731,668 +1340,53 @@ export namespace Issuing {
         | 'womens_ready_to_wear_stores'
         | 'wrecking_and_salvage_yards';
 
-      export type BlockedCardPresence = 'not_present' | 'present';
+      export type Interval =
+        | 'all_time'
+        | 'daily'
+        | 'monthly'
+        | 'per_authorization'
+        | 'weekly'
+        | 'yearly';
+    }
+  }
 
-      export type BlockedCategory =
-        | 'ac_refrigeration_repair'
-        | 'accounting_bookkeeping_services'
-        | 'advertising_services'
-        | 'agricultural_cooperative'
-        | 'airlines_air_carriers'
-        | 'airports_flying_fields'
-        | 'ambulance_services'
-        | 'amusement_parks_carnivals'
-        | 'antique_reproductions'
-        | 'antique_shops'
-        | 'aquariums'
-        | 'architectural_surveying_services'
-        | 'art_dealers_and_galleries'
-        | 'artists_supply_and_craft_shops'
-        | 'auto_and_home_supply_stores'
-        | 'auto_body_repair_shops'
-        | 'auto_paint_shops'
-        | 'auto_service_shops'
-        | 'automated_cash_disburse'
-        | 'automated_fuel_dispensers'
-        | 'automobile_associations'
-        | 'automotive_parts_and_accessories_stores'
-        | 'automotive_tire_stores'
-        | 'bail_and_bond_payments'
-        | 'bakeries'
-        | 'bands_orchestras'
-        | 'barber_and_beauty_shops'
-        | 'betting_casino_gambling'
-        | 'bicycle_shops'
-        | 'billiard_pool_establishments'
-        | 'boat_dealers'
-        | 'boat_rentals_and_leases'
-        | 'book_stores'
-        | 'books_periodicals_and_newspapers'
-        | 'bowling_alleys'
-        | 'bus_lines'
-        | 'business_secretarial_schools'
-        | 'buying_shopping_services'
-        | 'cable_satellite_and_other_pay_television_and_radio'
-        | 'camera_and_photographic_supply_stores'
-        | 'candy_nut_and_confectionery_stores'
-        | 'car_and_truck_dealers_new_used'
-        | 'car_and_truck_dealers_used_only'
-        | 'car_rental_agencies'
-        | 'car_washes'
-        | 'carpentry_services'
-        | 'carpet_upholstery_cleaning'
-        | 'caterers'
-        | 'charitable_and_social_service_organizations_fundraising'
-        | 'chemicals_and_allied_products'
-        | 'child_care_services'
-        | 'childrens_and_infants_wear_stores'
-        | 'chiropodists_podiatrists'
-        | 'chiropractors'
-        | 'cigar_stores_and_stands'
-        | 'civic_social_fraternal_associations'
-        | 'cleaning_and_maintenance'
-        | 'clothing_rental'
-        | 'colleges_universities'
-        | 'commercial_equipment'
-        | 'commercial_footwear'
-        | 'commercial_photography_art_and_graphics'
-        | 'commuter_transport_and_ferries'
-        | 'computer_network_services'
-        | 'computer_programming'
-        | 'computer_repair'
-        | 'computer_software_stores'
-        | 'computers_peripherals_and_software'
-        | 'concrete_work_services'
-        | 'construction_materials'
-        | 'consulting_public_relations'
-        | 'correspondence_schools'
-        | 'cosmetic_stores'
-        | 'counseling_services'
-        | 'country_clubs'
-        | 'courier_services'
-        | 'court_costs'
-        | 'credit_reporting_agencies'
-        | 'cruise_lines'
-        | 'dairy_products_stores'
-        | 'dance_hall_studios_schools'
-        | 'dating_escort_services'
-        | 'dentists_orthodontists'
-        | 'department_stores'
-        | 'detective_agencies'
-        | 'digital_goods_applications'
-        | 'digital_goods_games'
-        | 'digital_goods_large_volume'
-        | 'digital_goods_media'
-        | 'direct_marketing_catalog_merchant'
-        | 'direct_marketing_combination_catalog_and_retail_merchant'
-        | 'direct_marketing_inbound_telemarketing'
-        | 'direct_marketing_insurance_services'
-        | 'direct_marketing_other'
-        | 'direct_marketing_outbound_telemarketing'
-        | 'direct_marketing_subscription'
-        | 'direct_marketing_travel'
-        | 'discount_stores'
-        | 'doctors'
-        | 'door_to_door_sales'
-        | 'drapery_window_covering_and_upholstery_stores'
-        | 'drinking_places'
-        | 'drug_stores_and_pharmacies'
-        | 'drugs_drug_proprietaries_and_druggist_sundries'
-        | 'dry_cleaners'
-        | 'durable_goods'
-        | 'duty_free_stores'
-        | 'eating_places_restaurants'
-        | 'educational_services'
-        | 'electric_razor_stores'
-        | 'electric_vehicle_charging'
-        | 'electrical_parts_and_equipment'
-        | 'electrical_services'
-        | 'electronics_repair_shops'
-        | 'electronics_stores'
-        | 'elementary_secondary_schools'
-        | 'emergency_services_gcas_visa_use_only'
-        | 'employment_temp_agencies'
-        | 'equipment_rental'
-        | 'exterminating_services'
-        | 'family_clothing_stores'
-        | 'fast_food_restaurants'
-        | 'financial_institutions'
-        | 'fines_government_administrative_entities'
-        | 'fireplace_fireplace_screens_and_accessories_stores'
-        | 'floor_covering_stores'
-        | 'florists'
-        | 'florists_supplies_nursery_stock_and_flowers'
-        | 'freezer_and_locker_meat_provisioners'
-        | 'fuel_dealers_non_automotive'
-        | 'funeral_services_crematories'
-        | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
-        | 'furniture_repair_refinishing'
-        | 'furriers_and_fur_shops'
-        | 'general_services'
-        | 'gift_card_novelty_and_souvenir_shops'
-        | 'glass_paint_and_wallpaper_stores'
-        | 'glassware_crystal_stores'
-        | 'golf_courses_public'
-        | 'government_licensed_horse_dog_racing_us_region_only'
-        | 'government_licensed_online_casions_online_gambling_us_region_only'
-        | 'government_owned_lotteries_non_us_region'
-        | 'government_owned_lotteries_us_region_only'
-        | 'government_services'
-        | 'grocery_stores_supermarkets'
-        | 'hardware_equipment_and_supplies'
-        | 'hardware_stores'
-        | 'health_and_beauty_spas'
-        | 'hearing_aids_sales_and_supplies'
-        | 'heating_plumbing_a_c'
-        | 'hobby_toy_and_game_shops'
-        | 'home_supply_warehouse_stores'
-        | 'hospitals'
-        | 'hotels_motels_and_resorts'
-        | 'household_appliance_stores'
-        | 'industrial_supplies'
-        | 'information_retrieval_services'
-        | 'insurance_default'
-        | 'insurance_underwriting_premiums'
-        | 'intra_company_purchases'
-        | 'jewelry_stores_watches_clocks_and_silverware_stores'
-        | 'landscaping_services'
-        | 'laundries'
-        | 'laundry_cleaning_services'
-        | 'legal_services_attorneys'
-        | 'luggage_and_leather_goods_stores'
-        | 'lumber_building_materials_stores'
-        | 'manual_cash_disburse'
-        | 'marinas_service_and_supplies'
-        | 'marketplaces'
-        | 'masonry_stonework_and_plaster'
-        | 'massage_parlors'
-        | 'medical_and_dental_labs'
-        | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
-        | 'medical_services'
-        | 'membership_organizations'
-        | 'mens_and_boys_clothing_and_accessories_stores'
-        | 'mens_womens_clothing_stores'
-        | 'metal_service_centers'
-        | 'miscellaneous'
-        | 'miscellaneous_apparel_and_accessory_shops'
-        | 'miscellaneous_auto_dealers'
-        | 'miscellaneous_business_services'
-        | 'miscellaneous_food_stores'
-        | 'miscellaneous_general_merchandise'
-        | 'miscellaneous_general_services'
-        | 'miscellaneous_home_furnishing_specialty_stores'
-        | 'miscellaneous_publishing_and_printing'
-        | 'miscellaneous_recreation_services'
-        | 'miscellaneous_repair_shops'
-        | 'miscellaneous_specialty_retail'
-        | 'mobile_home_dealers'
-        | 'motion_picture_theaters'
-        | 'motor_freight_carriers_and_trucking'
-        | 'motor_homes_dealers'
-        | 'motor_vehicle_supplies_and_new_parts'
-        | 'motorcycle_shops_and_dealers'
-        | 'motorcycle_shops_dealers'
-        | 'music_stores_musical_instruments_pianos_and_sheet_music'
-        | 'news_dealers_and_newsstands'
-        | 'non_fi_money_orders'
-        | 'non_fi_stored_value_card_purchase_load'
-        | 'nondurable_goods'
-        | 'nurseries_lawn_and_garden_supply_stores'
-        | 'nursing_personal_care'
-        | 'office_and_commercial_furniture'
-        | 'opticians_eyeglasses'
-        | 'optometrists_ophthalmologist'
-        | 'orthopedic_goods_prosthetic_devices'
-        | 'osteopaths'
-        | 'package_stores_beer_wine_and_liquor'
-        | 'paints_varnishes_and_supplies'
-        | 'parking_lots_garages'
-        | 'passenger_railways'
-        | 'pawn_shops'
-        | 'pet_shops_pet_food_and_supplies'
-        | 'petroleum_and_petroleum_products'
-        | 'photo_developing'
-        | 'photographic_photocopy_microfilm_equipment_and_supplies'
-        | 'photographic_studios'
-        | 'picture_video_production'
-        | 'piece_goods_notions_and_other_dry_goods'
-        | 'plumbing_heating_equipment_and_supplies'
-        | 'political_organizations'
-        | 'postal_services_government_only'
-        | 'precious_stones_and_metals_watches_and_jewelry'
-        | 'professional_services'
-        | 'public_warehousing_and_storage'
-        | 'quick_copy_repro_and_blueprint'
-        | 'railroads'
-        | 'real_estate_agents_and_managers_rentals'
-        | 'record_stores'
-        | 'recreational_vehicle_rentals'
-        | 'religious_goods_stores'
-        | 'religious_organizations'
-        | 'roofing_siding_sheet_metal'
-        | 'secretarial_support_services'
-        | 'security_brokers_dealers'
-        | 'service_stations'
-        | 'sewing_needlework_fabric_and_piece_goods_stores'
-        | 'shoe_repair_hat_cleaning'
-        | 'shoe_stores'
-        | 'small_appliance_repair'
-        | 'snowmobile_dealers'
-        | 'special_trade_services'
-        | 'specialty_cleaning'
-        | 'sporting_goods_stores'
-        | 'sporting_recreation_camps'
-        | 'sports_and_riding_apparel_stores'
-        | 'sports_clubs_fields'
-        | 'stamp_and_coin_stores'
-        | 'stationary_office_supplies_printing_and_writing_paper'
-        | 'stationery_stores_office_and_school_supply_stores'
-        | 'swimming_pools_sales'
-        | 't_ui_travel_germany'
-        | 'tailors_alterations'
-        | 'tax_payments_government_agencies'
-        | 'tax_preparation_services'
-        | 'taxicabs_limousines'
-        | 'telecommunication_equipment_and_telephone_sales'
-        | 'telecommunication_services'
-        | 'telegraph_services'
-        | 'tent_and_awning_shops'
-        | 'testing_laboratories'
-        | 'theatrical_ticket_agencies'
-        | 'timeshares'
-        | 'tire_retreading_and_repair'
-        | 'tolls_bridge_fees'
-        | 'tourist_attractions_and_exhibits'
-        | 'towing_services'
-        | 'trailer_parks_campgrounds'
-        | 'transportation_services'
-        | 'travel_agencies_tour_operators'
-        | 'truck_stop_iteration'
-        | 'truck_utility_trailer_rentals'
-        | 'typesetting_plate_making_and_related_services'
-        | 'typewriter_stores'
-        | 'u_s_federal_government_agencies_or_departments'
-        | 'uniforms_commercial_clothing'
-        | 'used_merchandise_and_secondhand_stores'
-        | 'utilities'
-        | 'variety_stores'
-        | 'veterinary_services'
-        | 'video_amusement_game_supplies'
-        | 'video_game_arcades'
-        | 'video_tape_rental_stores'
-        | 'vocational_trade_schools'
-        | 'watch_jewelry_repair'
-        | 'welding_repair'
-        | 'wholesale_clubs'
-        | 'wig_and_toupee_stores'
-        | 'wires_money_orders'
-        | 'womens_accessory_and_specialty_shops'
-        | 'womens_ready_to_wear_stores'
-        | 'wrecking_and_salvage_yards';
+  export namespace Wallets {
+    export interface ApplePay {
+      /**
+       * Apple Pay Eligibility
+       */
+      eligible: boolean;
 
-      export interface SpendingLimit {
-        /**
-         * Maximum amount allowed to spend per interval. This amount is in the card's currency and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-         */
-        amount: number;
-
-        /**
-         * Array of strings containing [categories](https://docs.stripe.com/api#issuing_authorization_object-merchant_data-category) this limit applies to. Omitting this field will apply the limit to all categories.
-         */
-        categories: Array<SpendingLimit.Category> | null;
-
-        /**
-         * Interval (or event) to which the amount applies.
-         */
-        interval: SpendingLimit.Interval;
-      }
-
-      export namespace SpendingLimit {
-        export type Category =
-          | 'ac_refrigeration_repair'
-          | 'accounting_bookkeeping_services'
-          | 'advertising_services'
-          | 'agricultural_cooperative'
-          | 'airlines_air_carriers'
-          | 'airports_flying_fields'
-          | 'ambulance_services'
-          | 'amusement_parks_carnivals'
-          | 'antique_reproductions'
-          | 'antique_shops'
-          | 'aquariums'
-          | 'architectural_surveying_services'
-          | 'art_dealers_and_galleries'
-          | 'artists_supply_and_craft_shops'
-          | 'auto_and_home_supply_stores'
-          | 'auto_body_repair_shops'
-          | 'auto_paint_shops'
-          | 'auto_service_shops'
-          | 'automated_cash_disburse'
-          | 'automated_fuel_dispensers'
-          | 'automobile_associations'
-          | 'automotive_parts_and_accessories_stores'
-          | 'automotive_tire_stores'
-          | 'bail_and_bond_payments'
-          | 'bakeries'
-          | 'bands_orchestras'
-          | 'barber_and_beauty_shops'
-          | 'betting_casino_gambling'
-          | 'bicycle_shops'
-          | 'billiard_pool_establishments'
-          | 'boat_dealers'
-          | 'boat_rentals_and_leases'
-          | 'book_stores'
-          | 'books_periodicals_and_newspapers'
-          | 'bowling_alleys'
-          | 'bus_lines'
-          | 'business_secretarial_schools'
-          | 'buying_shopping_services'
-          | 'cable_satellite_and_other_pay_television_and_radio'
-          | 'camera_and_photographic_supply_stores'
-          | 'candy_nut_and_confectionery_stores'
-          | 'car_and_truck_dealers_new_used'
-          | 'car_and_truck_dealers_used_only'
-          | 'car_rental_agencies'
-          | 'car_washes'
-          | 'carpentry_services'
-          | 'carpet_upholstery_cleaning'
-          | 'caterers'
-          | 'charitable_and_social_service_organizations_fundraising'
-          | 'chemicals_and_allied_products'
-          | 'child_care_services'
-          | 'childrens_and_infants_wear_stores'
-          | 'chiropodists_podiatrists'
-          | 'chiropractors'
-          | 'cigar_stores_and_stands'
-          | 'civic_social_fraternal_associations'
-          | 'cleaning_and_maintenance'
-          | 'clothing_rental'
-          | 'colleges_universities'
-          | 'commercial_equipment'
-          | 'commercial_footwear'
-          | 'commercial_photography_art_and_graphics'
-          | 'commuter_transport_and_ferries'
-          | 'computer_network_services'
-          | 'computer_programming'
-          | 'computer_repair'
-          | 'computer_software_stores'
-          | 'computers_peripherals_and_software'
-          | 'concrete_work_services'
-          | 'construction_materials'
-          | 'consulting_public_relations'
-          | 'correspondence_schools'
-          | 'cosmetic_stores'
-          | 'counseling_services'
-          | 'country_clubs'
-          | 'courier_services'
-          | 'court_costs'
-          | 'credit_reporting_agencies'
-          | 'cruise_lines'
-          | 'dairy_products_stores'
-          | 'dance_hall_studios_schools'
-          | 'dating_escort_services'
-          | 'dentists_orthodontists'
-          | 'department_stores'
-          | 'detective_agencies'
-          | 'digital_goods_applications'
-          | 'digital_goods_games'
-          | 'digital_goods_large_volume'
-          | 'digital_goods_media'
-          | 'direct_marketing_catalog_merchant'
-          | 'direct_marketing_combination_catalog_and_retail_merchant'
-          | 'direct_marketing_inbound_telemarketing'
-          | 'direct_marketing_insurance_services'
-          | 'direct_marketing_other'
-          | 'direct_marketing_outbound_telemarketing'
-          | 'direct_marketing_subscription'
-          | 'direct_marketing_travel'
-          | 'discount_stores'
-          | 'doctors'
-          | 'door_to_door_sales'
-          | 'drapery_window_covering_and_upholstery_stores'
-          | 'drinking_places'
-          | 'drug_stores_and_pharmacies'
-          | 'drugs_drug_proprietaries_and_druggist_sundries'
-          | 'dry_cleaners'
-          | 'durable_goods'
-          | 'duty_free_stores'
-          | 'eating_places_restaurants'
-          | 'educational_services'
-          | 'electric_razor_stores'
-          | 'electric_vehicle_charging'
-          | 'electrical_parts_and_equipment'
-          | 'electrical_services'
-          | 'electronics_repair_shops'
-          | 'electronics_stores'
-          | 'elementary_secondary_schools'
-          | 'emergency_services_gcas_visa_use_only'
-          | 'employment_temp_agencies'
-          | 'equipment_rental'
-          | 'exterminating_services'
-          | 'family_clothing_stores'
-          | 'fast_food_restaurants'
-          | 'financial_institutions'
-          | 'fines_government_administrative_entities'
-          | 'fireplace_fireplace_screens_and_accessories_stores'
-          | 'floor_covering_stores'
-          | 'florists'
-          | 'florists_supplies_nursery_stock_and_flowers'
-          | 'freezer_and_locker_meat_provisioners'
-          | 'fuel_dealers_non_automotive'
-          | 'funeral_services_crematories'
-          | 'furniture_home_furnishings_and_equipment_stores_except_appliances'
-          | 'furniture_repair_refinishing'
-          | 'furriers_and_fur_shops'
-          | 'general_services'
-          | 'gift_card_novelty_and_souvenir_shops'
-          | 'glass_paint_and_wallpaper_stores'
-          | 'glassware_crystal_stores'
-          | 'golf_courses_public'
-          | 'government_licensed_horse_dog_racing_us_region_only'
-          | 'government_licensed_online_casions_online_gambling_us_region_only'
-          | 'government_owned_lotteries_non_us_region'
-          | 'government_owned_lotteries_us_region_only'
-          | 'government_services'
-          | 'grocery_stores_supermarkets'
-          | 'hardware_equipment_and_supplies'
-          | 'hardware_stores'
-          | 'health_and_beauty_spas'
-          | 'hearing_aids_sales_and_supplies'
-          | 'heating_plumbing_a_c'
-          | 'hobby_toy_and_game_shops'
-          | 'home_supply_warehouse_stores'
-          | 'hospitals'
-          | 'hotels_motels_and_resorts'
-          | 'household_appliance_stores'
-          | 'industrial_supplies'
-          | 'information_retrieval_services'
-          | 'insurance_default'
-          | 'insurance_underwriting_premiums'
-          | 'intra_company_purchases'
-          | 'jewelry_stores_watches_clocks_and_silverware_stores'
-          | 'landscaping_services'
-          | 'laundries'
-          | 'laundry_cleaning_services'
-          | 'legal_services_attorneys'
-          | 'luggage_and_leather_goods_stores'
-          | 'lumber_building_materials_stores'
-          | 'manual_cash_disburse'
-          | 'marinas_service_and_supplies'
-          | 'marketplaces'
-          | 'masonry_stonework_and_plaster'
-          | 'massage_parlors'
-          | 'medical_and_dental_labs'
-          | 'medical_dental_ophthalmic_and_hospital_equipment_and_supplies'
-          | 'medical_services'
-          | 'membership_organizations'
-          | 'mens_and_boys_clothing_and_accessories_stores'
-          | 'mens_womens_clothing_stores'
-          | 'metal_service_centers'
-          | 'miscellaneous'
-          | 'miscellaneous_apparel_and_accessory_shops'
-          | 'miscellaneous_auto_dealers'
-          | 'miscellaneous_business_services'
-          | 'miscellaneous_food_stores'
-          | 'miscellaneous_general_merchandise'
-          | 'miscellaneous_general_services'
-          | 'miscellaneous_home_furnishing_specialty_stores'
-          | 'miscellaneous_publishing_and_printing'
-          | 'miscellaneous_recreation_services'
-          | 'miscellaneous_repair_shops'
-          | 'miscellaneous_specialty_retail'
-          | 'mobile_home_dealers'
-          | 'motion_picture_theaters'
-          | 'motor_freight_carriers_and_trucking'
-          | 'motor_homes_dealers'
-          | 'motor_vehicle_supplies_and_new_parts'
-          | 'motorcycle_shops_and_dealers'
-          | 'motorcycle_shops_dealers'
-          | 'music_stores_musical_instruments_pianos_and_sheet_music'
-          | 'news_dealers_and_newsstands'
-          | 'non_fi_money_orders'
-          | 'non_fi_stored_value_card_purchase_load'
-          | 'nondurable_goods'
-          | 'nurseries_lawn_and_garden_supply_stores'
-          | 'nursing_personal_care'
-          | 'office_and_commercial_furniture'
-          | 'opticians_eyeglasses'
-          | 'optometrists_ophthalmologist'
-          | 'orthopedic_goods_prosthetic_devices'
-          | 'osteopaths'
-          | 'package_stores_beer_wine_and_liquor'
-          | 'paints_varnishes_and_supplies'
-          | 'parking_lots_garages'
-          | 'passenger_railways'
-          | 'pawn_shops'
-          | 'pet_shops_pet_food_and_supplies'
-          | 'petroleum_and_petroleum_products'
-          | 'photo_developing'
-          | 'photographic_photocopy_microfilm_equipment_and_supplies'
-          | 'photographic_studios'
-          | 'picture_video_production'
-          | 'piece_goods_notions_and_other_dry_goods'
-          | 'plumbing_heating_equipment_and_supplies'
-          | 'political_organizations'
-          | 'postal_services_government_only'
-          | 'precious_stones_and_metals_watches_and_jewelry'
-          | 'professional_services'
-          | 'public_warehousing_and_storage'
-          | 'quick_copy_repro_and_blueprint'
-          | 'railroads'
-          | 'real_estate_agents_and_managers_rentals'
-          | 'record_stores'
-          | 'recreational_vehicle_rentals'
-          | 'religious_goods_stores'
-          | 'religious_organizations'
-          | 'roofing_siding_sheet_metal'
-          | 'secretarial_support_services'
-          | 'security_brokers_dealers'
-          | 'service_stations'
-          | 'sewing_needlework_fabric_and_piece_goods_stores'
-          | 'shoe_repair_hat_cleaning'
-          | 'shoe_stores'
-          | 'small_appliance_repair'
-          | 'snowmobile_dealers'
-          | 'special_trade_services'
-          | 'specialty_cleaning'
-          | 'sporting_goods_stores'
-          | 'sporting_recreation_camps'
-          | 'sports_and_riding_apparel_stores'
-          | 'sports_clubs_fields'
-          | 'stamp_and_coin_stores'
-          | 'stationary_office_supplies_printing_and_writing_paper'
-          | 'stationery_stores_office_and_school_supply_stores'
-          | 'swimming_pools_sales'
-          | 't_ui_travel_germany'
-          | 'tailors_alterations'
-          | 'tax_payments_government_agencies'
-          | 'tax_preparation_services'
-          | 'taxicabs_limousines'
-          | 'telecommunication_equipment_and_telephone_sales'
-          | 'telecommunication_services'
-          | 'telegraph_services'
-          | 'tent_and_awning_shops'
-          | 'testing_laboratories'
-          | 'theatrical_ticket_agencies'
-          | 'timeshares'
-          | 'tire_retreading_and_repair'
-          | 'tolls_bridge_fees'
-          | 'tourist_attractions_and_exhibits'
-          | 'towing_services'
-          | 'trailer_parks_campgrounds'
-          | 'transportation_services'
-          | 'travel_agencies_tour_operators'
-          | 'truck_stop_iteration'
-          | 'truck_utility_trailer_rentals'
-          | 'typesetting_plate_making_and_related_services'
-          | 'typewriter_stores'
-          | 'u_s_federal_government_agencies_or_departments'
-          | 'uniforms_commercial_clothing'
-          | 'used_merchandise_and_secondhand_stores'
-          | 'utilities'
-          | 'variety_stores'
-          | 'veterinary_services'
-          | 'video_amusement_game_supplies'
-          | 'video_game_arcades'
-          | 'video_tape_rental_stores'
-          | 'vocational_trade_schools'
-          | 'watch_jewelry_repair'
-          | 'welding_repair'
-          | 'wholesale_clubs'
-          | 'wig_and_toupee_stores'
-          | 'wires_money_orders'
-          | 'womens_accessory_and_specialty_shops'
-          | 'womens_ready_to_wear_stores'
-          | 'wrecking_and_salvage_yards';
-
-        export type Interval =
-          | 'all_time'
-          | 'daily'
-          | 'monthly'
-          | 'per_authorization'
-          | 'weekly'
-          | 'yearly';
-      }
+      /**
+       * Reason the card is ineligible for Apple Pay
+       */
+      ineligible_reason: ApplePay.IneligibleReason | null;
     }
 
-    export namespace Wallets {
-      export interface ApplePay {
-        /**
-         * Apple Pay Eligibility
-         */
-        eligible: boolean;
+    export interface GooglePay {
+      /**
+       * Google Pay Eligibility
+       */
+      eligible: boolean;
 
-        /**
-         * Reason the card is ineligible for Apple Pay
-         */
-        ineligible_reason: ApplePay.IneligibleReason | null;
-      }
+      /**
+       * Reason the card is ineligible for Google Pay
+       */
+      ineligible_reason: GooglePay.IneligibleReason | null;
+    }
 
-      export interface GooglePay {
-        /**
-         * Google Pay Eligibility
-         */
-        eligible: boolean;
+    export namespace ApplePay {
+      export type IneligibleReason =
+        | 'missing_agreement'
+        | 'missing_cardholder_contact'
+        | 'unsupported_region';
+    }
 
-        /**
-         * Reason the card is ineligible for Google Pay
-         */
-        ineligible_reason: GooglePay.IneligibleReason | null;
-      }
-
-      export namespace ApplePay {
-        export type IneligibleReason =
-          | 'missing_agreement'
-          | 'missing_cardholder_contact'
-          | 'unsupported_region';
-      }
-
-      export namespace GooglePay {
-        export type IneligibleReason =
-          | 'missing_agreement'
-          | 'missing_cardholder_contact'
-          | 'unsupported_region';
-      }
+    export namespace GooglePay {
+      export type IneligibleReason =
+        | 'missing_agreement'
+        | 'missing_cardholder_contact'
+        | 'unsupported_region';
     }
   }
 }

--- a/src/resources/Issuing/Disputes.ts
+++ b/src/resources/Issuing/Disputes.ts
@@ -116,7 +116,7 @@ export interface Dispute {
    */
   currency: string;
 
-  evidence: Issuing.Dispute.Evidence;
+  evidence: Dispute.Evidence;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -126,7 +126,7 @@ export interface Dispute {
   /**
    * The enum that describes the dispute loss outcome. If the dispute is not lost, this field will be absent. New enum values may be added in the future, so be sure to handle unknown values.
    */
-  loss_reason?: Issuing.Dispute.LossReason;
+  loss_reason?: Dispute.LossReason;
 
   /**
    * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -136,7 +136,7 @@ export interface Dispute {
   /**
    * Current status of the dispute.
    */
-  status: Issuing.Dispute.Status;
+  status: Dispute.Status;
 
   /**
    * The transaction being disputed.
@@ -146,318 +146,311 @@ export interface Dispute {
   /**
    * [Treasury](https://docs.stripe.com/api/treasury) details related to this dispute if it was created on a [FinancialAccount](https://docs.stripe.com/api/treasury/financial_accounts)
    */
-  treasury?: Issuing.Dispute.Treasury | null;
+  treasury?: Dispute.Treasury | null;
 }
-export namespace Issuing {
-  export namespace Dispute {
-    export interface Evidence {
-      canceled?: Evidence.Canceled;
+export namespace Dispute {
+  export interface Evidence {
+    canceled?: Evidence.Canceled;
 
-      duplicate?: Evidence.Duplicate;
+    duplicate?: Evidence.Duplicate;
 
-      fraudulent?: Evidence.Fraudulent;
+    fraudulent?: Evidence.Fraudulent;
 
-      merchandise_not_as_described?: Evidence.MerchandiseNotAsDescribed;
+    merchandise_not_as_described?: Evidence.MerchandiseNotAsDescribed;
 
-      no_valid_authorization?: Evidence.NoValidAuthorization;
+    no_valid_authorization?: Evidence.NoValidAuthorization;
 
-      not_received?: Evidence.NotReceived;
+    not_received?: Evidence.NotReceived;
 
-      other?: Evidence.Other;
+    other?: Evidence.Other;
+
+    /**
+     * The reason for filing the dispute. Its value will match the field containing the evidence.
+     */
+    reason: Evidence.Reason;
+
+    service_not_as_described?: Evidence.ServiceNotAsDescribed;
+  }
+
+  export type LossReason =
+    | 'cardholder_authentication_issuer_liability'
+    | 'eci5_token_transaction_with_tavv'
+    | 'excess_disputes_in_timeframe'
+    | 'has_not_met_the_minimum_dispute_amount_requirements'
+    | 'invalid_duplicate_dispute'
+    | 'invalid_incorrect_amount_dispute'
+    | 'invalid_no_authorization'
+    | 'invalid_use_of_disputes'
+    | 'merchandise_delivered_or_shipped'
+    | 'merchandise_or_service_as_described'
+    | 'not_cancelled'
+    | 'other'
+    | 'refund_issued'
+    | 'submitted_beyond_allowable_time_limit'
+    | 'transaction_3ds_required'
+    | 'transaction_approved_after_prior_fraud_dispute'
+    | 'transaction_authorized'
+    | 'transaction_electronically_read'
+    | 'transaction_qualifies_for_visa_easy_payment_service'
+    | 'transaction_unattended';
+
+  export type Status = 'expired' | 'lost' | 'submitted' | 'unsubmitted' | 'won';
+
+  export interface Treasury {
+    /**
+     * The Treasury [DebitReversal](https://docs.stripe.com/api/treasury/debit_reversals) representing this Issuing dispute
+     */
+    debit_reversal: string | null;
+
+    /**
+     * The Treasury [ReceivedDebit](https://docs.stripe.com/api/treasury/received_debits) that is being disputed.
+     */
+    received_debit: string;
+  }
+
+  export namespace Evidence {
+    export interface Canceled {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
 
       /**
-       * The reason for filing the dispute. Its value will match the field containing the evidence.
+       * Date when order was canceled.
        */
-      reason: Evidence.Reason;
+      canceled_at: number | null;
 
-      service_not_as_described?: Evidence.ServiceNotAsDescribed;
+      /**
+       * Whether the cardholder was provided with a cancellation policy.
+       */
+      cancellation_policy_provided: boolean | null;
+
+      /**
+       * Reason for canceling the order.
+       */
+      cancellation_reason: string | null;
+
+      /**
+       * Date when the cardholder expected to receive the product.
+       */
+      expected_at: number | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+
+      /**
+       * Description of the merchandise or service that was purchased.
+       */
+      product_description: string | null;
+
+      /**
+       * Whether the product was a merchandise or service.
+       */
+      product_type: Canceled.ProductType | null;
+
+      /**
+       * Result of cardholder's attempt to return the product.
+       */
+      return_status: Canceled.ReturnStatus | null;
+
+      /**
+       * Date when the product was returned or attempted to be returned.
+       */
+      returned_at: number | null;
     }
 
-    export type LossReason =
-      | 'cardholder_authentication_issuer_liability'
-      | 'eci5_token_transaction_with_tavv'
-      | 'excess_disputes_in_timeframe'
-      | 'has_not_met_the_minimum_dispute_amount_requirements'
-      | 'invalid_duplicate_dispute'
-      | 'invalid_incorrect_amount_dispute'
-      | 'invalid_no_authorization'
-      | 'invalid_use_of_disputes'
-      | 'merchandise_delivered_or_shipped'
-      | 'merchandise_or_service_as_described'
-      | 'not_cancelled'
+    export interface Duplicate {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
+
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the card statement showing that the product had already been paid for.
+       */
+      card_statement: string | File | null;
+
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the receipt showing that the product had been paid for in cash.
+       */
+      cash_receipt: string | File | null;
+
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Image of the front and back of the check that was used to pay for the product.
+       */
+      check_image: string | File | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+
+      /**
+       * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or more transactions that are copies of each other, this is original undisputed one.
+       */
+      original_transaction: string | null;
+    }
+
+    export interface Fraudulent {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+    }
+
+    export interface MerchandiseNotAsDescribed {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+
+      /**
+       * Date when the product was received.
+       */
+      received_at: number | null;
+
+      /**
+       * Description of the cardholder's attempt to return the product.
+       */
+      return_description: string | null;
+
+      /**
+       * Result of cardholder's attempt to return the product.
+       */
+      return_status: MerchandiseNotAsDescribed.ReturnStatus | null;
+
+      /**
+       * Date when the product was returned or attempted to be returned.
+       */
+      returned_at: number | null;
+    }
+
+    export interface NoValidAuthorization {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+    }
+
+    export interface NotReceived {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
+
+      /**
+       * Date when the cardholder expected to receive the product.
+       */
+      expected_at: number | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+
+      /**
+       * Description of the merchandise or service that was purchased.
+       */
+      product_description: string | null;
+
+      /**
+       * Whether the product was a merchandise or service.
+       */
+      product_type: NotReceived.ProductType | null;
+    }
+
+    export interface Other {
+      /**
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
+       */
+      additional_documentation: string | File | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+
+      /**
+       * Description of the merchandise or service that was purchased.
+       */
+      product_description: string | null;
+
+      /**
+       * Whether the product was a merchandise or service.
+       */
+      product_type: Other.ProductType | null;
+    }
+
+    export type Reason =
+      | 'canceled'
+      | 'duplicate'
+      | 'fraudulent'
+      | 'merchandise_not_as_described'
+      | 'no_valid_authorization'
+      | 'not_received'
       | 'other'
-      | 'refund_issued'
-      | 'submitted_beyond_allowable_time_limit'
-      | 'transaction_3ds_required'
-      | 'transaction_approved_after_prior_fraud_dispute'
-      | 'transaction_authorized'
-      | 'transaction_electronically_read'
-      | 'transaction_qualifies_for_visa_easy_payment_service'
-      | 'transaction_unattended';
+      | 'service_not_as_described';
 
-    export type Status =
-      | 'expired'
-      | 'lost'
-      | 'submitted'
-      | 'unsubmitted'
-      | 'won';
-
-    export interface Treasury {
+    export interface ServiceNotAsDescribed {
       /**
-       * The Treasury [DebitReversal](https://docs.stripe.com/api/treasury/debit_reversals) representing this Issuing dispute
+       * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
        */
-      debit_reversal: string | null;
+      additional_documentation: string | File | null;
 
       /**
-       * The Treasury [ReceivedDebit](https://docs.stripe.com/api/treasury/received_debits) that is being disputed.
+       * Date when order was canceled.
        */
-      received_debit: string;
+      canceled_at: number | null;
+
+      /**
+       * Reason for canceling the order.
+       */
+      cancellation_reason: string | null;
+
+      /**
+       * Explanation of why the cardholder is disputing this transaction.
+       */
+      explanation: string | null;
+
+      /**
+       * Date when the product was received.
+       */
+      received_at: number | null;
     }
 
-    export namespace Evidence {
-      export interface Canceled {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
+    export namespace Canceled {
+      export type ProductType = 'merchandise' | 'service';
 
-        /**
-         * Date when order was canceled.
-         */
-        canceled_at: number | null;
+      export type ReturnStatus = 'merchant_rejected' | 'successful';
+    }
 
-        /**
-         * Whether the cardholder was provided with a cancellation policy.
-         */
-        cancellation_policy_provided: boolean | null;
+    export namespace MerchandiseNotAsDescribed {
+      export type ReturnStatus = 'merchant_rejected' | 'successful';
+    }
 
-        /**
-         * Reason for canceling the order.
-         */
-        cancellation_reason: string | null;
+    export namespace NotReceived {
+      export type ProductType = 'merchandise' | 'service';
+    }
 
-        /**
-         * Date when the cardholder expected to receive the product.
-         */
-        expected_at: number | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-
-        /**
-         * Description of the merchandise or service that was purchased.
-         */
-        product_description: string | null;
-
-        /**
-         * Whether the product was a merchandise or service.
-         */
-        product_type: Canceled.ProductType | null;
-
-        /**
-         * Result of cardholder's attempt to return the product.
-         */
-        return_status: Canceled.ReturnStatus | null;
-
-        /**
-         * Date when the product was returned or attempted to be returned.
-         */
-        returned_at: number | null;
-      }
-
-      export interface Duplicate {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the card statement showing that the product had already been paid for.
-         */
-        card_statement: string | File | null;
-
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Copy of the receipt showing that the product had been paid for in cash.
-         */
-        cash_receipt: string | File | null;
-
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Image of the front and back of the check that was used to pay for the product.
-         */
-        check_image: string | File | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-
-        /**
-         * Transaction (e.g., ipi_...) that the disputed transaction is a duplicate of. Of the two or more transactions that are copies of each other, this is original undisputed one.
-         */
-        original_transaction: string | null;
-      }
-
-      export interface Fraudulent {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-      }
-
-      export interface MerchandiseNotAsDescribed {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-
-        /**
-         * Date when the product was received.
-         */
-        received_at: number | null;
-
-        /**
-         * Description of the cardholder's attempt to return the product.
-         */
-        return_description: string | null;
-
-        /**
-         * Result of cardholder's attempt to return the product.
-         */
-        return_status: MerchandiseNotAsDescribed.ReturnStatus | null;
-
-        /**
-         * Date when the product was returned or attempted to be returned.
-         */
-        returned_at: number | null;
-      }
-
-      export interface NoValidAuthorization {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-      }
-
-      export interface NotReceived {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * Date when the cardholder expected to receive the product.
-         */
-        expected_at: number | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-
-        /**
-         * Description of the merchandise or service that was purchased.
-         */
-        product_description: string | null;
-
-        /**
-         * Whether the product was a merchandise or service.
-         */
-        product_type: NotReceived.ProductType | null;
-      }
-
-      export interface Other {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-
-        /**
-         * Description of the merchandise or service that was purchased.
-         */
-        product_description: string | null;
-
-        /**
-         * Whether the product was a merchandise or service.
-         */
-        product_type: Other.ProductType | null;
-      }
-
-      export type Reason =
-        | 'canceled'
-        | 'duplicate'
-        | 'fraudulent'
-        | 'merchandise_not_as_described'
-        | 'no_valid_authorization'
-        | 'not_received'
-        | 'other'
-        | 'service_not_as_described';
-
-      export interface ServiceNotAsDescribed {
-        /**
-         * (ID of a [file upload](https://stripe.com/docs/guides/file-upload)) Additional documentation supporting the dispute.
-         */
-        additional_documentation: string | File | null;
-
-        /**
-         * Date when order was canceled.
-         */
-        canceled_at: number | null;
-
-        /**
-         * Reason for canceling the order.
-         */
-        cancellation_reason: string | null;
-
-        /**
-         * Explanation of why the cardholder is disputing this transaction.
-         */
-        explanation: string | null;
-
-        /**
-         * Date when the product was received.
-         */
-        received_at: number | null;
-      }
-
-      export namespace Canceled {
-        export type ProductType = 'merchandise' | 'service';
-
-        export type ReturnStatus = 'merchant_rejected' | 'successful';
-      }
-
-      export namespace MerchandiseNotAsDescribed {
-        export type ReturnStatus = 'merchant_rejected' | 'successful';
-      }
-
-      export namespace NotReceived {
-        export type ProductType = 'merchandise' | 'service';
-      }
-
-      export namespace Other {
-        export type ProductType = 'merchandise' | 'service';
-      }
+    export namespace Other {
+      export type ProductType = 'merchandise' | 'service';
     }
   }
 }

--- a/src/resources/Issuing/PersonalizationDesigns.ts
+++ b/src/resources/Issuing/PersonalizationDesigns.ts
@@ -93,7 +93,7 @@ export interface PersonalizationDesign {
   /**
    * Hash containing carrier text, for use with physical bundles that support carrier text.
    */
-  carrier_text: Issuing.PersonalizationDesign.CarrierText | null;
+  carrier_text: PersonalizationDesign.CarrierText | null;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -125,85 +125,83 @@ export interface PersonalizationDesign {
    */
   physical_bundle: string | PhysicalBundle;
 
-  preferences: Issuing.PersonalizationDesign.Preferences;
+  preferences: PersonalizationDesign.Preferences;
 
-  rejection_reasons: Issuing.PersonalizationDesign.RejectionReasons;
+  rejection_reasons: PersonalizationDesign.RejectionReasons;
 
   /**
    * Whether this personalization design can be used to create cards.
    */
-  status: Issuing.PersonalizationDesign.Status;
+  status: PersonalizationDesign.Status;
 }
-export namespace Issuing {
-  export namespace PersonalizationDesign {
-    export interface CarrierText {
-      /**
-       * The footer body text of the carrier letter.
-       */
-      footer_body: string | null;
+export namespace PersonalizationDesign {
+  export interface CarrierText {
+    /**
+     * The footer body text of the carrier letter.
+     */
+    footer_body: string | null;
 
-      /**
-       * The footer title text of the carrier letter.
-       */
-      footer_title: string | null;
+    /**
+     * The footer title text of the carrier letter.
+     */
+    footer_title: string | null;
 
-      /**
-       * The header body text of the carrier letter.
-       */
-      header_body: string | null;
+    /**
+     * The header body text of the carrier letter.
+     */
+    header_body: string | null;
 
-      /**
-       * The header title text of the carrier letter.
-       */
-      header_title: string | null;
-    }
+    /**
+     * The header title text of the carrier letter.
+     */
+    header_title: string | null;
+  }
 
-    export interface Preferences {
-      /**
-       * Whether we use this personalization design to create cards when one isn't specified. A connected account uses the Connect platform's default design if no personalization design is set as the default design.
-       */
-      is_default: boolean;
+  export interface Preferences {
+    /**
+     * Whether we use this personalization design to create cards when one isn't specified. A connected account uses the Connect platform's default design if no personalization design is set as the default design.
+     */
+    is_default: boolean;
 
-      /**
-       * Whether this personalization design is used to create cards when one is not specified and a default for this connected account does not exist.
-       */
-      is_platform_default: boolean | null;
-    }
+    /**
+     * Whether this personalization design is used to create cards when one is not specified and a default for this connected account does not exist.
+     */
+    is_platform_default: boolean | null;
+  }
 
-    export interface RejectionReasons {
-      /**
-       * The reason(s) the card logo was rejected.
-       */
-      card_logo: Array<RejectionReasons.CardLogo> | null;
+  export interface RejectionReasons {
+    /**
+     * The reason(s) the card logo was rejected.
+     */
+    card_logo: Array<RejectionReasons.CardLogo> | null;
 
-      /**
-       * The reason(s) the carrier text was rejected.
-       */
-      carrier_text: Array<RejectionReasons.CarrierText> | null;
-    }
+    /**
+     * The reason(s) the carrier text was rejected.
+     */
+    carrier_text: Array<RejectionReasons.CarrierText> | null;
+  }
 
-    export type Status = 'active' | 'inactive' | 'rejected' | 'review';
+  export type Status = 'active' | 'inactive' | 'rejected' | 'review';
 
-    export namespace RejectionReasons {
-      export type CardLogo =
-        | 'geographic_location'
-        | 'inappropriate'
-        | 'network_name'
-        | 'non_binary_image'
-        | 'non_fiat_currency'
-        | 'other'
-        | 'other_entity'
-        | 'promotional_material';
+  export namespace RejectionReasons {
+    export type CardLogo =
+      | 'geographic_location'
+      | 'inappropriate'
+      | 'network_name'
+      | 'non_binary_image'
+      | 'non_fiat_currency'
+      | 'other'
+      | 'other_entity'
+      | 'promotional_material';
 
-      export type CarrierText =
-        | 'geographic_location'
-        | 'inappropriate'
-        | 'network_name'
-        | 'non_fiat_currency'
-        | 'other'
-        | 'other_entity'
-        | 'promotional_material';
-    }
+    export type CarrierText =
+      | 'geographic_location'
+      | 'inappropriate'
+      | 'network_name'
+      | 'non_fiat_currency'
+      | 'other'
+      | 'other_entity'
+      | 'promotional_material';
   }
 }
 export namespace Issuing {

--- a/src/resources/Issuing/PhysicalBundles.ts
+++ b/src/resources/Issuing/PhysicalBundles.ts
@@ -49,7 +49,7 @@ export interface PhysicalBundle {
    */
   object: 'issuing.physical_bundle';
 
-  features: Issuing.PhysicalBundle.Features;
+  features: PhysicalBundle.Features;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -64,43 +64,41 @@ export interface PhysicalBundle {
   /**
    * Whether this physical bundle can be used to create cards.
    */
-  status: Issuing.PhysicalBundle.Status;
+  status: PhysicalBundle.Status;
 
   /**
    * Whether this physical bundle is a standard Stripe offering or custom-made for you.
    */
-  type: Issuing.PhysicalBundle.Type;
+  type: PhysicalBundle.Type;
 }
-export namespace Issuing {
-  export namespace PhysicalBundle {
-    export interface Features {
-      /**
-       * The policy for how to use card logo images in a card design with this physical bundle.
-       */
-      card_logo: Features.CardLogo;
+export namespace PhysicalBundle {
+  export interface Features {
+    /**
+     * The policy for how to use card logo images in a card design with this physical bundle.
+     */
+    card_logo: Features.CardLogo;
 
-      /**
-       * The policy for how to use carrier letter text in a card design with this physical bundle.
-       */
-      carrier_text: Features.CarrierText;
+    /**
+     * The policy for how to use carrier letter text in a card design with this physical bundle.
+     */
+    carrier_text: Features.CarrierText;
 
-      /**
-       * The policy for how to use a second line on a card with this physical bundle.
-       */
-      second_line: Features.SecondLine;
-    }
+    /**
+     * The policy for how to use a second line on a card with this physical bundle.
+     */
+    second_line: Features.SecondLine;
+  }
 
-    export type Status = 'active' | 'inactive' | 'review';
+  export type Status = 'active' | 'inactive' | 'review';
 
-    export type Type = 'custom' | 'standard';
+  export type Type = 'custom' | 'standard';
 
-    export namespace Features {
-      export type CardLogo = 'optional' | 'required' | 'unsupported';
+  export namespace Features {
+    export type CardLogo = 'optional' | 'required' | 'unsupported';
 
-      export type CarrierText = 'optional' | 'required' | 'unsupported';
+    export type CarrierText = 'optional' | 'required' | 'unsupported';
 
-      export type SecondLine = 'optional' | 'required' | 'unsupported';
-    }
+    export type SecondLine = 'optional' | 'required' | 'unsupported';
   }
 }
 export namespace Issuing {

--- a/src/resources/Issuing/Tokens.ts
+++ b/src/resources/Issuing/Tokens.ts
@@ -87,9 +87,9 @@ export interface Token {
   /**
    * The token service provider / card network associated with the token.
    */
-  network: Issuing.Token.Network;
+  network: Token.Network;
 
-  network_data?: Issuing.Token.NetworkData;
+  network_data?: Token.NetworkData;
 
   /**
    * Time at which the token was last updated by the card network. Measured in seconds since the Unix epoch.
@@ -99,215 +99,213 @@ export interface Token {
   /**
    * The usage state of the token.
    */
-  status: Issuing.Token.Status;
+  status: Token.Status;
 
   /**
    * The digital wallet for this token, if one was used.
    */
-  wallet_provider?: Issuing.Token.WalletProvider;
+  wallet_provider?: Token.WalletProvider;
 }
-export namespace Issuing {
-  export namespace Token {
-    export type Network = 'mastercard' | 'visa';
+export namespace Token {
+  export type Network = 'mastercard' | 'visa';
 
-    export interface NetworkData {
-      device?: NetworkData.Device;
+  export interface NetworkData {
+    device?: NetworkData.Device;
 
-      mastercard?: NetworkData.Mastercard;
+    mastercard?: NetworkData.Mastercard;
+
+    /**
+     * The network that the token is associated with. An additional hash is included with a name matching this value, containing tokenization data specific to the card network.
+     */
+    type: NetworkData.Type;
+
+    visa?: NetworkData.Visa;
+
+    wallet_provider?: NetworkData.WalletProvider;
+  }
+
+  export type Status = 'active' | 'deleted' | 'requested' | 'suspended';
+
+  export type WalletProvider = 'apple_pay' | 'google_pay' | 'samsung_pay';
+
+  export namespace NetworkData {
+    export interface Device {
+      /**
+       * An obfuscated ID derived from the device ID.
+       */
+      device_fingerprint?: string;
 
       /**
-       * The network that the token is associated with. An additional hash is included with a name matching this value, containing tokenization data specific to the card network.
+       * The IP address of the device at provisioning time.
        */
-      type: NetworkData.Type;
+      ip_address?: string;
 
-      visa?: NetworkData.Visa;
+      /**
+       * The geographic latitude/longitude coordinates of the device at provisioning time. The format is [+-]decimal/[+-]decimal.
+       */
+      location?: string;
 
-      wallet_provider?: NetworkData.WalletProvider;
+      /**
+       * The name of the device used for tokenization.
+       */
+      name?: string;
+
+      /**
+       * The phone number of the device used for tokenization.
+       */
+      phone_number?: string;
+
+      /**
+       * The type of device used for tokenization.
+       */
+      type?: Device.Type;
     }
 
-    export type Status = 'active' | 'deleted' | 'requested' | 'suspended';
+    export interface Mastercard {
+      /**
+       * A unique reference ID from MasterCard to represent the card account number.
+       */
+      card_reference_id?: string;
 
-    export type WalletProvider = 'apple_pay' | 'google_pay' | 'samsung_pay';
+      /**
+       * The network-unique identifier for the token.
+       */
+      token_reference_id: string;
 
-    export namespace NetworkData {
-      export interface Device {
+      /**
+       * The ID of the entity requesting tokenization, specific to MasterCard.
+       */
+      token_requestor_id: string;
+
+      /**
+       * The name of the entity requesting tokenization, if known. This is directly provided from MasterCard.
+       */
+      token_requestor_name?: string;
+    }
+
+    export type Type = 'mastercard' | 'visa';
+
+    export interface Visa {
+      /**
+       * A unique reference ID from Visa to represent the card account number.
+       */
+      card_reference_id: string | null;
+
+      /**
+       * The network-unique identifier for the token.
+       */
+      token_reference_id: string;
+
+      /**
+       * The ID of the entity requesting tokenization, specific to Visa.
+       */
+      token_requestor_id: string;
+
+      /**
+       * Degree of risk associated with the token between `01` and `99`, with higher number indicating higher risk. A `00` value indicates the token was not scored by Visa.
+       */
+      token_risk_score?: string;
+    }
+
+    export interface WalletProvider {
+      /**
+       * The wallet provider-given account ID of the digital wallet the token belongs to.
+       */
+      account_id?: string;
+
+      /**
+       * An evaluation on the trustworthiness of the wallet account between 1 and 5. A higher score indicates more trustworthy.
+       */
+      account_trust_score?: number;
+
+      /**
+       * The method used for tokenizing a card.
+       */
+      card_number_source?: WalletProvider.CardNumberSource;
+
+      cardholder_address?: WalletProvider.CardholderAddress;
+
+      /**
+       * The name of the cardholder tokenizing the card.
+       */
+      cardholder_name?: string;
+
+      /**
+       * An evaluation on the trustworthiness of the device. A higher score indicates more trustworthy.
+       */
+      device_trust_score?: number;
+
+      /**
+       * The hashed email address of the cardholder's account with the wallet provider.
+       */
+      hashed_account_email_address?: string;
+
+      /**
+       * The reasons for suggested tokenization given by the card network.
+       */
+      reason_codes?: Array<WalletProvider.ReasonCode>;
+
+      /**
+       * The recommendation on responding to the tokenization request.
+       */
+      suggested_decision?: WalletProvider.SuggestedDecision;
+
+      /**
+       * The version of the standard for mapping reason codes followed by the wallet provider.
+       */
+      suggested_decision_version?: string;
+    }
+
+    export namespace Device {
+      export type Type = 'other' | 'phone' | 'watch';
+    }
+
+    export namespace WalletProvider {
+      export type CardNumberSource = 'app' | 'manual' | 'on_file' | 'other';
+
+      export interface CardholderAddress {
         /**
-         * An obfuscated ID derived from the device ID.
+         * The street address of the cardholder tokenizing the card.
          */
-        device_fingerprint?: string;
+        line1: string;
 
         /**
-         * The IP address of the device at provisioning time.
+         * The postal code of the cardholder tokenizing the card.
          */
-        ip_address?: string;
-
-        /**
-         * The geographic latitude/longitude coordinates of the device at provisioning time. The format is [+-]decimal/[+-]decimal.
-         */
-        location?: string;
-
-        /**
-         * The name of the device used for tokenization.
-         */
-        name?: string;
-
-        /**
-         * The phone number of the device used for tokenization.
-         */
-        phone_number?: string;
-
-        /**
-         * The type of device used for tokenization.
-         */
-        type?: Device.Type;
+        postal_code: string;
       }
 
-      export interface Mastercard {
-        /**
-         * A unique reference ID from MasterCard to represent the card account number.
-         */
-        card_reference_id?: string;
+      export type ReasonCode =
+        | 'account_card_too_new'
+        | 'account_recently_changed'
+        | 'account_too_new'
+        | 'account_too_new_since_launch'
+        | 'additional_device'
+        | 'data_expired'
+        | 'defer_id_v_decision'
+        | 'device_recently_lost'
+        | 'good_activity_history'
+        | 'has_suspended_tokens'
+        | 'high_risk'
+        | 'inactive_account'
+        | 'long_account_tenure'
+        | 'low_account_score'
+        | 'low_device_score'
+        | 'low_phone_number_score'
+        | 'network_service_error'
+        | 'outside_home_territory'
+        | 'provisioning_cardholder_mismatch'
+        | 'provisioning_device_and_cardholder_mismatch'
+        | 'provisioning_device_mismatch'
+        | 'same_device_no_prior_authentication'
+        | 'same_device_successful_prior_authentication'
+        | 'software_update'
+        | 'suspicious_activity'
+        | 'too_many_different_cardholders'
+        | 'too_many_recent_attempts'
+        | 'too_many_recent_tokens';
 
-        /**
-         * The network-unique identifier for the token.
-         */
-        token_reference_id: string;
-
-        /**
-         * The ID of the entity requesting tokenization, specific to MasterCard.
-         */
-        token_requestor_id: string;
-
-        /**
-         * The name of the entity requesting tokenization, if known. This is directly provided from MasterCard.
-         */
-        token_requestor_name?: string;
-      }
-
-      export type Type = 'mastercard' | 'visa';
-
-      export interface Visa {
-        /**
-         * A unique reference ID from Visa to represent the card account number.
-         */
-        card_reference_id: string | null;
-
-        /**
-         * The network-unique identifier for the token.
-         */
-        token_reference_id: string;
-
-        /**
-         * The ID of the entity requesting tokenization, specific to Visa.
-         */
-        token_requestor_id: string;
-
-        /**
-         * Degree of risk associated with the token between `01` and `99`, with higher number indicating higher risk. A `00` value indicates the token was not scored by Visa.
-         */
-        token_risk_score?: string;
-      }
-
-      export interface WalletProvider {
-        /**
-         * The wallet provider-given account ID of the digital wallet the token belongs to.
-         */
-        account_id?: string;
-
-        /**
-         * An evaluation on the trustworthiness of the wallet account between 1 and 5. A higher score indicates more trustworthy.
-         */
-        account_trust_score?: number;
-
-        /**
-         * The method used for tokenizing a card.
-         */
-        card_number_source?: WalletProvider.CardNumberSource;
-
-        cardholder_address?: WalletProvider.CardholderAddress;
-
-        /**
-         * The name of the cardholder tokenizing the card.
-         */
-        cardholder_name?: string;
-
-        /**
-         * An evaluation on the trustworthiness of the device. A higher score indicates more trustworthy.
-         */
-        device_trust_score?: number;
-
-        /**
-         * The hashed email address of the cardholder's account with the wallet provider.
-         */
-        hashed_account_email_address?: string;
-
-        /**
-         * The reasons for suggested tokenization given by the card network.
-         */
-        reason_codes?: Array<WalletProvider.ReasonCode>;
-
-        /**
-         * The recommendation on responding to the tokenization request.
-         */
-        suggested_decision?: WalletProvider.SuggestedDecision;
-
-        /**
-         * The version of the standard for mapping reason codes followed by the wallet provider.
-         */
-        suggested_decision_version?: string;
-      }
-
-      export namespace Device {
-        export type Type = 'other' | 'phone' | 'watch';
-      }
-
-      export namespace WalletProvider {
-        export type CardNumberSource = 'app' | 'manual' | 'on_file' | 'other';
-
-        export interface CardholderAddress {
-          /**
-           * The street address of the cardholder tokenizing the card.
-           */
-          line1: string;
-
-          /**
-           * The postal code of the cardholder tokenizing the card.
-           */
-          postal_code: string;
-        }
-
-        export type ReasonCode =
-          | 'account_card_too_new'
-          | 'account_recently_changed'
-          | 'account_too_new'
-          | 'account_too_new_since_launch'
-          | 'additional_device'
-          | 'data_expired'
-          | 'defer_id_v_decision'
-          | 'device_recently_lost'
-          | 'good_activity_history'
-          | 'has_suspended_tokens'
-          | 'high_risk'
-          | 'inactive_account'
-          | 'long_account_tenure'
-          | 'low_account_score'
-          | 'low_device_score'
-          | 'low_phone_number_score'
-          | 'network_service_error'
-          | 'outside_home_territory'
-          | 'provisioning_cardholder_mismatch'
-          | 'provisioning_device_and_cardholder_mismatch'
-          | 'provisioning_device_mismatch'
-          | 'same_device_no_prior_authentication'
-          | 'same_device_successful_prior_authentication'
-          | 'software_update'
-          | 'suspicious_activity'
-          | 'too_many_different_cardholders'
-          | 'too_many_recent_attempts'
-          | 'too_many_recent_tokens';
-
-        export type SuggestedDecision = 'approve' | 'decline' | 'require_auth';
-      }
+      export type SuggestedDecision = 'approve' | 'decline' | 'require_auth';
     }
   }
 }

--- a/src/resources/Issuing/Transactions.ts
+++ b/src/resources/Issuing/Transactions.ts
@@ -343,7 +343,7 @@ export interface Transaction {
   /**
    * Detailed breakdown of amount components. These amounts are denominated in `currency` and in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
    */
-  amount_details: Issuing.Transaction.AmountDetails | null;
+  amount_details: Transaction.AmountDetails | null;
 
   /**
    * The `Authorization` object that led to this transaction.
@@ -395,7 +395,7 @@ export interface Transaction {
    */
   merchant_currency: string;
 
-  merchant_data: Issuing.Transaction.MerchantData;
+  merchant_data: Transaction.MerchantData;
 
   /**
    * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
@@ -405,12 +405,12 @@ export interface Transaction {
   /**
    * Details about the transaction, such as processing dates, set by the card network.
    */
-  network_data: Issuing.Transaction.NetworkData | null;
+  network_data: Transaction.NetworkData | null;
 
   /**
    * Additional purchase information that is optionally provided by the merchant.
    */
-  purchase_details?: Issuing.Transaction.PurchaseDetails | null;
+  purchase_details?: Transaction.PurchaseDetails | null;
 
   /**
    * [Token](https://docs.stripe.com/api/issuing/tokens/object) object used for this transaction. If a network token was not used for this transaction, this field will be null.
@@ -420,371 +420,369 @@ export interface Transaction {
   /**
    * [Treasury](https://docs.stripe.com/api/treasury) details related to this transaction if it was created on a [FinancialAccount](/docs/api/treasury/financial_accounts
    */
-  treasury?: Issuing.Transaction.Treasury | null;
+  treasury?: Transaction.Treasury | null;
 
   /**
    * The nature of the transaction.
    */
-  type: Issuing.Transaction.Type;
+  type: Transaction.Type;
 
   /**
    * The digital wallet used for this transaction. One of `apple_pay`, `google_pay`, or `samsung_pay`.
    */
-  wallet: Issuing.Transaction.Wallet | null;
+  wallet: Transaction.Wallet | null;
 }
-export namespace Issuing {
-  export namespace Transaction {
-    export interface AmountDetails {
+export namespace Transaction {
+  export interface AmountDetails {
+    /**
+     * The fee charged by the ATM for the cash withdrawal.
+     */
+    atm_fee: number | null;
+
+    /**
+     * The amount of cash requested by the cardholder.
+     */
+    cashback_amount: number | null;
+  }
+
+  export interface MerchantData {
+    /**
+     * A categorization of the seller's type of business. See our [merchant categories guide](https://docs.stripe.com/issuing/merchant-categories) for a list of possible values.
+     */
+    category: string;
+
+    /**
+     * The merchant category code for the seller's business
+     */
+    category_code: string;
+
+    /**
+     * City where the seller is located
+     */
+    city: string | null;
+
+    /**
+     * Country where the seller is located
+     */
+    country: string | null;
+
+    /**
+     * Name of the seller
+     */
+    name: string | null;
+
+    /**
+     * Identifier assigned to the seller by the card network. Different card networks may assign different network_id fields to the same merchant.
+     */
+    network_id: string;
+
+    /**
+     * Postal code where the seller is located
+     */
+    postal_code: string | null;
+
+    /**
+     * State where the seller is located
+     */
+    state: string | null;
+
+    /**
+     * The seller's tax identification number. Currently populated for French merchants only.
+     */
+    tax_id: string | null;
+
+    /**
+     * An ID assigned by the seller to the location of the sale.
+     */
+    terminal_id: string | null;
+
+    /**
+     * URL provided by the merchant on a 3DS request
+     */
+    url: string | null;
+  }
+
+  export interface NetworkData {
+    /**
+     * A code created by Stripe which is shared with the merchant to validate the authorization. This field will be populated if the authorization message was approved. The code typically starts with the letter "S", followed by a six-digit number. For example, "S498162". Please note that the code is not guaranteed to be unique across authorizations.
+     */
+    authorization_code: string | null;
+
+    /**
+     * The date the transaction was processed by the card network. This can be different from the date the seller recorded the transaction depending on when the acquirer submits the transaction to the network.
+     */
+    processing_date: string | null;
+
+    /**
+     * Unique identifier for the authorization assigned by the card network used to match subsequent messages, disputes, and transactions.
+     */
+    transaction_id: string | null;
+  }
+
+  export interface PurchaseDetails {
+    /**
+     * Fleet-specific information for transactions using Fleet cards.
+     */
+    fleet: PurchaseDetails.Fleet | null;
+
+    /**
+     * Information about the flight that was purchased with this transaction.
+     */
+    flight: PurchaseDetails.Flight | null;
+
+    /**
+     * Information about fuel that was purchased with this transaction.
+     */
+    fuel: PurchaseDetails.Fuel | null;
+
+    /**
+     * Information about lodging that was purchased with this transaction.
+     */
+    lodging: PurchaseDetails.Lodging | null;
+
+    /**
+     * The line items in the purchase.
+     */
+    receipt: Array<PurchaseDetails.Receipt> | null;
+
+    /**
+     * A merchant-specific order number.
+     */
+    reference: string | null;
+  }
+
+  export interface Treasury {
+    /**
+     * The Treasury [ReceivedCredit](https://docs.stripe.com/api/treasury/received_credits) representing this Issuing transaction if it is a refund
+     */
+    received_credit: string | null;
+
+    /**
+     * The Treasury [ReceivedDebit](https://docs.stripe.com/api/treasury/received_debits) representing this Issuing transaction if it is a capture
+     */
+    received_debit: string | null;
+  }
+
+  export type Type = 'capture' | 'refund';
+
+  export type Wallet = 'apple_pay' | 'google_pay' | 'samsung_pay';
+
+  export namespace PurchaseDetails {
+    export interface Fleet {
       /**
-       * The fee charged by the ATM for the cash withdrawal.
+       * Answers to prompts presented to cardholder at point of sale.
        */
-      atm_fee: number | null;
+      cardholder_prompt_data: Fleet.CardholderPromptData | null;
 
       /**
-       * The amount of cash requested by the cardholder.
+       * The type of purchase. One of `fuel_purchase`, `non_fuel_purchase`, or `fuel_and_non_fuel_purchase`.
        */
-      cashback_amount: number | null;
+      purchase_type: string | null;
+
+      /**
+       * More information about the total amount. This information is not guaranteed to be accurate as some merchants may provide unreliable data.
+       */
+      reported_breakdown: Fleet.ReportedBreakdown | null;
+
+      /**
+       * The type of fuel service. One of `non_fuel_transaction`, `full_service`, or `self_service`.
+       */
+      service_type: string | null;
     }
 
-    export interface MerchantData {
+    export interface Flight {
       /**
-       * A categorization of the seller's type of business. See our [merchant categories guide](https://docs.stripe.com/issuing/merchant-categories) for a list of possible values.
+       * The time that the flight departed.
        */
-      category: string;
+      departure_at: number | null;
 
       /**
-       * The merchant category code for the seller's business
+       * The name of the passenger.
        */
-      category_code: string;
+      passenger_name: string | null;
 
       /**
-       * City where the seller is located
+       * Whether the ticket is refundable.
        */
-      city: string | null;
+      refundable: boolean | null;
 
       /**
-       * Country where the seller is located
+       * The legs of the trip.
        */
-      country: string | null;
+      segments: Array<Flight.Segment> | null;
 
       /**
-       * Name of the seller
+       * The travel agency that issued the ticket.
        */
-      name: string | null;
-
-      /**
-       * Identifier assigned to the seller by the card network. Different card networks may assign different network_id fields to the same merchant.
-       */
-      network_id: string;
-
-      /**
-       * Postal code where the seller is located
-       */
-      postal_code: string | null;
-
-      /**
-       * State where the seller is located
-       */
-      state: string | null;
-
-      /**
-       * The seller's tax identification number. Currently populated for French merchants only.
-       */
-      tax_id: string | null;
-
-      /**
-       * An ID assigned by the seller to the location of the sale.
-       */
-      terminal_id: string | null;
-
-      /**
-       * URL provided by the merchant on a 3DS request
-       */
-      url: string | null;
+      travel_agency: string | null;
     }
 
-    export interface NetworkData {
+    export interface Fuel {
       /**
-       * A code created by Stripe which is shared with the merchant to validate the authorization. This field will be populated if the authorization message was approved. The code typically starts with the letter "S", followed by a six-digit number. For example, "S498162". Please note that the code is not guaranteed to be unique across authorizations.
+       * [Conexxus Payment System Product Code](https://www.conexxus.org/conexxus-payment-system-product-codes) identifying the primary fuel product purchased.
        */
-      authorization_code: string | null;
+      industry_product_code: string | null;
 
       /**
-       * The date the transaction was processed by the card network. This can be different from the date the seller recorded the transaction depending on when the acquirer submits the transaction to the network.
+       * The quantity of `unit`s of fuel that was dispensed, represented as a decimal string with at most 12 decimal places.
        */
-      processing_date: string | null;
+      quantity_decimal: Decimal | null;
 
       /**
-       * Unique identifier for the authorization assigned by the card network used to match subsequent messages, disputes, and transactions.
+       * The type of fuel that was purchased. One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
        */
-      transaction_id: string | null;
+      type: string;
+
+      /**
+       * The units for `quantity_decimal`. One of `charging_minute`, `imperial_gallon`, `kilogram`, `kilowatt_hour`, `liter`, `pound`, `us_gallon`, or `other`.
+       */
+      unit: string;
+
+      /**
+       * The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
+       */
+      unit_cost_decimal: Decimal;
     }
 
-    export interface PurchaseDetails {
+    export interface Lodging {
       /**
-       * Fleet-specific information for transactions using Fleet cards.
+       * The time of checking into the lodging.
        */
-      fleet: PurchaseDetails.Fleet | null;
+      check_in_at: number | null;
 
       /**
-       * Information about the flight that was purchased with this transaction.
+       * The number of nights stayed at the lodging.
        */
-      flight: PurchaseDetails.Flight | null;
-
-      /**
-       * Information about fuel that was purchased with this transaction.
-       */
-      fuel: PurchaseDetails.Fuel | null;
-
-      /**
-       * Information about lodging that was purchased with this transaction.
-       */
-      lodging: PurchaseDetails.Lodging | null;
-
-      /**
-       * The line items in the purchase.
-       */
-      receipt: Array<PurchaseDetails.Receipt> | null;
-
-      /**
-       * A merchant-specific order number.
-       */
-      reference: string | null;
+      nights: number | null;
     }
 
-    export interface Treasury {
+    export interface Receipt {
       /**
-       * The Treasury [ReceivedCredit](https://docs.stripe.com/api/treasury/received_credits) representing this Issuing transaction if it is a refund
+       * The description of the item. The maximum length of this field is 26 characters.
        */
-      received_credit: string | null;
+      description: string | null;
 
       /**
-       * The Treasury [ReceivedDebit](https://docs.stripe.com/api/treasury/received_debits) representing this Issuing transaction if it is a capture
+       * The quantity of the item.
        */
-      received_debit: string | null;
+      quantity: number | null;
+
+      /**
+       * The total for this line item in cents.
+       */
+      total: number | null;
+
+      /**
+       * The unit cost of the item in cents.
+       */
+      unit_cost: number | null;
     }
 
-    export type Type = 'capture' | 'refund';
-
-    export type Wallet = 'apple_pay' | 'google_pay' | 'samsung_pay';
-
-    export namespace PurchaseDetails {
-      export interface Fleet {
+    export namespace Fleet {
+      export interface CardholderPromptData {
         /**
-         * Answers to prompts presented to cardholder at point of sale.
+         * Driver ID.
          */
-        cardholder_prompt_data: Fleet.CardholderPromptData | null;
+        driver_id: string | null;
 
         /**
-         * The type of purchase. One of `fuel_purchase`, `non_fuel_purchase`, or `fuel_and_non_fuel_purchase`.
+         * Odometer reading.
          */
-        purchase_type: string | null;
+        odometer: number | null;
 
         /**
-         * More information about the total amount. This information is not guaranteed to be accurate as some merchants may provide unreliable data.
+         * An alphanumeric ID. This field is used when a vehicle ID, driver ID, or generic ID is entered by the cardholder, but the merchant or card network did not specify the prompt type.
          */
-        reported_breakdown: Fleet.ReportedBreakdown | null;
+        unspecified_id: string | null;
 
         /**
-         * The type of fuel service. One of `non_fuel_transaction`, `full_service`, or `self_service`.
+         * User ID.
          */
-        service_type: string | null;
+        user_id: string | null;
+
+        /**
+         * Vehicle number.
+         */
+        vehicle_number: string | null;
       }
 
-      export interface Flight {
+      export interface ReportedBreakdown {
         /**
-         * The time that the flight departed.
+         * Breakdown of fuel portion of the purchase.
          */
-        departure_at: number | null;
+        fuel: ReportedBreakdown.Fuel | null;
 
         /**
-         * The name of the passenger.
+         * Breakdown of non-fuel portion of the purchase.
          */
-        passenger_name: string | null;
+        non_fuel: ReportedBreakdown.NonFuel | null;
 
         /**
-         * Whether the ticket is refundable.
+         * Information about tax included in this transaction.
          */
-        refundable: boolean | null;
-
-        /**
-         * The legs of the trip.
-         */
-        segments: Array<Flight.Segment> | null;
-
-        /**
-         * The travel agency that issued the ticket.
-         */
-        travel_agency: string | null;
+        tax: ReportedBreakdown.Tax | null;
       }
 
-      export interface Fuel {
-        /**
-         * [Conexxus Payment System Product Code](https://www.conexxus.org/conexxus-payment-system-product-codes) identifying the primary fuel product purchased.
-         */
-        industry_product_code: string | null;
-
-        /**
-         * The quantity of `unit`s of fuel that was dispensed, represented as a decimal string with at most 12 decimal places.
-         */
-        quantity_decimal: Decimal | null;
-
-        /**
-         * The type of fuel that was purchased. One of `diesel`, `unleaded_plus`, `unleaded_regular`, `unleaded_super`, or `other`.
-         */
-        type: string;
-
-        /**
-         * The units for `quantity_decimal`. One of `charging_minute`, `imperial_gallon`, `kilogram`, `kilowatt_hour`, `liter`, `pound`, `us_gallon`, or `other`.
-         */
-        unit: string;
-
-        /**
-         * The cost in cents per each unit of fuel, represented as a decimal string with at most 12 decimal places.
-         */
-        unit_cost_decimal: Decimal;
-      }
-
-      export interface Lodging {
-        /**
-         * The time of checking into the lodging.
-         */
-        check_in_at: number | null;
-
-        /**
-         * The number of nights stayed at the lodging.
-         */
-        nights: number | null;
-      }
-
-      export interface Receipt {
-        /**
-         * The description of the item. The maximum length of this field is 26 characters.
-         */
-        description: string | null;
-
-        /**
-         * The quantity of the item.
-         */
-        quantity: number | null;
-
-        /**
-         * The total for this line item in cents.
-         */
-        total: number | null;
-
-        /**
-         * The unit cost of the item in cents.
-         */
-        unit_cost: number | null;
-      }
-
-      export namespace Fleet {
-        export interface CardholderPromptData {
+      export namespace ReportedBreakdown {
+        export interface Fuel {
           /**
-           * Driver ID.
+           * Gross fuel amount that should equal Fuel Volume multipled by Fuel Unit Cost, inclusive of taxes.
            */
-          driver_id: string | null;
-
-          /**
-           * Odometer reading.
-           */
-          odometer: number | null;
-
-          /**
-           * An alphanumeric ID. This field is used when a vehicle ID, driver ID, or generic ID is entered by the cardholder, but the merchant or card network did not specify the prompt type.
-           */
-          unspecified_id: string | null;
-
-          /**
-           * User ID.
-           */
-          user_id: string | null;
-
-          /**
-           * Vehicle number.
-           */
-          vehicle_number: string | null;
+          gross_amount_decimal: Decimal | null;
         }
 
-        export interface ReportedBreakdown {
+        export interface NonFuel {
           /**
-           * Breakdown of fuel portion of the purchase.
+           * Gross non-fuel amount that should equal the sum of the line items, inclusive of taxes.
            */
-          fuel: ReportedBreakdown.Fuel | null;
-
-          /**
-           * Breakdown of non-fuel portion of the purchase.
-           */
-          non_fuel: ReportedBreakdown.NonFuel | null;
-
-          /**
-           * Information about tax included in this transaction.
-           */
-          tax: ReportedBreakdown.Tax | null;
+          gross_amount_decimal: Decimal | null;
         }
 
-        export namespace ReportedBreakdown {
-          export interface Fuel {
-            /**
-             * Gross fuel amount that should equal Fuel Volume multipled by Fuel Unit Cost, inclusive of taxes.
-             */
-            gross_amount_decimal: Decimal | null;
-          }
+        export interface Tax {
+          /**
+           * Amount of state or provincial Sales Tax included in the transaction amount. Null if not reported by merchant or not subject to tax.
+           */
+          local_amount_decimal: Decimal | null;
 
-          export interface NonFuel {
-            /**
-             * Gross non-fuel amount that should equal the sum of the line items, inclusive of taxes.
-             */
-            gross_amount_decimal: Decimal | null;
-          }
-
-          export interface Tax {
-            /**
-             * Amount of state or provincial Sales Tax included in the transaction amount. Null if not reported by merchant or not subject to tax.
-             */
-            local_amount_decimal: Decimal | null;
-
-            /**
-             * Amount of national Sales Tax or VAT included in the transaction amount. Null if not reported by merchant or not subject to tax.
-             */
-            national_amount_decimal: Decimal | null;
-          }
+          /**
+           * Amount of national Sales Tax or VAT included in the transaction amount. Null if not reported by merchant or not subject to tax.
+           */
+          national_amount_decimal: Decimal | null;
         }
       }
+    }
 
-      export namespace Flight {
-        export interface Segment {
-          /**
-           * The three-letter IATA airport code of the flight's destination.
-           */
-          arrival_airport_code: string | null;
+    export namespace Flight {
+      export interface Segment {
+        /**
+         * The three-letter IATA airport code of the flight's destination.
+         */
+        arrival_airport_code: string | null;
 
-          /**
-           * The airline carrier code.
-           */
-          carrier: string | null;
+        /**
+         * The airline carrier code.
+         */
+        carrier: string | null;
 
-          /**
-           * The three-letter IATA airport code that the flight departed from.
-           */
-          departure_airport_code: string | null;
+        /**
+         * The three-letter IATA airport code that the flight departed from.
+         */
+        departure_airport_code: string | null;
 
-          /**
-           * The flight number.
-           */
-          flight_number: string | null;
+        /**
+         * The flight number.
+         */
+        flight_number: string | null;
 
-          /**
-           * The flight's service class.
-           */
-          service_class: string | null;
+        /**
+         * The flight's service class.
+         */
+        service_class: string | null;
 
-          /**
-           * Whether a stopover is allowed on this flight.
-           */
-          stopover_allowed: boolean | null;
-        }
+        /**
+         * Whether a stopover is allowed on this flight.
+         */
+        stopover_allowed: boolean | null;
       }
     }
   }

--- a/src/resources/Radar/PaymentEvaluations.ts
+++ b/src/resources/Radar/PaymentEvaluations.ts
@@ -35,7 +35,7 @@ export interface PaymentEvaluation {
   /**
    * Client device metadata attached to this payment evaluation.
    */
-  client_device_metadata_details?: Radar.PaymentEvaluation.ClientDeviceMetadataDetails;
+  client_device_metadata_details?: PaymentEvaluation.ClientDeviceMetadataDetails;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -45,12 +45,12 @@ export interface PaymentEvaluation {
   /**
    * Customer details attached to this payment evaluation.
    */
-  customer_details?: Radar.PaymentEvaluation.CustomerDetails;
+  customer_details?: PaymentEvaluation.CustomerDetails;
 
   /**
    * Event information associated with the payment evaluation, such as refunds, dispute, early fraud warnings, or user interventions.
    */
-  events?: Array<Radar.PaymentEvaluation.Event>;
+  events?: Array<PaymentEvaluation.Event>;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -65,126 +65,172 @@ export interface PaymentEvaluation {
   /**
    * Indicates the final outcome for the payment evaluation.
    */
-  outcome?: Radar.PaymentEvaluation.Outcome | null;
+  outcome?: PaymentEvaluation.Outcome | null;
 
   /**
    * Payment details attached to this payment evaluation.
    */
-  payment_details?: Radar.PaymentEvaluation.PaymentDetails;
+  payment_details?: PaymentEvaluation.PaymentDetails;
 
   /**
    * Recommended action based on the score of the `fraudulent_payment` signal. Possible values are `block`, `continue` and `request_three_d_secure`.
    */
-  recommended_action: Radar.PaymentEvaluation.RecommendedAction;
+  recommended_action: PaymentEvaluation.RecommendedAction;
 
   /**
    * Collection of signals for this payment evaluation.
    */
-  signals: Radar.PaymentEvaluation.Signals;
+  signals: PaymentEvaluation.Signals;
 }
-export namespace Radar {
-  export namespace PaymentEvaluation {
-    export interface ClientDeviceMetadataDetails {
-      /**
-       * ID for the Radar Session associated with the payment evaluation. A [Radar Session](https://docs.stripe.com/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
-       */
-      radar_session: string;
-    }
+export namespace PaymentEvaluation {
+  export interface ClientDeviceMetadataDetails {
+    /**
+     * ID for the Radar Session associated with the payment evaluation. A [Radar Session](https://docs.stripe.com/radar/radar-session) is a snapshot of the browser metadata and device details that help Radar make more accurate predictions on your payments.
+     */
+    radar_session: string;
+  }
 
-    export interface CustomerDetails {
-      /**
-       * The ID of the customer associated with the payment evaluation.
-       */
-      customer: string | null;
+  export interface CustomerDetails {
+    /**
+     * The ID of the customer associated with the payment evaluation.
+     */
+    customer: string | null;
 
-      /**
-       * The ID of the Account representing the customer associated with the payment evaluation.
-       */
-      customer_account: string | null;
+    /**
+     * The ID of the Account representing the customer associated with the payment evaluation.
+     */
+    customer_account: string | null;
 
-      /**
-       * The customer's email address.
-       */
-      email: string | null;
+    /**
+     * The customer's email address.
+     */
+    email: string | null;
 
-      /**
-       * The customer's full name or business name.
-       */
-      name: string | null;
+    /**
+     * The customer's full name or business name.
+     */
+    name: string | null;
 
-      /**
-       * The customer's phone number.
-       */
-      phone: string | null;
-    }
+    /**
+     * The customer's phone number.
+     */
+    phone: string | null;
+  }
 
-    export interface Event {
-      /**
-       * Dispute opened event details attached to this payment evaluation.
-       */
-      dispute_opened?: Event.DisputeOpened;
+  export interface Event {
+    /**
+     * Dispute opened event details attached to this payment evaluation.
+     */
+    dispute_opened?: Event.DisputeOpened;
 
-      /**
-       * Early Fraud Warning Received event details attached to this payment evaluation.
-       */
-      early_fraud_warning_received?: Event.EarlyFraudWarningReceived;
+    /**
+     * Early Fraud Warning Received event details attached to this payment evaluation.
+     */
+    early_fraud_warning_received?: Event.EarlyFraudWarningReceived;
 
-      /**
-       * Timestamp when the event occurred.
-       */
-      occurred_at: number;
+    /**
+     * Timestamp when the event occurred.
+     */
+    occurred_at: number;
 
-      /**
-       * Refunded Event details attached to this payment evaluation.
-       */
-      refunded?: Event.Refunded;
+    /**
+     * Refunded Event details attached to this payment evaluation.
+     */
+    refunded?: Event.Refunded;
 
-      /**
-       * Indicates the type of event attached to the payment evaluation.
-       */
-      type: Event.Type;
+    /**
+     * Indicates the type of event attached to the payment evaluation.
+     */
+    type: Event.Type;
 
-      /**
-       * User intervention raised event details attached to this payment evaluation
-       */
-      user_intervention_raised?: Event.UserInterventionRaised;
+    /**
+     * User intervention raised event details attached to this payment evaluation
+     */
+    user_intervention_raised?: Event.UserInterventionRaised;
 
-      /**
-       * User Intervention Resolved Event details attached to this payment evaluation
-       */
-      user_intervention_resolved?: Event.UserInterventionResolved;
-    }
+    /**
+     * User Intervention Resolved Event details attached to this payment evaluation
+     */
+    user_intervention_resolved?: Event.UserInterventionResolved;
+  }
 
-    export interface Outcome {
-      /**
-       * Details of a merchant_blocked outcome attached to this payment evaluation.
-       */
-      merchant_blocked?: Outcome.MerchantBlocked;
+  export interface Outcome {
+    /**
+     * Details of a merchant_blocked outcome attached to this payment evaluation.
+     */
+    merchant_blocked?: Outcome.MerchantBlocked;
 
-      /**
-       * The PaymentIntent ID associated with the payment evaluation.
-       */
-      payment_intent_id?: string;
+    /**
+     * The PaymentIntent ID associated with the payment evaluation.
+     */
+    payment_intent_id?: string;
 
-      /**
-       * Details of an rejected outcome attached to this payment evaluation.
-       */
-      rejected?: Outcome.Rejected;
+    /**
+     * Details of an rejected outcome attached to this payment evaluation.
+     */
+    rejected?: Outcome.Rejected;
 
-      /**
-       * Details of a succeeded outcome attached to this payment evaluation.
-       */
-      succeeded?: Outcome.Succeeded;
+    /**
+     * Details of a succeeded outcome attached to this payment evaluation.
+     */
+    succeeded?: Outcome.Succeeded;
 
-      /**
-       * Indicates the outcome of the payment evaluation.
-       */
-      type: Outcome.Type;
-    }
+    /**
+     * Indicates the outcome of the payment evaluation.
+     */
+    type: Outcome.Type;
+  }
 
-    export interface PaymentDetails {
+  export interface PaymentDetails {
+    /**
+     * Amount intended to be collected by this payment. A positive integer representing how much to charge in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+     */
+    amount: number;
+
+    /**
+     * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+     */
+    currency: string;
+
+    /**
+     * An arbitrary string attached to the object. Often useful for displaying to users.
+     */
+    description: string | null;
+
+    /**
+     * Details about the payment's customer presence and type.
+     */
+    money_movement_details: PaymentDetails.MoneyMovementDetails | null;
+
+    /**
+     * Details about the payment method used for the payment.
+     */
+    payment_method_details: PaymentDetails.PaymentMethodDetails | null;
+
+    /**
+     * Shipping details for the payment evaluation.
+     */
+    shipping_details: PaymentDetails.ShippingDetails | null;
+
+    /**
+     * Payment statement descriptor.
+     */
+    statement_descriptor: string | null;
+  }
+
+  export type RecommendedAction = 'block' | 'continue';
+
+  export interface Signals {
+    /**
+     * A payment evaluation signal with evaluated_at, risk_level, and score fields.
+     */
+    fraudulent_payment: Signals.FraudulentPayment;
+  }
+
+  export namespace Event {
+    export interface DisputeOpened {
       /**
-       * Amount intended to be collected by this payment. A positive integer representing how much to charge in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The minimum amount is $0.50 US or [equivalent in charge currency](https://docs.stripe.com/currencies#minimum-and-maximum-charge-amounts). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+       * Amount to dispute for this payment. A positive integer representing how much to charge in [the smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (for example, 100 cents to charge 1.00 USD or 100 to charge 100 Yen, a zero-decimal currency).
        */
       amount: number;
 
@@ -194,410 +240,358 @@ export namespace Radar {
       currency: string;
 
       /**
-       * An arbitrary string attached to the object. Often useful for displaying to users.
+       * Reason given by cardholder for dispute.
        */
-      description: string | null;
-
-      /**
-       * Details about the payment's customer presence and type.
-       */
-      money_movement_details: PaymentDetails.MoneyMovementDetails | null;
-
-      /**
-       * Details about the payment method used for the payment.
-       */
-      payment_method_details: PaymentDetails.PaymentMethodDetails | null;
-
-      /**
-       * Shipping details for the payment evaluation.
-       */
-      shipping_details: PaymentDetails.ShippingDetails | null;
-
-      /**
-       * Payment statement descriptor.
-       */
-      statement_descriptor: string | null;
+      reason: DisputeOpened.Reason;
     }
 
-    export type RecommendedAction = 'block' | 'continue';
-
-    export interface Signals {
+    export interface EarlyFraudWarningReceived {
       /**
-       * A payment evaluation signal with evaluated_at, risk_level, and score fields.
+       * The type of fraud labeled by the issuer.
        */
-      fraudulent_payment: Signals.FraudulentPayment;
+      fraud_type: EarlyFraudWarningReceived.FraudType;
     }
 
-    export namespace Event {
-      export interface DisputeOpened {
-        /**
-         * Amount to dispute for this payment. A positive integer representing how much to charge in [the smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (for example, 100 cents to charge 1.00 USD or 100 to charge 100 Yen, a zero-decimal currency).
-         */
-        amount: number;
+    export interface Refunded {
+      /**
+       * Amount refunded for this payment. A positive integer representing how much to charge in [the smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (for example, 100 cents to charge 1.00 USD or 100 to charge 100 Yen, a zero-decimal currency).
+       */
+      amount: number;
 
-        /**
-         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-         */
-        currency: string;
+      /**
+       * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+       */
+      currency: string;
 
+      /**
+       * Indicates the reason for the refund.
+       */
+      reason: Refunded.Reason;
+    }
+
+    export type Type =
+      | 'dispute_opened'
+      | 'early_fraud_warning_received'
+      | 'refunded'
+      | 'user_intervention_raised'
+      | 'user_intervention_resolved';
+
+    export interface UserInterventionRaised {
+      /**
+       * User intervention raised custom event details attached to this payment evaluation
+       */
+      custom?: UserInterventionRaised.Custom;
+
+      /**
+       * Unique identifier for the user intervention event.
+       */
+      key: string;
+
+      /**
+       * Type of user intervention raised.
+       */
+      type: UserInterventionRaised.Type;
+    }
+
+    export interface UserInterventionResolved {
+      /**
+       * Unique ID of this intervention. Use this to provide the result.
+       */
+      key: string;
+
+      /**
+       * Result of the intervention if it has been completed.
+       */
+      outcome: UserInterventionResolved.Outcome | null;
+    }
+
+    export namespace DisputeOpened {
+      export type Reason =
+        | 'account_not_available'
+        | 'credit_not_processed'
+        | 'customer_initiated'
+        | 'duplicate'
+        | 'fraudulent'
+        | 'general'
+        | 'noncompliant'
+        | 'product_not_received'
+        | 'product_unacceptable'
+        | 'subscription_canceled'
+        | 'unrecognized';
+    }
+
+    export namespace EarlyFraudWarningReceived {
+      export type FraudType =
+        | 'made_with_lost_card'
+        | 'made_with_stolen_card'
+        | 'other'
+        | 'unauthorized_use_of_card';
+    }
+
+    export namespace Refunded {
+      export type Reason =
+        | 'duplicate'
+        | 'fraudulent'
+        | 'other'
+        | 'requested_by_customer';
+    }
+
+    export namespace UserInterventionRaised {
+      export interface Custom {
         /**
-         * Reason given by cardholder for dispute.
+         * Custom type of user intervention raised. The string must use a snake case description for the type of intervention performed.
          */
-        reason: DisputeOpened.Reason;
+        type: string;
       }
 
-      export interface EarlyFraudWarningReceived {
+      export type Type = '3ds' | 'captcha' | 'custom';
+    }
+
+    export namespace UserInterventionResolved {
+      export type Outcome = 'abandoned' | 'failed' | 'passed';
+    }
+  }
+
+  export namespace Outcome {
+    export interface MerchantBlocked {
+      /**
+       * The reason the payment was blocked by the merchant.
+       */
+      reason: MerchantBlocked.Reason;
+    }
+
+    export interface Rejected {
+      /**
+       * Details of an rejected card outcome attached to this payment evaluation.
+       */
+      card?: Rejected.Card;
+    }
+
+    export interface Succeeded {
+      /**
+       * Details of an succeeded card outcome attached to this payment evaluation.
+       */
+      card?: Succeeded.Card;
+    }
+
+    export type Type = 'failed' | 'merchant_blocked' | 'rejected' | 'succeeded';
+
+    export namespace MerchantBlocked {
+      export type Reason =
+        | 'authentication_required'
+        | 'blocked_for_fraud'
+        | 'invalid_payment'
+        | 'other';
+    }
+
+    export namespace Rejected {
+      export interface Card {
         /**
-         * The type of fraud labeled by the issuer.
+         * Result of the address line 1 check.
          */
-        fraud_type: EarlyFraudWarningReceived.FraudType;
+        address_line1_check: Card.AddressLine1Check;
+
+        /**
+         * Indicates whether the cardholder provided a postal code and if it matched the cardholder's billing address.
+         */
+        address_postal_code_check: Card.AddressPostalCodeCheck;
+
+        /**
+         * Result of the CVC check.
+         */
+        cvc_check: Card.CvcCheck;
+
+        /**
+         * Card issuer's reason for the network decline.
+         */
+        reason: Card.Reason;
       }
 
-      export interface Refunded {
-        /**
-         * Amount refunded for this payment. A positive integer representing how much to charge in [the smallest currency unit](https://docs.stripe.com/currencies#zero-decimal) (for example, 100 cents to charge 1.00 USD or 100 to charge 100 Yen, a zero-decimal currency).
-         */
-        amount: number;
+      export namespace Card {
+        export type AddressLine1Check =
+          | 'fail'
+          | 'pass'
+          | 'unavailable'
+          | 'unchecked';
 
-        /**
-         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-         */
-        currency: string;
+        export type AddressPostalCodeCheck =
+          | 'fail'
+          | 'pass'
+          | 'unavailable'
+          | 'unchecked';
 
-        /**
-         * Indicates the reason for the refund.
-         */
-        reason: Refunded.Reason;
-      }
+        export type CvcCheck = 'fail' | 'pass' | 'unavailable' | 'unchecked';
 
-      export type Type =
-        | 'dispute_opened'
-        | 'early_fraud_warning_received'
-        | 'refunded'
-        | 'user_intervention_raised'
-        | 'user_intervention_resolved';
-
-      export interface UserInterventionRaised {
-        /**
-         * User intervention raised custom event details attached to this payment evaluation
-         */
-        custom?: UserInterventionRaised.Custom;
-
-        /**
-         * Unique identifier for the user intervention event.
-         */
-        key: string;
-
-        /**
-         * Type of user intervention raised.
-         */
-        type: UserInterventionRaised.Type;
-      }
-
-      export interface UserInterventionResolved {
-        /**
-         * Unique ID of this intervention. Use this to provide the result.
-         */
-        key: string;
-
-        /**
-         * Result of the intervention if it has been completed.
-         */
-        outcome: UserInterventionResolved.Outcome | null;
-      }
-
-      export namespace DisputeOpened {
         export type Reason =
-          | 'account_not_available'
-          | 'credit_not_processed'
-          | 'customer_initiated'
-          | 'duplicate'
-          | 'fraudulent'
-          | 'general'
-          | 'noncompliant'
-          | 'product_not_received'
-          | 'product_unacceptable'
-          | 'subscription_canceled'
-          | 'unrecognized';
-      }
-
-      export namespace EarlyFraudWarningReceived {
-        export type FraudType =
-          | 'made_with_lost_card'
-          | 'made_with_stolen_card'
+          | 'authentication_failed'
+          | 'do_not_honor'
+          | 'expired'
+          | 'incorrect_cvc'
+          | 'incorrect_number'
+          | 'incorrect_postal_code'
+          | 'insufficient_funds'
+          | 'invalid_account'
+          | 'lost_card'
           | 'other'
-          | 'unauthorized_use_of_card';
-      }
-
-      export namespace Refunded {
-        export type Reason =
-          | 'duplicate'
-          | 'fraudulent'
-          | 'other'
-          | 'requested_by_customer';
-      }
-
-      export namespace UserInterventionRaised {
-        export interface Custom {
-          /**
-           * Custom type of user intervention raised. The string must use a snake case description for the type of intervention performed.
-           */
-          type: string;
-        }
-
-        export type Type = '3ds' | 'captcha' | 'custom';
-      }
-
-      export namespace UserInterventionResolved {
-        export type Outcome = 'abandoned' | 'failed' | 'passed';
+          | 'processing_error'
+          | 'reported_stolen'
+          | 'try_again_later';
       }
     }
 
-    export namespace Outcome {
-      export interface MerchantBlocked {
+    export namespace Succeeded {
+      export interface Card {
         /**
-         * The reason the payment was blocked by the merchant.
+         * Result of the address line 1 check.
          */
-        reason: MerchantBlocked.Reason;
-      }
+        address_line1_check: Card.AddressLine1Check;
 
-      export interface Rejected {
         /**
-         * Details of an rejected card outcome attached to this payment evaluation.
+         * Indicates whether the cardholder provided a postal code and if it matched the cardholder's billing address.
          */
-        card?: Rejected.Card;
-      }
+        address_postal_code_check: Card.AddressPostalCodeCheck;
 
-      export interface Succeeded {
         /**
-         * Details of an succeeded card outcome attached to this payment evaluation.
+         * Result of the CVC check.
          */
-        card?: Succeeded.Card;
+        cvc_check: Card.CvcCheck;
       }
 
-      export type Type =
-        | 'failed'
-        | 'merchant_blocked'
-        | 'rejected'
-        | 'succeeded';
+      export namespace Card {
+        export type AddressLine1Check =
+          | 'fail'
+          | 'pass'
+          | 'unavailable'
+          | 'unchecked';
 
-      export namespace MerchantBlocked {
-        export type Reason =
-          | 'authentication_required'
-          | 'blocked_for_fraud'
-          | 'invalid_payment'
-          | 'other';
+        export type AddressPostalCodeCheck =
+          | 'fail'
+          | 'pass'
+          | 'unavailable'
+          | 'unchecked';
+
+        export type CvcCheck = 'fail' | 'pass' | 'unavailable' | 'unchecked';
+      }
+    }
+  }
+
+  export namespace PaymentDetails {
+    export interface MoneyMovementDetails {
+      /**
+       * Describes card money movement details for the payment evaluation.
+       */
+      card: MoneyMovementDetails.Card | null;
+
+      /**
+       * Describes the type of money movement. Currently only `card` is supported.
+       */
+      money_movement_type: 'card';
+    }
+
+    export interface PaymentMethodDetails {
+      /**
+       * Billing information associated with the payment evaluation.
+       */
+      billing_details: PaymentMethodDetails.BillingDetails | null;
+
+      /**
+       * The payment method used in this payment evaluation.
+       */
+      payment_method: string | PaymentMethod;
+    }
+
+    export interface ShippingDetails {
+      /**
+       * Address data.
+       */
+      address: Address;
+
+      /**
+       * Shipping name.
+       */
+      name: string | null;
+
+      /**
+       * Shipping phone number.
+       */
+      phone: string | null;
+    }
+
+    export namespace MoneyMovementDetails {
+      export interface Card {
+        /**
+         * Describes the presence of the customer during the payment.
+         */
+        customer_presence: Card.CustomerPresence | null;
+
+        /**
+         * Describes the type of payment.
+         */
+        payment_type: Card.PaymentType | null;
       }
 
-      export namespace Rejected {
-        export interface Card {
-          /**
-           * Result of the address line 1 check.
-           */
-          address_line1_check: Card.AddressLine1Check;
+      export namespace Card {
+        export type CustomerPresence = 'off_session' | 'on_session';
 
-          /**
-           * Indicates whether the cardholder provided a postal code and if it matched the cardholder's billing address.
-           */
-          address_postal_code_check: Card.AddressPostalCodeCheck;
-
-          /**
-           * Result of the CVC check.
-           */
-          cvc_check: Card.CvcCheck;
-
-          /**
-           * Card issuer's reason for the network decline.
-           */
-          reason: Card.Reason;
-        }
-
-        export namespace Card {
-          export type AddressLine1Check =
-            | 'fail'
-            | 'pass'
-            | 'unavailable'
-            | 'unchecked';
-
-          export type AddressPostalCodeCheck =
-            | 'fail'
-            | 'pass'
-            | 'unavailable'
-            | 'unchecked';
-
-          export type CvcCheck = 'fail' | 'pass' | 'unavailable' | 'unchecked';
-
-          export type Reason =
-            | 'authentication_failed'
-            | 'do_not_honor'
-            | 'expired'
-            | 'incorrect_cvc'
-            | 'incorrect_number'
-            | 'incorrect_postal_code'
-            | 'insufficient_funds'
-            | 'invalid_account'
-            | 'lost_card'
-            | 'other'
-            | 'processing_error'
-            | 'reported_stolen'
-            | 'try_again_later';
-        }
-      }
-
-      export namespace Succeeded {
-        export interface Card {
-          /**
-           * Result of the address line 1 check.
-           */
-          address_line1_check: Card.AddressLine1Check;
-
-          /**
-           * Indicates whether the cardholder provided a postal code and if it matched the cardholder's billing address.
-           */
-          address_postal_code_check: Card.AddressPostalCodeCheck;
-
-          /**
-           * Result of the CVC check.
-           */
-          cvc_check: Card.CvcCheck;
-        }
-
-        export namespace Card {
-          export type AddressLine1Check =
-            | 'fail'
-            | 'pass'
-            | 'unavailable'
-            | 'unchecked';
-
-          export type AddressPostalCodeCheck =
-            | 'fail'
-            | 'pass'
-            | 'unavailable'
-            | 'unchecked';
-
-          export type CvcCheck = 'fail' | 'pass' | 'unavailable' | 'unchecked';
-        }
+        export type PaymentType =
+          | 'one_off'
+          | 'recurring'
+          | 'setup_one_off'
+          | 'setup_recurring';
       }
     }
 
-    export namespace PaymentDetails {
-      export interface MoneyMovementDetails {
-        /**
-         * Describes card money movement details for the payment evaluation.
-         */
-        card: MoneyMovementDetails.Card | null;
-
-        /**
-         * Describes the type of money movement. Currently only `card` is supported.
-         */
-        money_movement_type: 'card';
-      }
-
-      export interface PaymentMethodDetails {
-        /**
-         * Billing information associated with the payment evaluation.
-         */
-        billing_details: PaymentMethodDetails.BillingDetails | null;
-
-        /**
-         * The payment method used in this payment evaluation.
-         */
-        payment_method: string | PaymentMethod;
-      }
-
-      export interface ShippingDetails {
+    export namespace PaymentMethodDetails {
+      export interface BillingDetails {
         /**
          * Address data.
          */
         address: Address;
 
         /**
-         * Shipping name.
+         * Email address.
+         */
+        email: string | null;
+
+        /**
+         * Full name.
          */
         name: string | null;
 
         /**
-         * Shipping phone number.
+         * Billing phone number (including extension).
          */
         phone: string | null;
       }
+    }
+  }
 
-      export namespace MoneyMovementDetails {
-        export interface Card {
-          /**
-           * Describes the presence of the customer during the payment.
-           */
-          customer_presence: Card.CustomerPresence | null;
+  export namespace Signals {
+    export interface FraudulentPayment {
+      /**
+       * The time when this signal was evaluated.
+       */
+      evaluated_at: number;
 
-          /**
-           * Describes the type of payment.
-           */
-          payment_type: Card.PaymentType | null;
-        }
+      /**
+       * Risk level of this signal, based on the score.
+       */
+      risk_level: FraudulentPayment.RiskLevel;
 
-        export namespace Card {
-          export type CustomerPresence = 'off_session' | 'on_session';
-
-          export type PaymentType =
-            | 'one_off'
-            | 'recurring'
-            | 'setup_one_off'
-            | 'setup_recurring';
-        }
-      }
-
-      export namespace PaymentMethodDetails {
-        export interface BillingDetails {
-          /**
-           * Address data.
-           */
-          address: Address;
-
-          /**
-           * Email address.
-           */
-          email: string | null;
-
-          /**
-           * Full name.
-           */
-          name: string | null;
-
-          /**
-           * Billing phone number (including extension).
-           */
-          phone: string | null;
-        }
-      }
+      /**
+       * Score for this signal. Possible values for evaluated payments are between 0 and 100. The value is returned with two decimal places and higher scores indicate a higher likelihood of the signal being true. A score of -1 is returned when a model evaluation was not performed, such as requests from incomplete integrations.
+       */
+      score: number;
     }
 
-    export namespace Signals {
-      export interface FraudulentPayment {
-        /**
-         * The time when this signal was evaluated.
-         */
-        evaluated_at: number;
-
-        /**
-         * Risk level of this signal, based on the score.
-         */
-        risk_level: FraudulentPayment.RiskLevel;
-
-        /**
-         * Score for this signal. Possible values for evaluated payments are between 0 and 100. The value is returned with two decimal places and higher scores indicate a higher likelihood of the signal being true. A score of -1 is returned when a model evaluation was not performed, such as requests from incomplete integrations.
-         */
-        score: number;
-      }
-
-      export namespace FraudulentPayment {
-        export type RiskLevel =
-          | 'elevated'
-          | 'highest'
-          | 'low'
-          | 'normal'
-          | 'not_assessed'
-          | 'unknown';
-      }
+    export namespace FraudulentPayment {
+      export type RiskLevel =
+        | 'elevated'
+        | 'highest'
+        | 'low'
+        | 'normal'
+        | 'not_assessed'
+        | 'unknown';
     }
   }
 }

--- a/src/resources/Radar/ValueListItems.ts
+++ b/src/resources/Radar/ValueListItems.ts
@@ -12,7 +12,7 @@ export class ValueListItemResource extends StripeResource {
     id: string,
     params?: Radar.ValueListItemDeleteParams,
     options?: RequestOptions
-  ): Promise<Response<Radar.DeletedValueListItem>> {
+  ): Promise<Response<DeletedValueListItem>> {
     return this._makeRequest(
       'DELETE',
       `/v1/radar/value_list_items/${encodeURIComponent(id)}`,
@@ -108,23 +108,21 @@ export interface ValueListItem {
    */
   value_list: string;
 }
-export namespace Radar {
-  export interface DeletedValueListItem {
-    /**
-     * Unique identifier for the object.
-     */
-    id: string;
+export interface DeletedValueListItem {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
 
-    /**
-     * String representing the object's type. Objects of the same type share the same value.
-     */
-    object: 'radar.value_list_item';
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'radar.value_list_item';
 
-    /**
-     * Always true for a deleted object
-     */
-    deleted: true;
-  }
+  /**
+   * Always true for a deleted object
+   */
+  deleted: true;
 }
 export namespace Radar {
   export interface ValueListItemCreateParams {

--- a/src/resources/Radar/ValueLists.ts
+++ b/src/resources/Radar/ValueLists.ts
@@ -18,7 +18,7 @@ export class ValueListResource extends StripeResource {
     id: string,
     params?: Radar.ValueListDeleteParams,
     options?: RequestOptions
-  ): Promise<Response<Radar.DeletedValueList>> {
+  ): Promise<Response<DeletedValueList>> {
     return this._makeRequest(
       'DELETE',
       `/v1/radar/value_lists/${encodeURIComponent(id)}`,
@@ -116,7 +116,7 @@ export interface ValueList {
   /**
    * The type of items in the value list. One of `card_fingerprint`, `card_bin`, `crypto_fingerprint`, `email`, `ip_address`, `country`, `string`, `case_sensitive_string`, `customer_id`, `account`, `sepa_debit_fingerprint`, or `us_bank_account_fingerprint`.
    */
-  item_type: Radar.ValueList.ItemType;
+  item_type: ValueList.ItemType;
 
   /**
    * List of items contained within this value list.
@@ -138,39 +138,36 @@ export interface ValueList {
    */
   name: string;
 }
-export namespace Radar {
-  export interface DeletedValueList {
-    /**
-     * Unique identifier for the object.
-     */
-    id: string;
+export interface DeletedValueList {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
 
-    /**
-     * String representing the object's type. Objects of the same type share the same value.
-     */
-    object: 'radar.value_list';
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'radar.value_list';
 
-    /**
-     * Always true for a deleted object
-     */
-    deleted: true;
-  }
-
-  export namespace ValueList {
-    export type ItemType =
-      | 'account'
-      | 'card_bin'
-      | 'card_fingerprint'
-      | 'case_sensitive_string'
-      | 'country'
-      | 'crypto_fingerprint'
-      | 'customer_id'
-      | 'email'
-      | 'ip_address'
-      | 'sepa_debit_fingerprint'
-      | 'string'
-      | 'us_bank_account_fingerprint';
-  }
+  /**
+   * Always true for a deleted object
+   */
+  deleted: true;
+}
+export namespace ValueList {
+  export type ItemType =
+    | 'account'
+    | 'card_bin'
+    | 'card_fingerprint'
+    | 'case_sensitive_string'
+    | 'country'
+    | 'crypto_fingerprint'
+    | 'customer_id'
+    | 'email'
+    | 'ip_address'
+    | 'sepa_debit_fingerprint'
+    | 'string'
+    | 'us_bank_account_fingerprint';
 }
 export namespace Radar {
   export interface ValueListCreateParams {

--- a/src/resources/Radar/index.ts
+++ b/src/resources/Radar/index.ts
@@ -14,11 +14,13 @@ import {
 import {
   Radar as RadarNamespace2,
   ValueList,
+  DeletedValueList,
   ValueListResource,
 } from './ValueLists.js';
 import {
   Radar as RadarNamespace3,
   ValueListItem,
+  DeletedValueListItem,
   ValueListItemResource,
 } from './ValueListItems.js';
 
@@ -52,12 +54,12 @@ export declare namespace Radar {
   export import ValueListUpdateParams = RadarNamespace2.ValueListUpdateParams;
   export import ValueListListParams = RadarNamespace2.ValueListListParams;
   export import ValueListCreateParams = RadarNamespace2.ValueListCreateParams;
-  export import DeletedValueList = RadarNamespace2.DeletedValueList;
+  export {DeletedValueList};
   export {ValueList, ValueListResource};
   export import ValueListItemDeleteParams = RadarNamespace3.ValueListItemDeleteParams;
   export import ValueListItemRetrieveParams = RadarNamespace3.ValueListItemRetrieveParams;
   export import ValueListItemListParams = RadarNamespace3.ValueListItemListParams;
   export import ValueListItemCreateParams = RadarNamespace3.ValueListItemCreateParams;
-  export import DeletedValueListItem = RadarNamespace3.DeletedValueListItem;
+  export {DeletedValueListItem};
   export {ValueListItem, ValueListItemResource};
 }

--- a/src/resources/Reporting/ReportRuns.ts
+++ b/src/resources/Reporting/ReportRuns.ts
@@ -80,7 +80,7 @@ export interface ReportRun {
    */
   livemode: boolean;
 
-  parameters: Reporting.ReportRun.Parameters;
+  parameters: ReportRun.Parameters;
 
   /**
    * The ID of the [report type](https://docs.stripe.com/reports/report-types) to run, such as `"balance.summary.1"`.
@@ -106,49 +106,47 @@ export interface ReportRun {
    */
   succeeded_at: number | null;
 }
-export namespace Reporting {
-  export namespace ReportRun {
-    export interface Parameters {
-      /**
-       * The set of output columns requested for inclusion in the report run.
-       */
-      columns?: Array<string>;
+export namespace ReportRun {
+  export interface Parameters {
+    /**
+     * The set of output columns requested for inclusion in the report run.
+     */
+    columns?: Array<string>;
 
-      /**
-       * Connected account ID by which to filter the report run.
-       */
-      connected_account?: string;
+    /**
+     * Connected account ID by which to filter the report run.
+     */
+    connected_account?: string;
 
-      /**
-       * Currency of objects to be included in the report run.
-       */
-      currency?: string;
+    /**
+     * Currency of objects to be included in the report run.
+     */
+    currency?: string;
 
-      /**
-       * Ending timestamp of data to be included in the report run. Can be any UTC timestamp between 1 second after the user specified `interval_start` and 1 second before this report's last `data_available_end` value.
-       */
-      interval_end?: number;
+    /**
+     * Ending timestamp of data to be included in the report run. Can be any UTC timestamp between 1 second after the user specified `interval_start` and 1 second before this report's last `data_available_end` value.
+     */
+    interval_end?: number;
 
-      /**
-       * Starting timestamp of data to be included in the report run. Can be any UTC timestamp between 1 second after this report's `data_available_start` and 1 second before the user specified `interval_end` value.
-       */
-      interval_start?: number;
+    /**
+     * Starting timestamp of data to be included in the report run. Can be any UTC timestamp between 1 second after this report's `data_available_start` and 1 second before the user specified `interval_end` value.
+     */
+    interval_start?: number;
 
-      /**
-       * Payout ID by which to filter the report run.
-       */
-      payout?: string;
+    /**
+     * Payout ID by which to filter the report run.
+     */
+    payout?: string;
 
-      /**
-       * Category of balance transactions to be included in the report run.
-       */
-      reporting_category?: string;
+    /**
+     * Category of balance transactions to be included in the report run.
+     */
+    reporting_category?: string;
 
-      /**
-       * Defaults to `Etc/UTC`. The output timezone for all timestamps in the report. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones). Has no effect on `interval_start` or `interval_end`.
-       */
-      timezone?: string;
-    }
+    /**
+     * Defaults to `Etc/UTC`. The output timezone for all timestamps in the report. A list of possible time zone values is maintained at the [IANA Time Zone Database](http://www.iana.org/time-zones). Has no effect on `interval_start` or `interval_end`.
+     */
+    timezone?: string;
   }
 }
 export namespace Reporting {

--- a/src/resources/Reserve/Holds.ts
+++ b/src/resources/Reserve/Holds.ts
@@ -33,7 +33,7 @@ export interface Hold {
   /**
    * Indicates which party created this ReserveHold.
    */
-  created_by: Reserve.Hold.CreatedBy;
+  created_by: Hold.CreatedBy;
 
   /**
    * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -58,9 +58,9 @@ export interface Hold {
   /**
    * The reason for the ReserveHold.
    */
-  reason: Reserve.Hold.Reason;
+  reason: Hold.Reason;
 
-  release_schedule: Reserve.Hold.ReleaseSchedule;
+  release_schedule: Hold.ReleaseSchedule;
 
   /**
    * The ReservePlan which produced this ReserveHold (i.e., resplan_123)
@@ -75,26 +75,24 @@ export interface Hold {
   /**
    * Which source balance type this ReserveHold reserves funds from. One of `bank_account`, `card`, or `fpx`.
    */
-  source_type: Reserve.Hold.SourceType;
+  source_type: Hold.SourceType;
 }
-export namespace Reserve {
-  export namespace Hold {
-    export type CreatedBy = 'application' | 'stripe';
+export namespace Hold {
+  export type CreatedBy = 'application' | 'stripe';
 
-    export type Reason = 'charge' | 'standalone';
+  export type Reason = 'charge' | 'standalone';
 
-    export interface ReleaseSchedule {
-      /**
-       * The time after which the ReserveHold is requested to be released.
-       */
-      release_after: number | null;
+  export interface ReleaseSchedule {
+    /**
+     * The time after which the ReserveHold is requested to be released.
+     */
+    release_after: number | null;
 
-      /**
-       * The time at which the ReserveHold is scheduled to be released, automatically set to midnight UTC of the day after `release_after`.
-       */
-      scheduled_release: number | null;
-    }
-
-    export type SourceType = 'bank_account' | 'card' | 'fpx';
+    /**
+     * The time at which the ReserveHold is scheduled to be released, automatically set to midnight UTC of the day after `release_after`.
+     */
+    scheduled_release: number | null;
   }
+
+  export type SourceType = 'bank_account' | 'card' | 'fpx';
 }

--- a/src/resources/Reserve/Plans.ts
+++ b/src/resources/Reserve/Plans.ts
@@ -21,7 +21,7 @@ export interface Plan {
   /**
    * Indicates which party created this ReservePlan.
    */
-  created_by: Reserve.Plan.CreatedBy;
+  created_by: Plan.CreatedBy;
 
   /**
    * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies). An unset currency indicates that the plan applies to all currencies.
@@ -33,7 +33,7 @@ export interface Plan {
    */
   disabled_at: number | null;
 
-  fixed_release?: Reserve.Plan.FixedRelease;
+  fixed_release?: Plan.FixedRelease;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -50,48 +50,46 @@ export interface Plan {
    */
   percent: number;
 
-  rolling_release?: Reserve.Plan.RollingRelease;
+  rolling_release?: Plan.RollingRelease;
 
   /**
    * The current status of the ReservePlan. The ReservePlan only affects charges if it is `active`.
    */
-  status: Reserve.Plan.Status;
+  status: Plan.Status;
 
   /**
    * The type of the ReservePlan.
    */
-  type: Reserve.Plan.Type;
+  type: Plan.Type;
 }
-export namespace Reserve {
-  export namespace Plan {
-    export type CreatedBy = 'application' | 'stripe';
+export namespace Plan {
+  export type CreatedBy = 'application' | 'stripe';
 
-    export interface FixedRelease {
-      /**
-       * The time after which all reserved funds are requested for release.
-       */
-      release_after: number;
+  export interface FixedRelease {
+    /**
+     * The time after which all reserved funds are requested for release.
+     */
+    release_after: number;
 
-      /**
-       * The time at which reserved funds are scheduled for release, automatically set to midnight UTC of the day after `release_after`.
-       */
-      scheduled_release: number;
-    }
-
-    export interface RollingRelease {
-      /**
-       * The number of days to reserve funds before releasing.
-       */
-      days_after_charge: number;
-
-      /**
-       * The time at which the ReservePlan expires.
-       */
-      expires_on: number | null;
-    }
-
-    export type Status = 'active' | 'disabled' | 'expired';
-
-    export type Type = 'fixed_release' | 'rolling_release';
+    /**
+     * The time at which reserved funds are scheduled for release, automatically set to midnight UTC of the day after `release_after`.
+     */
+    scheduled_release: number;
   }
+
+  export interface RollingRelease {
+    /**
+     * The number of days to reserve funds before releasing.
+     */
+    days_after_charge: number;
+
+    /**
+     * The time at which the ReservePlan expires.
+     */
+    expires_on: number | null;
+  }
+
+  export type Status = 'active' | 'disabled' | 'expired';
+
+  export type Type = 'fixed_release' | 'rolling_release';
 }

--- a/src/resources/Reserve/Releases.ts
+++ b/src/resources/Reserve/Releases.ts
@@ -30,7 +30,7 @@ export interface Release {
   /**
    * Indicates which party created this ReserveRelease.
    */
-  created_by: Reserve.Release.CreatedBy;
+  created_by: Release.CreatedBy;
 
   /**
    * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
@@ -50,7 +50,7 @@ export interface Release {
   /**
    * The reason for the ReserveRelease, indicating why the funds were released.
    */
-  reason: Reserve.Release.Reason;
+  reason: Release.Reason;
 
   /**
    * The release timestamp of the funds.
@@ -67,37 +67,35 @@ export interface Release {
    */
   reserve_plan: string | Plan | null;
 
-  source_transaction?: Reserve.Release.SourceTransaction;
+  source_transaction?: Release.SourceTransaction;
 }
-export namespace Reserve {
-  export namespace Release {
-    export type CreatedBy = 'application' | 'stripe';
+export namespace Release {
+  export type CreatedBy = 'application' | 'stripe';
 
-    export type Reason =
-      | 'bulk_hold_expiry'
-      | 'hold_released_early'
-      | 'hold_reversed'
-      | 'plan_disabled';
+  export type Reason =
+    | 'bulk_hold_expiry'
+    | 'hold_released_early'
+    | 'hold_reversed'
+    | 'plan_disabled';
 
-    export interface SourceTransaction {
-      /**
-       * The ID of the dispute.
-       */
-      dispute?: string | Dispute;
+  export interface SourceTransaction {
+    /**
+     * The ID of the dispute.
+     */
+    dispute?: string | Dispute;
 
-      /**
-       * The ID of the refund.
-       */
-      refund?: string | Refund;
+    /**
+     * The ID of the refund.
+     */
+    refund?: string | Refund;
 
-      /**
-       * The type of source transaction.
-       */
-      type: SourceTransaction.Type;
-    }
+    /**
+     * The type of source transaction.
+     */
+    type: SourceTransaction.Type;
+  }
 
-    export namespace SourceTransaction {
-      export type Type = 'dispute' | 'refund';
-    }
+  export namespace SourceTransaction {
+    export type Type = 'dispute' | 'refund';
   }
 }

--- a/src/resources/Sigma/ScheduledQueryRuns.ts
+++ b/src/resources/Sigma/ScheduledQueryRuns.ts
@@ -60,7 +60,7 @@ export interface ScheduledQueryRun {
    */
   data_load_time: number;
 
-  error?: Sigma.ScheduledQueryRun.Error;
+  error?: ScheduledQueryRun.Error;
 
   /**
    * The file object representing the results of the query.
@@ -92,14 +92,12 @@ export interface ScheduledQueryRun {
    */
   title: string;
 }
-export namespace Sigma {
-  export namespace ScheduledQueryRun {
-    export interface Error {
-      /**
-       * Information about the run failure.
-       */
-      message: string;
-    }
+export namespace ScheduledQueryRun {
+  export interface Error {
+    /**
+     * Information about the run failure.
+     */
+    message: string;
   }
 }
 export namespace Sigma {

--- a/src/resources/Tax/Associations.ts
+++ b/src/resources/Tax/Associations.ts
@@ -43,49 +43,47 @@ export interface Association {
   /**
    * Information about the tax transactions linked to this payment intent
    */
-  tax_transaction_attempts: Array<Tax.Association.TaxTransactionAttempt> | null;
+  tax_transaction_attempts: Array<Association.TaxTransactionAttempt> | null;
 }
-export namespace Tax {
-  export namespace Association {
-    export interface TaxTransactionAttempt {
-      committed?: TaxTransactionAttempt.Committed;
+export namespace Association {
+  export interface TaxTransactionAttempt {
+    committed?: TaxTransactionAttempt.Committed;
 
-      errored?: TaxTransactionAttempt.Errored;
+    errored?: TaxTransactionAttempt.Errored;
 
+    /**
+     * The source of the tax transaction attempt. This is either a refund or a payment intent.
+     */
+    source: string;
+
+    /**
+     * The status of the transaction attempt. This can be `errored` or `committed`.
+     */
+    status: string;
+  }
+
+  export namespace TaxTransactionAttempt {
+    export interface Committed {
       /**
-       * The source of the tax transaction attempt. This is either a refund or a payment intent.
+       * The [Tax Transaction](https://docs.stripe.com/api/tax/transaction/object)
        */
-      source: string;
-
-      /**
-       * The status of the transaction attempt. This can be `errored` or `committed`.
-       */
-      status: string;
+      transaction: string;
     }
 
-    export namespace TaxTransactionAttempt {
-      export interface Committed {
-        /**
-         * The [Tax Transaction](https://docs.stripe.com/api/tax/transaction/object)
-         */
-        transaction: string;
-      }
+    export interface Errored {
+      /**
+       * Details on why we couldn't commit the tax transaction.
+       */
+      reason: Errored.Reason;
+    }
 
-      export interface Errored {
-        /**
-         * Details on why we couldn't commit the tax transaction.
-         */
-        reason: Errored.Reason;
-      }
-
-      export namespace Errored {
-        export type Reason =
-          | 'another_payment_associated_with_calculation'
-          | 'calculation_expired'
-          | 'currency_mismatch'
-          | 'original_transaction_voided'
-          | 'unique_reference_violation';
-      }
+    export namespace Errored {
+      export type Reason =
+        | 'another_payment_associated_with_calculation'
+        | 'calculation_expired'
+        | 'currency_mismatch'
+        | 'original_transaction_voided'
+        | 'unique_reference_violation';
     }
   }
 }

--- a/src/resources/Tax/CalculationLineItems.ts
+++ b/src/resources/Tax/CalculationLineItems.ts
@@ -51,136 +51,129 @@ export interface CalculationLineItem {
   /**
    * Specifies whether the `amount` includes taxes. If `tax_behavior=inclusive`, then the amount includes taxes.
    */
-  tax_behavior: Tax.CalculationLineItem.TaxBehavior;
+  tax_behavior: CalculationLineItem.TaxBehavior;
 
   /**
    * Detailed account of taxes relevant to this line item.
    */
-  tax_breakdown?: Array<Tax.CalculationLineItem.TaxBreakdown> | null;
+  tax_breakdown?: Array<CalculationLineItem.TaxBreakdown> | null;
 
   /**
    * The [tax code](https://docs.stripe.com/tax/tax-categories) ID used for this resource.
    */
   tax_code: string;
 }
-export namespace Tax {
-  export namespace CalculationLineItem {
-    export type TaxBehavior = 'exclusive' | 'inclusive';
+export namespace CalculationLineItem {
+  export type TaxBehavior = 'exclusive' | 'inclusive';
 
-    export interface TaxBreakdown {
+  export interface TaxBreakdown {
+    /**
+     * The amount of tax, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+     */
+    amount: number;
+
+    jurisdiction: TaxBreakdown.Jurisdiction;
+
+    /**
+     * Indicates whether the jurisdiction was determined by the origin (merchant's address) or destination (customer's address).
+     */
+    sourcing: TaxBreakdown.Sourcing;
+
+    /**
+     * Details regarding the rate for this tax. This field will be `null` when the tax is not imposed, for example if the product is exempt from tax.
+     */
+    tax_rate_details: TaxBreakdown.TaxRateDetails | null;
+
+    /**
+     * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
+     */
+    taxability_reason: TaxBreakdown.TaxabilityReason;
+
+    /**
+     * The amount on which tax is calculated, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+     */
+    taxable_amount: number;
+  }
+
+  export namespace TaxBreakdown {
+    export interface Jurisdiction {
       /**
-       * The amount of tax, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
        */
-      amount: number;
-
-      jurisdiction: TaxBreakdown.Jurisdiction;
+      country: string;
 
       /**
-       * Indicates whether the jurisdiction was determined by the origin (merchant's address) or destination (customer's address).
+       * A human-readable name for the jurisdiction imposing the tax.
        */
-      sourcing: TaxBreakdown.Sourcing;
+      display_name: string;
 
       /**
-       * Details regarding the rate for this tax. This field will be `null` when the tax is not imposed, for example if the product is exempt from tax.
+       * Indicates the level of the jurisdiction imposing the tax.
        */
-      tax_rate_details: TaxBreakdown.TaxRateDetails | null;
+      level: Jurisdiction.Level;
 
       /**
-       * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
+       * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2), without country prefix. For example, "NY" for New York, United States.
        */
-      taxability_reason: TaxBreakdown.TaxabilityReason;
-
-      /**
-       * The amount on which tax is calculated, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-       */
-      taxable_amount: number;
+      state: string | null;
     }
 
-    export namespace TaxBreakdown {
-      export interface Jurisdiction {
-        /**
-         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-         */
-        country: string;
+    export type Sourcing = 'destination' | 'origin';
 
-        /**
-         * A human-readable name for the jurisdiction imposing the tax.
-         */
-        display_name: string;
+    export interface TaxRateDetails {
+      /**
+       * A localized display name for tax type, intended to be human-readable. For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
+       */
+      display_name: string;
 
-        /**
-         * Indicates the level of the jurisdiction imposing the tax.
-         */
-        level: Jurisdiction.Level;
+      /**
+       * The tax rate percentage as a string. For example, 8.5% is represented as "8.5".
+       */
+      percentage_decimal: string;
 
-        /**
-         * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2), without country prefix. For example, "NY" for New York, United States.
-         */
-        state: string | null;
-      }
+      /**
+       * The tax type, such as `vat` or `sales_tax`.
+       */
+      tax_type: TaxRateDetails.TaxType;
+    }
 
-      export type Sourcing = 'destination' | 'origin';
+    export type TaxabilityReason =
+      | 'customer_exempt'
+      | 'not_collecting'
+      | 'not_subject_to_tax'
+      | 'not_supported'
+      | 'portion_product_exempt'
+      | 'portion_reduced_rated'
+      | 'portion_standard_rated'
+      | 'product_exempt'
+      | 'product_exempt_holiday'
+      | 'proportionally_rated'
+      | 'reduced_rated'
+      | 'reverse_charge'
+      | 'standard_rated'
+      | 'taxable_basis_reduced'
+      | 'zero_rated';
 
-      export interface TaxRateDetails {
-        /**
-         * A localized display name for tax type, intended to be human-readable. For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
-         */
-        display_name: string;
+    export namespace Jurisdiction {
+      export type Level = 'city' | 'country' | 'county' | 'district' | 'state';
+    }
 
-        /**
-         * The tax rate percentage as a string. For example, 8.5% is represented as "8.5".
-         */
-        percentage_decimal: string;
-
-        /**
-         * The tax type, such as `vat` or `sales_tax`.
-         */
-        tax_type: TaxRateDetails.TaxType;
-      }
-
-      export type TaxabilityReason =
-        | 'customer_exempt'
-        | 'not_collecting'
-        | 'not_subject_to_tax'
-        | 'not_supported'
-        | 'portion_product_exempt'
-        | 'portion_reduced_rated'
-        | 'portion_standard_rated'
-        | 'product_exempt'
-        | 'product_exempt_holiday'
-        | 'proportionally_rated'
-        | 'reduced_rated'
-        | 'reverse_charge'
-        | 'standard_rated'
-        | 'taxable_basis_reduced'
-        | 'zero_rated';
-
-      export namespace Jurisdiction {
-        export type Level =
-          | 'city'
-          | 'country'
-          | 'county'
-          | 'district'
-          | 'state';
-      }
-
-      export namespace TaxRateDetails {
-        export type TaxType =
-          | 'amusement_tax'
-          | 'communications_tax'
-          | 'gst'
-          | 'hst'
-          | 'igst'
-          | 'jct'
-          | 'lease_tax'
-          | 'pst'
-          | 'qst'
-          | 'retail_delivery_fee'
-          | 'rst'
-          | 'sales_tax'
-          | 'service_tax'
-          | 'vat';
-      }
+    export namespace TaxRateDetails {
+      export type TaxType =
+        | 'amusement_tax'
+        | 'communications_tax'
+        | 'gst'
+        | 'hst'
+        | 'igst'
+        | 'jct'
+        | 'lease_tax'
+        | 'pst'
+        | 'qst'
+        | 'retail_delivery_fee'
+        | 'rst'
+        | 'sales_tax'
+        | 'service_tax'
+        | 'vat';
     }
   }
 }

--- a/src/resources/Tax/Calculations.ts
+++ b/src/resources/Tax/Calculations.ts
@@ -85,7 +85,7 @@ export interface Calculation {
    */
   customer: string | null;
 
-  customer_details: Tax.Calculation.CustomerDetails;
+  customer_details: Calculation.CustomerDetails;
 
   /**
    * Timestamp of date at which the tax calculation will expire.
@@ -105,12 +105,12 @@ export interface Calculation {
   /**
    * The details of the ship from location, such as the address.
    */
-  ship_from_details: Tax.Calculation.ShipFromDetails | null;
+  ship_from_details: Calculation.ShipFromDetails | null;
 
   /**
    * The shipping cost details for the calculation.
    */
-  shipping_cost: Tax.Calculation.ShippingCost | null;
+  shipping_cost: Calculation.ShippingCost | null;
 
   /**
    * The amount of tax to be collected on top of the line item prices.
@@ -125,77 +125,245 @@ export interface Calculation {
   /**
    * Breakdown of individual tax amounts that add up to the total.
    */
-  tax_breakdown: Array<Tax.Calculation.TaxBreakdown>;
+  tax_breakdown: Array<Calculation.TaxBreakdown>;
 
   /**
    * The calculation uses the tax rules and rates that are in effect at this timestamp. You can use a date up to 31 days in the past or up to 31 days in the future. If you use a future date, Stripe doesn't guarantee that the expected tax rules and rate being used match the actual rules and rate that will be in effect on that date. We deploy tax changes before their effective date, but not within a fixed window.
    */
   tax_date: number;
 }
-export namespace Tax {
-  export namespace Calculation {
-    export interface CustomerDetails {
+export namespace Calculation {
+  export interface CustomerDetails {
+    /**
+     * The customer's postal address (for example, home or business location).
+     */
+    address: Address | null;
+
+    /**
+     * The type of customer address provided.
+     */
+    address_source: CustomerDetails.AddressSource | null;
+
+    /**
+     * The customer's IP address (IPv4 or IPv6).
+     */
+    ip_address: string | null;
+
+    /**
+     * The customer's tax IDs (for example, EU VAT numbers).
+     */
+    tax_ids: Array<CustomerDetails.TaxId>;
+
+    /**
+     * The taxability override used for taxation.
+     */
+    taxability_override: CustomerDetails.TaxabilityOverride;
+  }
+
+  export interface ShipFromDetails {
+    address: Address;
+  }
+
+  export interface ShippingCost {
+    /**
+     * The shipping amount in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units). If `tax_behavior=inclusive`, then this amount includes taxes. Otherwise, taxes were calculated on top of this amount.
+     */
+    amount: number;
+
+    /**
+     * The amount of tax calculated for shipping, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+     */
+    amount_tax: number;
+
+    /**
+     * The ID of an existing [ShippingRate](https://docs.stripe.com/api/shipping_rates/object).
+     */
+    shipping_rate?: string;
+
+    /**
+     * Specifies whether the `amount` includes taxes. If `tax_behavior=inclusive`, then the amount includes taxes.
+     */
+    tax_behavior: ShippingCost.TaxBehavior;
+
+    /**
+     * Detailed account of taxes relevant to shipping cost.
+     */
+    tax_breakdown?: Array<ShippingCost.TaxBreakdown>;
+
+    /**
+     * The [tax code](https://docs.stripe.com/tax/tax-categories) ID used for shipping.
+     */
+    tax_code: string;
+  }
+
+  export interface TaxBreakdown {
+    /**
+     * The amount of tax, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+     */
+    amount: number;
+
+    /**
+     * Specifies whether the tax amount is included in the line item amount.
+     */
+    inclusive: boolean;
+
+    tax_rate_details: TaxBreakdown.TaxRateDetails;
+
+    /**
+     * The reasoning behind this tax, for example, if the product is tax exempt. We might extend the possible values for this field to support new tax rules.
+     */
+    taxability_reason: TaxBreakdown.TaxabilityReason;
+
+    /**
+     * The amount on which tax is calculated, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+     */
+    taxable_amount: number;
+  }
+
+  export namespace CustomerDetails {
+    export type AddressSource = 'billing' | 'shipping';
+
+    export interface TaxId {
       /**
-       * The customer's postal address (for example, home or business location).
+       * The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `pl_nip`, `it_cf`, `fo_vat`, `gi_tin`, `py_ruc`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `lk_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `al_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, `ao_tin`, `bs_tin`, `bb_tin`, `cd_nif`, `mr_nif`, `me_pib`, `zw_tin`, `ba_tin`, `gn_nif`, `mk_vat`, `sr_fin`, `sn_ninea`, `am_tin`, `np_pan`, `tj_tin`, `ug_tin`, `zm_tin`, `kh_tin`, `aw_tin`, `az_tin`, `bd_bin`, `bj_ifu`, `et_tin`, `kg_tin`, `la_tin`, `cm_niu`, `cv_nif`, `bf_ifu`, or `unknown`
        */
-      address: Address | null;
+      type: TaxId.Type;
 
       /**
-       * The type of customer address provided.
+       * The value of the tax ID.
        */
-      address_source: CustomerDetails.AddressSource | null;
-
-      /**
-       * The customer's IP address (IPv4 or IPv6).
-       */
-      ip_address: string | null;
-
-      /**
-       * The customer's tax IDs (for example, EU VAT numbers).
-       */
-      tax_ids: Array<CustomerDetails.TaxId>;
-
-      /**
-       * The taxability override used for taxation.
-       */
-      taxability_override: CustomerDetails.TaxabilityOverride;
+      value: string;
     }
 
-    export interface ShipFromDetails {
-      address: Address;
+    export type TaxabilityOverride =
+      | 'customer_exempt'
+      | 'none'
+      | 'reverse_charge';
+
+    export namespace TaxId {
+      export type Type =
+        | 'ad_nrt'
+        | 'ae_trn'
+        | 'al_tin'
+        | 'am_tin'
+        | 'ao_tin'
+        | 'ar_cuit'
+        | 'au_abn'
+        | 'au_arn'
+        | 'aw_tin'
+        | 'az_tin'
+        | 'ba_tin'
+        | 'bb_tin'
+        | 'bd_bin'
+        | 'bf_ifu'
+        | 'bg_uic'
+        | 'bh_vat'
+        | 'bj_ifu'
+        | 'bo_tin'
+        | 'br_cnpj'
+        | 'br_cpf'
+        | 'bs_tin'
+        | 'by_tin'
+        | 'ca_bn'
+        | 'ca_gst_hst'
+        | 'ca_pst_bc'
+        | 'ca_pst_mb'
+        | 'ca_pst_sk'
+        | 'ca_qst'
+        | 'cd_nif'
+        | 'ch_uid'
+        | 'ch_vat'
+        | 'cl_tin'
+        | 'cm_niu'
+        | 'cn_tin'
+        | 'co_nit'
+        | 'cr_tin'
+        | 'cv_nif'
+        | 'de_stn'
+        | 'do_rcn'
+        | 'ec_ruc'
+        | 'eg_tin'
+        | 'es_cif'
+        | 'et_tin'
+        | 'eu_oss_vat'
+        | 'eu_vat'
+        | 'fo_vat'
+        | 'gb_vat'
+        | 'ge_vat'
+        | 'gi_tin'
+        | 'gn_nif'
+        | 'hk_br'
+        | 'hr_oib'
+        | 'hu_tin'
+        | 'id_npwp'
+        | 'il_vat'
+        | 'in_gst'
+        | 'is_vat'
+        | 'it_cf'
+        | 'jp_cn'
+        | 'jp_rn'
+        | 'jp_trn'
+        | 'ke_pin'
+        | 'kg_tin'
+        | 'kh_tin'
+        | 'kr_brn'
+        | 'kz_bin'
+        | 'la_tin'
+        | 'li_uid'
+        | 'li_vat'
+        | 'lk_vat'
+        | 'ma_vat'
+        | 'md_vat'
+        | 'me_pib'
+        | 'mk_vat'
+        | 'mr_nif'
+        | 'mx_rfc'
+        | 'my_frp'
+        | 'my_itn'
+        | 'my_sst'
+        | 'ng_tin'
+        | 'no_vat'
+        | 'no_voec'
+        | 'np_pan'
+        | 'nz_gst'
+        | 'om_vat'
+        | 'pe_ruc'
+        | 'ph_tin'
+        | 'pl_nip'
+        | 'py_ruc'
+        | 'ro_tin'
+        | 'rs_pib'
+        | 'ru_inn'
+        | 'ru_kpp'
+        | 'sa_vat'
+        | 'sg_gst'
+        | 'sg_uen'
+        | 'si_tin'
+        | 'sn_ninea'
+        | 'sr_fin'
+        | 'sv_nit'
+        | 'th_vat'
+        | 'tj_tin'
+        | 'tr_tin'
+        | 'tw_vat'
+        | 'tz_vat'
+        | 'ua_vat'
+        | 'ug_tin'
+        | 'unknown'
+        | 'us_ein'
+        | 'uy_ruc'
+        | 'uz_tin'
+        | 'uz_vat'
+        | 've_rif'
+        | 'vn_tin'
+        | 'za_vat'
+        | 'zm_tin'
+        | 'zw_tin';
     }
+  }
 
-    export interface ShippingCost {
-      /**
-       * The shipping amount in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units). If `tax_behavior=inclusive`, then this amount includes taxes. Otherwise, taxes were calculated on top of this amount.
-       */
-      amount: number;
-
-      /**
-       * The amount of tax calculated for shipping, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-       */
-      amount_tax: number;
-
-      /**
-       * The ID of an existing [ShippingRate](https://docs.stripe.com/api/shipping_rates/object).
-       */
-      shipping_rate?: string;
-
-      /**
-       * Specifies whether the `amount` includes taxes. If `tax_behavior=inclusive`, then the amount includes taxes.
-       */
-      tax_behavior: ShippingCost.TaxBehavior;
-
-      /**
-       * Detailed account of taxes relevant to shipping cost.
-       */
-      tax_breakdown?: Array<ShippingCost.TaxBreakdown>;
-
-      /**
-       * The [tax code](https://docs.stripe.com/tax/tax-categories) ID used for shipping.
-       */
-      tax_code: string;
-    }
+  export namespace ShippingCost {
+    export type TaxBehavior = 'exclusive' | 'inclusive';
 
     export interface TaxBreakdown {
       /**
@@ -203,15 +371,20 @@ export namespace Tax {
        */
       amount: number;
 
+      jurisdiction: TaxBreakdown.Jurisdiction;
+
       /**
-       * Specifies whether the tax amount is included in the line item amount.
+       * Indicates whether the jurisdiction was determined by the origin (merchant's address) or destination (customer's address).
        */
-      inclusive: boolean;
-
-      tax_rate_details: TaxBreakdown.TaxRateDetails;
+      sourcing: TaxBreakdown.Sourcing;
 
       /**
-       * The reasoning behind this tax, for example, if the product is tax exempt. We might extend the possible values for this field to support new tax rules.
+       * Details regarding the rate for this tax. This field will be `null` when the tax is not imposed, for example if the product is exempt from tax.
+       */
+      tax_rate_details: TaxBreakdown.TaxRateDetails | null;
+
+      /**
+       * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
        */
       taxability_reason: TaxBreakdown.TaxabilityReason;
 
@@ -221,299 +394,46 @@ export namespace Tax {
       taxable_amount: number;
     }
 
-    export namespace CustomerDetails {
-      export type AddressSource = 'billing' | 'shipping';
-
-      export interface TaxId {
-        /**
-         * The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `pl_nip`, `it_cf`, `fo_vat`, `gi_tin`, `py_ruc`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `lk_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `al_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, `ao_tin`, `bs_tin`, `bb_tin`, `cd_nif`, `mr_nif`, `me_pib`, `zw_tin`, `ba_tin`, `gn_nif`, `mk_vat`, `sr_fin`, `sn_ninea`, `am_tin`, `np_pan`, `tj_tin`, `ug_tin`, `zm_tin`, `kh_tin`, `aw_tin`, `az_tin`, `bd_bin`, `bj_ifu`, `et_tin`, `kg_tin`, `la_tin`, `cm_niu`, `cv_nif`, `bf_ifu`, or `unknown`
-         */
-        type: TaxId.Type;
-
-        /**
-         * The value of the tax ID.
-         */
-        value: string;
-      }
-
-      export type TaxabilityOverride =
-        | 'customer_exempt'
-        | 'none'
-        | 'reverse_charge';
-
-      export namespace TaxId {
-        export type Type =
-          | 'ad_nrt'
-          | 'ae_trn'
-          | 'al_tin'
-          | 'am_tin'
-          | 'ao_tin'
-          | 'ar_cuit'
-          | 'au_abn'
-          | 'au_arn'
-          | 'aw_tin'
-          | 'az_tin'
-          | 'ba_tin'
-          | 'bb_tin'
-          | 'bd_bin'
-          | 'bf_ifu'
-          | 'bg_uic'
-          | 'bh_vat'
-          | 'bj_ifu'
-          | 'bo_tin'
-          | 'br_cnpj'
-          | 'br_cpf'
-          | 'bs_tin'
-          | 'by_tin'
-          | 'ca_bn'
-          | 'ca_gst_hst'
-          | 'ca_pst_bc'
-          | 'ca_pst_mb'
-          | 'ca_pst_sk'
-          | 'ca_qst'
-          | 'cd_nif'
-          | 'ch_uid'
-          | 'ch_vat'
-          | 'cl_tin'
-          | 'cm_niu'
-          | 'cn_tin'
-          | 'co_nit'
-          | 'cr_tin'
-          | 'cv_nif'
-          | 'de_stn'
-          | 'do_rcn'
-          | 'ec_ruc'
-          | 'eg_tin'
-          | 'es_cif'
-          | 'et_tin'
-          | 'eu_oss_vat'
-          | 'eu_vat'
-          | 'fo_vat'
-          | 'gb_vat'
-          | 'ge_vat'
-          | 'gi_tin'
-          | 'gn_nif'
-          | 'hk_br'
-          | 'hr_oib'
-          | 'hu_tin'
-          | 'id_npwp'
-          | 'il_vat'
-          | 'in_gst'
-          | 'is_vat'
-          | 'it_cf'
-          | 'jp_cn'
-          | 'jp_rn'
-          | 'jp_trn'
-          | 'ke_pin'
-          | 'kg_tin'
-          | 'kh_tin'
-          | 'kr_brn'
-          | 'kz_bin'
-          | 'la_tin'
-          | 'li_uid'
-          | 'li_vat'
-          | 'lk_vat'
-          | 'ma_vat'
-          | 'md_vat'
-          | 'me_pib'
-          | 'mk_vat'
-          | 'mr_nif'
-          | 'mx_rfc'
-          | 'my_frp'
-          | 'my_itn'
-          | 'my_sst'
-          | 'ng_tin'
-          | 'no_vat'
-          | 'no_voec'
-          | 'np_pan'
-          | 'nz_gst'
-          | 'om_vat'
-          | 'pe_ruc'
-          | 'ph_tin'
-          | 'pl_nip'
-          | 'py_ruc'
-          | 'ro_tin'
-          | 'rs_pib'
-          | 'ru_inn'
-          | 'ru_kpp'
-          | 'sa_vat'
-          | 'sg_gst'
-          | 'sg_uen'
-          | 'si_tin'
-          | 'sn_ninea'
-          | 'sr_fin'
-          | 'sv_nit'
-          | 'th_vat'
-          | 'tj_tin'
-          | 'tr_tin'
-          | 'tw_vat'
-          | 'tz_vat'
-          | 'ua_vat'
-          | 'ug_tin'
-          | 'unknown'
-          | 'us_ein'
-          | 'uy_ruc'
-          | 'uz_tin'
-          | 'uz_vat'
-          | 've_rif'
-          | 'vn_tin'
-          | 'za_vat'
-          | 'zm_tin'
-          | 'zw_tin';
-      }
-    }
-
-    export namespace ShippingCost {
-      export type TaxBehavior = 'exclusive' | 'inclusive';
-
-      export interface TaxBreakdown {
-        /**
-         * The amount of tax, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-         */
-        amount: number;
-
-        jurisdiction: TaxBreakdown.Jurisdiction;
-
-        /**
-         * Indicates whether the jurisdiction was determined by the origin (merchant's address) or destination (customer's address).
-         */
-        sourcing: TaxBreakdown.Sourcing;
-
-        /**
-         * Details regarding the rate for this tax. This field will be `null` when the tax is not imposed, for example if the product is exempt from tax.
-         */
-        tax_rate_details: TaxBreakdown.TaxRateDetails | null;
-
-        /**
-         * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
-         */
-        taxability_reason: TaxBreakdown.TaxabilityReason;
-
-        /**
-         * The amount on which tax is calculated, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-         */
-        taxable_amount: number;
-      }
-
-      export namespace TaxBreakdown {
-        export interface Jurisdiction {
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country: string;
-
-          /**
-           * A human-readable name for the jurisdiction imposing the tax.
-           */
-          display_name: string;
-
-          /**
-           * Indicates the level of the jurisdiction imposing the tax.
-           */
-          level: Jurisdiction.Level;
-
-          /**
-           * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2), without country prefix. For example, "NY" for New York, United States.
-           */
-          state: string | null;
-        }
-
-        export type Sourcing = 'destination' | 'origin';
-
-        export interface TaxRateDetails {
-          /**
-           * A localized display name for tax type, intended to be human-readable. For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
-           */
-          display_name: string;
-
-          /**
-           * The tax rate percentage as a string. For example, 8.5% is represented as "8.5".
-           */
-          percentage_decimal: string;
-
-          /**
-           * The tax type, such as `vat` or `sales_tax`.
-           */
-          tax_type: TaxRateDetails.TaxType;
-        }
-
-        export type TaxabilityReason =
-          | 'customer_exempt'
-          | 'not_collecting'
-          | 'not_subject_to_tax'
-          | 'not_supported'
-          | 'portion_product_exempt'
-          | 'portion_reduced_rated'
-          | 'portion_standard_rated'
-          | 'product_exempt'
-          | 'product_exempt_holiday'
-          | 'proportionally_rated'
-          | 'reduced_rated'
-          | 'reverse_charge'
-          | 'standard_rated'
-          | 'taxable_basis_reduced'
-          | 'zero_rated';
-
-        export namespace Jurisdiction {
-          export type Level =
-            | 'city'
-            | 'country'
-            | 'county'
-            | 'district'
-            | 'state';
-        }
-
-        export namespace TaxRateDetails {
-          export type TaxType =
-            | 'amusement_tax'
-            | 'communications_tax'
-            | 'gst'
-            | 'hst'
-            | 'igst'
-            | 'jct'
-            | 'lease_tax'
-            | 'pst'
-            | 'qst'
-            | 'retail_delivery_fee'
-            | 'rst'
-            | 'sales_tax'
-            | 'service_tax'
-            | 'vat';
-        }
-      }
-    }
-
     export namespace TaxBreakdown {
-      export interface TaxRateDetails {
+      export interface Jurisdiction {
         /**
          * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
          */
-        country: string | null;
+        country: string;
 
         /**
-         * The amount of the tax rate when the `rate_type` is `flat_amount`. Tax rates with `rate_type` `percentage` can vary based on the transaction, resulting in this field being `null`. This field exposes the amount and currency of the flat tax rate.
+         * A human-readable name for the jurisdiction imposing the tax.
          */
-        flat_amount: TaxRateDetails.FlatAmount | null;
+        display_name: string;
 
         /**
-         * The tax rate percentage as a string. For example, 8.5% is represented as `"8.5"`.
+         * Indicates the level of the jurisdiction imposing the tax.
+         */
+        level: Jurisdiction.Level;
+
+        /**
+         * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2), without country prefix. For example, "NY" for New York, United States.
+         */
+        state: string | null;
+      }
+
+      export type Sourcing = 'destination' | 'origin';
+
+      export interface TaxRateDetails {
+        /**
+         * A localized display name for tax type, intended to be human-readable. For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
+         */
+        display_name: string;
+
+        /**
+         * The tax rate percentage as a string. For example, 8.5% is represented as "8.5".
          */
         percentage_decimal: string;
 
         /**
-         * Indicates the type of tax rate applied to the taxable amount. This value can be `null` when no tax applies to the location. This field is only present for TaxRates created by Stripe Tax.
-         */
-        rate_type: TaxRateDetails.RateType | null;
-
-        /**
-         * State, county, province, or region ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
-         */
-        state: string | null;
-
-        /**
          * The tax type, such as `vat` or `sales_tax`.
          */
-        tax_type: TaxRateDetails.TaxType | null;
+        tax_type: TaxRateDetails.TaxType;
       }
 
       export type TaxabilityReason =
@@ -533,21 +453,16 @@ export namespace Tax {
         | 'taxable_basis_reduced'
         | 'zero_rated';
 
+      export namespace Jurisdiction {
+        export type Level =
+          | 'city'
+          | 'country'
+          | 'county'
+          | 'district'
+          | 'state';
+      }
+
       export namespace TaxRateDetails {
-        export interface FlatAmount {
-          /**
-           * Amount of the tax when the `rate_type` is `flat_amount`. This positive integer represents how much to charge in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
-           */
-          amount: number;
-
-          /**
-           * Three-letter ISO currency code, in lowercase.
-           */
-          currency: string;
-        }
-
-        export type RateType = 'flat_amount' | 'percentage';
-
         export type TaxType =
           | 'amusement_tax'
           | 'communications_tax'
@@ -564,6 +479,89 @@ export namespace Tax {
           | 'service_tax'
           | 'vat';
       }
+    }
+  }
+
+  export namespace TaxBreakdown {
+    export interface TaxRateDetails {
+      /**
+       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+       */
+      country: string | null;
+
+      /**
+       * The amount of the tax rate when the `rate_type` is `flat_amount`. Tax rates with `rate_type` `percentage` can vary based on the transaction, resulting in this field being `null`. This field exposes the amount and currency of the flat tax rate.
+       */
+      flat_amount: TaxRateDetails.FlatAmount | null;
+
+      /**
+       * The tax rate percentage as a string. For example, 8.5% is represented as `"8.5"`.
+       */
+      percentage_decimal: string;
+
+      /**
+       * Indicates the type of tax rate applied to the taxable amount. This value can be `null` when no tax applies to the location. This field is only present for TaxRates created by Stripe Tax.
+       */
+      rate_type: TaxRateDetails.RateType | null;
+
+      /**
+       * State, county, province, or region ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
+       */
+      state: string | null;
+
+      /**
+       * The tax type, such as `vat` or `sales_tax`.
+       */
+      tax_type: TaxRateDetails.TaxType | null;
+    }
+
+    export type TaxabilityReason =
+      | 'customer_exempt'
+      | 'not_collecting'
+      | 'not_subject_to_tax'
+      | 'not_supported'
+      | 'portion_product_exempt'
+      | 'portion_reduced_rated'
+      | 'portion_standard_rated'
+      | 'product_exempt'
+      | 'product_exempt_holiday'
+      | 'proportionally_rated'
+      | 'reduced_rated'
+      | 'reverse_charge'
+      | 'standard_rated'
+      | 'taxable_basis_reduced'
+      | 'zero_rated';
+
+    export namespace TaxRateDetails {
+      export interface FlatAmount {
+        /**
+         * Amount of the tax when the `rate_type` is `flat_amount`. This positive integer represents how much to charge in the smallest currency unit (e.g., 100 cents to charge $1.00 or 100 to charge ¥100, a zero-decimal currency). The amount value supports up to eight digits (e.g., a value of 99999999 for a USD charge of $999,999.99).
+         */
+        amount: number;
+
+        /**
+         * Three-letter ISO currency code, in lowercase.
+         */
+        currency: string;
+      }
+
+      export type RateType = 'flat_amount' | 'percentage';
+
+      export type TaxType =
+        | 'amusement_tax'
+        | 'communications_tax'
+        | 'gst'
+        | 'hst'
+        | 'igst'
+        | 'jct'
+        | 'lease_tax'
+        | 'pst'
+        | 'qst'
+        | 'retail_delivery_fee'
+        | 'rst'
+        | 'sales_tax'
+        | 'service_tax'
+        | 'vat';
     }
   }
 }

--- a/src/resources/Tax/Registrations.ts
+++ b/src/resources/Tax/Registrations.ts
@@ -84,7 +84,7 @@ export interface Registration {
    */
   country: string;
 
-  country_options: Tax.Registration.CountryOptions;
+  country_options: Registration.CountryOptions;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -104,1656 +104,1654 @@ export interface Registration {
   /**
    * The status of the registration. This field is present for convenience and can be deduced from `active_from` and `expires_at`.
    */
-  status: Tax.Registration.Status;
+  status: Registration.Status;
 }
-export namespace Tax {
-  export namespace Registration {
-    export interface CountryOptions {
-      ae?: CountryOptions.Ae;
+export namespace Registration {
+  export interface CountryOptions {
+    ae?: CountryOptions.Ae;
 
-      al?: CountryOptions.Al;
+    al?: CountryOptions.Al;
 
-      am?: CountryOptions.Am;
+    am?: CountryOptions.Am;
 
-      ao?: CountryOptions.Ao;
+    ao?: CountryOptions.Ao;
 
-      at?: CountryOptions.At;
+    at?: CountryOptions.At;
 
-      au?: CountryOptions.Au;
+    au?: CountryOptions.Au;
 
-      aw?: CountryOptions.Aw;
+    aw?: CountryOptions.Aw;
 
-      az?: CountryOptions.Az;
+    az?: CountryOptions.Az;
 
-      ba?: CountryOptions.Ba;
+    ba?: CountryOptions.Ba;
 
-      bb?: CountryOptions.Bb;
+    bb?: CountryOptions.Bb;
 
-      bd?: CountryOptions.Bd;
+    bd?: CountryOptions.Bd;
 
-      be?: CountryOptions.Be;
+    be?: CountryOptions.Be;
 
-      bf?: CountryOptions.Bf;
+    bf?: CountryOptions.Bf;
 
-      bg?: CountryOptions.Bg;
+    bg?: CountryOptions.Bg;
 
-      bh?: CountryOptions.Bh;
+    bh?: CountryOptions.Bh;
 
-      bj?: CountryOptions.Bj;
+    bj?: CountryOptions.Bj;
 
-      bs?: CountryOptions.Bs;
+    bs?: CountryOptions.Bs;
 
-      by?: CountryOptions.By;
+    by?: CountryOptions.By;
 
-      ca?: CountryOptions.Ca;
+    ca?: CountryOptions.Ca;
 
-      cd?: CountryOptions.Cd;
+    cd?: CountryOptions.Cd;
 
-      ch?: CountryOptions.Ch;
+    ch?: CountryOptions.Ch;
 
-      cl?: CountryOptions.Cl;
+    cl?: CountryOptions.Cl;
 
-      cm?: CountryOptions.Cm;
+    cm?: CountryOptions.Cm;
 
-      co?: CountryOptions.Co;
+    co?: CountryOptions.Co;
 
-      cr?: CountryOptions.Cr;
+    cr?: CountryOptions.Cr;
 
-      cv?: CountryOptions.Cv;
+    cv?: CountryOptions.Cv;
 
-      cy?: CountryOptions.Cy;
+    cy?: CountryOptions.Cy;
 
-      cz?: CountryOptions.Cz;
+    cz?: CountryOptions.Cz;
 
-      de?: CountryOptions.De;
+    de?: CountryOptions.De;
 
-      dk?: CountryOptions.Dk;
+    dk?: CountryOptions.Dk;
 
-      ec?: CountryOptions.Ec;
+    ec?: CountryOptions.Ec;
 
-      ee?: CountryOptions.Ee;
+    ee?: CountryOptions.Ee;
 
-      eg?: CountryOptions.Eg;
+    eg?: CountryOptions.Eg;
 
-      es?: CountryOptions.Es;
+    es?: CountryOptions.Es;
 
-      et?: CountryOptions.Et;
+    et?: CountryOptions.Et;
 
-      fi?: CountryOptions.Fi;
+    fi?: CountryOptions.Fi;
 
-      fr?: CountryOptions.Fr;
+    fr?: CountryOptions.Fr;
 
-      gb?: CountryOptions.Gb;
+    gb?: CountryOptions.Gb;
 
-      ge?: CountryOptions.Ge;
+    ge?: CountryOptions.Ge;
 
-      gn?: CountryOptions.Gn;
+    gn?: CountryOptions.Gn;
 
-      gr?: CountryOptions.Gr;
+    gr?: CountryOptions.Gr;
 
-      hr?: CountryOptions.Hr;
+    hr?: CountryOptions.Hr;
 
-      hu?: CountryOptions.Hu;
+    hu?: CountryOptions.Hu;
 
-      id?: CountryOptions.Id;
+    id?: CountryOptions.Id;
 
-      ie?: CountryOptions.Ie;
+    ie?: CountryOptions.Ie;
 
-      in?: CountryOptions.In;
+    in?: CountryOptions.In;
 
-      is?: CountryOptions.Is;
+    is?: CountryOptions.Is;
 
-      it?: CountryOptions.It;
+    it?: CountryOptions.It;
 
-      jp?: CountryOptions.Jp;
+    jp?: CountryOptions.Jp;
 
-      ke?: CountryOptions.Ke;
+    ke?: CountryOptions.Ke;
 
-      kg?: CountryOptions.Kg;
+    kg?: CountryOptions.Kg;
 
-      kh?: CountryOptions.Kh;
+    kh?: CountryOptions.Kh;
 
-      kr?: CountryOptions.Kr;
+    kr?: CountryOptions.Kr;
 
-      kz?: CountryOptions.Kz;
+    kz?: CountryOptions.Kz;
 
-      la?: CountryOptions.La;
+    la?: CountryOptions.La;
 
-      lk?: CountryOptions.Lk;
+    lk?: CountryOptions.Lk;
 
-      lt?: CountryOptions.Lt;
+    lt?: CountryOptions.Lt;
 
-      lu?: CountryOptions.Lu;
+    lu?: CountryOptions.Lu;
 
-      lv?: CountryOptions.Lv;
+    lv?: CountryOptions.Lv;
 
-      ma?: CountryOptions.Ma;
+    ma?: CountryOptions.Ma;
 
-      md?: CountryOptions.Md;
+    md?: CountryOptions.Md;
 
-      me?: CountryOptions.Me;
+    me?: CountryOptions.Me;
 
-      mk?: CountryOptions.Mk;
+    mk?: CountryOptions.Mk;
 
-      mr?: CountryOptions.Mr;
+    mr?: CountryOptions.Mr;
 
-      mt?: CountryOptions.Mt;
+    mt?: CountryOptions.Mt;
 
-      mx?: CountryOptions.Mx;
+    mx?: CountryOptions.Mx;
 
-      my?: CountryOptions.My;
+    my?: CountryOptions.My;
 
-      ng?: CountryOptions.Ng;
+    ng?: CountryOptions.Ng;
 
-      nl?: CountryOptions.Nl;
+    nl?: CountryOptions.Nl;
 
-      no?: CountryOptions.No;
+    no?: CountryOptions.No;
 
-      np?: CountryOptions.Np;
+    np?: CountryOptions.Np;
 
-      nz?: CountryOptions.Nz;
+    nz?: CountryOptions.Nz;
 
-      om?: CountryOptions.Om;
+    om?: CountryOptions.Om;
 
-      pe?: CountryOptions.Pe;
+    pe?: CountryOptions.Pe;
 
-      ph?: CountryOptions.Ph;
+    ph?: CountryOptions.Ph;
 
-      pl?: CountryOptions.Pl;
+    pl?: CountryOptions.Pl;
 
-      pt?: CountryOptions.Pt;
+    pt?: CountryOptions.Pt;
 
-      ro?: CountryOptions.Ro;
+    ro?: CountryOptions.Ro;
 
-      rs?: CountryOptions.Rs;
+    rs?: CountryOptions.Rs;
 
-      ru?: CountryOptions.Ru;
+    ru?: CountryOptions.Ru;
 
-      sa?: CountryOptions.Sa;
+    sa?: CountryOptions.Sa;
 
-      se?: CountryOptions.Se;
+    se?: CountryOptions.Se;
 
-      sg?: CountryOptions.Sg;
+    sg?: CountryOptions.Sg;
 
-      si?: CountryOptions.Si;
+    si?: CountryOptions.Si;
 
-      sk?: CountryOptions.Sk;
+    sk?: CountryOptions.Sk;
 
-      sn?: CountryOptions.Sn;
+    sn?: CountryOptions.Sn;
 
-      sr?: CountryOptions.Sr;
+    sr?: CountryOptions.Sr;
 
-      th?: CountryOptions.Th;
+    th?: CountryOptions.Th;
 
-      tj?: CountryOptions.Tj;
+    tj?: CountryOptions.Tj;
 
-      tr?: CountryOptions.Tr;
+    tr?: CountryOptions.Tr;
 
-      tw?: CountryOptions.Tw;
+    tw?: CountryOptions.Tw;
 
-      tz?: CountryOptions.Tz;
+    tz?: CountryOptions.Tz;
 
-      ua?: CountryOptions.Ua;
+    ua?: CountryOptions.Ua;
 
-      ug?: CountryOptions.Ug;
+    ug?: CountryOptions.Ug;
 
-      us?: CountryOptions.Us;
+    us?: CountryOptions.Us;
 
-      uy?: CountryOptions.Uy;
+    uy?: CountryOptions.Uy;
 
-      uz?: CountryOptions.Uz;
+    uz?: CountryOptions.Uz;
 
-      vn?: CountryOptions.Vn;
+    vn?: CountryOptions.Vn;
 
-      za?: CountryOptions.Za;
+    za?: CountryOptions.Za;
 
-      zm?: CountryOptions.Zm;
+    zm?: CountryOptions.Zm;
 
-      zw?: CountryOptions.Zw;
+    zw?: CountryOptions.Zw;
+  }
+
+  export type Status = 'active' | 'expired' | 'scheduled';
+
+  export namespace CountryOptions {
+    export interface Ae {
+      standard?: Ae.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
     }
 
-    export type Status = 'active' | 'expired' | 'scheduled';
-
-    export namespace CountryOptions {
-      export interface Ae {
-        standard?: Ae.Standard;
-
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Al {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Am {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Ao {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface At {
-        standard?: At.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: At.Type;
-      }
-
-      export interface Au {
-        standard?: Au.Standard;
-
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Aw {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Az {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Ba {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Bb {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Bd {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Be {
-        standard?: Be.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Be.Type;
-      }
-
-      export interface Bf {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Bg {
-        standard?: Bg.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Bg.Type;
-      }
-
-      export interface Bh {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Bj {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Bs {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface By {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Ca {
-        province_standard?: Ca.ProvinceStandard;
-
-        /**
-         * Type of registration in Canada.
-         */
-        type: Ca.Type;
-      }
-
-      export interface Cd {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Ch {
-        standard?: Ch.Standard;
-
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Cl {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Cm {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Co {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Cr {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Cv {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Cy {
-        standard?: Cy.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Cy.Type;
-      }
-
-      export interface Cz {
-        standard?: Cz.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Cz.Type;
-      }
-
-      export interface De {
-        standard?: De.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: De.Type;
-      }
-
-      export interface Dk {
-        standard?: Dk.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Dk.Type;
-      }
-
-      export interface Ec {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Ee {
-        standard?: Ee.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Ee.Type;
-      }
-
-      export interface Eg {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Es {
-        standard?: Es.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Es.Type;
-      }
-
-      export interface Et {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Fi {
-        standard?: Fi.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Fi.Type;
-      }
-
-      export interface Fr {
-        standard?: Fr.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Fr.Type;
-      }
-
-      export interface Gb {
-        standard?: Gb.Standard;
-
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Ge {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
-
-      export interface Gn {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
-
-      export interface Gr {
-        standard?: Gr.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Gr.Type;
-      }
-
-      export interface Hr {
-        standard?: Hr.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Hr.Type;
+    export interface Al {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Am {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ao {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface At {
+      standard?: At.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: At.Type;
+    }
+
+    export interface Au {
+      standard?: Au.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Aw {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Az {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ba {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Bb {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Bd {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Be {
+      standard?: Be.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Be.Type;
+    }
+
+    export interface Bf {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Bg {
+      standard?: Bg.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Bg.Type;
+    }
+
+    export interface Bh {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Bj {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Bs {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface By {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ca {
+      province_standard?: Ca.ProvinceStandard;
+
+      /**
+       * Type of registration in Canada.
+       */
+      type: Ca.Type;
+    }
+
+    export interface Cd {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Ch {
+      standard?: Ch.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Cl {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Cm {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Co {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Cr {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Cv {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Cy {
+      standard?: Cy.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Cy.Type;
+    }
+
+    export interface Cz {
+      standard?: Cz.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Cz.Type;
+    }
+
+    export interface De {
+      standard?: De.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: De.Type;
+    }
+
+    export interface Dk {
+      standard?: Dk.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Dk.Type;
+    }
+
+    export interface Ec {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ee {
+      standard?: Ee.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Ee.Type;
+    }
+
+    export interface Eg {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Es {
+      standard?: Es.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Es.Type;
+    }
+
+    export interface Et {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Fi {
+      standard?: Fi.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Fi.Type;
+    }
+
+    export interface Fr {
+      standard?: Fr.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Fr.Type;
+    }
+
+    export interface Gb {
+      standard?: Gb.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Ge {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Gn {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Gr {
+      standard?: Gr.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Gr.Type;
+    }
+
+    export interface Hr {
+      standard?: Hr.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Hr.Type;
+    }
+
+    export interface Hu {
+      standard?: Hu.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Hu.Type;
+    }
+
+    export interface Id {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ie {
+      standard?: Ie.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Ie.Type;
+    }
+
+    export interface In {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Is {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface It {
+      standard?: It.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: It.Type;
+    }
+
+    export interface Jp {
+      standard?: Jp.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Ke {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Kg {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Kh {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Kr {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Kz {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface La {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Lk {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Lt {
+      standard?: Lt.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Lt.Type;
+    }
+
+    export interface Lu {
+      standard?: Lu.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Lu.Type;
+    }
+
+    export interface Lv {
+      standard?: Lv.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Lv.Type;
+    }
+
+    export interface Ma {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Md {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Me {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Mk {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Mr {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Mt {
+      standard?: Mt.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Mt.Type;
+    }
+
+    export interface Mx {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface My {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ng {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Nl {
+      standard?: Nl.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Nl.Type;
+    }
+
+    export interface No {
+      standard?: No.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Np {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Nz {
+      standard?: Nz.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Om {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Pe {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ph {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Pl {
+      standard?: Pl.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Pl.Type;
+    }
+
+    export interface Pt {
+      standard?: Pt.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Pt.Type;
+    }
+
+    export interface Ro {
+      standard?: Ro.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Ro.Type;
+    }
+
+    export interface Rs {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Ru {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Sa {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Se {
+      standard?: Se.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Se.Type;
+    }
+
+    export interface Sg {
+      standard?: Sg.Standard;
+
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Si {
+      standard?: Si.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Si.Type;
+    }
+
+    export interface Sk {
+      standard?: Sk.Standard;
+
+      /**
+       * Type of registration in an EU country.
+       */
+      type: Sk.Type;
+    }
+
+    export interface Sn {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Sr {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Th {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Tj {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Tr {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Tw {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Tz {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ua {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Ug {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Us {
+      local_amusement_tax?: Us.LocalAmusementTax;
+
+      local_lease_tax?: Us.LocalLeaseTax;
+
+      /**
+       * Two-letter US state code ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
+       */
+      state: string;
+
+      state_sales_tax?: Us.StateSalesTax;
+
+      /**
+       * Type of registration in the US.
+       */
+      type: Us.Type;
+    }
+
+    export interface Uy {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Uz {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Vn {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Za {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export interface Zm {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'simplified';
+    }
+
+    export interface Zw {
+      /**
+       * Type of registration in `country`.
+       */
+      type: 'standard';
+    }
+
+    export namespace Ae {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an Default standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
+      }
+    }
+
+    export namespace At {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Au {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an Default standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
+      }
+    }
+
+    export namespace Be {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Bg {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Ca {
+      export interface ProvinceStandard {
+        /**
+         * Two-letter CA province code ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
+         */
+        province: string;
+      }
+
+      export type Type = 'province_standard' | 'simplified' | 'standard';
+    }
+
+    export namespace Ch {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an Default standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
+      }
+    }
+
+    export namespace Cy {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Cz {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace De {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Dk {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Ee {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Es {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
+      }
+
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
+
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
+      }
+    }
+
+    export namespace Fi {
+      export interface Standard {
+        /**
+         * Place of supply scheme used in an EU standard registration.
+         */
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Hu {
-        standard?: Hu.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Hu.Type;
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Id {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
-
-      export interface Ie {
-        standard?: Ie.Standard;
+    }
 
+    export namespace Fr {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: Ie.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface In {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Is {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface It {
-        standard?: It.Standard;
-
+    export namespace Gb {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an Default standard registration.
          */
-        type: It.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Jp {
-        standard?: Jp.Standard;
-
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
       }
+    }
 
-      export interface Ke {
+    export namespace Gr {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Kg {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Kh {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Kr {
+    export namespace Hr {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Kz {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface La {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Lk {
+    export namespace Hu {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Lt {
-        standard?: Lt.Standard;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Lt.Type;
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Lu {
-        standard?: Lu.Standard;
-
+    export namespace Ie {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: Lu.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Lv {
-        standard?: Lv.Standard;
-
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Lv.Type;
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Ma {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Md {
+    export namespace It {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Me {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Mk {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Mr {
+    export namespace Jp {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an Default standard registration.
          */
-        type: 'standard';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
-
-      export interface Mt {
-        standard?: Mt.Standard;
 
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Mt.Type;
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
       }
+    }
 
-      export interface Mx {
+    export namespace Lt {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface My {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Ng {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Nl {
-        standard?: Nl.Standard;
-
+    export namespace Lu {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: Nl.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface No {
-        standard?: No.Standard;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Np {
+    export namespace Lv {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Nz {
-        standard?: Nz.Standard;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Om {
+    export namespace Mt {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'standard';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Pe {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Ph {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
-
-      export interface Pl {
-        standard?: Pl.Standard;
+    }
 
+    export namespace Nl {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: Pl.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Pt {
-        standard?: Pt.Standard;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Pt.Type;
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Ro {
-        standard?: Ro.Standard;
-
+    export namespace No {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an Default standard registration.
          */
-        type: Ro.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Rs {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
       }
+    }
 
-      export interface Ru {
+    export namespace Nz {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an Default standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Sa {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
       }
-
-      export interface Se {
-        standard?: Se.Standard;
+    }
 
+    export namespace Pl {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: Se.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Sg {
-        standard?: Sg.Standard;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
-
-      export interface Si {
-        standard?: Si.Standard;
+    }
 
+    export namespace Pt {
+      export interface Standard {
         /**
-         * Type of registration in an EU country.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: Si.Type;
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Sk {
-        standard?: Sk.Standard;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in an EU country.
-         */
-        type: Sk.Type;
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Sn {
+    export namespace Ro {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Sr {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'standard';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Th {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Tj {
+    export namespace Se {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Tr {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Tw {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Tz {
+    export namespace Sg {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an Default standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Ua {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
       }
+    }
 
-      export interface Ug {
+    export namespace Si {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'simplified';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
-
-      export interface Us {
-        local_amusement_tax?: Us.LocalAmusementTax;
-
-        local_lease_tax?: Us.LocalLeaseTax;
-
-        /**
-         * Two-letter US state code ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
-         */
-        state: string;
 
-        state_sales_tax?: Us.StateSalesTax;
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-        /**
-         * Type of registration in the US.
-         */
-        type: Us.Type;
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Uy {
+    export namespace Sk {
+      export interface Standard {
         /**
-         * Type of registration in `country`.
+         * Place of supply scheme used in an EU standard registration.
          */
-        type: 'standard';
+        place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
       }
 
-      export interface Uz {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
-      }
+      export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
 
-      export interface Vn {
-        /**
-         * Type of registration in `country`.
-         */
-        type: 'simplified';
+      export namespace Standard {
+        export type PlaceOfSupplyScheme =
+          | 'inbound_goods'
+          | 'small_seller'
+          | 'standard';
       }
+    }
 
-      export interface Za {
+    export namespace Us {
+      export interface LocalAmusementTax {
         /**
-         * Type of registration in `country`.
+         * A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
          */
-        type: 'standard';
+        jurisdiction: string;
       }
 
-      export interface Zm {
+      export interface LocalLeaseTax {
         /**
-         * Type of registration in `country`.
+         * A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
          */
-        type: 'simplified';
+        jurisdiction: string;
       }
 
-      export interface Zw {
+      export interface StateSalesTax {
         /**
-         * Type of registration in `country`.
+         * Elections for the state sales tax registration.
          */
-        type: 'standard';
-      }
-
-      export namespace Ae {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace At {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Au {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace Be {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Bg {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Ca {
-        export interface ProvinceStandard {
-          /**
-           * Two-letter CA province code ([ISO 3166-2](https://en.wikipedia.org/wiki/ISO_3166-2)).
-           */
-          province: string;
-        }
-
-        export type Type = 'province_standard' | 'simplified' | 'standard';
-      }
-
-      export namespace Ch {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace Cy {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Cz {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace De {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Dk {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Ee {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Es {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Fi {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Fr {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Gb {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace Gr {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Hr {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Hu {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Ie {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace It {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Jp {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
+        elections?: Array<StateSalesTax.Election>;
       }
 
-      export namespace Lt {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Lu {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Lv {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Mt {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Nl {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace No {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace Nz {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace Pl {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Pt {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Ro {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Se {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Sg {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an Default standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme = 'inbound_goods' | 'standard';
-        }
-      }
-
-      export namespace Si {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
-
-      export namespace Sk {
-        export interface Standard {
-          /**
-           * Place of supply scheme used in an EU standard registration.
-           */
-          place_of_supply_scheme: Standard.PlaceOfSupplyScheme;
-        }
-
-        export type Type = 'ioss' | 'oss_non_union' | 'oss_union' | 'standard';
-
-        export namespace Standard {
-          export type PlaceOfSupplyScheme =
-            | 'inbound_goods'
-            | 'small_seller'
-            | 'standard';
-        }
-      }
+      export type Type =
+        | 'local_amusement_tax'
+        | 'local_lease_tax'
+        | 'state_communications_tax'
+        | 'state_retail_delivery_fee'
+        | 'state_sales_tax';
 
-      export namespace Us {
-        export interface LocalAmusementTax {
+      export namespace StateSalesTax {
+        export interface Election {
           /**
            * A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
            */
-          jurisdiction: string;
-        }
+          jurisdiction?: string;
 
-        export interface LocalLeaseTax {
           /**
-           * A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
+           * The type of the election for the state sales tax registration.
            */
-          jurisdiction: string;
+          type: Election.Type;
         }
 
-        export interface StateSalesTax {
-          /**
-           * Elections for the state sales tax registration.
-           */
-          elections?: Array<StateSalesTax.Election>;
-        }
-
-        export type Type =
-          | 'local_amusement_tax'
-          | 'local_lease_tax'
-          | 'state_communications_tax'
-          | 'state_retail_delivery_fee'
-          | 'state_sales_tax';
-
-        export namespace StateSalesTax {
-          export interface Election {
-            /**
-             * A [FIPS code](https://www.census.gov/library/reference/code-lists/ansi.html) representing the local jurisdiction.
-             */
-            jurisdiction?: string;
-
-            /**
-             * The type of the election for the state sales tax registration.
-             */
-            type: Election.Type;
-          }
-
-          export namespace Election {
-            export type Type =
-              | 'local_use_tax'
-              | 'simplified_sellers_use_tax'
-              | 'single_local_use_tax';
-          }
+        export namespace Election {
+          export type Type =
+            | 'local_use_tax'
+            | 'simplified_sellers_use_tax'
+            | 'single_local_use_tax';
         }
       }
     }

--- a/src/resources/Tax/Settings.ts
+++ b/src/resources/Tax/Settings.ts
@@ -35,12 +35,12 @@ export interface Settings {
    */
   object: 'tax.settings';
 
-  defaults: Tax.Settings.Defaults;
+  defaults: Settings.Defaults;
 
   /**
    * The place where your business is located.
    */
-  head_office: Tax.Settings.HeadOffice | null;
+  head_office: Settings.HeadOffice | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -50,59 +50,57 @@ export interface Settings {
   /**
    * The status of the Tax `Settings`.
    */
-  status: Tax.Settings.Status;
+  status: Settings.Status;
 
-  status_details: Tax.Settings.StatusDetails;
+  status_details: Settings.StatusDetails;
 }
-export namespace Tax {
-  export namespace Settings {
-    export interface Defaults {
+export namespace Settings {
+  export interface Defaults {
+    /**
+     * The tax calculation provider this account uses. Defaults to `stripe` when not using a [third-party provider](https://docs.stripe.com/tax/third-party-apps).
+     */
+    provider: Defaults.Provider;
+
+    /**
+     * Default [tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#tax-behavior) used to specify whether the price is considered inclusive of taxes or exclusive of taxes. If the item's price has a tax behavior set, it will take precedence over the default tax behavior.
+     */
+    tax_behavior: Defaults.TaxBehavior | null;
+
+    /**
+     * Default [tax code](https://stripe.com/docs/tax/tax-categories) used to classify your products and prices.
+     */
+    tax_code: string | null;
+  }
+
+  export interface HeadOffice {
+    address: Address;
+  }
+
+  export type Status = 'active' | 'pending';
+
+  export interface StatusDetails {
+    active?: StatusDetails.Active;
+
+    pending?: StatusDetails.Pending;
+  }
+
+  export namespace Defaults {
+    export type Provider = 'anrok' | 'avalara' | 'sphere' | 'stripe';
+
+    export type TaxBehavior =
+      | 'exclusive'
+      | 'inclusive'
+      | 'inferred_by_currency';
+  }
+
+  export namespace StatusDetails {
+    export interface Active {}
+
+    export interface Pending {
       /**
-       * The tax calculation provider this account uses. Defaults to `stripe` when not using a [third-party provider](https://docs.stripe.com/tax/third-party-apps).
+       * The list of missing fields that are required to perform calculations. It includes the entry `head_office` when the status is `pending`. It is recommended to set the optional values even if they aren't listed as required for calculating taxes. Calculations can fail if missing fields aren't explicitly provided on every call.
        */
-      provider: Defaults.Provider;
-
-      /**
-       * Default [tax behavior](https://stripe.com/docs/tax/products-prices-tax-categories-tax-behavior#tax-behavior) used to specify whether the price is considered inclusive of taxes or exclusive of taxes. If the item's price has a tax behavior set, it will take precedence over the default tax behavior.
-       */
-      tax_behavior: Defaults.TaxBehavior | null;
-
-      /**
-       * Default [tax code](https://stripe.com/docs/tax/tax-categories) used to classify your products and prices.
-       */
-      tax_code: string | null;
-    }
-
-    export interface HeadOffice {
-      address: Address;
-    }
-
-    export type Status = 'active' | 'pending';
-
-    export interface StatusDetails {
-      active?: StatusDetails.Active;
-
-      pending?: StatusDetails.Pending;
-    }
-
-    export namespace Defaults {
-      export type Provider = 'anrok' | 'avalara' | 'sphere' | 'stripe';
-
-      export type TaxBehavior =
-        | 'exclusive'
-        | 'inclusive'
-        | 'inferred_by_currency';
-    }
-
-    export namespace StatusDetails {
-      export interface Active {}
-
-      export interface Pending {
-        /**
-         * The list of missing fields that are required to perform calculations. It includes the entry `head_office` when the status is `pending`. It is recommended to set the optional values even if they aren't listed as required for calculating taxes. Calculations can fail if missing fields aren't explicitly provided on every call.
-         */
-        missing_fields: Array<string> | null;
-      }
+      missing_fields: Array<string> | null;
     }
   }
 }

--- a/src/resources/Tax/TransactionLineItems.ts
+++ b/src/resources/Tax/TransactionLineItems.ts
@@ -51,12 +51,12 @@ export interface TransactionLineItem {
   /**
    * If `type=reversal`, contains information about what was reversed.
    */
-  reversal: Tax.TransactionLineItem.Reversal | null;
+  reversal: TransactionLineItem.Reversal | null;
 
   /**
    * Specifies whether the `amount` includes taxes. If `tax_behavior=inclusive`, then the amount includes taxes.
    */
-  tax_behavior: Tax.TransactionLineItem.TaxBehavior;
+  tax_behavior: TransactionLineItem.TaxBehavior;
 
   /**
    * The [tax code](https://docs.stripe.com/tax/tax-categories) ID used for this resource.
@@ -66,19 +66,17 @@ export interface TransactionLineItem {
   /**
    * If `reversal`, this line item reverses an earlier transaction.
    */
-  type: Tax.TransactionLineItem.Type;
+  type: TransactionLineItem.Type;
 }
-export namespace Tax {
-  export namespace TransactionLineItem {
-    export interface Reversal {
-      /**
-       * The `id` of the line item to reverse in the original transaction.
-       */
-      original_line_item: string;
-    }
-
-    export type TaxBehavior = 'exclusive' | 'inclusive';
-
-    export type Type = 'reversal' | 'transaction';
+export namespace TransactionLineItem {
+  export interface Reversal {
+    /**
+     * The `id` of the line item to reverse in the original transaction.
+     */
+    original_line_item: string;
   }
+
+  export type TaxBehavior = 'exclusive' | 'inclusive';
+
+  export type Type = 'reversal' | 'transaction';
 }

--- a/src/resources/Tax/Transactions.ts
+++ b/src/resources/Tax/Transactions.ts
@@ -99,7 +99,7 @@ export interface Transaction {
    */
   customer: string | null;
 
-  customer_details: Tax.Transaction.CustomerDetails;
+  customer_details: Transaction.CustomerDetails;
 
   /**
    * The tax collected or refunded, by line item.
@@ -129,17 +129,17 @@ export interface Transaction {
   /**
    * If `type=reversal`, contains information about what was reversed.
    */
-  reversal: Tax.Transaction.Reversal | null;
+  reversal: Transaction.Reversal | null;
 
   /**
    * The details of the ship from location, such as the address.
    */
-  ship_from_details: Tax.Transaction.ShipFromDetails | null;
+  ship_from_details: Transaction.ShipFromDetails | null;
 
   /**
    * The shipping cost details for the transaction.
    */
-  shipping_cost: Tax.Transaction.ShippingCost | null;
+  shipping_cost: Transaction.ShippingCost | null;
 
   /**
    * The calculation uses the tax rules and rates that are in effect at this timestamp. You can use a date up to 31 days in the past or up to 31 days in the future. If you use a future date, Stripe doesn't guarantee that the expected tax rules and rate being used match the actual rules and rate that will be in effect on that date. We deploy tax changes before their effective date, but not within a fixed window.
@@ -149,341 +149,339 @@ export interface Transaction {
   /**
    * If `reversal`, this transaction reverses an earlier transaction.
    */
-  type: Tax.Transaction.Type;
+  type: Transaction.Type;
 }
-export namespace Tax {
-  export namespace Transaction {
-    export interface CustomerDetails {
+export namespace Transaction {
+  export interface CustomerDetails {
+    /**
+     * The customer's postal address (for example, home or business location).
+     */
+    address: Address | null;
+
+    /**
+     * The type of customer address provided.
+     */
+    address_source: CustomerDetails.AddressSource | null;
+
+    /**
+     * The customer's IP address (IPv4 or IPv6).
+     */
+    ip_address: string | null;
+
+    /**
+     * The customer's tax IDs (for example, EU VAT numbers).
+     */
+    tax_ids: Array<CustomerDetails.TaxId>;
+
+    /**
+     * The taxability override used for taxation.
+     */
+    taxability_override: CustomerDetails.TaxabilityOverride;
+  }
+
+  export interface Reversal {
+    /**
+     * The `id` of the reversed `Transaction` object.
+     */
+    original_transaction: string | null;
+  }
+
+  export interface ShipFromDetails {
+    address: Address;
+  }
+
+  export interface ShippingCost {
+    /**
+     * The shipping amount in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units). If `tax_behavior=inclusive`, then this amount includes taxes. Otherwise, taxes were calculated on top of this amount.
+     */
+    amount: number;
+
+    /**
+     * The amount of tax calculated for shipping, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
+     */
+    amount_tax: number;
+
+    /**
+     * The ID of an existing [ShippingRate](https://docs.stripe.com/api/shipping_rates/object).
+     */
+    shipping_rate?: string;
+
+    /**
+     * Specifies whether the `amount` includes taxes. If `tax_behavior=inclusive`, then the amount includes taxes.
+     */
+    tax_behavior: ShippingCost.TaxBehavior;
+
+    /**
+     * Detailed account of taxes relevant to shipping cost. (It is not populated for the transaction resource object and will be removed in the next API version.)
+     */
+    tax_breakdown?: Array<ShippingCost.TaxBreakdown>;
+
+    /**
+     * The [tax code](https://docs.stripe.com/tax/tax-categories) ID used for shipping.
+     */
+    tax_code: string;
+  }
+
+  export type Type = 'reversal' | 'transaction';
+
+  export namespace CustomerDetails {
+    export type AddressSource = 'billing' | 'shipping';
+
+    export interface TaxId {
       /**
-       * The customer's postal address (for example, home or business location).
+       * The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `pl_nip`, `it_cf`, `fo_vat`, `gi_tin`, `py_ruc`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `lk_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `al_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, `ao_tin`, `bs_tin`, `bb_tin`, `cd_nif`, `mr_nif`, `me_pib`, `zw_tin`, `ba_tin`, `gn_nif`, `mk_vat`, `sr_fin`, `sn_ninea`, `am_tin`, `np_pan`, `tj_tin`, `ug_tin`, `zm_tin`, `kh_tin`, `aw_tin`, `az_tin`, `bd_bin`, `bj_ifu`, `et_tin`, `kg_tin`, `la_tin`, `cm_niu`, `cv_nif`, `bf_ifu`, or `unknown`
        */
-      address: Address | null;
+      type: TaxId.Type;
 
       /**
-       * The type of customer address provided.
+       * The value of the tax ID.
        */
-      address_source: CustomerDetails.AddressSource | null;
-
-      /**
-       * The customer's IP address (IPv4 or IPv6).
-       */
-      ip_address: string | null;
-
-      /**
-       * The customer's tax IDs (for example, EU VAT numbers).
-       */
-      tax_ids: Array<CustomerDetails.TaxId>;
-
-      /**
-       * The taxability override used for taxation.
-       */
-      taxability_override: CustomerDetails.TaxabilityOverride;
+      value: string;
     }
 
-    export interface Reversal {
-      /**
-       * The `id` of the reversed `Transaction` object.
-       */
-      original_transaction: string | null;
-    }
+    export type TaxabilityOverride =
+      | 'customer_exempt'
+      | 'none'
+      | 'reverse_charge';
 
-    export interface ShipFromDetails {
-      address: Address;
+    export namespace TaxId {
+      export type Type =
+        | 'ad_nrt'
+        | 'ae_trn'
+        | 'al_tin'
+        | 'am_tin'
+        | 'ao_tin'
+        | 'ar_cuit'
+        | 'au_abn'
+        | 'au_arn'
+        | 'aw_tin'
+        | 'az_tin'
+        | 'ba_tin'
+        | 'bb_tin'
+        | 'bd_bin'
+        | 'bf_ifu'
+        | 'bg_uic'
+        | 'bh_vat'
+        | 'bj_ifu'
+        | 'bo_tin'
+        | 'br_cnpj'
+        | 'br_cpf'
+        | 'bs_tin'
+        | 'by_tin'
+        | 'ca_bn'
+        | 'ca_gst_hst'
+        | 'ca_pst_bc'
+        | 'ca_pst_mb'
+        | 'ca_pst_sk'
+        | 'ca_qst'
+        | 'cd_nif'
+        | 'ch_uid'
+        | 'ch_vat'
+        | 'cl_tin'
+        | 'cm_niu'
+        | 'cn_tin'
+        | 'co_nit'
+        | 'cr_tin'
+        | 'cv_nif'
+        | 'de_stn'
+        | 'do_rcn'
+        | 'ec_ruc'
+        | 'eg_tin'
+        | 'es_cif'
+        | 'et_tin'
+        | 'eu_oss_vat'
+        | 'eu_vat'
+        | 'fo_vat'
+        | 'gb_vat'
+        | 'ge_vat'
+        | 'gi_tin'
+        | 'gn_nif'
+        | 'hk_br'
+        | 'hr_oib'
+        | 'hu_tin'
+        | 'id_npwp'
+        | 'il_vat'
+        | 'in_gst'
+        | 'is_vat'
+        | 'it_cf'
+        | 'jp_cn'
+        | 'jp_rn'
+        | 'jp_trn'
+        | 'ke_pin'
+        | 'kg_tin'
+        | 'kh_tin'
+        | 'kr_brn'
+        | 'kz_bin'
+        | 'la_tin'
+        | 'li_uid'
+        | 'li_vat'
+        | 'lk_vat'
+        | 'ma_vat'
+        | 'md_vat'
+        | 'me_pib'
+        | 'mk_vat'
+        | 'mr_nif'
+        | 'mx_rfc'
+        | 'my_frp'
+        | 'my_itn'
+        | 'my_sst'
+        | 'ng_tin'
+        | 'no_vat'
+        | 'no_voec'
+        | 'np_pan'
+        | 'nz_gst'
+        | 'om_vat'
+        | 'pe_ruc'
+        | 'ph_tin'
+        | 'pl_nip'
+        | 'py_ruc'
+        | 'ro_tin'
+        | 'rs_pib'
+        | 'ru_inn'
+        | 'ru_kpp'
+        | 'sa_vat'
+        | 'sg_gst'
+        | 'sg_uen'
+        | 'si_tin'
+        | 'sn_ninea'
+        | 'sr_fin'
+        | 'sv_nit'
+        | 'th_vat'
+        | 'tj_tin'
+        | 'tr_tin'
+        | 'tw_vat'
+        | 'tz_vat'
+        | 'ua_vat'
+        | 'ug_tin'
+        | 'unknown'
+        | 'us_ein'
+        | 'uy_ruc'
+        | 'uz_tin'
+        | 'uz_vat'
+        | 've_rif'
+        | 'vn_tin'
+        | 'za_vat'
+        | 'zm_tin'
+        | 'zw_tin';
     }
+  }
 
-    export interface ShippingCost {
+  export namespace ShippingCost {
+    export type TaxBehavior = 'exclusive' | 'inclusive';
+
+    export interface TaxBreakdown {
       /**
-       * The shipping amount in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units). If `tax_behavior=inclusive`, then this amount includes taxes. Otherwise, taxes were calculated on top of this amount.
+       * The amount of tax, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
        */
       amount: number;
 
-      /**
-       * The amount of tax calculated for shipping, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-       */
-      amount_tax: number;
+      jurisdiction: TaxBreakdown.Jurisdiction;
 
       /**
-       * The ID of an existing [ShippingRate](https://docs.stripe.com/api/shipping_rates/object).
+       * Indicates whether the jurisdiction was determined by the origin (merchant's address) or destination (customer's address).
        */
-      shipping_rate?: string;
+      sourcing: TaxBreakdown.Sourcing;
 
       /**
-       * Specifies whether the `amount` includes taxes. If `tax_behavior=inclusive`, then the amount includes taxes.
+       * Details regarding the rate for this tax. This field will be `null` when the tax is not imposed, for example if the product is exempt from tax.
        */
-      tax_behavior: ShippingCost.TaxBehavior;
+      tax_rate_details: TaxBreakdown.TaxRateDetails | null;
 
       /**
-       * Detailed account of taxes relevant to shipping cost. (It is not populated for the transaction resource object and will be removed in the next API version.)
+       * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
        */
-      tax_breakdown?: Array<ShippingCost.TaxBreakdown>;
+      taxability_reason: TaxBreakdown.TaxabilityReason;
 
       /**
-       * The [tax code](https://docs.stripe.com/tax/tax-categories) ID used for shipping.
+       * The amount on which tax is calculated, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
        */
-      tax_code: string;
+      taxable_amount: number;
     }
 
-    export type Type = 'reversal' | 'transaction';
-
-    export namespace CustomerDetails {
-      export type AddressSource = 'billing' | 'shipping';
-
-      export interface TaxId {
+    export namespace TaxBreakdown {
+      export interface Jurisdiction {
         /**
-         * The type of the tax ID, one of `ad_nrt`, `ar_cuit`, `eu_vat`, `bo_tin`, `br_cnpj`, `br_cpf`, `cn_tin`, `co_nit`, `cr_tin`, `do_rcn`, `ec_ruc`, `eu_oss_vat`, `hr_oib`, `pe_ruc`, `ro_tin`, `rs_pib`, `sv_nit`, `uy_ruc`, `ve_rif`, `vn_tin`, `gb_vat`, `nz_gst`, `au_abn`, `au_arn`, `in_gst`, `no_vat`, `no_voec`, `za_vat`, `ch_vat`, `mx_rfc`, `sg_uen`, `ru_inn`, `ru_kpp`, `ca_bn`, `hk_br`, `es_cif`, `pl_nip`, `it_cf`, `fo_vat`, `gi_tin`, `py_ruc`, `tw_vat`, `th_vat`, `jp_cn`, `jp_rn`, `jp_trn`, `li_uid`, `li_vat`, `lk_vat`, `my_itn`, `us_ein`, `kr_brn`, `ca_qst`, `ca_gst_hst`, `ca_pst_bc`, `ca_pst_mb`, `ca_pst_sk`, `my_sst`, `sg_gst`, `ae_trn`, `cl_tin`, `sa_vat`, `id_npwp`, `my_frp`, `il_vat`, `ge_vat`, `ua_vat`, `is_vat`, `bg_uic`, `hu_tin`, `si_tin`, `ke_pin`, `tr_tin`, `eg_tin`, `ph_tin`, `al_tin`, `bh_vat`, `kz_bin`, `ng_tin`, `om_vat`, `de_stn`, `ch_uid`, `tz_vat`, `uz_vat`, `uz_tin`, `md_vat`, `ma_vat`, `by_tin`, `ao_tin`, `bs_tin`, `bb_tin`, `cd_nif`, `mr_nif`, `me_pib`, `zw_tin`, `ba_tin`, `gn_nif`, `mk_vat`, `sr_fin`, `sn_ninea`, `am_tin`, `np_pan`, `tj_tin`, `ug_tin`, `zm_tin`, `kh_tin`, `aw_tin`, `az_tin`, `bd_bin`, `bj_ifu`, `et_tin`, `kg_tin`, `la_tin`, `cm_niu`, `cv_nif`, `bf_ifu`, or `unknown`
+         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
          */
-        type: TaxId.Type;
+        country: string;
 
         /**
-         * The value of the tax ID.
+         * A human-readable name for the jurisdiction imposing the tax.
          */
-        value: string;
+        display_name: string;
+
+        /**
+         * Indicates the level of the jurisdiction imposing the tax.
+         */
+        level: Jurisdiction.Level;
+
+        /**
+         * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2), without country prefix. For example, "NY" for New York, United States.
+         */
+        state: string | null;
       }
 
-      export type TaxabilityOverride =
+      export type Sourcing = 'destination' | 'origin';
+
+      export interface TaxRateDetails {
+        /**
+         * A localized display name for tax type, intended to be human-readable. For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
+         */
+        display_name: string;
+
+        /**
+         * The tax rate percentage as a string. For example, 8.5% is represented as "8.5".
+         */
+        percentage_decimal: string;
+
+        /**
+         * The tax type, such as `vat` or `sales_tax`.
+         */
+        tax_type: TaxRateDetails.TaxType;
+      }
+
+      export type TaxabilityReason =
         | 'customer_exempt'
-        | 'none'
-        | 'reverse_charge';
+        | 'not_collecting'
+        | 'not_subject_to_tax'
+        | 'not_supported'
+        | 'portion_product_exempt'
+        | 'portion_reduced_rated'
+        | 'portion_standard_rated'
+        | 'product_exempt'
+        | 'product_exempt_holiday'
+        | 'proportionally_rated'
+        | 'reduced_rated'
+        | 'reverse_charge'
+        | 'standard_rated'
+        | 'taxable_basis_reduced'
+        | 'zero_rated';
 
-      export namespace TaxId {
-        export type Type =
-          | 'ad_nrt'
-          | 'ae_trn'
-          | 'al_tin'
-          | 'am_tin'
-          | 'ao_tin'
-          | 'ar_cuit'
-          | 'au_abn'
-          | 'au_arn'
-          | 'aw_tin'
-          | 'az_tin'
-          | 'ba_tin'
-          | 'bb_tin'
-          | 'bd_bin'
-          | 'bf_ifu'
-          | 'bg_uic'
-          | 'bh_vat'
-          | 'bj_ifu'
-          | 'bo_tin'
-          | 'br_cnpj'
-          | 'br_cpf'
-          | 'bs_tin'
-          | 'by_tin'
-          | 'ca_bn'
-          | 'ca_gst_hst'
-          | 'ca_pst_bc'
-          | 'ca_pst_mb'
-          | 'ca_pst_sk'
-          | 'ca_qst'
-          | 'cd_nif'
-          | 'ch_uid'
-          | 'ch_vat'
-          | 'cl_tin'
-          | 'cm_niu'
-          | 'cn_tin'
-          | 'co_nit'
-          | 'cr_tin'
-          | 'cv_nif'
-          | 'de_stn'
-          | 'do_rcn'
-          | 'ec_ruc'
-          | 'eg_tin'
-          | 'es_cif'
-          | 'et_tin'
-          | 'eu_oss_vat'
-          | 'eu_vat'
-          | 'fo_vat'
-          | 'gb_vat'
-          | 'ge_vat'
-          | 'gi_tin'
-          | 'gn_nif'
-          | 'hk_br'
-          | 'hr_oib'
-          | 'hu_tin'
-          | 'id_npwp'
-          | 'il_vat'
-          | 'in_gst'
-          | 'is_vat'
-          | 'it_cf'
-          | 'jp_cn'
-          | 'jp_rn'
-          | 'jp_trn'
-          | 'ke_pin'
-          | 'kg_tin'
-          | 'kh_tin'
-          | 'kr_brn'
-          | 'kz_bin'
-          | 'la_tin'
-          | 'li_uid'
-          | 'li_vat'
-          | 'lk_vat'
-          | 'ma_vat'
-          | 'md_vat'
-          | 'me_pib'
-          | 'mk_vat'
-          | 'mr_nif'
-          | 'mx_rfc'
-          | 'my_frp'
-          | 'my_itn'
-          | 'my_sst'
-          | 'ng_tin'
-          | 'no_vat'
-          | 'no_voec'
-          | 'np_pan'
-          | 'nz_gst'
-          | 'om_vat'
-          | 'pe_ruc'
-          | 'ph_tin'
-          | 'pl_nip'
-          | 'py_ruc'
-          | 'ro_tin'
-          | 'rs_pib'
-          | 'ru_inn'
-          | 'ru_kpp'
-          | 'sa_vat'
-          | 'sg_gst'
-          | 'sg_uen'
-          | 'si_tin'
-          | 'sn_ninea'
-          | 'sr_fin'
-          | 'sv_nit'
-          | 'th_vat'
-          | 'tj_tin'
-          | 'tr_tin'
-          | 'tw_vat'
-          | 'tz_vat'
-          | 'ua_vat'
-          | 'ug_tin'
-          | 'unknown'
-          | 'us_ein'
-          | 'uy_ruc'
-          | 'uz_tin'
-          | 'uz_vat'
-          | 've_rif'
-          | 'vn_tin'
-          | 'za_vat'
-          | 'zm_tin'
-          | 'zw_tin';
-      }
-    }
-
-    export namespace ShippingCost {
-      export type TaxBehavior = 'exclusive' | 'inclusive';
-
-      export interface TaxBreakdown {
-        /**
-         * The amount of tax, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-         */
-        amount: number;
-
-        jurisdiction: TaxBreakdown.Jurisdiction;
-
-        /**
-         * Indicates whether the jurisdiction was determined by the origin (merchant's address) or destination (customer's address).
-         */
-        sourcing: TaxBreakdown.Sourcing;
-
-        /**
-         * Details regarding the rate for this tax. This field will be `null` when the tax is not imposed, for example if the product is exempt from tax.
-         */
-        tax_rate_details: TaxBreakdown.TaxRateDetails | null;
-
-        /**
-         * The reasoning behind this tax, for example, if the product is tax exempt. The possible values for this field may be extended as new tax rules are supported.
-         */
-        taxability_reason: TaxBreakdown.TaxabilityReason;
-
-        /**
-         * The amount on which tax is calculated, in the [smallest currency unit](https://docs.stripe.com/currencies#minor-units).
-         */
-        taxable_amount: number;
+      export namespace Jurisdiction {
+        export type Level =
+          | 'city'
+          | 'country'
+          | 'county'
+          | 'district'
+          | 'state';
       }
 
-      export namespace TaxBreakdown {
-        export interface Jurisdiction {
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country: string;
-
-          /**
-           * A human-readable name for the jurisdiction imposing the tax.
-           */
-          display_name: string;
-
-          /**
-           * Indicates the level of the jurisdiction imposing the tax.
-           */
-          level: Jurisdiction.Level;
-
-          /**
-           * [ISO 3166-2 subdivision code](https://en.wikipedia.org/wiki/ISO_3166-2), without country prefix. For example, "NY" for New York, United States.
-           */
-          state: string | null;
-        }
-
-        export type Sourcing = 'destination' | 'origin';
-
-        export interface TaxRateDetails {
-          /**
-           * A localized display name for tax type, intended to be human-readable. For example, "Local Sales and Use Tax", "Value-added tax (VAT)", or "Umsatzsteuer (USt.)".
-           */
-          display_name: string;
-
-          /**
-           * The tax rate percentage as a string. For example, 8.5% is represented as "8.5".
-           */
-          percentage_decimal: string;
-
-          /**
-           * The tax type, such as `vat` or `sales_tax`.
-           */
-          tax_type: TaxRateDetails.TaxType;
-        }
-
-        export type TaxabilityReason =
-          | 'customer_exempt'
-          | 'not_collecting'
-          | 'not_subject_to_tax'
-          | 'not_supported'
-          | 'portion_product_exempt'
-          | 'portion_reduced_rated'
-          | 'portion_standard_rated'
-          | 'product_exempt'
-          | 'product_exempt_holiday'
-          | 'proportionally_rated'
-          | 'reduced_rated'
-          | 'reverse_charge'
-          | 'standard_rated'
-          | 'taxable_basis_reduced'
-          | 'zero_rated';
-
-        export namespace Jurisdiction {
-          export type Level =
-            | 'city'
-            | 'country'
-            | 'county'
-            | 'district'
-            | 'state';
-        }
-
-        export namespace TaxRateDetails {
-          export type TaxType =
-            | 'amusement_tax'
-            | 'communications_tax'
-            | 'gst'
-            | 'hst'
-            | 'igst'
-            | 'jct'
-            | 'lease_tax'
-            | 'pst'
-            | 'qst'
-            | 'retail_delivery_fee'
-            | 'rst'
-            | 'sales_tax'
-            | 'service_tax'
-            | 'vat';
-        }
+      export namespace TaxRateDetails {
+        export type TaxType =
+          | 'amusement_tax'
+          | 'communications_tax'
+          | 'gst'
+          | 'hst'
+          | 'igst'
+          | 'jct'
+          | 'lease_tax'
+          | 'pst'
+          | 'qst'
+          | 'retail_delivery_fee'
+          | 'rst'
+          | 'sales_tax'
+          | 'service_tax'
+          | 'vat';
       }
     }
   }

--- a/src/resources/Terminal/Configurations.ts
+++ b/src/resources/Terminal/Configurations.ts
@@ -13,7 +13,7 @@ export class ConfigurationResource extends StripeResource {
     id: string,
     params?: Terminal.ConfigurationDeleteParams,
     options?: RequestOptions
-  ): Promise<Response<Terminal.DeletedConfiguration>> {
+  ): Promise<Response<DeletedConfiguration>> {
     return this._makeRequest(
       'DELETE',
       `/v1/terminal/configurations/${encodeURIComponent(id)}`,
@@ -28,7 +28,7 @@ export class ConfigurationResource extends StripeResource {
     id: string,
     params?: Terminal.ConfigurationRetrieveParams,
     options?: RequestOptions
-  ): Promise<Response<Configuration | Terminal.DeletedConfiguration>> {
+  ): Promise<Response<Configuration | DeletedConfiguration>> {
     return this._makeRequest(
       'GET',
       `/v1/terminal/configurations/${encodeURIComponent(id)}`,
@@ -43,7 +43,7 @@ export class ConfigurationResource extends StripeResource {
     id: string,
     params?: Terminal.ConfigurationUpdateParams,
     options?: RequestOptions
-  ): Promise<Response<Configuration | Terminal.DeletedConfiguration>> {
+  ): Promise<Response<Configuration | DeletedConfiguration>> {
     return this._makeRequest(
       'POST',
       `/v1/terminal/configurations/${encodeURIComponent(id)}`,
@@ -94,11 +94,11 @@ export interface Configuration {
    */
   object: 'terminal.configuration';
 
-  bbpos_wisepad3?: Terminal.Configuration.BbposWisepad3;
+  bbpos_wisepad3?: Configuration.BbposWisepad3;
 
-  bbpos_wisepos_e?: Terminal.Configuration.BbposWiseposE;
+  bbpos_wisepos_e?: Configuration.BbposWiseposE;
 
-  cellular?: Terminal.Configuration.Cellular;
+  cellular?: Configuration.Cellular;
 
   /**
    * Always true for a deleted object
@@ -120,619 +120,616 @@ export interface Configuration {
    */
   name: string | null;
 
-  offline?: Terminal.Configuration.Offline;
+  offline?: Configuration.Offline;
 
-  reboot_window?: Terminal.Configuration.RebootWindow;
+  reboot_window?: Configuration.RebootWindow;
 
-  stripe_s700?: Terminal.Configuration.StripeS700;
+  stripe_s700?: Configuration.StripeS700;
 
-  stripe_s710?: Terminal.Configuration.StripeS710;
+  stripe_s710?: Configuration.StripeS710;
 
-  tipping?: Terminal.Configuration.Tipping;
+  tipping?: Configuration.Tipping;
 
-  verifone_m425?: Terminal.Configuration.VerifoneM425;
+  verifone_m425?: Configuration.VerifoneM425;
 
-  verifone_p400?: Terminal.Configuration.VerifoneP400;
+  verifone_p400?: Configuration.VerifoneP400;
 
-  verifone_p630?: Terminal.Configuration.VerifoneP630;
+  verifone_p630?: Configuration.VerifoneP630;
 
-  verifone_ux700?: Terminal.Configuration.VerifoneUx700;
+  verifone_ux700?: Configuration.VerifoneUx700;
 
-  verifone_v660p?: Terminal.Configuration.VerifoneV660p;
+  verifone_v660p?: Configuration.VerifoneV660p;
 
-  wifi?: Terminal.Configuration.Wifi;
+  wifi?: Configuration.Wifi;
 }
-export namespace Terminal {
-  export interface DeletedConfiguration {
-    /**
-     * Unique identifier for the object.
-     */
-    id: string;
+export interface DeletedConfiguration {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
 
-    /**
-     * String representing the object's type. Objects of the same type share the same value.
-     */
-    object: 'terminal.configuration';
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'terminal.configuration';
 
+  /**
+   * Always true for a deleted object
+   */
+  deleted: true;
+}
+export namespace Configuration {
+  export interface BbposWisepad3 {
     /**
-     * Always true for a deleted object
+     * A File ID representing an image to display on the reader
      */
-    deleted: true;
+    splashscreen?: string | File;
   }
 
-  export namespace Configuration {
-    export interface BbposWisepad3 {
+  export interface BbposWiseposE {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface Cellular {
+    /**
+     * Whether a cellular-capable reader can connect to the internet over cellular.
+     */
+    enabled: boolean;
+  }
+
+  export interface Offline {
+    /**
+     * Determines whether to allow transactions to be collected while reader is offline. Defaults to false.
+     */
+    enabled: boolean | null;
+  }
+
+  export interface RebootWindow {
+    /**
+     * Integer between 0 to 23 that represents the end hour of the reboot time window. The value must be different than the start_hour.
+     */
+    end_hour: number;
+
+    /**
+     * Integer between 0 to 23 that represents the start hour of the reboot time window.
+     */
+    start_hour: number;
+  }
+
+  export interface StripeS700 {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface StripeS710 {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface Tipping {
+    aed?: Tipping.Aed;
+
+    aud?: Tipping.Aud;
+
+    cad?: Tipping.Cad;
+
+    chf?: Tipping.Chf;
+
+    czk?: Tipping.Czk;
+
+    dkk?: Tipping.Dkk;
+
+    eur?: Tipping.Eur;
+
+    gbp?: Tipping.Gbp;
+
+    gip?: Tipping.Gip;
+
+    hkd?: Tipping.Hkd;
+
+    huf?: Tipping.Huf;
+
+    jpy?: Tipping.Jpy;
+
+    mxn?: Tipping.Mxn;
+
+    myr?: Tipping.Myr;
+
+    nok?: Tipping.Nok;
+
+    nzd?: Tipping.Nzd;
+
+    pln?: Tipping.Pln;
+
+    ron?: Tipping.Ron;
+
+    sek?: Tipping.Sek;
+
+    sgd?: Tipping.Sgd;
+
+    usd?: Tipping.Usd;
+  }
+
+  export interface VerifoneM425 {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface VerifoneP400 {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface VerifoneP630 {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface VerifoneUx700 {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface VerifoneV660p {
+    /**
+     * A File ID representing an image to display on the reader
+     */
+    splashscreen?: string | File;
+  }
+
+  export interface Wifi {
+    enterprise_eap_peap?: Wifi.EnterpriseEapPeap;
+
+    enterprise_eap_tls?: Wifi.EnterpriseEapTls;
+
+    personal_psk?: Wifi.PersonalPsk;
+
+    /**
+     * Security type of the WiFi network. The hash with the corresponding name contains the credentials for this security type.
+     */
+    type: Wifi.Type;
+  }
+
+  export namespace Tipping {
+    export interface Aed {
       /**
-       * A File ID representing an image to display on the reader
+       * Fixed amounts displayed when collecting a tip
        */
-      splashscreen?: string | File;
-    }
-
-    export interface BbposWiseposE {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface Cellular {
-      /**
-       * Whether a cellular-capable reader can connect to the internet over cellular.
-       */
-      enabled: boolean;
-    }
-
-    export interface Offline {
-      /**
-       * Determines whether to allow transactions to be collected while reader is offline. Defaults to false.
-       */
-      enabled: boolean | null;
-    }
-
-    export interface RebootWindow {
-      /**
-       * Integer between 0 to 23 that represents the end hour of the reboot time window. The value must be different than the start_hour.
-       */
-      end_hour: number;
+      fixed_amounts?: Array<number> | null;
 
       /**
-       * Integer between 0 to 23 that represents the start hour of the reboot time window.
+       * Percentages displayed when collecting a tip
        */
-      start_hour: number;
-    }
-
-    export interface StripeS700 {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface StripeS710 {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface Tipping {
-      aed?: Tipping.Aed;
-
-      aud?: Tipping.Aud;
-
-      cad?: Tipping.Cad;
-
-      chf?: Tipping.Chf;
-
-      czk?: Tipping.Czk;
-
-      dkk?: Tipping.Dkk;
-
-      eur?: Tipping.Eur;
-
-      gbp?: Tipping.Gbp;
-
-      gip?: Tipping.Gip;
-
-      hkd?: Tipping.Hkd;
-
-      huf?: Tipping.Huf;
-
-      jpy?: Tipping.Jpy;
-
-      mxn?: Tipping.Mxn;
-
-      myr?: Tipping.Myr;
-
-      nok?: Tipping.Nok;
-
-      nzd?: Tipping.Nzd;
-
-      pln?: Tipping.Pln;
-
-      ron?: Tipping.Ron;
-
-      sek?: Tipping.Sek;
-
-      sgd?: Tipping.Sgd;
-
-      usd?: Tipping.Usd;
-    }
-
-    export interface VerifoneM425 {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface VerifoneP400 {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface VerifoneP630 {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface VerifoneUx700 {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface VerifoneV660p {
-      /**
-       * A File ID representing an image to display on the reader
-       */
-      splashscreen?: string | File;
-    }
-
-    export interface Wifi {
-      enterprise_eap_peap?: Wifi.EnterpriseEapPeap;
-
-      enterprise_eap_tls?: Wifi.EnterpriseEapTls;
-
-      personal_psk?: Wifi.PersonalPsk;
+      percentages?: Array<number> | null;
 
       /**
-       * Security type of the WiFi network. The hash with the corresponding name contains the credentials for this security type.
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
        */
-      type: Wifi.Type;
+      smart_tip_threshold?: number;
     }
 
-    export namespace Tipping {
-      export interface Aed {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
+    export interface Aud {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
 
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
 
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Aud {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Cad {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Chf {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Czk {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Dkk {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Eur {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Gbp {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Gip {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Hkd {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Huf {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Jpy {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Mxn {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Myr {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Nok {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Nzd {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Pln {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Ron {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Sek {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Sgd {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
-
-      export interface Usd {
-        /**
-         * Fixed amounts displayed when collecting a tip
-         */
-        fixed_amounts?: Array<number> | null;
-
-        /**
-         * Percentages displayed when collecting a tip
-         */
-        percentages?: Array<number> | null;
-
-        /**
-         * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
-         */
-        smart_tip_threshold?: number;
-      }
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
     }
 
-    export namespace Wifi {
-      export interface EnterpriseEapPeap {
-        /**
-         * A File ID representing a PEM file containing the server certificate
-         */
-        ca_certificate_file?: string;
+    export interface Cad {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
 
-        /**
-         * Password for connecting to the WiFi network
-         */
-        password: string;
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
 
-        /**
-         * Name of the WiFi network
-         */
-        ssid: string;
-
-        /**
-         * Username for connecting to the WiFi network
-         */
-        username: string;
-      }
-
-      export interface EnterpriseEapTls {
-        /**
-         * A File ID representing a PEM file containing the server certificate
-         */
-        ca_certificate_file?: string;
-
-        /**
-         * A File ID representing a PEM file containing the client certificate
-         */
-        client_certificate_file: string;
-
-        /**
-         * A File ID representing a PEM file containing the client RSA private key
-         */
-        private_key_file: string;
-
-        /**
-         * Password for the private key file
-         */
-        private_key_file_password?: string;
-
-        /**
-         * Name of the WiFi network
-         */
-        ssid: string;
-      }
-
-      export interface PersonalPsk {
-        /**
-         * Password for connecting to the WiFi network
-         */
-        password: string;
-
-        /**
-         * Name of the WiFi network
-         */
-        ssid: string;
-      }
-
-      export type Type =
-        | 'enterprise_eap_peap'
-        | 'enterprise_eap_tls'
-        | 'personal_psk';
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
     }
+
+    export interface Chf {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Czk {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Dkk {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Eur {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Gbp {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Gip {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Hkd {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Huf {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Jpy {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Mxn {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Myr {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Nok {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Nzd {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Pln {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Ron {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Sek {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Sgd {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+
+    export interface Usd {
+      /**
+       * Fixed amounts displayed when collecting a tip
+       */
+      fixed_amounts?: Array<number> | null;
+
+      /**
+       * Percentages displayed when collecting a tip
+       */
+      percentages?: Array<number> | null;
+
+      /**
+       * Below this amount, fixed amounts will be displayed; above it, percentages will be displayed
+       */
+      smart_tip_threshold?: number;
+    }
+  }
+
+  export namespace Wifi {
+    export interface EnterpriseEapPeap {
+      /**
+       * A File ID representing a PEM file containing the server certificate
+       */
+      ca_certificate_file?: string;
+
+      /**
+       * Password for connecting to the WiFi network
+       */
+      password: string;
+
+      /**
+       * Name of the WiFi network
+       */
+      ssid: string;
+
+      /**
+       * Username for connecting to the WiFi network
+       */
+      username: string;
+    }
+
+    export interface EnterpriseEapTls {
+      /**
+       * A File ID representing a PEM file containing the server certificate
+       */
+      ca_certificate_file?: string;
+
+      /**
+       * A File ID representing a PEM file containing the client certificate
+       */
+      client_certificate_file: string;
+
+      /**
+       * A File ID representing a PEM file containing the client RSA private key
+       */
+      private_key_file: string;
+
+      /**
+       * Password for the private key file
+       */
+      private_key_file_password?: string;
+
+      /**
+       * Name of the WiFi network
+       */
+      ssid: string;
+    }
+
+    export interface PersonalPsk {
+      /**
+       * Password for connecting to the WiFi network
+       */
+      password: string;
+
+      /**
+       * Name of the WiFi network
+       */
+      ssid: string;
+    }
+
+    export type Type =
+      | 'enterprise_eap_peap'
+      | 'enterprise_eap_tls'
+      | 'personal_psk';
   }
 }
 export namespace Terminal {

--- a/src/resources/Terminal/Locations.ts
+++ b/src/resources/Terminal/Locations.ts
@@ -20,7 +20,7 @@ export class LocationResource extends StripeResource {
     id: string,
     params?: Terminal.LocationDeleteParams,
     options?: RequestOptions
-  ): Promise<Response<Terminal.DeletedLocation>> {
+  ): Promise<Response<DeletedLocation>> {
     return this._makeRequest(
       'DELETE',
       `/v1/terminal/locations/${encodeURIComponent(id)}`,
@@ -35,7 +35,7 @@ export class LocationResource extends StripeResource {
     id: string,
     params?: Terminal.LocationRetrieveParams,
     options?: RequestOptions
-  ): Promise<Response<Location | Terminal.DeletedLocation>> {
+  ): Promise<Response<Location | DeletedLocation>> {
     return this._makeRequest(
       'GET',
       `/v1/terminal/locations/${encodeURIComponent(id)}`,
@@ -50,7 +50,7 @@ export class LocationResource extends StripeResource {
     id: string,
     params?: Terminal.LocationUpdateParams,
     options?: RequestOptions
-  ): Promise<Response<Location | Terminal.DeletedLocation>> {
+  ): Promise<Response<Location | DeletedLocation>> {
     return this._makeRequest(
       'POST',
       `/v1/terminal/locations/${encodeURIComponent(id)}`,
@@ -98,9 +98,9 @@ export interface Location {
 
   address: Address;
 
-  address_kana?: Terminal.Location.AddressKana;
+  address_kana?: Location.AddressKana;
 
-  address_kanji?: Terminal.Location.AddressKanji;
+  address_kanji?: Location.AddressKanji;
 
   /**
    * The ID of a configuration that will be used to customize all readers in this location.
@@ -142,98 +142,95 @@ export interface Location {
    */
   phone?: string;
 }
-export namespace Terminal {
-  export interface DeletedLocation {
+export interface DeletedLocation {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'terminal.location';
+
+  /**
+   * Always true for a deleted object
+   */
+  deleted: true;
+}
+export namespace Location {
+  export interface AddressKana {
     /**
-     * Unique identifier for the object.
+     * City/Ward.
      */
-    id: string;
+    city: string | null;
 
     /**
-     * String representing the object's type. Objects of the same type share the same value.
+     * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
      */
-    object: 'terminal.location';
+    country: string | null;
 
     /**
-     * Always true for a deleted object
+     * Block/Building number.
      */
-    deleted: true;
+    line1: string | null;
+
+    /**
+     * Building details.
+     */
+    line2: string | null;
+
+    /**
+     * ZIP or postal code.
+     */
+    postal_code: string | null;
+
+    /**
+     * Prefecture.
+     */
+    state: string | null;
+
+    /**
+     * Town/cho-me.
+     */
+    town: string | null;
   }
 
-  export namespace Location {
-    export interface AddressKana {
-      /**
-       * City/Ward.
-       */
-      city: string | null;
+  export interface AddressKanji {
+    /**
+     * City/Ward.
+     */
+    city: string | null;
 
-      /**
-       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-       */
-      country: string | null;
+    /**
+     * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+     */
+    country: string | null;
 
-      /**
-       * Block/Building number.
-       */
-      line1: string | null;
+    /**
+     * Block/Building number.
+     */
+    line1: string | null;
 
-      /**
-       * Building details.
-       */
-      line2: string | null;
+    /**
+     * Building details.
+     */
+    line2: string | null;
 
-      /**
-       * ZIP or postal code.
-       */
-      postal_code: string | null;
+    /**
+     * ZIP or postal code.
+     */
+    postal_code: string | null;
 
-      /**
-       * Prefecture.
-       */
-      state: string | null;
+    /**
+     * Prefecture.
+     */
+    state: string | null;
 
-      /**
-       * Town/cho-me.
-       */
-      town: string | null;
-    }
-
-    export interface AddressKanji {
-      /**
-       * City/Ward.
-       */
-      city: string | null;
-
-      /**
-       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-       */
-      country: string | null;
-
-      /**
-       * Block/Building number.
-       */
-      line1: string | null;
-
-      /**
-       * Building details.
-       */
-      line2: string | null;
-
-      /**
-       * ZIP or postal code.
-       */
-      postal_code: string | null;
-
-      /**
-       * Prefecture.
-       */
-      state: string | null;
-
-      /**
-       * Town/cho-me.
-       */
-      town: string | null;
-    }
+    /**
+     * Town/cho-me.
+     */
+    town: string | null;
   }
 }
 export namespace Terminal {

--- a/src/resources/Terminal/OnboardingLinks.ts
+++ b/src/resources/Terminal/OnboardingLinks.ts
@@ -25,7 +25,7 @@ export interface OnboardingLink {
   /**
    * Link type options associated with the current onboarding link object.
    */
-  link_options: Terminal.OnboardingLink.LinkOptions;
+  link_options: OnboardingLink.LinkOptions;
 
   /**
    * The type of link being generated.
@@ -42,27 +42,25 @@ export interface OnboardingLink {
    */
   redirect_url: string;
 }
-export namespace Terminal {
-  export namespace OnboardingLink {
-    export interface LinkOptions {
+export namespace OnboardingLink {
+  export interface LinkOptions {
+    /**
+     * The options associated with the Apple Terms and Conditions link type.
+     */
+    apple_terms_and_conditions: LinkOptions.AppleTermsAndConditions | null;
+  }
+
+  export namespace LinkOptions {
+    export interface AppleTermsAndConditions {
       /**
-       * The options associated with the Apple Terms and Conditions link type.
+       * Whether the link should also support users relinking their Apple account.
        */
-      apple_terms_and_conditions: LinkOptions.AppleTermsAndConditions | null;
-    }
+      allow_relinking: boolean | null;
 
-    export namespace LinkOptions {
-      export interface AppleTermsAndConditions {
-        /**
-         * Whether the link should also support users relinking their Apple account.
-         */
-        allow_relinking: boolean | null;
-
-        /**
-         * The business name of the merchant accepting Apple's Terms and Conditions.
-         */
-        merchant_display_name: string;
-      }
+      /**
+       * The business name of the merchant accepting Apple's Terms and Conditions.
+       */
+      merchant_display_name: string;
     }
   }
 }

--- a/src/resources/Terminal/Readers.ts
+++ b/src/resources/Terminal/Readers.ts
@@ -24,7 +24,7 @@ export class ReaderResource extends StripeResource {
     id: string,
     params?: Terminal.ReaderDeleteParams,
     options?: RequestOptions
-  ): Promise<Response<Terminal.DeletedReader>> {
+  ): Promise<Response<DeletedReader>> {
     return this._makeRequest(
       'DELETE',
       `/v1/terminal/readers/${encodeURIComponent(id)}`,
@@ -39,7 +39,7 @@ export class ReaderResource extends StripeResource {
     id: string,
     params?: Terminal.ReaderRetrieveParams,
     options?: RequestOptions
-  ): Promise<Response<Reader | Terminal.DeletedReader>> {
+  ): Promise<Response<Reader | DeletedReader>> {
     return this._makeRequest(
       'GET',
       `/v1/terminal/readers/${encodeURIComponent(id)}`,
@@ -54,7 +54,7 @@ export class ReaderResource extends StripeResource {
     id: string,
     params?: Terminal.ReaderUpdateParams,
     options?: RequestOptions
-  ): Promise<Response<Reader | Terminal.DeletedReader>> {
+  ): Promise<Response<Reader | DeletedReader>> {
     return this._makeRequest(
       'POST',
       `/v1/terminal/readers/${encodeURIComponent(id)}`,
@@ -222,7 +222,7 @@ export interface Reader {
   /**
    * The most recent action performed by the reader.
    */
-  action: Terminal.Reader.Action | null;
+  action: Reader.Action | null;
 
   /**
    * Always true for a deleted object
@@ -237,7 +237,7 @@ export interface Reader {
   /**
    * Device type of the reader.
    */
-  device_type: Terminal.Reader.DeviceType;
+  device_type: Reader.DeviceType;
 
   /**
    * The local IP address of the reader.
@@ -277,972 +277,965 @@ export interface Reader {
   /**
    * The networking status of the reader. We do not recommend using this field in flows that may block taking payments.
    */
-  status: Terminal.Reader.Status | null;
+  status: Reader.Status | null;
 }
-export namespace Terminal {
-  export interface DeletedReader {
+export interface DeletedReader {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
+
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'terminal.reader';
+
+  /**
+   * Always true for a deleted object
+   */
+  deleted: true;
+
+  /**
+   * Device type of the reader.
+   */
+  device_type: DeletedReader.DeviceType;
+
+  /**
+   * Serial number of the reader.
+   */
+  serial_number: string;
+}
+export namespace DeletedReader {
+  export type DeviceType =
+    | 'bbpos_chipper2x'
+    | 'bbpos_wisepad3'
+    | 'bbpos_wisepos_e'
+    | 'mobile_phone_reader'
+    | 'simulated_stripe_s700'
+    | 'simulated_stripe_s710'
+    | 'simulated_verifone_m425'
+    | 'simulated_verifone_p630'
+    | 'simulated_verifone_ux700'
+    | 'simulated_verifone_v660p'
+    | 'simulated_wisepos_e'
+    | 'stripe_m2'
+    | 'stripe_s700'
+    | 'stripe_s710'
+    | 'verifone_P400'
+    | 'verifone_m425'
+    | 'verifone_p630'
+    | 'verifone_ux700'
+    | 'verifone_v660p';
+}
+export namespace Reader {
+  export interface Action {
     /**
-     * Unique identifier for the object.
+     * The reader action failed due to an [API error](https://docs.stripe.com/api/errors). Only present when `status` is `failed` and the underlying failure was an API error. Avoid parsing the `message` field for programmatic logic; use `type` or `code` instead. The `message` field is for display to humans only and may be updated at anytime. Requires [reader version](https://docs.stripe.com/terminal/readers/stripe-reader-s700-s710#reader-software-version) 2.42 or later. Readers on older versions always return null.
      */
-    id: string;
+    api_error: Action.ApiError | null;
 
     /**
-     * String representing the object's type. Objects of the same type share the same value.
+     * Represents a reader action to collect customer inputs
      */
-    object: 'terminal.reader';
+    collect_inputs?: Action.CollectInputs;
 
     /**
-     * Always true for a deleted object
+     * Represents a reader action to collect a payment method
      */
-    deleted: true;
+    collect_payment_method?: Action.CollectPaymentMethod;
 
     /**
-     * Device type of the reader.
+     * Represents a reader action to confirm a payment
      */
-    device_type: DeletedReader.DeviceType;
+    confirm_payment_intent?: Action.ConfirmPaymentIntent;
 
     /**
-     * Serial number of the reader.
+     * Failure code, only set if status is `failed`.
      */
-    serial_number: string;
+    failure_code: string | null;
+
+    /**
+     * Detailed failure message, only set if status is `failed`.
+     */
+    failure_message: string | null;
+
+    /**
+     * Represents a reader action to print content
+     */
+    print_content?: Action.PrintContent;
+
+    /**
+     * Represents a reader action to process a payment intent
+     */
+    process_payment_intent?: Action.ProcessPaymentIntent;
+
+    /**
+     * Represents a reader action to process a setup intent
+     */
+    process_setup_intent?: Action.ProcessSetupIntent;
+
+    /**
+     * Represents a reader action to refund a payment
+     */
+    refund_payment?: Action.RefundPayment;
+
+    /**
+     * Represents a reader action to set the reader display
+     */
+    set_reader_display?: Action.SetReaderDisplay;
+
+    /**
+     * Status of the action performed by the reader.
+     */
+    status: Action.Status;
+
+    /**
+     * Type of action performed by the reader.
+     */
+    type: Action.Type;
   }
 
-  export namespace DeletedReader {
-    export type DeviceType =
-      | 'bbpos_chipper2x'
-      | 'bbpos_wisepad3'
-      | 'bbpos_wisepos_e'
-      | 'mobile_phone_reader'
-      | 'simulated_stripe_s700'
-      | 'simulated_stripe_s710'
-      | 'simulated_verifone_m425'
-      | 'simulated_verifone_p630'
-      | 'simulated_verifone_ux700'
-      | 'simulated_verifone_v660p'
-      | 'simulated_wisepos_e'
-      | 'stripe_m2'
-      | 'stripe_s700'
-      | 'stripe_s710'
-      | 'verifone_P400'
-      | 'verifone_m425'
-      | 'verifone_p630'
-      | 'verifone_ux700'
-      | 'verifone_v660p';
-  }
+  export type DeviceType =
+    | 'bbpos_chipper2x'
+    | 'bbpos_wisepad3'
+    | 'bbpos_wisepos_e'
+    | 'mobile_phone_reader'
+    | 'simulated_stripe_s700'
+    | 'simulated_stripe_s710'
+    | 'simulated_verifone_m425'
+    | 'simulated_verifone_p630'
+    | 'simulated_verifone_ux700'
+    | 'simulated_verifone_v660p'
+    | 'simulated_wisepos_e'
+    | 'stripe_m2'
+    | 'stripe_s700'
+    | 'stripe_s710'
+    | 'verifone_P400'
+    | 'verifone_m425'
+    | 'verifone_p630'
+    | 'verifone_ux700'
+    | 'verifone_v660p';
 
-  export namespace Reader {
-    export interface Action {
-      /**
-       * The reader action failed due to an [API error](https://docs.stripe.com/api/errors). Only present when `status` is `failed` and the underlying failure was an API error. Avoid parsing the `message` field for programmatic logic; use `type` or `code` instead. The `message` field is for display to humans only and may be updated at anytime. Requires [reader version](https://docs.stripe.com/terminal/readers/stripe-reader-s700-s710#reader-software-version) 2.42 or later. Readers on older versions always return null.
-       */
-      api_error: Action.ApiError | null;
+  export type Status = 'offline' | 'online';
 
+  export namespace Action {
+    export interface ApiError {
       /**
-       * Represents a reader action to collect customer inputs
+       * For card errors resulting from a card issuer decline, a short string indicating [how to proceed with an error](https://docs.stripe.com/declines#retrying-issuer-declines) if they provide one.
        */
-      collect_inputs?: Action.CollectInputs;
+      advice_code?: string;
 
       /**
-       * Represents a reader action to collect a payment method
+       * For card errors, the ID of the failed charge.
        */
-      collect_payment_method?: Action.CollectPaymentMethod;
+      charge?: string;
 
       /**
-       * Represents a reader action to confirm a payment
+       * For some errors that could be handled programmatically, a short string indicating the [error code](https://docs.stripe.com/error-codes) reported.
        */
-      confirm_payment_intent?: Action.ConfirmPaymentIntent;
+      code?: ApiError.Code;
 
       /**
-       * Failure code, only set if status is `failed`.
+       * For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://docs.stripe.com/declines#issuer-declines) if they provide one.
        */
-      failure_code: string | null;
+      decline_code?: string;
 
       /**
-       * Detailed failure message, only set if status is `failed`.
+       * A URL to more information about the [error code](https://docs.stripe.com/error-codes) reported.
        */
-      failure_message: string | null;
+      doc_url?: string;
 
       /**
-       * Represents a reader action to print content
+       * A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
        */
-      print_content?: Action.PrintContent;
+      message?: string;
 
       /**
-       * Represents a reader action to process a payment intent
+       * For card errors resulting from a card issuer decline, a 2 digit code which indicates the advice given to merchant by the card network on how to proceed with an error.
        */
-      process_payment_intent?: Action.ProcessPaymentIntent;
+      network_advice_code?: string;
 
       /**
-       * Represents a reader action to process a setup intent
+       * For payments declined by the network, an alphanumeric code which indicates the reason the payment failed.
        */
-      process_setup_intent?: Action.ProcessSetupIntent;
+      network_decline_code?: string;
 
       /**
-       * Represents a reader action to refund a payment
+       * If the error is parameter-specific, the parameter related to the error. For example, you can use this to display a message near the correct form field.
        */
-      refund_payment?: Action.RefundPayment;
+      param?: string;
 
       /**
-       * Represents a reader action to set the reader display
+       * A PaymentIntent guides you through the process of collecting a payment from your customer.
+       * We recommend that you create exactly one PaymentIntent for each order or
+       * customer session in your system. You can reference the PaymentIntent later to
+       * see the history of payment attempts for a particular session.
+       *
+       * A PaymentIntent transitions through
+       * [multiple statuses](https://docs.stripe.com/payments/paymentintents/lifecycle)
+       * throughout its lifetime as it interfaces with Stripe.js to perform
+       * authentication flows and ultimately creates at most one successful charge.
+       *
+       * Related guide: [Payment Intents API](https://docs.stripe.com/payments/payment-intents)
        */
-      set_reader_display?: Action.SetReaderDisplay;
+      payment_intent?: PaymentIntent;
 
       /**
-       * Status of the action performed by the reader.
+       * PaymentMethod objects represent your customer's payment instruments.
+       * You can use them with [PaymentIntents](https://docs.stripe.com/payments/payment-intents) to collect payments or save them to
+       * Customer objects to store instrument details for future payments.
+       *
+       * Related guides: [Payment Methods](https://docs.stripe.com/payments/payment-methods) and [More Payment Scenarios](https://docs.stripe.com/payments/more-payment-scenarios).
        */
-      status: Action.Status;
+      payment_method?: PaymentMethod;
 
       /**
-       * Type of action performed by the reader.
+       * If the error is specific to the type of payment method, the payment method type that had a problem. This field is only populated for invoice-related errors.
        */
-      type: Action.Type;
+      payment_method_type?: string;
+
+      /**
+       * A URL to the request log entry in your dashboard.
+       */
+      request_log_url?: string;
+
+      /**
+       * A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.
+       * For example, you can use a SetupIntent to set up and save your customer's card without immediately collecting a payment.
+       * Later, you can use [PaymentIntents](https://api.stripe.com#payment_intents) to drive the payment flow.
+       *
+       * Create a SetupIntent when you're ready to collect your customer's payment credentials.
+       * Don't maintain long-lived, unconfirmed SetupIntents because they might not be valid.
+       * The SetupIntent transitions through multiple [statuses](https://docs.stripe.com/payments/intents#intent-statuses) as it guides
+       * you through the setup process.
+       *
+       * Successful SetupIntents result in payment credentials that are optimized for future payments.
+       * For example, cardholders in [certain regions](https://stripe.com/guides/strong-customer-authentication) might need to be run through
+       * [Strong Customer Authentication](https://docs.stripe.com/strong-customer-authentication) during payment method collection
+       * to streamline later [off-session payments](https://docs.stripe.com/payments/setup-intents).
+       * If you use the SetupIntent with a [Customer](https://api.stripe.com#setup_intent_object-customer),
+       * it automatically attaches the resulting payment method to that Customer after successful setup.
+       * We recommend using SetupIntents or [setup_future_usage](https://api.stripe.com#payment_intent_object-setup_future_usage) on
+       * PaymentIntents to save payment methods to prevent saving invalid or unoptimized payment methods.
+       *
+       * By using SetupIntents, you can reduce friction for your customers, even as regulations change over time.
+       *
+       * Related guide: [Setup Intents API](https://docs.stripe.com/payments/setup-intents)
+       */
+      setup_intent?: SetupIntent;
+
+      source?: CustomerSource;
+
+      /**
+       * The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
+       */
+      type: ApiError.Type;
     }
 
-    export type DeviceType =
-      | 'bbpos_chipper2x'
-      | 'bbpos_wisepad3'
-      | 'bbpos_wisepos_e'
-      | 'mobile_phone_reader'
-      | 'simulated_stripe_s700'
-      | 'simulated_stripe_s710'
-      | 'simulated_verifone_m425'
-      | 'simulated_verifone_p630'
-      | 'simulated_verifone_ux700'
-      | 'simulated_verifone_v660p'
-      | 'simulated_wisepos_e'
-      | 'stripe_m2'
-      | 'stripe_s700'
-      | 'stripe_s710'
-      | 'verifone_P400'
-      | 'verifone_m425'
-      | 'verifone_p630'
-      | 'verifone_ux700'
-      | 'verifone_v660p';
+    export interface CollectInputs {
+      /**
+       * List of inputs to be collected.
+       */
+      inputs: Array<CollectInputs.Input>;
 
-    export type Status = 'offline' | 'online';
+      /**
+       * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+       */
+      metadata: Metadata | null;
+    }
 
-    export namespace Action {
-      export interface ApiError {
-        /**
-         * For card errors resulting from a card issuer decline, a short string indicating [how to proceed with an error](https://docs.stripe.com/declines#retrying-issuer-declines) if they provide one.
-         */
-        advice_code?: string;
+    export interface CollectPaymentMethod {
+      /**
+       * Represents a per-transaction override of a reader configuration
+       */
+      collect_config?: CollectPaymentMethod.CollectConfig;
 
-        /**
-         * For card errors, the ID of the failed charge.
-         */
-        charge?: string;
+      /**
+       * Most recent PaymentIntent processed by the reader.
+       */
+      payment_intent: string | PaymentIntent;
 
-        /**
-         * For some errors that could be handled programmatically, a short string indicating the [error code](https://docs.stripe.com/error-codes) reported.
-         */
-        code?: ApiError.Code;
+      /**
+       * PaymentMethod objects represent your customer's payment instruments.
+       * You can use them with [PaymentIntents](https://docs.stripe.com/payments/payment-intents) to collect payments or save them to
+       * Customer objects to store instrument details for future payments.
+       *
+       * Related guides: [Payment Methods](https://docs.stripe.com/payments/payment-methods) and [More Payment Scenarios](https://docs.stripe.com/payments/more-payment-scenarios).
+       */
+      payment_method?: PaymentMethod;
+    }
 
-        /**
-         * For card errors resulting from a card issuer decline, a short string indicating the [card issuer's reason for the decline](https://docs.stripe.com/declines#issuer-declines) if they provide one.
-         */
-        decline_code?: string;
+    export interface ConfirmPaymentIntent {
+      /**
+       * Represents a per-transaction override of a reader configuration
+       */
+      confirm_config?: ConfirmPaymentIntent.ConfirmConfig;
 
-        /**
-         * A URL to more information about the [error code](https://docs.stripe.com/error-codes) reported.
-         */
-        doc_url?: string;
+      /**
+       * Most recent PaymentIntent processed by the reader.
+       */
+      payment_intent: string | PaymentIntent;
+    }
 
-        /**
-         * A human-readable message providing more details about the error. For card errors, these messages can be shown to your users.
-         */
-        message?: string;
+    export interface PrintContent {
+      /**
+       * Metadata of an uploaded file
+       */
+      image?: PrintContent.Image;
 
-        /**
-         * For card errors resulting from a card issuer decline, a 2 digit code which indicates the advice given to merchant by the card network on how to proceed with an error.
-         */
-        network_advice_code?: string;
+      /**
+       * The type of content to print. Currently supports `image`.
+       */
+      type: 'image';
+    }
 
-        /**
-         * For payments declined by the network, an alphanumeric code which indicates the reason the payment failed.
-         */
-        network_decline_code?: string;
+    export interface ProcessPaymentIntent {
+      /**
+       * Most recent PaymentIntent processed by the reader.
+       */
+      payment_intent: string | PaymentIntent;
 
-        /**
-         * If the error is parameter-specific, the parameter related to the error. For example, you can use this to display a message near the correct form field.
-         */
-        param?: string;
+      /**
+       * Represents a per-transaction override of a reader configuration
+       */
+      process_config?: ProcessPaymentIntent.ProcessConfig;
+    }
 
-        /**
-         * A PaymentIntent guides you through the process of collecting a payment from your customer.
-         * We recommend that you create exactly one PaymentIntent for each order or
-         * customer session in your system. You can reference the PaymentIntent later to
-         * see the history of payment attempts for a particular session.
-         *
-         * A PaymentIntent transitions through
-         * [multiple statuses](https://docs.stripe.com/payments/paymentintents/lifecycle)
-         * throughout its lifetime as it interfaces with Stripe.js to perform
-         * authentication flows and ultimately creates at most one successful charge.
-         *
-         * Related guide: [Payment Intents API](https://docs.stripe.com/payments/payment-intents)
-         */
-        payment_intent?: PaymentIntent;
+    export interface ProcessSetupIntent {
+      /**
+       * ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod.
+       */
+      generated_card?: string;
 
-        /**
-         * PaymentMethod objects represent your customer's payment instruments.
-         * You can use them with [PaymentIntents](https://docs.stripe.com/payments/payment-intents) to collect payments or save them to
-         * Customer objects to store instrument details for future payments.
-         *
-         * Related guides: [Payment Methods](https://docs.stripe.com/payments/payment-methods) and [More Payment Scenarios](https://docs.stripe.com/payments/more-payment-scenarios).
-         */
-        payment_method?: PaymentMethod;
+      /**
+       * Represents a per-setup override of a reader configuration
+       */
+      process_config?: ProcessSetupIntent.ProcessConfig;
 
-        /**
-         * If the error is specific to the type of payment method, the payment method type that had a problem. This field is only populated for invoice-related errors.
-         */
-        payment_method_type?: string;
+      /**
+       * Most recent SetupIntent processed by the reader.
+       */
+      setup_intent: string | SetupIntent;
+    }
 
-        /**
-         * A URL to the request log entry in your dashboard.
-         */
-        request_log_url?: string;
+    export interface RefundPayment {
+      /**
+       * The amount being refunded.
+       */
+      amount?: number;
 
-        /**
-         * A SetupIntent guides you through the process of setting up and saving a customer's payment credentials for future payments.
-         * For example, you can use a SetupIntent to set up and save your customer's card without immediately collecting a payment.
-         * Later, you can use [PaymentIntents](https://api.stripe.com#payment_intents) to drive the payment flow.
-         *
-         * Create a SetupIntent when you're ready to collect your customer's payment credentials.
-         * Don't maintain long-lived, unconfirmed SetupIntents because they might not be valid.
-         * The SetupIntent transitions through multiple [statuses](https://docs.stripe.com/payments/intents#intent-statuses) as it guides
-         * you through the setup process.
-         *
-         * Successful SetupIntents result in payment credentials that are optimized for future payments.
-         * For example, cardholders in [certain regions](https://stripe.com/guides/strong-customer-authentication) might need to be run through
-         * [Strong Customer Authentication](https://docs.stripe.com/strong-customer-authentication) during payment method collection
-         * to streamline later [off-session payments](https://docs.stripe.com/payments/setup-intents).
-         * If you use the SetupIntent with a [Customer](https://api.stripe.com#setup_intent_object-customer),
-         * it automatically attaches the resulting payment method to that Customer after successful setup.
-         * We recommend using SetupIntents or [setup_future_usage](https://api.stripe.com#payment_intent_object-setup_future_usage) on
-         * PaymentIntents to save payment methods to prevent saving invalid or unoptimized payment methods.
-         *
-         * By using SetupIntents, you can reduce friction for your customers, even as regulations change over time.
-         *
-         * Related guide: [Setup Intents API](https://docs.stripe.com/payments/setup-intents)
-         */
-        setup_intent?: SetupIntent;
+      /**
+       * Charge that is being refunded.
+       */
+      charge?: string | Charge;
 
-        source?: CustomerSource;
+      /**
+       * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+       */
+      metadata?: Metadata;
 
-        /**
-         * The type of error returned. One of `api_error`, `card_error`, `idempotency_error`, or `invalid_request_error`
-         */
-        type: ApiError.Type;
-      }
+      /**
+       * Payment intent that is being refunded.
+       */
+      payment_intent?: string | PaymentIntent;
 
-      export interface CollectInputs {
-        /**
-         * List of inputs to be collected.
-         */
-        inputs: Array<CollectInputs.Input>;
+      /**
+       * The reason for the refund.
+       */
+      reason?: RefundPayment.Reason;
 
-        /**
-         * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
-         */
-        metadata: Metadata | null;
-      }
+      /**
+       * Unique identifier for the refund object.
+       */
+      refund?: string | Refund;
 
-      export interface CollectPaymentMethod {
-        /**
-         * Represents a per-transaction override of a reader configuration
-         */
-        collect_config?: CollectPaymentMethod.CollectConfig;
+      /**
+       * Boolean indicating whether the application fee should be refunded when refunding this charge. If a full charge refund is given, the full application fee will be refunded. Otherwise, the application fee will be refunded in an amount proportional to the amount of the charge refunded. An application fee can be refunded only by the application that created the charge.
+       */
+      refund_application_fee?: boolean;
 
-        /**
-         * Most recent PaymentIntent processed by the reader.
-         */
-        payment_intent: string | PaymentIntent;
+      /**
+       * Represents a per-transaction override of a reader configuration
+       */
+      refund_payment_config?: RefundPayment.RefundPaymentConfig;
 
-        /**
-         * PaymentMethod objects represent your customer's payment instruments.
-         * You can use them with [PaymentIntents](https://docs.stripe.com/payments/payment-intents) to collect payments or save them to
-         * Customer objects to store instrument details for future payments.
-         *
-         * Related guides: [Payment Methods](https://docs.stripe.com/payments/payment-methods) and [More Payment Scenarios](https://docs.stripe.com/payments/more-payment-scenarios).
-         */
-        payment_method?: PaymentMethod;
-      }
+      /**
+       * Boolean indicating whether the transfer should be reversed when refunding this charge. The transfer will be reversed proportionally to the amount being refunded (either the entire or partial amount). A transfer can be reversed only by the application that created the charge.
+       */
+      reverse_transfer?: boolean;
+    }
 
-      export interface ConfirmPaymentIntent {
-        /**
-         * Represents a per-transaction override of a reader configuration
-         */
-        confirm_config?: ConfirmPaymentIntent.ConfirmConfig;
+    export interface SetReaderDisplay {
+      /**
+       * Cart object to be displayed by the reader, including line items, amounts, and currency.
+       */
+      cart: SetReaderDisplay.Cart | null;
 
-        /**
-         * Most recent PaymentIntent processed by the reader.
-         */
-        payment_intent: string | PaymentIntent;
-      }
+      /**
+       * Type of information to be displayed by the reader. Only `cart` is currently supported.
+       */
+      type: 'cart';
+    }
 
-      export interface PrintContent {
-        /**
-         * Metadata of an uploaded file
-         */
-        image?: PrintContent.Image;
+    export type Status = 'failed' | 'in_progress' | 'succeeded';
 
-        /**
-         * The type of content to print. Currently supports `image`.
-         */
-        type: 'image';
-      }
+    export type Type =
+      | 'collect_inputs'
+      | 'collect_payment_method'
+      | 'confirm_payment_intent'
+      | 'print_content'
+      | 'process_payment_intent'
+      | 'process_setup_intent'
+      | 'refund_payment'
+      | 'set_reader_display';
 
-      export interface ProcessPaymentIntent {
-        /**
-         * Most recent PaymentIntent processed by the reader.
-         */
-        payment_intent: string | PaymentIntent;
-
-        /**
-         * Represents a per-transaction override of a reader configuration
-         */
-        process_config?: ProcessPaymentIntent.ProcessConfig;
-      }
-
-      export interface ProcessSetupIntent {
-        /**
-         * ID of a card PaymentMethod generated from the card_present PaymentMethod that may be attached to a Customer for future transactions. Only present if it was possible to generate a card PaymentMethod.
-         */
-        generated_card?: string;
-
-        /**
-         * Represents a per-setup override of a reader configuration
-         */
-        process_config?: ProcessSetupIntent.ProcessConfig;
-
-        /**
-         * Most recent SetupIntent processed by the reader.
-         */
-        setup_intent: string | SetupIntent;
-      }
-
-      export interface RefundPayment {
-        /**
-         * The amount being refunded.
-         */
-        amount?: number;
-
-        /**
-         * Charge that is being refunded.
-         */
-        charge?: string | Charge;
-
-        /**
-         * Set of [key-value pairs](https://docs.stripe.com/api/metadata) that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
-         */
-        metadata?: Metadata;
-
-        /**
-         * Payment intent that is being refunded.
-         */
-        payment_intent?: string | PaymentIntent;
-
-        /**
-         * The reason for the refund.
-         */
-        reason?: RefundPayment.Reason;
-
-        /**
-         * Unique identifier for the refund object.
-         */
-        refund?: string | Refund;
-
-        /**
-         * Boolean indicating whether the application fee should be refunded when refunding this charge. If a full charge refund is given, the full application fee will be refunded. Otherwise, the application fee will be refunded in an amount proportional to the amount of the charge refunded. An application fee can be refunded only by the application that created the charge.
-         */
-        refund_application_fee?: boolean;
-
-        /**
-         * Represents a per-transaction override of a reader configuration
-         */
-        refund_payment_config?: RefundPayment.RefundPaymentConfig;
-
-        /**
-         * Boolean indicating whether the transfer should be reversed when refunding this charge. The transfer will be reversed proportionally to the amount being refunded (either the entire or partial amount). A transfer can be reversed only by the application that created the charge.
-         */
-        reverse_transfer?: boolean;
-      }
-
-      export interface SetReaderDisplay {
-        /**
-         * Cart object to be displayed by the reader, including line items, amounts, and currency.
-         */
-        cart: SetReaderDisplay.Cart | null;
-
-        /**
-         * Type of information to be displayed by the reader. Only `cart` is currently supported.
-         */
-        type: 'cart';
-      }
-
-      export type Status = 'failed' | 'in_progress' | 'succeeded';
+    export namespace ApiError {
+      export type Code =
+        | 'account_closed'
+        | 'account_country_invalid_address'
+        | 'account_error_country_change_requires_additional_steps'
+        | 'account_information_mismatch'
+        | 'account_invalid'
+        | 'account_number_invalid'
+        | 'account_token_required_for_v2_account'
+        | 'acss_debit_session_incomplete'
+        | 'action_blocked'
+        | 'alipay_upgrade_required'
+        | 'amount_too_large'
+        | 'amount_too_small'
+        | 'api_key_expired'
+        | 'application_fees_not_allowed'
+        | 'approval_required'
+        | 'authentication_required'
+        | 'balance_insufficient'
+        | 'balance_invalid_parameter'
+        | 'bank_account_bad_routing_numbers'
+        | 'bank_account_declined'
+        | 'bank_account_exists'
+        | 'bank_account_restricted'
+        | 'bank_account_unusable'
+        | 'bank_account_unverified'
+        | 'bank_account_verification_failed'
+        | 'billing_invalid_mandate'
+        | 'bitcoin_upgrade_required'
+        | 'capture_charge_authorization_expired'
+        | 'capture_unauthorized_payment'
+        | 'card_decline_rate_limit_exceeded'
+        | 'card_declined'
+        | 'cardholder_phone_number_required'
+        | 'charge_already_captured'
+        | 'charge_already_refunded'
+        | 'charge_disputed'
+        | 'charge_exceeds_source_limit'
+        | 'charge_exceeds_transaction_limit'
+        | 'charge_expired_for_capture'
+        | 'charge_invalid_parameter'
+        | 'charge_not_refundable'
+        | 'clearing_code_unsupported'
+        | 'country_code_invalid'
+        | 'country_unsupported'
+        | 'coupon_expired'
+        | 'customer_max_payment_methods'
+        | 'customer_max_subscriptions'
+        | 'customer_session_expired'
+        | 'customer_tax_location_invalid'
+        | 'debit_not_authorized'
+        | 'email_invalid'
+        | 'expired_card'
+        | 'financial_connections_account_inactive'
+        | 'financial_connections_account_pending_account_numbers'
+        | 'financial_connections_account_unavailable_account_numbers'
+        | 'financial_connections_no_successful_transaction_refresh'
+        | 'forwarding_api_inactive'
+        | 'forwarding_api_invalid_parameter'
+        | 'forwarding_api_retryable_upstream_error'
+        | 'forwarding_api_upstream_connection_error'
+        | 'forwarding_api_upstream_connection_timeout'
+        | 'forwarding_api_upstream_error'
+        | 'idempotency_key_in_use'
+        | 'incorrect_address'
+        | 'incorrect_cvc'
+        | 'incorrect_number'
+        | 'incorrect_zip'
+        | 'india_recurring_payment_mandate_canceled'
+        | 'instant_payouts_config_disabled'
+        | 'instant_payouts_currency_disabled'
+        | 'instant_payouts_limit_exceeded'
+        | 'instant_payouts_unsupported'
+        | 'insufficient_funds'
+        | 'intent_invalid_state'
+        | 'intent_verification_method_missing'
+        | 'invalid_card_type'
+        | 'invalid_characters'
+        | 'invalid_charge_amount'
+        | 'invalid_cvc'
+        | 'invalid_expiry_month'
+        | 'invalid_expiry_year'
+        | 'invalid_mandate_reference_prefix_format'
+        | 'invalid_number'
+        | 'invalid_source_usage'
+        | 'invalid_tax_location'
+        | 'invoice_no_customer_line_items'
+        | 'invoice_no_payment_method_types'
+        | 'invoice_no_subscription_line_items'
+        | 'invoice_not_editable'
+        | 'invoice_on_behalf_of_not_editable'
+        | 'invoice_payment_intent_requires_action'
+        | 'invoice_upcoming_none'
+        | 'livemode_mismatch'
+        | 'lock_timeout'
+        | 'missing'
+        | 'no_account'
+        | 'not_allowed_on_standard_account'
+        | 'out_of_inventory'
+        | 'ownership_declaration_not_allowed'
+        | 'parameter_invalid_empty'
+        | 'parameter_invalid_integer'
+        | 'parameter_invalid_string_blank'
+        | 'parameter_invalid_string_empty'
+        | 'parameter_missing'
+        | 'parameter_unknown'
+        | 'parameters_exclusive'
+        | 'payment_intent_action_required'
+        | 'payment_intent_authentication_failure'
+        | 'payment_intent_incompatible_payment_method'
+        | 'payment_intent_invalid_parameter'
+        | 'payment_intent_konbini_rejected_confirmation_number'
+        | 'payment_intent_mandate_invalid'
+        | 'payment_intent_payment_attempt_expired'
+        | 'payment_intent_payment_attempt_failed'
+        | 'payment_intent_rate_limit_exceeded'
+        | 'payment_intent_unexpected_state'
+        | 'payment_method_bank_account_already_verified'
+        | 'payment_method_bank_account_blocked'
+        | 'payment_method_billing_details_address_missing'
+        | 'payment_method_configuration_failures'
+        | 'payment_method_currency_mismatch'
+        | 'payment_method_customer_decline'
+        | 'payment_method_invalid_parameter'
+        | 'payment_method_invalid_parameter_testmode'
+        | 'payment_method_microdeposit_failed'
+        | 'payment_method_microdeposit_processing_error'
+        | 'payment_method_microdeposit_verification_amounts_invalid'
+        | 'payment_method_microdeposit_verification_amounts_mismatch'
+        | 'payment_method_microdeposit_verification_attempts_exceeded'
+        | 'payment_method_microdeposit_verification_descriptor_code_mismatch'
+        | 'payment_method_microdeposit_verification_timeout'
+        | 'payment_method_not_available'
+        | 'payment_method_provider_decline'
+        | 'payment_method_provider_timeout'
+        | 'payment_method_unactivated'
+        | 'payment_method_unexpected_state'
+        | 'payment_method_unsupported_type'
+        | 'payout_reconciliation_not_ready'
+        | 'payouts_limit_exceeded'
+        | 'payouts_not_allowed'
+        | 'platform_account_required'
+        | 'platform_api_key_expired'
+        | 'postal_code_invalid'
+        | 'processing_error'
+        | 'product_inactive'
+        | 'progressive_onboarding_limit_exceeded'
+        | 'rate_limit'
+        | 'refer_to_customer'
+        | 'refund_disputed_payment'
+        | 'request_blocked'
+        | 'resource_already_exists'
+        | 'resource_missing'
+        | 'return_intent_already_processed'
+        | 'routing_number_invalid'
+        | 'secret_key_required'
+        | 'sepa_unsupported_account'
+        | 'service_period_coupon_with_metered_tiered_item_unsupported'
+        | 'setup_attempt_failed'
+        | 'setup_intent_authentication_failure'
+        | 'setup_intent_invalid_parameter'
+        | 'setup_intent_mandate_invalid'
+        | 'setup_intent_mobile_wallet_unsupported'
+        | 'setup_intent_setup_attempt_expired'
+        | 'setup_intent_unexpected_state'
+        | 'shipping_address_invalid'
+        | 'shipping_calculation_failed'
+        | 'siret_invalid'
+        | 'sku_inactive'
+        | 'state_unsupported'
+        | 'status_transition_invalid'
+        | 'storer_capability_missing'
+        | 'storer_capability_not_active'
+        | 'stripe_tax_inactive'
+        | 'tax_id_invalid'
+        | 'tax_id_prohibited'
+        | 'taxes_calculation_failed'
+        | 'terminal_location_country_unsupported'
+        | 'terminal_reader_busy'
+        | 'terminal_reader_hardware_fault'
+        | 'terminal_reader_invalid_location_for_activation'
+        | 'terminal_reader_invalid_location_for_payment'
+        | 'terminal_reader_offline'
+        | 'terminal_reader_timeout'
+        | 'testmode_charges_only'
+        | 'tls_version_unsupported'
+        | 'token_already_used'
+        | 'token_card_network_invalid'
+        | 'token_in_use'
+        | 'transfer_source_balance_parameters_mismatch'
+        | 'transfers_not_allowed'
+        | 'url_invalid';
 
       export type Type =
-        | 'collect_inputs'
-        | 'collect_payment_method'
-        | 'confirm_payment_intent'
-        | 'print_content'
-        | 'process_payment_intent'
-        | 'process_setup_intent'
-        | 'refund_payment'
-        | 'set_reader_display';
+        | 'api_error'
+        | 'card_error'
+        | 'idempotency_error'
+        | 'invalid_request_error';
+    }
 
-      export namespace ApiError {
-        export type Code =
-          | 'account_closed'
-          | 'account_country_invalid_address'
-          | 'account_error_country_change_requires_additional_steps'
-          | 'account_information_mismatch'
-          | 'account_invalid'
-          | 'account_number_invalid'
-          | 'account_token_required_for_v2_account'
-          | 'acss_debit_session_incomplete'
-          | 'action_blocked'
-          | 'alipay_upgrade_required'
-          | 'amount_too_large'
-          | 'amount_too_small'
-          | 'api_key_expired'
-          | 'application_fees_not_allowed'
-          | 'approval_required'
-          | 'authentication_required'
-          | 'balance_insufficient'
-          | 'balance_invalid_parameter'
-          | 'bank_account_bad_routing_numbers'
-          | 'bank_account_declined'
-          | 'bank_account_exists'
-          | 'bank_account_restricted'
-          | 'bank_account_unusable'
-          | 'bank_account_unverified'
-          | 'bank_account_verification_failed'
-          | 'billing_invalid_mandate'
-          | 'bitcoin_upgrade_required'
-          | 'capture_charge_authorization_expired'
-          | 'capture_unauthorized_payment'
-          | 'card_decline_rate_limit_exceeded'
-          | 'card_declined'
-          | 'cardholder_phone_number_required'
-          | 'charge_already_captured'
-          | 'charge_already_refunded'
-          | 'charge_disputed'
-          | 'charge_exceeds_source_limit'
-          | 'charge_exceeds_transaction_limit'
-          | 'charge_expired_for_capture'
-          | 'charge_invalid_parameter'
-          | 'charge_not_refundable'
-          | 'clearing_code_unsupported'
-          | 'country_code_invalid'
-          | 'country_unsupported'
-          | 'coupon_expired'
-          | 'customer_max_payment_methods'
-          | 'customer_max_subscriptions'
-          | 'customer_session_expired'
-          | 'customer_tax_location_invalid'
-          | 'debit_not_authorized'
-          | 'email_invalid'
-          | 'expired_card'
-          | 'financial_connections_account_inactive'
-          | 'financial_connections_account_pending_account_numbers'
-          | 'financial_connections_account_unavailable_account_numbers'
-          | 'financial_connections_no_successful_transaction_refresh'
-          | 'forwarding_api_inactive'
-          | 'forwarding_api_invalid_parameter'
-          | 'forwarding_api_retryable_upstream_error'
-          | 'forwarding_api_upstream_connection_error'
-          | 'forwarding_api_upstream_connection_timeout'
-          | 'forwarding_api_upstream_error'
-          | 'idempotency_key_in_use'
-          | 'incorrect_address'
-          | 'incorrect_cvc'
-          | 'incorrect_number'
-          | 'incorrect_zip'
-          | 'india_recurring_payment_mandate_canceled'
-          | 'instant_payouts_config_disabled'
-          | 'instant_payouts_currency_disabled'
-          | 'instant_payouts_limit_exceeded'
-          | 'instant_payouts_unsupported'
-          | 'insufficient_funds'
-          | 'intent_invalid_state'
-          | 'intent_verification_method_missing'
-          | 'invalid_card_type'
-          | 'invalid_characters'
-          | 'invalid_charge_amount'
-          | 'invalid_cvc'
-          | 'invalid_expiry_month'
-          | 'invalid_expiry_year'
-          | 'invalid_mandate_reference_prefix_format'
-          | 'invalid_number'
-          | 'invalid_source_usage'
-          | 'invalid_tax_location'
-          | 'invoice_no_customer_line_items'
-          | 'invoice_no_payment_method_types'
-          | 'invoice_no_subscription_line_items'
-          | 'invoice_not_editable'
-          | 'invoice_on_behalf_of_not_editable'
-          | 'invoice_payment_intent_requires_action'
-          | 'invoice_upcoming_none'
-          | 'livemode_mismatch'
-          | 'lock_timeout'
-          | 'missing'
-          | 'no_account'
-          | 'not_allowed_on_standard_account'
-          | 'out_of_inventory'
-          | 'ownership_declaration_not_allowed'
-          | 'parameter_invalid_empty'
-          | 'parameter_invalid_integer'
-          | 'parameter_invalid_string_blank'
-          | 'parameter_invalid_string_empty'
-          | 'parameter_missing'
-          | 'parameter_unknown'
-          | 'parameters_exclusive'
-          | 'payment_intent_action_required'
-          | 'payment_intent_authentication_failure'
-          | 'payment_intent_incompatible_payment_method'
-          | 'payment_intent_invalid_parameter'
-          | 'payment_intent_konbini_rejected_confirmation_number'
-          | 'payment_intent_mandate_invalid'
-          | 'payment_intent_payment_attempt_expired'
-          | 'payment_intent_payment_attempt_failed'
-          | 'payment_intent_rate_limit_exceeded'
-          | 'payment_intent_unexpected_state'
-          | 'payment_method_bank_account_already_verified'
-          | 'payment_method_bank_account_blocked'
-          | 'payment_method_billing_details_address_missing'
-          | 'payment_method_configuration_failures'
-          | 'payment_method_currency_mismatch'
-          | 'payment_method_customer_decline'
-          | 'payment_method_invalid_parameter'
-          | 'payment_method_invalid_parameter_testmode'
-          | 'payment_method_microdeposit_failed'
-          | 'payment_method_microdeposit_processing_error'
-          | 'payment_method_microdeposit_verification_amounts_invalid'
-          | 'payment_method_microdeposit_verification_amounts_mismatch'
-          | 'payment_method_microdeposit_verification_attempts_exceeded'
-          | 'payment_method_microdeposit_verification_descriptor_code_mismatch'
-          | 'payment_method_microdeposit_verification_timeout'
-          | 'payment_method_not_available'
-          | 'payment_method_provider_decline'
-          | 'payment_method_provider_timeout'
-          | 'payment_method_unactivated'
-          | 'payment_method_unexpected_state'
-          | 'payment_method_unsupported_type'
-          | 'payout_reconciliation_not_ready'
-          | 'payouts_limit_exceeded'
-          | 'payouts_not_allowed'
-          | 'platform_account_required'
-          | 'platform_api_key_expired'
-          | 'postal_code_invalid'
-          | 'processing_error'
-          | 'product_inactive'
-          | 'progressive_onboarding_limit_exceeded'
-          | 'rate_limit'
-          | 'refer_to_customer'
-          | 'refund_disputed_payment'
-          | 'request_blocked'
-          | 'resource_already_exists'
-          | 'resource_missing'
-          | 'return_intent_already_processed'
-          | 'routing_number_invalid'
-          | 'secret_key_required'
-          | 'sepa_unsupported_account'
-          | 'service_period_coupon_with_metered_tiered_item_unsupported'
-          | 'setup_attempt_failed'
-          | 'setup_intent_authentication_failure'
-          | 'setup_intent_invalid_parameter'
-          | 'setup_intent_mandate_invalid'
-          | 'setup_intent_mobile_wallet_unsupported'
-          | 'setup_intent_setup_attempt_expired'
-          | 'setup_intent_unexpected_state'
-          | 'shipping_address_invalid'
-          | 'shipping_calculation_failed'
-          | 'siret_invalid'
-          | 'sku_inactive'
-          | 'state_unsupported'
-          | 'status_transition_invalid'
-          | 'storer_capability_missing'
-          | 'storer_capability_not_active'
-          | 'stripe_tax_inactive'
-          | 'tax_id_invalid'
-          | 'tax_id_prohibited'
-          | 'taxes_calculation_failed'
-          | 'terminal_location_country_unsupported'
-          | 'terminal_reader_busy'
-          | 'terminal_reader_hardware_fault'
-          | 'terminal_reader_invalid_location_for_activation'
-          | 'terminal_reader_invalid_location_for_payment'
-          | 'terminal_reader_offline'
-          | 'terminal_reader_timeout'
-          | 'testmode_charges_only'
-          | 'tls_version_unsupported'
-          | 'token_already_used'
-          | 'token_card_network_invalid'
-          | 'token_in_use'
-          | 'transfer_source_balance_parameters_mismatch'
-          | 'transfers_not_allowed'
-          | 'url_invalid';
+    export namespace CollectInputs {
+      export interface Input {
+        /**
+         * Default text of input being collected.
+         */
+        custom_text: Input.CustomText | null;
 
-        export type Type =
-          | 'api_error'
-          | 'card_error'
-          | 'idempotency_error'
-          | 'invalid_request_error';
+        /**
+         * Information about a email being collected using a reader
+         */
+        email?: Input.Email;
+
+        /**
+         * Information about a number being collected using a reader
+         */
+        numeric?: Input.Numeric;
+
+        /**
+         * Information about a phone number being collected using a reader
+         */
+        phone?: Input.Phone;
+
+        /**
+         * Indicate that this input is required, disabling the skip button.
+         */
+        required: boolean | null;
+
+        /**
+         * Information about a selection being collected using a reader
+         */
+        selection?: Input.Selection;
+
+        /**
+         * Information about a signature being collected using a reader
+         */
+        signature?: Input.Signature;
+
+        /**
+         * Indicate that this input was skipped by the user.
+         */
+        skipped?: boolean;
+
+        /**
+         * Information about text being collected using a reader
+         */
+        text?: Input.Text;
+
+        /**
+         * List of toggles being collected. Values are present if collection is complete.
+         */
+        toggles: Array<Input.Toggle> | null;
+
+        /**
+         * Type of input being collected.
+         */
+        type: Input.Type;
       }
 
-      export namespace CollectInputs {
-        export interface Input {
+      export namespace Input {
+        export interface CustomText {
           /**
-           * Default text of input being collected.
+           * Customize the default description for this input
            */
-          custom_text: Input.CustomText | null;
+          description: string | null;
 
           /**
-           * Information about a email being collected using a reader
+           * Customize the default label for this input's skip button
            */
-          email?: Input.Email;
+          skip_button: string | null;
 
           /**
-           * Information about a number being collected using a reader
+           * Customize the default label for this input's submit button
            */
-          numeric?: Input.Numeric;
+          submit_button: string | null;
 
           /**
-           * Information about a phone number being collected using a reader
+           * Customize the default title for this input
            */
-          phone?: Input.Phone;
-
-          /**
-           * Indicate that this input is required, disabling the skip button.
-           */
-          required: boolean | null;
-
-          /**
-           * Information about a selection being collected using a reader
-           */
-          selection?: Input.Selection;
-
-          /**
-           * Information about a signature being collected using a reader
-           */
-          signature?: Input.Signature;
-
-          /**
-           * Indicate that this input was skipped by the user.
-           */
-          skipped?: boolean;
-
-          /**
-           * Information about text being collected using a reader
-           */
-          text?: Input.Text;
-
-          /**
-           * List of toggles being collected. Values are present if collection is complete.
-           */
-          toggles: Array<Input.Toggle> | null;
-
-          /**
-           * Type of input being collected.
-           */
-          type: Input.Type;
+          title: string | null;
         }
 
-        export namespace Input {
-          export interface CustomText {
-            /**
-             * Customize the default description for this input
-             */
-            description: string | null;
+        export interface Email {
+          /**
+           * The collected email address
+           */
+          value: string | null;
+        }
 
-            /**
-             * Customize the default label for this input's skip button
-             */
-            skip_button: string | null;
+        export interface Numeric {
+          /**
+           * The collected number
+           */
+          value: string | null;
+        }
 
-            /**
-             * Customize the default label for this input's submit button
-             */
-            submit_button: string | null;
+        export interface Phone {
+          /**
+           * The collected phone number
+           */
+          value: string | null;
+        }
 
-            /**
-             * Customize the default title for this input
-             */
-            title: string | null;
-          }
+        export interface Selection {
+          /**
+           * List of possible choices to be selected
+           */
+          choices: Array<Selection.Choice>;
 
-          export interface Email {
-            /**
-             * The collected email address
-             */
-            value: string | null;
-          }
+          /**
+           * The id of the selected choice
+           */
+          id: string | null;
 
-          export interface Numeric {
-            /**
-             * The collected number
-             */
-            value: string | null;
-          }
+          /**
+           * The text of the selected choice
+           */
+          text: string | null;
+        }
 
-          export interface Phone {
-            /**
-             * The collected phone number
-             */
-            value: string | null;
-          }
+        export interface Signature {
+          /**
+           * The File ID of a collected signature image
+           */
+          value: string | null;
+        }
 
-          export interface Selection {
-            /**
-             * List of possible choices to be selected
-             */
-            choices: Array<Selection.Choice>;
+        export interface Text {
+          /**
+           * The collected text value
+           */
+          value: string | null;
+        }
 
+        export interface Toggle {
+          /**
+           * The toggle's default value. Can be `enabled` or `disabled`.
+           */
+          default_value: Toggle.DefaultValue | null;
+
+          /**
+           * The toggle's description text. Maximum 50 characters.
+           */
+          description: string | null;
+
+          /**
+           * The toggle's title text. Maximum 50 characters.
+           */
+          title: string | null;
+
+          /**
+           * The toggle's collected value. Can be `enabled` or `disabled`.
+           */
+          value: Toggle.Value | null;
+        }
+
+        export type Type =
+          | 'email'
+          | 'numeric'
+          | 'phone'
+          | 'selection'
+          | 'signature'
+          | 'text';
+
+        export namespace Selection {
+          export interface Choice {
             /**
-             * The id of the selected choice
+             * The identifier for the selected choice. Maximum 50 characters.
              */
             id: string | null;
 
             /**
-             * The text of the selected choice
+             * The button style for the choice. Can be `primary` or `secondary`.
              */
-            text: string | null;
-          }
-
-          export interface Signature {
-            /**
-             * The File ID of a collected signature image
-             */
-            value: string | null;
-          }
-
-          export interface Text {
-            /**
-             * The collected text value
-             */
-            value: string | null;
-          }
-
-          export interface Toggle {
-            /**
-             * The toggle's default value. Can be `enabled` or `disabled`.
-             */
-            default_value: Toggle.DefaultValue | null;
+            style: Choice.Style | null;
 
             /**
-             * The toggle's description text. Maximum 50 characters.
+             * The text to be selected. Maximum 30 characters.
              */
-            description: string | null;
-
-            /**
-             * The toggle's title text. Maximum 50 characters.
-             */
-            title: string | null;
-
-            /**
-             * The toggle's collected value. Can be `enabled` or `disabled`.
-             */
-            value: Toggle.Value | null;
+            text: string;
           }
 
-          export type Type =
-            | 'email'
-            | 'numeric'
-            | 'phone'
-            | 'selection'
-            | 'signature'
-            | 'text';
-
-          export namespace Selection {
-            export interface Choice {
-              /**
-               * The identifier for the selected choice. Maximum 50 characters.
-               */
-              id: string | null;
-
-              /**
-               * The button style for the choice. Can be `primary` or `secondary`.
-               */
-              style: Choice.Style | null;
-
-              /**
-               * The text to be selected. Maximum 30 characters.
-               */
-              text: string;
-            }
-
-            export namespace Choice {
-              export type Style = 'primary' | 'secondary';
-            }
+          export namespace Choice {
+            export type Style = 'primary' | 'secondary';
           }
+        }
 
-          export namespace Toggle {
-            export type DefaultValue = 'disabled' | 'enabled';
+        export namespace Toggle {
+          export type DefaultValue = 'disabled' | 'enabled';
 
-            export type Value = 'disabled' | 'enabled';
-          }
+          export type Value = 'disabled' | 'enabled';
         }
       }
+    }
 
-      export namespace CollectPaymentMethod {
-        export interface CollectConfig {
-          /**
-           * Enable customer-initiated cancellation when processing this payment.
-           */
-          enable_customer_cancellation?: boolean;
+    export namespace CollectPaymentMethod {
+      export interface CollectConfig {
+        /**
+         * Enable customer-initiated cancellation when processing this payment.
+         */
+        enable_customer_cancellation?: boolean;
 
-          /**
-           * Override showing a tipping selection screen on this transaction.
-           */
-          skip_tipping?: boolean;
+        /**
+         * Override showing a tipping selection screen on this transaction.
+         */
+        skip_tipping?: boolean;
 
-          /**
-           * Represents a per-transaction tipping configuration
-           */
-          tipping?: CollectConfig.Tipping;
-        }
-
-        export namespace CollectConfig {
-          export interface Tipping {
-            /**
-             * Amount used to calculate tip suggestions on tipping selection screen for this transaction. Must be a positive integer in the smallest currency unit (e.g., 100 cents to represent $1.00 or 100 to represent ¥100, a zero-decimal currency).
-             */
-            amount_eligible?: number;
-          }
-        }
+        /**
+         * Represents a per-transaction tipping configuration
+         */
+        tipping?: CollectConfig.Tipping;
       }
 
-      export namespace ConfirmPaymentIntent {
-        export interface ConfirmConfig {
+      export namespace CollectConfig {
+        export interface Tipping {
           /**
-           * If the customer doesn't abandon authenticating the payment, they're redirected to this URL after completion.
+           * Amount used to calculate tip suggestions on tipping selection screen for this transaction. Must be a positive integer in the smallest currency unit (e.g., 100 cents to represent $1.00 or 100 to represent ¥100, a zero-decimal currency).
            */
-          return_url?: string;
+          amount_eligible?: number;
         }
       }
+    }
 
-      export namespace PrintContent {
-        export interface Image {
-          /**
-           * Creation time of the object (in seconds since the Unix epoch).
-           */
-          created_at: number;
+    export namespace ConfirmPaymentIntent {
+      export interface ConfirmConfig {
+        /**
+         * If the customer doesn't abandon authenticating the payment, they're redirected to this URL after completion.
+         */
+        return_url?: string;
+      }
+    }
 
-          /**
-           * The original name of the uploaded file (e.g. `receipt.png`).
-           */
-          filename: string;
+    export namespace PrintContent {
+      export interface Image {
+        /**
+         * Creation time of the object (in seconds since the Unix epoch).
+         */
+        created_at: number;
 
-          /**
-           * The size (in bytes) of the uploaded file.
-           */
-          size: number;
+        /**
+         * The original name of the uploaded file (e.g. `receipt.png`).
+         */
+        filename: string;
 
-          /**
-           * The format of the uploaded file.
-           */
-          type: string;
-        }
+        /**
+         * The size (in bytes) of the uploaded file.
+         */
+        size: number;
+
+        /**
+         * The format of the uploaded file.
+         */
+        type: string;
+      }
+    }
+
+    export namespace ProcessPaymentIntent {
+      export interface ProcessConfig {
+        /**
+         * Enable customer-initiated cancellation when processing this payment.
+         */
+        enable_customer_cancellation?: boolean;
+
+        /**
+         * If the customer doesn't abandon authenticating the payment, they're redirected to this URL after completion.
+         */
+        return_url?: string;
+
+        /**
+         * Override showing a tipping selection screen on this transaction.
+         */
+        skip_tipping?: boolean;
+
+        /**
+         * Represents a per-transaction tipping configuration
+         */
+        tipping?: ProcessConfig.Tipping;
       }
 
-      export namespace ProcessPaymentIntent {
-        export interface ProcessConfig {
+      export namespace ProcessConfig {
+        export interface Tipping {
           /**
-           * Enable customer-initiated cancellation when processing this payment.
+           * Amount used to calculate tip suggestions on tipping selection screen for this transaction. Must be a positive integer in the smallest currency unit (e.g., 100 cents to represent $1.00 or 100 to represent ¥100, a zero-decimal currency).
            */
-          enable_customer_cancellation?: boolean;
-
-          /**
-           * If the customer doesn't abandon authenticating the payment, they're redirected to this URL after completion.
-           */
-          return_url?: string;
-
-          /**
-           * Override showing a tipping selection screen on this transaction.
-           */
-          skip_tipping?: boolean;
-
-          /**
-           * Represents a per-transaction tipping configuration
-           */
-          tipping?: ProcessConfig.Tipping;
-        }
-
-        export namespace ProcessConfig {
-          export interface Tipping {
-            /**
-             * Amount used to calculate tip suggestions on tipping selection screen for this transaction. Must be a positive integer in the smallest currency unit (e.g., 100 cents to represent $1.00 or 100 to represent ¥100, a zero-decimal currency).
-             */
-            amount_eligible?: number;
-          }
+          amount_eligible?: number;
         }
       }
+    }
 
-      export namespace ProcessSetupIntent {
-        export interface ProcessConfig {
-          /**
-           * Enable customer-initiated cancellation when processing this SetupIntent.
-           */
-          enable_customer_cancellation?: boolean;
-        }
+    export namespace ProcessSetupIntent {
+      export interface ProcessConfig {
+        /**
+         * Enable customer-initiated cancellation when processing this SetupIntent.
+         */
+        enable_customer_cancellation?: boolean;
+      }
+    }
+
+    export namespace RefundPayment {
+      export type Reason = 'duplicate' | 'fraudulent' | 'requested_by_customer';
+
+      export interface RefundPaymentConfig {
+        /**
+         * Enable customer-initiated cancellation when refunding this payment.
+         */
+        enable_customer_cancellation?: boolean;
+      }
+    }
+
+    export namespace SetReaderDisplay {
+      export interface Cart {
+        /**
+         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         */
+        currency: string;
+
+        /**
+         * List of line items in the cart.
+         */
+        line_items: Array<Cart.LineItem>;
+
+        /**
+         * Tax amount for the entire cart. A positive integer in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+         */
+        tax: number | null;
+
+        /**
+         * Total amount for the entire cart, including tax. A positive integer in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+         */
+        total: number;
       }
 
-      export namespace RefundPayment {
-        export type Reason =
-          | 'duplicate'
-          | 'fraudulent'
-          | 'requested_by_customer';
-
-        export interface RefundPaymentConfig {
+      export namespace Cart {
+        export interface LineItem {
           /**
-           * Enable customer-initiated cancellation when refunding this payment.
+           * The amount of the line item. A positive integer in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
            */
-          enable_customer_cancellation?: boolean;
-        }
-      }
-
-      export namespace SetReaderDisplay {
-        export interface Cart {
-          /**
-           * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
-           */
-          currency: string;
+          amount: number;
 
           /**
-           * List of line items in the cart.
+           * Description of the line item.
            */
-          line_items: Array<Cart.LineItem>;
+          description: string;
 
           /**
-           * Tax amount for the entire cart. A positive integer in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
+           * The quantity of the line item.
            */
-          tax: number | null;
-
-          /**
-           * Total amount for the entire cart, including tax. A positive integer in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-           */
-          total: number;
-        }
-
-        export namespace Cart {
-          export interface LineItem {
-            /**
-             * The amount of the line item. A positive integer in the [smallest currency unit](https://docs.stripe.com/currencies#zero-decimal).
-             */
-            amount: number;
-
-            /**
-             * Description of the line item.
-             */
-            description: string;
-
-            /**
-             * The quantity of the line item.
-             */
-            quantity: number;
-          }
+          quantity: number;
         }
       }
     }

--- a/src/resources/Terminal/index.ts
+++ b/src/resources/Terminal/index.ts
@@ -4,6 +4,7 @@ import {Stripe} from '../../stripe.core.js';
 import {
   Terminal as TerminalNamespace0,
   Configuration,
+  DeletedConfiguration,
   ConfigurationResource,
 } from './Configurations.js';
 import {
@@ -14,6 +15,7 @@ import {
 import {
   Terminal as TerminalNamespace2,
   Location,
+  DeletedLocation,
   LocationResource,
 } from './Locations.js';
 import {
@@ -24,6 +26,7 @@ import {
 import {
   Terminal as TerminalNamespace4,
   Reader,
+  DeletedReader,
   ReaderResource,
 } from './Readers.js';
 
@@ -55,7 +58,7 @@ export declare namespace Terminal {
   export import ConfigurationUpdateParams = TerminalNamespace0.ConfigurationUpdateParams;
   export import ConfigurationListParams = TerminalNamespace0.ConfigurationListParams;
   export import ConfigurationCreateParams = TerminalNamespace0.ConfigurationCreateParams;
-  export import DeletedConfiguration = TerminalNamespace0.DeletedConfiguration;
+  export {DeletedConfiguration};
   export {Configuration, ConfigurationResource};
   export import ConnectionTokenCreateParams = TerminalNamespace1.ConnectionTokenCreateParams;
   export {ConnectionToken, ConnectionTokenResource};
@@ -64,7 +67,7 @@ export declare namespace Terminal {
   export import LocationUpdateParams = TerminalNamespace2.LocationUpdateParams;
   export import LocationListParams = TerminalNamespace2.LocationListParams;
   export import LocationCreateParams = TerminalNamespace2.LocationCreateParams;
-  export import DeletedLocation = TerminalNamespace2.DeletedLocation;
+  export {DeletedLocation};
   export {Location, LocationResource};
   export import OnboardingLinkCreateParams = TerminalNamespace3.OnboardingLinkCreateParams;
   export {OnboardingLink, OnboardingLinkResource};
@@ -81,6 +84,6 @@ export declare namespace Terminal {
   export import ReaderProcessSetupIntentParams = TerminalNamespace4.ReaderProcessSetupIntentParams;
   export import ReaderRefundPaymentParams = TerminalNamespace4.ReaderRefundPaymentParams;
   export import ReaderSetReaderDisplayParams = TerminalNamespace4.ReaderSetReaderDisplayParams;
-  export import DeletedReader = TerminalNamespace4.DeletedReader;
+  export {DeletedReader};
   export {Reader, ReaderResource};
 }

--- a/src/resources/TestHelpers/TestClocks.ts
+++ b/src/resources/TestHelpers/TestClocks.ts
@@ -12,7 +12,7 @@ export class TestClockResource extends StripeResource {
     id: string,
     params?: TestHelpers.TestClockDeleteParams,
     options?: RequestOptions
-  ): Promise<Response<TestHelpers.DeletedTestClock>> {
+  ): Promise<Response<DeletedTestClock>> {
     return this._makeRequest(
       'DELETE',
       `/v1/test_helpers/test_clocks/${encodeURIComponent(id)}`,
@@ -126,42 +126,39 @@ export interface TestClock {
   /**
    * The status of the Test Clock.
    */
-  status: TestHelpers.TestClock.Status;
+  status: TestClock.Status;
 
-  status_details: TestHelpers.TestClock.StatusDetails;
+  status_details: TestClock.StatusDetails;
 }
-export namespace TestHelpers {
-  export interface DeletedTestClock {
-    /**
-     * Unique identifier for the object.
-     */
-    id: string;
+export interface DeletedTestClock {
+  /**
+   * Unique identifier for the object.
+   */
+  id: string;
 
-    /**
-     * String representing the object's type. Objects of the same type share the same value.
-     */
-    object: 'test_helpers.test_clock';
+  /**
+   * String representing the object's type. Objects of the same type share the same value.
+   */
+  object: 'test_helpers.test_clock';
 
-    /**
-     * Always true for a deleted object
-     */
-    deleted: true;
+  /**
+   * Always true for a deleted object
+   */
+  deleted: true;
+}
+export namespace TestClock {
+  export type Status = 'advancing' | 'internal_failure' | 'ready';
+
+  export interface StatusDetails {
+    advancing?: StatusDetails.Advancing;
   }
 
-  export namespace TestClock {
-    export type Status = 'advancing' | 'internal_failure' | 'ready';
-
-    export interface StatusDetails {
-      advancing?: StatusDetails.Advancing;
-    }
-
-    export namespace StatusDetails {
-      export interface Advancing {
-        /**
-         * The `frozen_time` that the Test Clock is advancing towards.
-         */
-        target_frozen_time: number;
-      }
+  export namespace StatusDetails {
+    export interface Advancing {
+      /**
+       * The `frozen_time` that the Test Clock is advancing towards.
+       */
+      target_frozen_time: number;
     }
   }
 }

--- a/src/resources/TestHelpers/index.ts
+++ b/src/resources/TestHelpers/index.ts
@@ -16,6 +16,7 @@ import {
 import {
   TestHelpers as TestHelpersNamespace3,
   TestClock,
+  DeletedTestClock,
   TestClockResource,
 } from './TestClocks.js';
 import {Issuing} from './Issuing/index.js';
@@ -50,7 +51,7 @@ export declare namespace TestHelpers {
   export import TestClockListParams = TestHelpersNamespace3.TestClockListParams;
   export import TestClockCreateParams = TestHelpersNamespace3.TestClockCreateParams;
   export import TestClockAdvanceParams = TestHelpersNamespace3.TestClockAdvanceParams;
-  export import DeletedTestClock = TestHelpersNamespace3.DeletedTestClock;
+  export {DeletedTestClock};
   export {TestClock, TestClockResource};
   export {Issuing};
   export {Terminal};

--- a/src/resources/Treasury/CreditReversals.ts
+++ b/src/resources/Treasury/CreditReversals.ts
@@ -102,7 +102,7 @@ export interface CreditReversal {
   /**
    * The rails used to reverse the funds.
    */
-  network: Treasury.CreditReversal.Network;
+  network: CreditReversal.Network;
 
   /**
    * The ReceivedCredit being reversed.
@@ -112,27 +112,25 @@ export interface CreditReversal {
   /**
    * Status of the CreditReversal
    */
-  status: Treasury.CreditReversal.Status;
+  status: CreditReversal.Status;
 
-  status_transitions: Treasury.CreditReversal.StatusTransitions;
+  status_transitions: CreditReversal.StatusTransitions;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction | null;
 }
-export namespace Treasury {
-  export namespace CreditReversal {
-    export type Network = 'ach' | 'stripe';
+export namespace CreditReversal {
+  export type Network = 'ach' | 'stripe';
 
-    export type Status = 'canceled' | 'posted' | 'processing';
+  export type Status = 'canceled' | 'posted' | 'processing';
 
-    export interface StatusTransitions {
-      /**
-       * Timestamp describing when the CreditReversal changed status to `posted`
-       */
-      posted_at: number | null;
-    }
+  export interface StatusTransitions {
+    /**
+     * Timestamp describing when the CreditReversal changed status to `posted`
+     */
+    posted_at: number | null;
   }
 }
 export namespace Treasury {

--- a/src/resources/Treasury/DebitReversals.ts
+++ b/src/resources/Treasury/DebitReversals.ts
@@ -92,7 +92,7 @@ export interface DebitReversal {
   /**
    * Other flows linked to a DebitReversal.
    */
-  linked_flows: Treasury.DebitReversal.LinkedFlows | null;
+  linked_flows: DebitReversal.LinkedFlows | null;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -107,7 +107,7 @@ export interface DebitReversal {
   /**
    * The rails used to reverse the funds.
    */
-  network: Treasury.DebitReversal.Network;
+  network: DebitReversal.Network;
 
   /**
    * The ReceivedDebit being reversed.
@@ -117,34 +117,32 @@ export interface DebitReversal {
   /**
    * Status of the DebitReversal
    */
-  status: Treasury.DebitReversal.Status;
+  status: DebitReversal.Status;
 
-  status_transitions: Treasury.DebitReversal.StatusTransitions;
+  status_transitions: DebitReversal.StatusTransitions;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction | null;
 }
-export namespace Treasury {
-  export namespace DebitReversal {
-    export interface LinkedFlows {
-      /**
-       * Set if there is an Issuing dispute associated with the DebitReversal.
-       */
-      issuing_dispute: string | null;
-    }
+export namespace DebitReversal {
+  export interface LinkedFlows {
+    /**
+     * Set if there is an Issuing dispute associated with the DebitReversal.
+     */
+    issuing_dispute: string | null;
+  }
 
-    export type Network = 'ach' | 'card';
+  export type Network = 'ach' | 'card';
 
-    export type Status = 'failed' | 'processing' | 'succeeded';
+  export type Status = 'failed' | 'processing' | 'succeeded';
 
-    export interface StatusTransitions {
-      /**
-       * Timestamp describing when the DebitReversal changed status to `completed`.
-       */
-      completed_at: number | null;
-    }
+  export interface StatusTransitions {
+    /**
+     * Timestamp describing when the DebitReversal changed status to `completed`.
+     */
+    completed_at: number | null;
   }
 }
 export namespace Treasury {

--- a/src/resources/Treasury/FinancialAccountFeatures.ts
+++ b/src/resources/Treasury/FinancialAccountFeatures.ts
@@ -10,41 +10,212 @@ export interface FinancialAccountFeatures {
   /**
    * Toggle settings for enabling/disabling a feature
    */
-  card_issuing?: Treasury.FinancialAccountFeatures.CardIssuing;
+  card_issuing?: FinancialAccountFeatures.CardIssuing;
 
   /**
    * Toggle settings for enabling/disabling a feature
    */
-  deposit_insurance?: Treasury.FinancialAccountFeatures.DepositInsurance;
+  deposit_insurance?: FinancialAccountFeatures.DepositInsurance;
 
   /**
    * Settings related to Financial Addresses features on a Financial Account
    */
-  financial_addresses?: Treasury.FinancialAccountFeatures.FinancialAddresses;
+  financial_addresses?: FinancialAccountFeatures.FinancialAddresses;
 
   /**
    * InboundTransfers contains inbound transfers features for a FinancialAccount.
    */
-  inbound_transfers?: Treasury.FinancialAccountFeatures.InboundTransfers;
+  inbound_transfers?: FinancialAccountFeatures.InboundTransfers;
 
   /**
    * Toggle settings for enabling/disabling a feature
    */
-  intra_stripe_flows?: Treasury.FinancialAccountFeatures.IntraStripeFlows;
+  intra_stripe_flows?: FinancialAccountFeatures.IntraStripeFlows;
 
   /**
    * Settings related to Outbound Payments features on a Financial Account
    */
-  outbound_payments?: Treasury.FinancialAccountFeatures.OutboundPayments;
+  outbound_payments?: FinancialAccountFeatures.OutboundPayments;
 
   /**
    * OutboundTransfers contains outbound transfers features for a FinancialAccount.
    */
-  outbound_transfers?: Treasury.FinancialAccountFeatures.OutboundTransfers;
+  outbound_transfers?: FinancialAccountFeatures.OutboundTransfers;
 }
-export namespace Treasury {
-  export namespace FinancialAccountFeatures {
-    export interface CardIssuing {
+export namespace FinancialAccountFeatures {
+  export interface CardIssuing {
+    /**
+     * Whether the FinancialAccount should have the Feature.
+     */
+    requested: boolean;
+
+    /**
+     * Whether the Feature is operational.
+     */
+    status: CardIssuing.Status;
+
+    /**
+     * Additional details; includes at least one entry when the status is not `active`.
+     */
+    status_details: Array<CardIssuing.StatusDetail>;
+  }
+
+  export interface DepositInsurance {
+    /**
+     * Whether the FinancialAccount should have the Feature.
+     */
+    requested: boolean;
+
+    /**
+     * Whether the Feature is operational.
+     */
+    status: DepositInsurance.Status;
+
+    /**
+     * Additional details; includes at least one entry when the status is not `active`.
+     */
+    status_details: Array<DepositInsurance.StatusDetail>;
+  }
+
+  export interface FinancialAddresses {
+    /**
+     * Toggle settings for enabling/disabling the ABA address feature
+     */
+    aba?: FinancialAddresses.Aba;
+  }
+
+  export interface InboundTransfers {
+    /**
+     * Toggle settings for enabling/disabling an inbound ACH specific feature
+     */
+    ach?: InboundTransfers.Ach;
+  }
+
+  export interface IntraStripeFlows {
+    /**
+     * Whether the FinancialAccount should have the Feature.
+     */
+    requested: boolean;
+
+    /**
+     * Whether the Feature is operational.
+     */
+    status: IntraStripeFlows.Status;
+
+    /**
+     * Additional details; includes at least one entry when the status is not `active`.
+     */
+    status_details: Array<IntraStripeFlows.StatusDetail>;
+  }
+
+  export interface OutboundPayments {
+    /**
+     * Toggle settings for enabling/disabling an outbound ACH specific feature
+     */
+    ach?: OutboundPayments.Ach;
+
+    /**
+     * Toggle settings for enabling/disabling a feature
+     */
+    us_domestic_wire?: OutboundPayments.UsDomesticWire;
+  }
+
+  export interface OutboundTransfers {
+    /**
+     * Toggle settings for enabling/disabling an outbound ACH specific feature
+     */
+    ach?: OutboundTransfers.Ach;
+
+    /**
+     * Toggle settings for enabling/disabling a feature
+     */
+    us_domestic_wire?: OutboundTransfers.UsDomesticWire;
+  }
+
+  export namespace CardIssuing {
+    export type Status = 'active' | 'pending' | 'restricted';
+
+    export interface StatusDetail {
+      /**
+       * Represents the reason why the status is `pending` or `restricted`.
+       */
+      code: StatusDetail.Code;
+
+      /**
+       * Represents what the user should do, if anything, to activate the Feature.
+       */
+      resolution: StatusDetail.Resolution | null;
+
+      /**
+       * The `platform_restrictions` that are restricting this Feature.
+       */
+      restriction?: StatusDetail.Restriction;
+    }
+
+    export namespace StatusDetail {
+      export type Code =
+        | 'activating'
+        | 'capability_not_requested'
+        | 'financial_account_closed'
+        | 'rejected_other'
+        | 'rejected_unsupported_business'
+        | 'requirements_past_due'
+        | 'requirements_pending_verification'
+        | 'restricted_by_platform'
+        | 'restricted_other';
+
+      export type Resolution =
+        | 'contact_stripe'
+        | 'provide_information'
+        | 'remove_restriction';
+
+      export type Restriction = 'inbound_flows' | 'outbound_flows';
+    }
+  }
+
+  export namespace DepositInsurance {
+    export type Status = 'active' | 'pending' | 'restricted';
+
+    export interface StatusDetail {
+      /**
+       * Represents the reason why the status is `pending` or `restricted`.
+       */
+      code: StatusDetail.Code;
+
+      /**
+       * Represents what the user should do, if anything, to activate the Feature.
+       */
+      resolution: StatusDetail.Resolution | null;
+
+      /**
+       * The `platform_restrictions` that are restricting this Feature.
+       */
+      restriction?: StatusDetail.Restriction;
+    }
+
+    export namespace StatusDetail {
+      export type Code =
+        | 'activating'
+        | 'capability_not_requested'
+        | 'financial_account_closed'
+        | 'rejected_other'
+        | 'rejected_unsupported_business'
+        | 'requirements_past_due'
+        | 'requirements_pending_verification'
+        | 'restricted_by_platform'
+        | 'restricted_other';
+
+      export type Resolution =
+        | 'contact_stripe'
+        | 'provide_information'
+        | 'remove_restriction';
+
+      export type Restriction = 'inbound_flows' | 'outbound_flows';
+    }
+  }
+
+  export namespace FinancialAddresses {
+    export interface Aba {
       /**
        * Whether the FinancialAccount should have the Feature.
        */
@@ -53,15 +224,58 @@ export namespace Treasury {
       /**
        * Whether the Feature is operational.
        */
-      status: CardIssuing.Status;
+      status: Aba.Status;
 
       /**
        * Additional details; includes at least one entry when the status is not `active`.
        */
-      status_details: Array<CardIssuing.StatusDetail>;
+      status_details: Array<Aba.StatusDetail>;
     }
 
-    export interface DepositInsurance {
+    export namespace Aba {
+      export type Status = 'active' | 'pending' | 'restricted';
+
+      export interface StatusDetail {
+        /**
+         * Represents the reason why the status is `pending` or `restricted`.
+         */
+        code: StatusDetail.Code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         */
+        resolution: StatusDetail.Resolution | null;
+
+        /**
+         * The `platform_restrictions` that are restricting this Feature.
+         */
+        restriction?: StatusDetail.Restriction;
+      }
+
+      export namespace StatusDetail {
+        export type Code =
+          | 'activating'
+          | 'capability_not_requested'
+          | 'financial_account_closed'
+          | 'rejected_other'
+          | 'rejected_unsupported_business'
+          | 'requirements_past_due'
+          | 'requirements_pending_verification'
+          | 'restricted_by_platform'
+          | 'restricted_other';
+
+        export type Resolution =
+          | 'contact_stripe'
+          | 'provide_information'
+          | 'remove_restriction';
+
+        export type Restriction = 'inbound_flows' | 'outbound_flows';
+      }
+    }
+  }
+
+  export namespace InboundTransfers {
+    export interface Ach {
       /**
        * Whether the FinancialAccount should have the Feature.
        */
@@ -70,29 +284,99 @@ export namespace Treasury {
       /**
        * Whether the Feature is operational.
        */
-      status: DepositInsurance.Status;
+      status: Ach.Status;
 
       /**
        * Additional details; includes at least one entry when the status is not `active`.
        */
-      status_details: Array<DepositInsurance.StatusDetail>;
+      status_details: Array<Ach.StatusDetail>;
     }
 
-    export interface FinancialAddresses {
+    export namespace Ach {
+      export type Status = 'active' | 'pending' | 'restricted';
+
+      export interface StatusDetail {
+        /**
+         * Represents the reason why the status is `pending` or `restricted`.
+         */
+        code: StatusDetail.Code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         */
+        resolution: StatusDetail.Resolution | null;
+
+        /**
+         * The `platform_restrictions` that are restricting this Feature.
+         */
+        restriction?: StatusDetail.Restriction;
+      }
+
+      export namespace StatusDetail {
+        export type Code =
+          | 'activating'
+          | 'capability_not_requested'
+          | 'financial_account_closed'
+          | 'rejected_other'
+          | 'rejected_unsupported_business'
+          | 'requirements_past_due'
+          | 'requirements_pending_verification'
+          | 'restricted_by_platform'
+          | 'restricted_other';
+
+        export type Resolution =
+          | 'contact_stripe'
+          | 'provide_information'
+          | 'remove_restriction';
+
+        export type Restriction = 'inbound_flows' | 'outbound_flows';
+      }
+    }
+  }
+
+  export namespace IntraStripeFlows {
+    export type Status = 'active' | 'pending' | 'restricted';
+
+    export interface StatusDetail {
       /**
-       * Toggle settings for enabling/disabling the ABA address feature
+       * Represents the reason why the status is `pending` or `restricted`.
        */
-      aba?: FinancialAddresses.Aba;
-    }
+      code: StatusDetail.Code;
 
-    export interface InboundTransfers {
       /**
-       * Toggle settings for enabling/disabling an inbound ACH specific feature
+       * Represents what the user should do, if anything, to activate the Feature.
        */
-      ach?: InboundTransfers.Ach;
+      resolution: StatusDetail.Resolution | null;
+
+      /**
+       * The `platform_restrictions` that are restricting this Feature.
+       */
+      restriction?: StatusDetail.Restriction;
     }
 
-    export interface IntraStripeFlows {
+    export namespace StatusDetail {
+      export type Code =
+        | 'activating'
+        | 'capability_not_requested'
+        | 'financial_account_closed'
+        | 'rejected_other'
+        | 'rejected_unsupported_business'
+        | 'requirements_past_due'
+        | 'requirements_pending_verification'
+        | 'restricted_by_platform'
+        | 'restricted_other';
+
+      export type Resolution =
+        | 'contact_stripe'
+        | 'provide_information'
+        | 'remove_restriction';
+
+      export type Restriction = 'inbound_flows' | 'outbound_flows';
+    }
+  }
+
+  export namespace OutboundPayments {
+    export interface Ach {
       /**
        * Whether the FinancialAccount should have the Feature.
        */
@@ -101,39 +385,32 @@ export namespace Treasury {
       /**
        * Whether the Feature is operational.
        */
-      status: IntraStripeFlows.Status;
+      status: Ach.Status;
 
       /**
        * Additional details; includes at least one entry when the status is not `active`.
        */
-      status_details: Array<IntraStripeFlows.StatusDetail>;
+      status_details: Array<Ach.StatusDetail>;
     }
 
-    export interface OutboundPayments {
+    export interface UsDomesticWire {
       /**
-       * Toggle settings for enabling/disabling an outbound ACH specific feature
+       * Whether the FinancialAccount should have the Feature.
        */
-      ach?: OutboundPayments.Ach;
+      requested: boolean;
 
       /**
-       * Toggle settings for enabling/disabling a feature
+       * Whether the Feature is operational.
        */
-      us_domestic_wire?: OutboundPayments.UsDomesticWire;
+      status: UsDomesticWire.Status;
+
+      /**
+       * Additional details; includes at least one entry when the status is not `active`.
+       */
+      status_details: Array<UsDomesticWire.StatusDetail>;
     }
 
-    export interface OutboundTransfers {
-      /**
-       * Toggle settings for enabling/disabling an outbound ACH specific feature
-       */
-      ach?: OutboundTransfers.Ach;
-
-      /**
-       * Toggle settings for enabling/disabling a feature
-       */
-      us_domestic_wire?: OutboundTransfers.UsDomesticWire;
-    }
-
-    export namespace CardIssuing {
+    export namespace Ach {
       export type Status = 'active' | 'pending' | 'restricted';
 
       export interface StatusDetail {
@@ -174,7 +451,84 @@ export namespace Treasury {
       }
     }
 
-    export namespace DepositInsurance {
+    export namespace UsDomesticWire {
+      export type Status = 'active' | 'pending' | 'restricted';
+
+      export interface StatusDetail {
+        /**
+         * Represents the reason why the status is `pending` or `restricted`.
+         */
+        code: StatusDetail.Code;
+
+        /**
+         * Represents what the user should do, if anything, to activate the Feature.
+         */
+        resolution: StatusDetail.Resolution | null;
+
+        /**
+         * The `platform_restrictions` that are restricting this Feature.
+         */
+        restriction?: StatusDetail.Restriction;
+      }
+
+      export namespace StatusDetail {
+        export type Code =
+          | 'activating'
+          | 'capability_not_requested'
+          | 'financial_account_closed'
+          | 'rejected_other'
+          | 'rejected_unsupported_business'
+          | 'requirements_past_due'
+          | 'requirements_pending_verification'
+          | 'restricted_by_platform'
+          | 'restricted_other';
+
+        export type Resolution =
+          | 'contact_stripe'
+          | 'provide_information'
+          | 'remove_restriction';
+
+        export type Restriction = 'inbound_flows' | 'outbound_flows';
+      }
+    }
+  }
+
+  export namespace OutboundTransfers {
+    export interface Ach {
+      /**
+       * Whether the FinancialAccount should have the Feature.
+       */
+      requested: boolean;
+
+      /**
+       * Whether the Feature is operational.
+       */
+      status: Ach.Status;
+
+      /**
+       * Additional details; includes at least one entry when the status is not `active`.
+       */
+      status_details: Array<Ach.StatusDetail>;
+    }
+
+    export interface UsDomesticWire {
+      /**
+       * Whether the FinancialAccount should have the Feature.
+       */
+      requested: boolean;
+
+      /**
+       * Whether the Feature is operational.
+       */
+      status: UsDomesticWire.Status;
+
+      /**
+       * Additional details; includes at least one entry when the status is not `active`.
+       */
+      status_details: Array<UsDomesticWire.StatusDetail>;
+    }
+
+    export namespace Ach {
       export type Status = 'active' | 'pending' | 'restricted';
 
       export interface StatusDetail {
@@ -215,127 +569,7 @@ export namespace Treasury {
       }
     }
 
-    export namespace FinancialAddresses {
-      export interface Aba {
-        /**
-         * Whether the FinancialAccount should have the Feature.
-         */
-        requested: boolean;
-
-        /**
-         * Whether the Feature is operational.
-         */
-        status: Aba.Status;
-
-        /**
-         * Additional details; includes at least one entry when the status is not `active`.
-         */
-        status_details: Array<Aba.StatusDetail>;
-      }
-
-      export namespace Aba {
-        export type Status = 'active' | 'pending' | 'restricted';
-
-        export interface StatusDetail {
-          /**
-           * Represents the reason why the status is `pending` or `restricted`.
-           */
-          code: StatusDetail.Code;
-
-          /**
-           * Represents what the user should do, if anything, to activate the Feature.
-           */
-          resolution: StatusDetail.Resolution | null;
-
-          /**
-           * The `platform_restrictions` that are restricting this Feature.
-           */
-          restriction?: StatusDetail.Restriction;
-        }
-
-        export namespace StatusDetail {
-          export type Code =
-            | 'activating'
-            | 'capability_not_requested'
-            | 'financial_account_closed'
-            | 'rejected_other'
-            | 'rejected_unsupported_business'
-            | 'requirements_past_due'
-            | 'requirements_pending_verification'
-            | 'restricted_by_platform'
-            | 'restricted_other';
-
-          export type Resolution =
-            | 'contact_stripe'
-            | 'provide_information'
-            | 'remove_restriction';
-
-          export type Restriction = 'inbound_flows' | 'outbound_flows';
-        }
-      }
-    }
-
-    export namespace InboundTransfers {
-      export interface Ach {
-        /**
-         * Whether the FinancialAccount should have the Feature.
-         */
-        requested: boolean;
-
-        /**
-         * Whether the Feature is operational.
-         */
-        status: Ach.Status;
-
-        /**
-         * Additional details; includes at least one entry when the status is not `active`.
-         */
-        status_details: Array<Ach.StatusDetail>;
-      }
-
-      export namespace Ach {
-        export type Status = 'active' | 'pending' | 'restricted';
-
-        export interface StatusDetail {
-          /**
-           * Represents the reason why the status is `pending` or `restricted`.
-           */
-          code: StatusDetail.Code;
-
-          /**
-           * Represents what the user should do, if anything, to activate the Feature.
-           */
-          resolution: StatusDetail.Resolution | null;
-
-          /**
-           * The `platform_restrictions` that are restricting this Feature.
-           */
-          restriction?: StatusDetail.Restriction;
-        }
-
-        export namespace StatusDetail {
-          export type Code =
-            | 'activating'
-            | 'capability_not_requested'
-            | 'financial_account_closed'
-            | 'rejected_other'
-            | 'rejected_unsupported_business'
-            | 'requirements_past_due'
-            | 'requirements_pending_verification'
-            | 'restricted_by_platform'
-            | 'restricted_other';
-
-          export type Resolution =
-            | 'contact_stripe'
-            | 'provide_information'
-            | 'remove_restriction';
-
-          export type Restriction = 'inbound_flows' | 'outbound_flows';
-        }
-      }
-    }
-
-    export namespace IntraStripeFlows {
+    export namespace UsDomesticWire {
       export type Status = 'active' | 'pending' | 'restricted';
 
       export interface StatusDetail {
@@ -373,242 +607,6 @@ export namespace Treasury {
           | 'remove_restriction';
 
         export type Restriction = 'inbound_flows' | 'outbound_flows';
-      }
-    }
-
-    export namespace OutboundPayments {
-      export interface Ach {
-        /**
-         * Whether the FinancialAccount should have the Feature.
-         */
-        requested: boolean;
-
-        /**
-         * Whether the Feature is operational.
-         */
-        status: Ach.Status;
-
-        /**
-         * Additional details; includes at least one entry when the status is not `active`.
-         */
-        status_details: Array<Ach.StatusDetail>;
-      }
-
-      export interface UsDomesticWire {
-        /**
-         * Whether the FinancialAccount should have the Feature.
-         */
-        requested: boolean;
-
-        /**
-         * Whether the Feature is operational.
-         */
-        status: UsDomesticWire.Status;
-
-        /**
-         * Additional details; includes at least one entry when the status is not `active`.
-         */
-        status_details: Array<UsDomesticWire.StatusDetail>;
-      }
-
-      export namespace Ach {
-        export type Status = 'active' | 'pending' | 'restricted';
-
-        export interface StatusDetail {
-          /**
-           * Represents the reason why the status is `pending` or `restricted`.
-           */
-          code: StatusDetail.Code;
-
-          /**
-           * Represents what the user should do, if anything, to activate the Feature.
-           */
-          resolution: StatusDetail.Resolution | null;
-
-          /**
-           * The `platform_restrictions` that are restricting this Feature.
-           */
-          restriction?: StatusDetail.Restriction;
-        }
-
-        export namespace StatusDetail {
-          export type Code =
-            | 'activating'
-            | 'capability_not_requested'
-            | 'financial_account_closed'
-            | 'rejected_other'
-            | 'rejected_unsupported_business'
-            | 'requirements_past_due'
-            | 'requirements_pending_verification'
-            | 'restricted_by_platform'
-            | 'restricted_other';
-
-          export type Resolution =
-            | 'contact_stripe'
-            | 'provide_information'
-            | 'remove_restriction';
-
-          export type Restriction = 'inbound_flows' | 'outbound_flows';
-        }
-      }
-
-      export namespace UsDomesticWire {
-        export type Status = 'active' | 'pending' | 'restricted';
-
-        export interface StatusDetail {
-          /**
-           * Represents the reason why the status is `pending` or `restricted`.
-           */
-          code: StatusDetail.Code;
-
-          /**
-           * Represents what the user should do, if anything, to activate the Feature.
-           */
-          resolution: StatusDetail.Resolution | null;
-
-          /**
-           * The `platform_restrictions` that are restricting this Feature.
-           */
-          restriction?: StatusDetail.Restriction;
-        }
-
-        export namespace StatusDetail {
-          export type Code =
-            | 'activating'
-            | 'capability_not_requested'
-            | 'financial_account_closed'
-            | 'rejected_other'
-            | 'rejected_unsupported_business'
-            | 'requirements_past_due'
-            | 'requirements_pending_verification'
-            | 'restricted_by_platform'
-            | 'restricted_other';
-
-          export type Resolution =
-            | 'contact_stripe'
-            | 'provide_information'
-            | 'remove_restriction';
-
-          export type Restriction = 'inbound_flows' | 'outbound_flows';
-        }
-      }
-    }
-
-    export namespace OutboundTransfers {
-      export interface Ach {
-        /**
-         * Whether the FinancialAccount should have the Feature.
-         */
-        requested: boolean;
-
-        /**
-         * Whether the Feature is operational.
-         */
-        status: Ach.Status;
-
-        /**
-         * Additional details; includes at least one entry when the status is not `active`.
-         */
-        status_details: Array<Ach.StatusDetail>;
-      }
-
-      export interface UsDomesticWire {
-        /**
-         * Whether the FinancialAccount should have the Feature.
-         */
-        requested: boolean;
-
-        /**
-         * Whether the Feature is operational.
-         */
-        status: UsDomesticWire.Status;
-
-        /**
-         * Additional details; includes at least one entry when the status is not `active`.
-         */
-        status_details: Array<UsDomesticWire.StatusDetail>;
-      }
-
-      export namespace Ach {
-        export type Status = 'active' | 'pending' | 'restricted';
-
-        export interface StatusDetail {
-          /**
-           * Represents the reason why the status is `pending` or `restricted`.
-           */
-          code: StatusDetail.Code;
-
-          /**
-           * Represents what the user should do, if anything, to activate the Feature.
-           */
-          resolution: StatusDetail.Resolution | null;
-
-          /**
-           * The `platform_restrictions` that are restricting this Feature.
-           */
-          restriction?: StatusDetail.Restriction;
-        }
-
-        export namespace StatusDetail {
-          export type Code =
-            | 'activating'
-            | 'capability_not_requested'
-            | 'financial_account_closed'
-            | 'rejected_other'
-            | 'rejected_unsupported_business'
-            | 'requirements_past_due'
-            | 'requirements_pending_verification'
-            | 'restricted_by_platform'
-            | 'restricted_other';
-
-          export type Resolution =
-            | 'contact_stripe'
-            | 'provide_information'
-            | 'remove_restriction';
-
-          export type Restriction = 'inbound_flows' | 'outbound_flows';
-        }
-      }
-
-      export namespace UsDomesticWire {
-        export type Status = 'active' | 'pending' | 'restricted';
-
-        export interface StatusDetail {
-          /**
-           * Represents the reason why the status is `pending` or `restricted`.
-           */
-          code: StatusDetail.Code;
-
-          /**
-           * Represents what the user should do, if anything, to activate the Feature.
-           */
-          resolution: StatusDetail.Resolution | null;
-
-          /**
-           * The `platform_restrictions` that are restricting this Feature.
-           */
-          restriction?: StatusDetail.Restriction;
-        }
-
-        export namespace StatusDetail {
-          export type Code =
-            | 'activating'
-            | 'capability_not_requested'
-            | 'financial_account_closed'
-            | 'rejected_other'
-            | 'rejected_unsupported_business'
-            | 'requirements_past_due'
-            | 'requirements_pending_verification'
-            | 'restricted_by_platform'
-            | 'restricted_other';
-
-          export type Resolution =
-            | 'contact_stripe'
-            | 'provide_information'
-            | 'remove_restriction';
-
-          export type Restriction = 'inbound_flows' | 'outbound_flows';
-        }
       }
     }
   }

--- a/src/resources/Treasury/FinancialAccounts.ts
+++ b/src/resources/Treasury/FinancialAccounts.ts
@@ -133,12 +133,12 @@ export interface FinancialAccount {
   /**
    * The array of paths to active Features in the Features hash.
    */
-  active_features?: Array<Treasury.FinancialAccount.ActiveFeature>;
+  active_features?: Array<FinancialAccount.ActiveFeature>;
 
   /**
    * Balance information for the FinancialAccount
    */
-  balance: Treasury.FinancialAccount.Balance;
+  balance: FinancialAccount.Balance;
 
   /**
    * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
@@ -159,7 +159,7 @@ export interface FinancialAccount {
   /**
    * The set of credentials that resolve to a FinancialAccount.
    */
-  financial_addresses: Array<Treasury.FinancialAccount.FinancialAddress>;
+  financial_addresses: Array<FinancialAccount.FinancialAddress>;
 
   is_default?: boolean;
 
@@ -181,183 +181,178 @@ export interface FinancialAccount {
   /**
    * The array of paths to pending Features in the Features hash.
    */
-  pending_features?: Array<Treasury.FinancialAccount.PendingFeature>;
+  pending_features?: Array<FinancialAccount.PendingFeature>;
 
   /**
    * The set of functionalities that the platform can restrict on the FinancialAccount.
    */
-  platform_restrictions?: Treasury.FinancialAccount.PlatformRestrictions | null;
+  platform_restrictions?: FinancialAccount.PlatformRestrictions | null;
 
   /**
    * The array of paths to restricted Features in the Features hash.
    */
-  restricted_features?: Array<Treasury.FinancialAccount.RestrictedFeature>;
+  restricted_features?: Array<FinancialAccount.RestrictedFeature>;
 
   /**
    * Status of this FinancialAccount.
    */
-  status: Treasury.FinancialAccount.Status;
+  status: FinancialAccount.Status;
 
-  status_details: Treasury.FinancialAccount.StatusDetails;
+  status_details: FinancialAccount.StatusDetails;
 
   /**
    * The currencies the FinancialAccount can hold a balance in. Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase.
    */
   supported_currencies: Array<string>;
 }
-export namespace Treasury {
-  export namespace FinancialAccount {
-    export type ActiveFeature =
-      | 'card_issuing'
-      | 'deposit_insurance'
-      | 'financial_addresses.aba'
-      | 'financial_addresses.aba.forwarding'
-      | 'inbound_transfers.ach'
-      | 'intra_stripe_flows'
-      | 'outbound_payments.ach'
-      | 'outbound_payments.us_domestic_wire'
-      | 'outbound_transfers.ach'
-      | 'outbound_transfers.us_domestic_wire'
-      | 'remote_deposit_capture';
+export namespace FinancialAccount {
+  export type ActiveFeature =
+    | 'card_issuing'
+    | 'deposit_insurance'
+    | 'financial_addresses.aba'
+    | 'financial_addresses.aba.forwarding'
+    | 'inbound_transfers.ach'
+    | 'intra_stripe_flows'
+    | 'outbound_payments.ach'
+    | 'outbound_payments.us_domestic_wire'
+    | 'outbound_transfers.ach'
+    | 'outbound_transfers.us_domestic_wire'
+    | 'remote_deposit_capture';
 
-    export interface Balance {
+  export interface Balance {
+    /**
+     * Funds the user can spend right now.
+     */
+    cash: {
+      [key: string]: number;
+    };
+
+    /**
+     * Funds not spendable yet, but will become available at a later time.
+     */
+    inbound_pending: {
+      [key: string]: number;
+    };
+
+    /**
+     * Funds in the account, but not spendable because they are being held for pending outbound flows.
+     */
+    outbound_pending: {
+      [key: string]: number;
+    };
+  }
+
+  export interface FinancialAddress {
+    /**
+     * ABA Records contain U.S. bank account details per the ABA format.
+     */
+    aba?: FinancialAddress.Aba;
+
+    /**
+     * The list of networks that the address supports
+     */
+    supported_networks?: Array<FinancialAddress.SupportedNetwork>;
+
+    /**
+     * The type of financial address
+     */
+    type: 'aba';
+  }
+
+  export type PendingFeature =
+    | 'card_issuing'
+    | 'deposit_insurance'
+    | 'financial_addresses.aba'
+    | 'financial_addresses.aba.forwarding'
+    | 'inbound_transfers.ach'
+    | 'intra_stripe_flows'
+    | 'outbound_payments.ach'
+    | 'outbound_payments.us_domestic_wire'
+    | 'outbound_transfers.ach'
+    | 'outbound_transfers.us_domestic_wire'
+    | 'remote_deposit_capture';
+
+  export interface PlatformRestrictions {
+    /**
+     * Restricts all inbound money movement.
+     */
+    inbound_flows: PlatformRestrictions.InboundFlows | null;
+
+    /**
+     * Restricts all outbound money movement.
+     */
+    outbound_flows: PlatformRestrictions.OutboundFlows | null;
+  }
+
+  export type RestrictedFeature =
+    | 'card_issuing'
+    | 'deposit_insurance'
+    | 'financial_addresses.aba'
+    | 'financial_addresses.aba.forwarding'
+    | 'inbound_transfers.ach'
+    | 'intra_stripe_flows'
+    | 'outbound_payments.ach'
+    | 'outbound_payments.us_domestic_wire'
+    | 'outbound_transfers.ach'
+    | 'outbound_transfers.us_domestic_wire'
+    | 'remote_deposit_capture';
+
+  export type Status = 'closed' | 'open';
+
+  export interface StatusDetails {
+    /**
+     * Details related to the closure of this FinancialAccount
+     */
+    closed: StatusDetails.Closed | null;
+  }
+
+  export namespace FinancialAddress {
+    export interface Aba {
       /**
-       * Funds the user can spend right now.
+       * The name of the person or business that owns the bank account.
        */
-      cash: {
-        [key: string]: number;
-      };
+      account_holder_name: string;
 
       /**
-       * Funds not spendable yet, but will become available at a later time.
+       * The account number.
        */
-      inbound_pending: {
-        [key: string]: number;
-      };
+      account_number?: string | null;
 
       /**
-       * Funds in the account, but not spendable because they are being held for pending outbound flows.
+       * The last four characters of the account number.
        */
-      outbound_pending: {
-        [key: string]: number;
-      };
+      account_number_last4: string;
+
+      /**
+       * Name of the bank.
+       */
+      bank_name: string;
+
+      /**
+       * Routing number for the account.
+       */
+      routing_number: string;
     }
 
-    export interface FinancialAddress {
-      /**
-       * ABA Records contain U.S. bank account details per the ABA format.
-       */
-      aba?: FinancialAddress.Aba;
+    export type SupportedNetwork = 'ach' | 'us_domestic_wire';
+  }
 
-      /**
-       * The list of networks that the address supports
-       */
-      supported_networks?: Array<FinancialAddress.SupportedNetwork>;
+  export namespace PlatformRestrictions {
+    export type InboundFlows = 'restricted' | 'unrestricted';
 
+    export type OutboundFlows = 'restricted' | 'unrestricted';
+  }
+
+  export namespace StatusDetails {
+    export interface Closed {
       /**
-       * The type of financial address
+       * The array that contains reasons for a FinancialAccount closure.
        */
-      type: 'aba';
+      reasons: Array<Closed.Reason>;
     }
 
-    export type PendingFeature =
-      | 'card_issuing'
-      | 'deposit_insurance'
-      | 'financial_addresses.aba'
-      | 'financial_addresses.aba.forwarding'
-      | 'inbound_transfers.ach'
-      | 'intra_stripe_flows'
-      | 'outbound_payments.ach'
-      | 'outbound_payments.us_domestic_wire'
-      | 'outbound_transfers.ach'
-      | 'outbound_transfers.us_domestic_wire'
-      | 'remote_deposit_capture';
-
-    export interface PlatformRestrictions {
-      /**
-       * Restricts all inbound money movement.
-       */
-      inbound_flows: PlatformRestrictions.InboundFlows | null;
-
-      /**
-       * Restricts all outbound money movement.
-       */
-      outbound_flows: PlatformRestrictions.OutboundFlows | null;
-    }
-
-    export type RestrictedFeature =
-      | 'card_issuing'
-      | 'deposit_insurance'
-      | 'financial_addresses.aba'
-      | 'financial_addresses.aba.forwarding'
-      | 'inbound_transfers.ach'
-      | 'intra_stripe_flows'
-      | 'outbound_payments.ach'
-      | 'outbound_payments.us_domestic_wire'
-      | 'outbound_transfers.ach'
-      | 'outbound_transfers.us_domestic_wire'
-      | 'remote_deposit_capture';
-
-    export type Status = 'closed' | 'open';
-
-    export interface StatusDetails {
-      /**
-       * Details related to the closure of this FinancialAccount
-       */
-      closed: StatusDetails.Closed | null;
-    }
-
-    export namespace FinancialAddress {
-      export interface Aba {
-        /**
-         * The name of the person or business that owns the bank account.
-         */
-        account_holder_name: string;
-
-        /**
-         * The account number.
-         */
-        account_number?: string | null;
-
-        /**
-         * The last four characters of the account number.
-         */
-        account_number_last4: string;
-
-        /**
-         * Name of the bank.
-         */
-        bank_name: string;
-
-        /**
-         * Routing number for the account.
-         */
-        routing_number: string;
-      }
-
-      export type SupportedNetwork = 'ach' | 'us_domestic_wire';
-    }
-
-    export namespace PlatformRestrictions {
-      export type InboundFlows = 'restricted' | 'unrestricted';
-
-      export type OutboundFlows = 'restricted' | 'unrestricted';
-    }
-
-    export namespace StatusDetails {
-      export interface Closed {
-        /**
-         * The array that contains reasons for a FinancialAccount closure.
-         */
-        reasons: Array<Closed.Reason>;
-      }
-
-      export namespace Closed {
-        export type Reason =
-          | 'account_rejected'
-          | 'closed_by_platform'
-          | 'other';
-      }
+    export namespace Closed {
+      export type Reason = 'account_rejected' | 'closed_by_platform' | 'other';
     }
   }
 }

--- a/src/resources/Treasury/InboundTransfers.ts
+++ b/src/resources/Treasury/InboundTransfers.ts
@@ -113,7 +113,7 @@ export interface InboundTransfer {
   /**
    * Details about this InboundTransfer's failure. Only set when status is `failed`.
    */
-  failure_details: Treasury.InboundTransfer.FailureDetails | null;
+  failure_details: InboundTransfer.FailureDetails | null;
 
   /**
    * The FinancialAccount that received the funds.
@@ -125,7 +125,7 @@ export interface InboundTransfer {
    */
   hosted_regulatory_receipt_url: string | null;
 
-  linked_flows: Treasury.InboundTransfer.LinkedFlows;
+  linked_flows: InboundTransfer.LinkedFlows;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -145,7 +145,7 @@ export interface InboundTransfer {
   /**
    * Details about the PaymentMethod for an InboundTransfer.
    */
-  origin_payment_method_details: Treasury.InboundTransfer.OriginPaymentMethodDetails | null;
+  origin_payment_method_details: InboundTransfer.OriginPaymentMethodDetails | null;
 
   /**
    * Returns `true` if the funds for an InboundTransfer were returned after the InboundTransfer went to the `succeeded` state.
@@ -160,140 +160,138 @@ export interface InboundTransfer {
   /**
    * Status of the InboundTransfer: `processing`, `succeeded`, `failed`, and `canceled`. An InboundTransfer is `processing` if it is created and pending. The status changes to `succeeded` once the funds have been "confirmed" and a `transaction` is created and posted. The status changes to `failed` if the transfer fails.
    */
-  status: Treasury.InboundTransfer.Status;
+  status: InboundTransfer.Status;
 
-  status_transitions: Treasury.InboundTransfer.StatusTransitions;
+  status_transitions: InboundTransfer.StatusTransitions;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction | null;
 }
-export namespace Treasury {
-  export namespace InboundTransfer {
-    export interface FailureDetails {
+export namespace InboundTransfer {
+  export interface FailureDetails {
+    /**
+     * Reason for the failure.
+     */
+    code: FailureDetails.Code;
+  }
+
+  export interface LinkedFlows {
+    /**
+     * If funds for this flow were returned after the flow went to the `succeeded` state, this field contains a reference to the ReceivedDebit return.
+     */
+    received_debit: string | null;
+  }
+
+  export interface OriginPaymentMethodDetails {
+    billing_details: OriginPaymentMethodDetails.BillingDetails;
+
+    /**
+     * The type of the payment method used in the InboundTransfer.
+     */
+    type: 'us_bank_account';
+
+    us_bank_account?: OriginPaymentMethodDetails.UsBankAccount;
+  }
+
+  export type Status = 'canceled' | 'failed' | 'processing' | 'succeeded';
+
+  export interface StatusTransitions {
+    /**
+     * Timestamp describing when an InboundTransfer changed status to `canceled`.
+     */
+    canceled_at?: number | null;
+
+    /**
+     * Timestamp describing when an InboundTransfer changed status to `failed`.
+     */
+    failed_at: number | null;
+
+    /**
+     * Timestamp describing when an InboundTransfer changed status to `succeeded`.
+     */
+    succeeded_at: number | null;
+  }
+
+  export namespace FailureDetails {
+    export type Code =
+      | 'account_closed'
+      | 'account_frozen'
+      | 'bank_account_restricted'
+      | 'bank_ownership_changed'
+      | 'debit_not_authorized'
+      | 'incorrect_account_holder_address'
+      | 'incorrect_account_holder_name'
+      | 'incorrect_account_holder_tax_id'
+      | 'insufficient_funds'
+      | 'invalid_account_number'
+      | 'invalid_currency'
+      | 'no_account'
+      | 'other';
+  }
+
+  export namespace OriginPaymentMethodDetails {
+    export interface BillingDetails {
+      address: Address;
+
       /**
-       * Reason for the failure.
+       * Email address.
        */
-      code: FailureDetails.Code;
+      email: string | null;
+
+      /**
+       * Full name.
+       */
+      name: string | null;
     }
 
-    export interface LinkedFlows {
+    export interface UsBankAccount {
       /**
-       * If funds for this flow were returned after the flow went to the `succeeded` state, this field contains a reference to the ReceivedDebit return.
+       * Account holder type: individual or company.
        */
-      received_debit: string | null;
+      account_holder_type: UsBankAccount.AccountHolderType | null;
+
+      /**
+       * Account type: checkings or savings. Defaults to checking if omitted.
+       */
+      account_type: UsBankAccount.AccountType | null;
+
+      /**
+       * Name of the bank associated with the bank account.
+       */
+      bank_name: string | null;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+       */
+      fingerprint: string | null;
+
+      /**
+       * Last four digits of the bank account number.
+       */
+      last4: string | null;
+
+      /**
+       * ID of the mandate used to make this payment.
+       */
+      mandate?: string | Mandate;
+
+      /**
+       * The network rails used. See the [docs](https://docs.stripe.com/treasury/money-movement/timelines) to learn more about money movement timelines for each network type.
+       */
+      network: 'ach';
+
+      /**
+       * Routing number of the bank account.
+       */
+      routing_number: string | null;
     }
 
-    export interface OriginPaymentMethodDetails {
-      billing_details: OriginPaymentMethodDetails.BillingDetails;
+    export namespace UsBankAccount {
+      export type AccountHolderType = 'company' | 'individual';
 
-      /**
-       * The type of the payment method used in the InboundTransfer.
-       */
-      type: 'us_bank_account';
-
-      us_bank_account?: OriginPaymentMethodDetails.UsBankAccount;
-    }
-
-    export type Status = 'canceled' | 'failed' | 'processing' | 'succeeded';
-
-    export interface StatusTransitions {
-      /**
-       * Timestamp describing when an InboundTransfer changed status to `canceled`.
-       */
-      canceled_at?: number | null;
-
-      /**
-       * Timestamp describing when an InboundTransfer changed status to `failed`.
-       */
-      failed_at: number | null;
-
-      /**
-       * Timestamp describing when an InboundTransfer changed status to `succeeded`.
-       */
-      succeeded_at: number | null;
-    }
-
-    export namespace FailureDetails {
-      export type Code =
-        | 'account_closed'
-        | 'account_frozen'
-        | 'bank_account_restricted'
-        | 'bank_ownership_changed'
-        | 'debit_not_authorized'
-        | 'incorrect_account_holder_address'
-        | 'incorrect_account_holder_name'
-        | 'incorrect_account_holder_tax_id'
-        | 'insufficient_funds'
-        | 'invalid_account_number'
-        | 'invalid_currency'
-        | 'no_account'
-        | 'other';
-    }
-
-    export namespace OriginPaymentMethodDetails {
-      export interface BillingDetails {
-        address: Address;
-
-        /**
-         * Email address.
-         */
-        email: string | null;
-
-        /**
-         * Full name.
-         */
-        name: string | null;
-      }
-
-      export interface UsBankAccount {
-        /**
-         * Account holder type: individual or company.
-         */
-        account_holder_type: UsBankAccount.AccountHolderType | null;
-
-        /**
-         * Account type: checkings or savings. Defaults to checking if omitted.
-         */
-        account_type: UsBankAccount.AccountType | null;
-
-        /**
-         * Name of the bank associated with the bank account.
-         */
-        bank_name: string | null;
-
-        /**
-         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
-         */
-        fingerprint: string | null;
-
-        /**
-         * Last four digits of the bank account number.
-         */
-        last4: string | null;
-
-        /**
-         * ID of the mandate used to make this payment.
-         */
-        mandate?: string | Mandate;
-
-        /**
-         * The network rails used. See the [docs](https://docs.stripe.com/treasury/money-movement/timelines) to learn more about money movement timelines for each network type.
-         */
-        network: 'ach';
-
-        /**
-         * Routing number of the bank account.
-         */
-        routing_number: string | null;
-      }
-
-      export namespace UsBankAccount {
-        export type AccountHolderType = 'company' | 'individual';
-
-        export type AccountType = 'checking' | 'savings';
-      }
+      export type AccountType = 'checking' | 'savings';
     }
   }
 }

--- a/src/resources/Treasury/OutboundPayments.ts
+++ b/src/resources/Treasury/OutboundPayments.ts
@@ -126,12 +126,12 @@ export interface OutboundPayment {
   /**
    * Details about the PaymentMethod for an OutboundPayment.
    */
-  destination_payment_method_details: Treasury.OutboundPayment.DestinationPaymentMethodDetails | null;
+  destination_payment_method_details: OutboundPayment.DestinationPaymentMethodDetails | null;
 
   /**
    * Details about the end user.
    */
-  end_user_details: Treasury.OutboundPayment.EndUserDetails | null;
+  end_user_details: OutboundPayment.EndUserDetails | null;
 
   /**
    * The date when funds are expected to arrive in the destination account.
@@ -161,7 +161,7 @@ export interface OutboundPayment {
   /**
    * Details about a returned OutboundPayment. Only set when the status is `returned`.
    */
-  returned_details: Treasury.OutboundPayment.ReturnedDetails | null;
+  returned_details: OutboundPayment.ReturnedDetails | null;
 
   /**
    * The description that appears on the receiving end for an OutboundPayment (for example, bank statement for external bank transfer).
@@ -171,219 +171,217 @@ export interface OutboundPayment {
   /**
    * Current status of the OutboundPayment: `processing`, `failed`, `posted`, `returned`, `canceled`. An OutboundPayment is `processing` if it has been created and is pending. The status changes to `posted` once the OutboundPayment has been "confirmed" and funds have left the account, or to `failed` or `canceled`. If an OutboundPayment fails to arrive at its destination, its status will change to `returned`.
    */
-  status: Treasury.OutboundPayment.Status;
+  status: OutboundPayment.Status;
 
-  status_transitions: Treasury.OutboundPayment.StatusTransitions;
+  status_transitions: OutboundPayment.StatusTransitions;
 
   /**
    * Details about network-specific tracking information if available.
    */
-  tracking_details: Treasury.OutboundPayment.TrackingDetails | null;
+  tracking_details: OutboundPayment.TrackingDetails | null;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction;
 }
-export namespace Treasury {
-  export namespace OutboundPayment {
-    export interface DestinationPaymentMethodDetails {
-      billing_details: DestinationPaymentMethodDetails.BillingDetails;
+export namespace OutboundPayment {
+  export interface DestinationPaymentMethodDetails {
+    billing_details: DestinationPaymentMethodDetails.BillingDetails;
 
-      financial_account?: DestinationPaymentMethodDetails.FinancialAccount;
+    financial_account?: DestinationPaymentMethodDetails.FinancialAccount;
+
+    /**
+     * The type of the payment method used in the OutboundPayment.
+     */
+    type: DestinationPaymentMethodDetails.Type;
+
+    us_bank_account?: DestinationPaymentMethodDetails.UsBankAccount;
+  }
+
+  export interface EndUserDetails {
+    /**
+     * IP address of the user initiating the OutboundPayment. Set if `present` is set to `true`. IP address collection is required for risk and compliance reasons. This will be used to help determine if the OutboundPayment is authorized or should be blocked.
+     */
+    ip_address: string | null;
+
+    /**
+     * `true` if the OutboundPayment creation request is being made on behalf of an end user by a platform. Otherwise, `false`.
+     */
+    present: boolean;
+  }
+
+  export interface ReturnedDetails {
+    /**
+     * Reason for the return.
+     */
+    code: ReturnedDetails.Code;
+
+    /**
+     * The Transaction associated with this object.
+     */
+    transaction: string | Transaction;
+  }
+
+  export type Status =
+    | 'canceled'
+    | 'failed'
+    | 'posted'
+    | 'processing'
+    | 'returned';
+
+  export interface StatusTransitions {
+    /**
+     * Timestamp describing when an OutboundPayment changed status to `canceled`.
+     */
+    canceled_at: number | null;
+
+    /**
+     * Timestamp describing when an OutboundPayment changed status to `failed`.
+     */
+    failed_at: number | null;
+
+    /**
+     * Timestamp describing when an OutboundPayment changed status to `posted`.
+     */
+    posted_at: number | null;
+
+    /**
+     * Timestamp describing when an OutboundPayment changed status to `returned`.
+     */
+    returned_at: number | null;
+  }
+
+  export interface TrackingDetails {
+    ach?: TrackingDetails.Ach;
+
+    /**
+     * The US bank account network used to send funds.
+     */
+    type: TrackingDetails.Type;
+
+    us_domestic_wire?: TrackingDetails.UsDomesticWire;
+  }
+
+  export namespace DestinationPaymentMethodDetails {
+    export interface BillingDetails {
+      address: Address;
 
       /**
-       * The type of the payment method used in the OutboundPayment.
+       * Email address.
        */
-      type: DestinationPaymentMethodDetails.Type;
+      email: string | null;
 
-      us_bank_account?: DestinationPaymentMethodDetails.UsBankAccount;
+      /**
+       * Full name.
+       */
+      name: string | null;
     }
 
-    export interface EndUserDetails {
+    export interface FinancialAccount {
       /**
-       * IP address of the user initiating the OutboundPayment. Set if `present` is set to `true`. IP address collection is required for risk and compliance reasons. This will be used to help determine if the OutboundPayment is authorized or should be blocked.
+       * Token of the FinancialAccount.
        */
-      ip_address: string | null;
+      id: string;
 
       /**
-       * `true` if the OutboundPayment creation request is being made on behalf of an end user by a platform. Otherwise, `false`.
+       * The rails used to send funds.
        */
-      present: boolean;
+      network: 'stripe';
     }
 
-    export interface ReturnedDetails {
+    export type Type = 'financial_account' | 'us_bank_account';
+
+    export interface UsBankAccount {
       /**
-       * Reason for the return.
+       * Account holder type: individual or company.
        */
-      code: ReturnedDetails.Code;
+      account_holder_type: UsBankAccount.AccountHolderType | null;
 
       /**
-       * The Transaction associated with this object.
+       * Account type: checkings or savings. Defaults to checking if omitted.
        */
-      transaction: string | Transaction;
+      account_type: UsBankAccount.AccountType | null;
+
+      /**
+       * Name of the bank associated with the bank account.
+       */
+      bank_name: string | null;
+
+      /**
+       * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
+       */
+      fingerprint: string | null;
+
+      /**
+       * Last four digits of the bank account number.
+       */
+      last4: string | null;
+
+      /**
+       * ID of the mandate used to make this payment.
+       */
+      mandate?: string | Mandate;
+
+      /**
+       * The network rails used. See the [docs](https://docs.stripe.com/treasury/money-movement/timelines) to learn more about money movement timelines for each network type.
+       */
+      network: UsBankAccount.Network;
+
+      /**
+       * Routing number of the bank account.
+       */
+      routing_number: string | null;
     }
 
-    export type Status =
-      | 'canceled'
-      | 'failed'
-      | 'posted'
-      | 'processing'
-      | 'returned';
+    export namespace UsBankAccount {
+      export type AccountHolderType = 'company' | 'individual';
 
-    export interface StatusTransitions {
-      /**
-       * Timestamp describing when an OutboundPayment changed status to `canceled`.
-       */
-      canceled_at: number | null;
+      export type AccountType = 'checking' | 'savings';
 
-      /**
-       * Timestamp describing when an OutboundPayment changed status to `failed`.
-       */
-      failed_at: number | null;
+      export type Network = 'ach' | 'us_domestic_wire';
+    }
+  }
 
-      /**
-       * Timestamp describing when an OutboundPayment changed status to `posted`.
-       */
-      posted_at: number | null;
+  export namespace ReturnedDetails {
+    export type Code =
+      | 'account_closed'
+      | 'account_frozen'
+      | 'bank_account_restricted'
+      | 'bank_ownership_changed'
+      | 'declined'
+      | 'incorrect_account_holder_name'
+      | 'invalid_account_number'
+      | 'invalid_currency'
+      | 'no_account'
+      | 'other';
+  }
 
+  export namespace TrackingDetails {
+    export interface Ach {
       /**
-       * Timestamp describing when an OutboundPayment changed status to `returned`.
+       * ACH trace ID of the OutboundPayment for payments sent over the `ach` network.
        */
-      returned_at: number | null;
+      trace_id: string;
     }
 
-    export interface TrackingDetails {
-      ach?: TrackingDetails.Ach;
+    export type Type = 'ach' | 'us_domestic_wire';
+
+    export interface UsDomesticWire {
+      /**
+       * CHIPS System Sequence Number (SSN) of the OutboundPayment for payments sent over the `us_domestic_wire` network.
+       */
+      chips: string | null;
 
       /**
-       * The US bank account network used to send funds.
+       * IMAD of the OutboundPayment for payments sent over the `us_domestic_wire` network.
        */
-      type: TrackingDetails.Type;
+      imad: string | null;
 
-      us_domestic_wire?: TrackingDetails.UsDomesticWire;
-    }
-
-    export namespace DestinationPaymentMethodDetails {
-      export interface BillingDetails {
-        address: Address;
-
-        /**
-         * Email address.
-         */
-        email: string | null;
-
-        /**
-         * Full name.
-         */
-        name: string | null;
-      }
-
-      export interface FinancialAccount {
-        /**
-         * Token of the FinancialAccount.
-         */
-        id: string;
-
-        /**
-         * The rails used to send funds.
-         */
-        network: 'stripe';
-      }
-
-      export type Type = 'financial_account' | 'us_bank_account';
-
-      export interface UsBankAccount {
-        /**
-         * Account holder type: individual or company.
-         */
-        account_holder_type: UsBankAccount.AccountHolderType | null;
-
-        /**
-         * Account type: checkings or savings. Defaults to checking if omitted.
-         */
-        account_type: UsBankAccount.AccountType | null;
-
-        /**
-         * Name of the bank associated with the bank account.
-         */
-        bank_name: string | null;
-
-        /**
-         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
-         */
-        fingerprint: string | null;
-
-        /**
-         * Last four digits of the bank account number.
-         */
-        last4: string | null;
-
-        /**
-         * ID of the mandate used to make this payment.
-         */
-        mandate?: string | Mandate;
-
-        /**
-         * The network rails used. See the [docs](https://docs.stripe.com/treasury/money-movement/timelines) to learn more about money movement timelines for each network type.
-         */
-        network: UsBankAccount.Network;
-
-        /**
-         * Routing number of the bank account.
-         */
-        routing_number: string | null;
-      }
-
-      export namespace UsBankAccount {
-        export type AccountHolderType = 'company' | 'individual';
-
-        export type AccountType = 'checking' | 'savings';
-
-        export type Network = 'ach' | 'us_domestic_wire';
-      }
-    }
-
-    export namespace ReturnedDetails {
-      export type Code =
-        | 'account_closed'
-        | 'account_frozen'
-        | 'bank_account_restricted'
-        | 'bank_ownership_changed'
-        | 'declined'
-        | 'incorrect_account_holder_name'
-        | 'invalid_account_number'
-        | 'invalid_currency'
-        | 'no_account'
-        | 'other';
-    }
-
-    export namespace TrackingDetails {
-      export interface Ach {
-        /**
-         * ACH trace ID of the OutboundPayment for payments sent over the `ach` network.
-         */
-        trace_id: string;
-      }
-
-      export type Type = 'ach' | 'us_domestic_wire';
-
-      export interface UsDomesticWire {
-        /**
-         * CHIPS System Sequence Number (SSN) of the OutboundPayment for payments sent over the `us_domestic_wire` network.
-         */
-        chips: string | null;
-
-        /**
-         * IMAD of the OutboundPayment for payments sent over the `us_domestic_wire` network.
-         */
-        imad: string | null;
-
-        /**
-         * OMAD of the OutboundPayment for payments sent over the `us_domestic_wire` network.
-         */
-        omad: string | null;
-      }
+      /**
+       * OMAD of the OutboundPayment for payments sent over the `us_domestic_wire` network.
+       */
+      omad: string | null;
     }
   }
 }

--- a/src/resources/Treasury/OutboundTransfers.ts
+++ b/src/resources/Treasury/OutboundTransfers.ts
@@ -116,7 +116,7 @@ export interface OutboundTransfer {
    */
   destination_payment_method: string | null;
 
-  destination_payment_method_details: Treasury.OutboundTransfer.DestinationPaymentMethodDetails;
+  destination_payment_method_details: OutboundTransfer.DestinationPaymentMethodDetails;
 
   /**
    * The date when funds are expected to arrive in the destination account.
@@ -146,7 +146,7 @@ export interface OutboundTransfer {
   /**
    * Details about a returned OutboundTransfer. Only set when the status is `returned`.
    */
-  returned_details: Treasury.OutboundTransfer.ReturnedDetails | null;
+  returned_details: OutboundTransfer.ReturnedDetails | null;
 
   /**
    * Information about the OutboundTransfer to be sent to the recipient account.
@@ -156,207 +156,205 @@ export interface OutboundTransfer {
   /**
    * Current status of the OutboundTransfer: `processing`, `failed`, `canceled`, `posted`, `returned`. An OutboundTransfer is `processing` if it has been created and is pending. The status changes to `posted` once the OutboundTransfer has been "confirmed" and funds have left the account, or to `failed` or `canceled`. If an OutboundTransfer fails to arrive at its destination, its status will change to `returned`.
    */
-  status: Treasury.OutboundTransfer.Status;
+  status: OutboundTransfer.Status;
 
-  status_transitions: Treasury.OutboundTransfer.StatusTransitions;
+  status_transitions: OutboundTransfer.StatusTransitions;
 
   /**
    * Details about network-specific tracking information if available.
    */
-  tracking_details: Treasury.OutboundTransfer.TrackingDetails | null;
+  tracking_details: OutboundTransfer.TrackingDetails | null;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction;
 }
-export namespace Treasury {
-  export namespace OutboundTransfer {
-    export interface DestinationPaymentMethodDetails {
-      billing_details: DestinationPaymentMethodDetails.BillingDetails;
+export namespace OutboundTransfer {
+  export interface DestinationPaymentMethodDetails {
+    billing_details: DestinationPaymentMethodDetails.BillingDetails;
 
-      financial_account?: DestinationPaymentMethodDetails.FinancialAccount;
+    financial_account?: DestinationPaymentMethodDetails.FinancialAccount;
+
+    /**
+     * The type of the payment method used in the OutboundTransfer.
+     */
+    type: DestinationPaymentMethodDetails.Type;
+
+    us_bank_account?: DestinationPaymentMethodDetails.UsBankAccount;
+  }
+
+  export interface ReturnedDetails {
+    /**
+     * Reason for the return.
+     */
+    code: ReturnedDetails.Code;
+
+    /**
+     * The Transaction associated with this object.
+     */
+    transaction: string | Transaction;
+  }
+
+  export type Status =
+    | 'canceled'
+    | 'failed'
+    | 'posted'
+    | 'processing'
+    | 'returned';
+
+  export interface StatusTransitions {
+    /**
+     * Timestamp describing when an OutboundTransfer changed status to `canceled`
+     */
+    canceled_at: number | null;
+
+    /**
+     * Timestamp describing when an OutboundTransfer changed status to `failed`
+     */
+    failed_at: number | null;
+
+    /**
+     * Timestamp describing when an OutboundTransfer changed status to `posted`
+     */
+    posted_at: number | null;
+
+    /**
+     * Timestamp describing when an OutboundTransfer changed status to `returned`
+     */
+    returned_at: number | null;
+  }
+
+  export interface TrackingDetails {
+    ach?: TrackingDetails.Ach;
+
+    /**
+     * The US bank account network used to send funds.
+     */
+    type: TrackingDetails.Type;
+
+    us_domestic_wire?: TrackingDetails.UsDomesticWire;
+  }
+
+  export namespace DestinationPaymentMethodDetails {
+    export interface BillingDetails {
+      address: Address;
 
       /**
-       * The type of the payment method used in the OutboundTransfer.
+       * Email address.
        */
-      type: DestinationPaymentMethodDetails.Type;
+      email: string | null;
 
-      us_bank_account?: DestinationPaymentMethodDetails.UsBankAccount;
+      /**
+       * Full name.
+       */
+      name: string | null;
     }
 
-    export interface ReturnedDetails {
+    export interface FinancialAccount {
       /**
-       * Reason for the return.
+       * Token of the FinancialAccount.
        */
-      code: ReturnedDetails.Code;
+      id: string;
 
       /**
-       * The Transaction associated with this object.
+       * The rails used to send funds.
        */
-      transaction: string | Transaction;
+      network: 'stripe';
     }
 
-    export type Status =
-      | 'canceled'
-      | 'failed'
-      | 'posted'
-      | 'processing'
-      | 'returned';
+    export type Type = 'financial_account' | 'us_bank_account';
 
-    export interface StatusTransitions {
+    export interface UsBankAccount {
       /**
-       * Timestamp describing when an OutboundTransfer changed status to `canceled`
+       * Account holder type: individual or company.
        */
-      canceled_at: number | null;
+      account_holder_type: UsBankAccount.AccountHolderType | null;
 
       /**
-       * Timestamp describing when an OutboundTransfer changed status to `failed`
+       * Account type: checkings or savings. Defaults to checking if omitted.
        */
-      failed_at: number | null;
+      account_type: UsBankAccount.AccountType | null;
 
       /**
-       * Timestamp describing when an OutboundTransfer changed status to `posted`
+       * Name of the bank associated with the bank account.
        */
-      posted_at: number | null;
+      bank_name: string | null;
 
       /**
-       * Timestamp describing when an OutboundTransfer changed status to `returned`
+       * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
        */
-      returned_at: number | null;
+      fingerprint: string | null;
+
+      /**
+       * Last four digits of the bank account number.
+       */
+      last4: string | null;
+
+      /**
+       * ID of the mandate used to make this payment.
+       */
+      mandate?: string | Mandate;
+
+      /**
+       * The network rails used. See the [docs](https://docs.stripe.com/treasury/money-movement/timelines) to learn more about money movement timelines for each network type.
+       */
+      network: UsBankAccount.Network;
+
+      /**
+       * Routing number of the bank account.
+       */
+      routing_number: string | null;
     }
 
-    export interface TrackingDetails {
-      ach?: TrackingDetails.Ach;
+    export namespace UsBankAccount {
+      export type AccountHolderType = 'company' | 'individual';
+
+      export type AccountType = 'checking' | 'savings';
+
+      export type Network = 'ach' | 'us_domestic_wire';
+    }
+  }
+
+  export namespace ReturnedDetails {
+    export type Code =
+      | 'account_closed'
+      | 'account_frozen'
+      | 'bank_account_restricted'
+      | 'bank_ownership_changed'
+      | 'declined'
+      | 'incorrect_account_holder_name'
+      | 'invalid_account_number'
+      | 'invalid_currency'
+      | 'no_account'
+      | 'other';
+  }
+
+  export namespace TrackingDetails {
+    export interface Ach {
+      /**
+       * ACH trace ID of the OutboundTransfer for transfers sent over the `ach` network.
+       */
+      trace_id: string;
+    }
+
+    export type Type = 'ach' | 'us_domestic_wire';
+
+    export interface UsDomesticWire {
+      /**
+       * CHIPS System Sequence Number (SSN) of the OutboundTransfer for transfers sent over the `us_domestic_wire` network.
+       */
+      chips: string | null;
 
       /**
-       * The US bank account network used to send funds.
+       * IMAD of the OutboundTransfer for transfers sent over the `us_domestic_wire` network.
        */
-      type: TrackingDetails.Type;
+      imad: string | null;
 
-      us_domestic_wire?: TrackingDetails.UsDomesticWire;
-    }
-
-    export namespace DestinationPaymentMethodDetails {
-      export interface BillingDetails {
-        address: Address;
-
-        /**
-         * Email address.
-         */
-        email: string | null;
-
-        /**
-         * Full name.
-         */
-        name: string | null;
-      }
-
-      export interface FinancialAccount {
-        /**
-         * Token of the FinancialAccount.
-         */
-        id: string;
-
-        /**
-         * The rails used to send funds.
-         */
-        network: 'stripe';
-      }
-
-      export type Type = 'financial_account' | 'us_bank_account';
-
-      export interface UsBankAccount {
-        /**
-         * Account holder type: individual or company.
-         */
-        account_holder_type: UsBankAccount.AccountHolderType | null;
-
-        /**
-         * Account type: checkings or savings. Defaults to checking if omitted.
-         */
-        account_type: UsBankAccount.AccountType | null;
-
-        /**
-         * Name of the bank associated with the bank account.
-         */
-        bank_name: string | null;
-
-        /**
-         * Uniquely identifies this particular bank account. You can use this attribute to check whether two bank accounts are the same.
-         */
-        fingerprint: string | null;
-
-        /**
-         * Last four digits of the bank account number.
-         */
-        last4: string | null;
-
-        /**
-         * ID of the mandate used to make this payment.
-         */
-        mandate?: string | Mandate;
-
-        /**
-         * The network rails used. See the [docs](https://docs.stripe.com/treasury/money-movement/timelines) to learn more about money movement timelines for each network type.
-         */
-        network: UsBankAccount.Network;
-
-        /**
-         * Routing number of the bank account.
-         */
-        routing_number: string | null;
-      }
-
-      export namespace UsBankAccount {
-        export type AccountHolderType = 'company' | 'individual';
-
-        export type AccountType = 'checking' | 'savings';
-
-        export type Network = 'ach' | 'us_domestic_wire';
-      }
-    }
-
-    export namespace ReturnedDetails {
-      export type Code =
-        | 'account_closed'
-        | 'account_frozen'
-        | 'bank_account_restricted'
-        | 'bank_ownership_changed'
-        | 'declined'
-        | 'incorrect_account_holder_name'
-        | 'invalid_account_number'
-        | 'invalid_currency'
-        | 'no_account'
-        | 'other';
-    }
-
-    export namespace TrackingDetails {
-      export interface Ach {
-        /**
-         * ACH trace ID of the OutboundTransfer for transfers sent over the `ach` network.
-         */
-        trace_id: string;
-      }
-
-      export type Type = 'ach' | 'us_domestic_wire';
-
-      export interface UsDomesticWire {
-        /**
-         * CHIPS System Sequence Number (SSN) of the OutboundTransfer for transfers sent over the `us_domestic_wire` network.
-         */
-        chips: string | null;
-
-        /**
-         * IMAD of the OutboundTransfer for transfers sent over the `us_domestic_wire` network.
-         */
-        imad: string | null;
-
-        /**
-         * OMAD of the OutboundTransfer for transfers sent over the `us_domestic_wire` network.
-         */
-        omad: string | null;
-      }
+      /**
+       * OMAD of the OutboundTransfer for transfers sent over the `us_domestic_wire` network.
+       */
+      omad: string | null;
     }
   }
 }

--- a/src/resources/Treasury/ReceivedCredits.ts
+++ b/src/resources/Treasury/ReceivedCredits.ts
@@ -77,7 +77,7 @@ export interface ReceivedCredit {
   /**
    * Reason for the failure. A ReceivedCredit might fail because the receiving FinancialAccount is closed or frozen.
    */
-  failure_code: Treasury.ReceivedCredit.FailureCode | null;
+  failure_code: ReceivedCredit.FailureCode | null;
 
   /**
    * The FinancialAccount that received the funds.
@@ -89,9 +89,9 @@ export interface ReceivedCredit {
    */
   hosted_regulatory_receipt_url: string | null;
 
-  initiating_payment_method_details: Treasury.ReceivedCredit.InitiatingPaymentMethodDetails;
+  initiating_payment_method_details: ReceivedCredit.InitiatingPaymentMethodDetails;
 
-  linked_flows: Treasury.ReceivedCredit.LinkedFlows;
+  linked_flows: ReceivedCredit.LinkedFlows;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -101,215 +101,213 @@ export interface ReceivedCredit {
   /**
    * The rails used to send the funds.
    */
-  network: Treasury.ReceivedCredit.Network;
+  network: ReceivedCredit.Network;
 
   /**
    * Details describing when a ReceivedCredit may be reversed.
    */
-  reversal_details: Treasury.ReceivedCredit.ReversalDetails | null;
+  reversal_details: ReceivedCredit.ReversalDetails | null;
 
   /**
    * Status of the ReceivedCredit. ReceivedCredits are created either `succeeded` (approved) or `failed` (declined). If a ReceivedCredit is declined, the failure reason can be found in the `failure_code` field.
    */
-  status: Treasury.ReceivedCredit.Status;
+  status: ReceivedCredit.Status;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction | null;
 }
-export namespace Treasury {
-  export namespace ReceivedCredit {
-    export type FailureCode =
-      | 'account_closed'
-      | 'account_frozen'
-      | 'international_transaction'
-      | 'other';
+export namespace ReceivedCredit {
+  export type FailureCode =
+    | 'account_closed'
+    | 'account_frozen'
+    | 'international_transaction'
+    | 'other';
 
-    export interface InitiatingPaymentMethodDetails {
+  export interface InitiatingPaymentMethodDetails {
+    /**
+     * Set when `type` is `balance`.
+     */
+    balance?: 'payments';
+
+    billing_details: InitiatingPaymentMethodDetails.BillingDetails;
+
+    financial_account?: InitiatingPaymentMethodDetails.FinancialAccount;
+
+    /**
+     * Set when `type` is `issuing_card`. This is an [Issuing Card](https://api.stripe.com#issuing_cards) ID.
+     */
+    issuing_card?: string;
+
+    /**
+     * Polymorphic type matching the originating money movement's source. This can be an external account, a Stripe balance, or a FinancialAccount.
+     */
+    type: InitiatingPaymentMethodDetails.Type;
+
+    us_bank_account?: InitiatingPaymentMethodDetails.UsBankAccount;
+  }
+
+  export interface LinkedFlows {
+    /**
+     * The CreditReversal created as a result of this ReceivedCredit being reversed.
+     */
+    credit_reversal: string | null;
+
+    /**
+     * Set if the ReceivedCredit was created due to an [Issuing Authorization](https://api.stripe.com#issuing_authorizations) object.
+     */
+    issuing_authorization: string | null;
+
+    /**
+     * Set if the ReceivedCredit is also viewable as an [Issuing transaction](https://api.stripe.com#issuing_transactions) object.
+     */
+    issuing_transaction: string | null;
+
+    /**
+     * ID of the source flow. Set if `network` is `stripe` and the source flow is visible to the user. Examples of source flows include OutboundPayments, payouts, or CreditReversals.
+     */
+    source_flow: string | null;
+
+    /**
+     * The expandable object of the source flow.
+     */
+    source_flow_details?: LinkedFlows.SourceFlowDetails | null;
+
+    /**
+     * The type of flow that originated the ReceivedCredit (for example, `outbound_payment`).
+     */
+    source_flow_type: string | null;
+  }
+
+  export type Network = 'ach' | 'card' | 'stripe' | 'us_domestic_wire';
+
+  export interface ReversalDetails {
+    /**
+     * Time before which a ReceivedCredit can be reversed.
+     */
+    deadline: number | null;
+
+    /**
+     * Set if a ReceivedCredit cannot be reversed.
+     */
+    restricted_reason: ReversalDetails.RestrictedReason | null;
+  }
+
+  export type Status = 'failed' | 'succeeded';
+
+  export namespace InitiatingPaymentMethodDetails {
+    export interface BillingDetails {
+      address: Address;
+
       /**
-       * Set when `type` is `balance`.
+       * Email address.
        */
-      balance?: 'payments';
-
-      billing_details: InitiatingPaymentMethodDetails.BillingDetails;
-
-      financial_account?: InitiatingPaymentMethodDetails.FinancialAccount;
+      email: string | null;
 
       /**
-       * Set when `type` is `issuing_card`. This is an [Issuing Card](https://api.stripe.com#issuing_cards) ID.
+       * Full name.
        */
-      issuing_card?: string;
-
-      /**
-       * Polymorphic type matching the originating money movement's source. This can be an external account, a Stripe balance, or a FinancialAccount.
-       */
-      type: InitiatingPaymentMethodDetails.Type;
-
-      us_bank_account?: InitiatingPaymentMethodDetails.UsBankAccount;
+      name: string | null;
     }
 
-    export interface LinkedFlows {
+    export interface FinancialAccount {
       /**
-       * The CreditReversal created as a result of this ReceivedCredit being reversed.
+       * The FinancialAccount ID.
        */
-      credit_reversal: string | null;
+      id: string;
 
       /**
-       * Set if the ReceivedCredit was created due to an [Issuing Authorization](https://api.stripe.com#issuing_authorizations) object.
+       * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over `stripe`.
        */
-      issuing_authorization: string | null;
-
-      /**
-       * Set if the ReceivedCredit is also viewable as an [Issuing transaction](https://api.stripe.com#issuing_transactions) object.
-       */
-      issuing_transaction: string | null;
-
-      /**
-       * ID of the source flow. Set if `network` is `stripe` and the source flow is visible to the user. Examples of source flows include OutboundPayments, payouts, or CreditReversals.
-       */
-      source_flow: string | null;
-
-      /**
-       * The expandable object of the source flow.
-       */
-      source_flow_details?: LinkedFlows.SourceFlowDetails | null;
-
-      /**
-       * The type of flow that originated the ReceivedCredit (for example, `outbound_payment`).
-       */
-      source_flow_type: string | null;
+      network: 'stripe';
     }
 
-    export type Network = 'ach' | 'card' | 'stripe' | 'us_domestic_wire';
+    export type Type =
+      | 'balance'
+      | 'financial_account'
+      | 'issuing_card'
+      | 'stripe'
+      | 'us_bank_account';
 
-    export interface ReversalDetails {
+    export interface UsBankAccount {
       /**
-       * Time before which a ReceivedCredit can be reversed.
+       * Bank name.
        */
-      deadline: number | null;
+      bank_name: string | null;
 
       /**
-       * Set if a ReceivedCredit cannot be reversed.
+       * The last four digits of the bank account number.
        */
-      restricted_reason: ReversalDetails.RestrictedReason | null;
+      last4: string | null;
+
+      /**
+       * The routing number for the bank account.
+       */
+      routing_number: string | null;
+    }
+  }
+
+  export namespace LinkedFlows {
+    export interface SourceFlowDetails {
+      /**
+       * You can reverse some [ReceivedCredits](https://api.stripe.com#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
+       */
+      credit_reversal?: CreditReversal;
+
+      /**
+       * Use [OutboundPayments](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments) to send funds to another party's external bank account or [FinancialAccount](https://api.stripe.com#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://api.stripe.com#outbound_transfers).
+       *
+       * Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
+       *
+       * Related guide: [Moving money with Treasury using OutboundPayment objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments)
+       */
+      outbound_payment?: OutboundPayment;
+
+      /**
+       * Use [OutboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers) to transfer funds from a [FinancialAccount](https://api.stripe.com#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://api.stripe.com#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
+       *
+       * Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
+       *
+       * Related guide: [Moving money with Treasury using OutboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers)
+       */
+      outbound_transfer?: OutboundTransfer;
+
+      /**
+       * A `Payout` object is created when you receive funds from Stripe, or when you
+       * initiate a payout to either a bank account or debit card of a [connected
+       * Stripe account](https://docs.stripe.com/docs/connect/bank-debit-card-payouts). You can retrieve individual payouts,
+       * and list all payouts. Payouts are made on [varying
+       * schedules](https://docs.stripe.com/docs/connect/manage-payout-schedule), depending on your country and
+       * industry.
+       *
+       * Related guide: [Receiving payouts](https://docs.stripe.com/payouts)
+       */
+      payout?: Payout;
+
+      /**
+       * The type of the source flow that originated the ReceivedCredit.
+       */
+      type: SourceFlowDetails.Type;
     }
 
-    export type Status = 'failed' | 'succeeded';
-
-    export namespace InitiatingPaymentMethodDetails {
-      export interface BillingDetails {
-        address: Address;
-
-        /**
-         * Email address.
-         */
-        email: string | null;
-
-        /**
-         * Full name.
-         */
-        name: string | null;
-      }
-
-      export interface FinancialAccount {
-        /**
-         * The FinancialAccount ID.
-         */
-        id: string;
-
-        /**
-         * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over `stripe`.
-         */
-        network: 'stripe';
-      }
-
+    export namespace SourceFlowDetails {
       export type Type =
-        | 'balance'
-        | 'financial_account'
-        | 'issuing_card'
-        | 'stripe'
-        | 'us_bank_account';
-
-      export interface UsBankAccount {
-        /**
-         * Bank name.
-         */
-        bank_name: string | null;
-
-        /**
-         * The last four digits of the bank account number.
-         */
-        last4: string | null;
-
-        /**
-         * The routing number for the bank account.
-         */
-        routing_number: string | null;
-      }
-    }
-
-    export namespace LinkedFlows {
-      export interface SourceFlowDetails {
-        /**
-         * You can reverse some [ReceivedCredits](https://api.stripe.com#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
-         */
-        credit_reversal?: CreditReversal;
-
-        /**
-         * Use [OutboundPayments](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments) to send funds to another party's external bank account or [FinancialAccount](https://api.stripe.com#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://api.stripe.com#outbound_transfers).
-         *
-         * Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
-         *
-         * Related guide: [Moving money with Treasury using OutboundPayment objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments)
-         */
-        outbound_payment?: OutboundPayment;
-
-        /**
-         * Use [OutboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers) to transfer funds from a [FinancialAccount](https://api.stripe.com#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://api.stripe.com#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
-         *
-         * Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
-         *
-         * Related guide: [Moving money with Treasury using OutboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers)
-         */
-        outbound_transfer?: OutboundTransfer;
-
-        /**
-         * A `Payout` object is created when you receive funds from Stripe, or when you
-         * initiate a payout to either a bank account or debit card of a [connected
-         * Stripe account](https://docs.stripe.com/docs/connect/bank-debit-card-payouts). You can retrieve individual payouts,
-         * and list all payouts. Payouts are made on [varying
-         * schedules](https://docs.stripe.com/docs/connect/manage-payout-schedule), depending on your country and
-         * industry.
-         *
-         * Related guide: [Receiving payouts](https://docs.stripe.com/payouts)
-         */
-        payout?: Payout;
-
-        /**
-         * The type of the source flow that originated the ReceivedCredit.
-         */
-        type: SourceFlowDetails.Type;
-      }
-
-      export namespace SourceFlowDetails {
-        export type Type =
-          | 'credit_reversal'
-          | 'other'
-          | 'outbound_payment'
-          | 'outbound_transfer'
-          | 'payout';
-      }
-    }
-
-    export namespace ReversalDetails {
-      export type RestrictedReason =
-        | 'already_reversed'
-        | 'deadline_passed'
-        | 'network_restricted'
+        | 'credit_reversal'
         | 'other'
-        | 'source_flow_restricted';
+        | 'outbound_payment'
+        | 'outbound_transfer'
+        | 'payout';
     }
+  }
+
+  export namespace ReversalDetails {
+    export type RestrictedReason =
+      | 'already_reversed'
+      | 'deadline_passed'
+      | 'network_restricted'
+      | 'other'
+      | 'source_flow_restricted';
   }
 }
 export namespace Treasury {

--- a/src/resources/Treasury/ReceivedDebits.ts
+++ b/src/resources/Treasury/ReceivedDebits.ts
@@ -73,7 +73,7 @@ export interface ReceivedDebit {
   /**
    * Reason for the failure. A ReceivedDebit might fail because the FinancialAccount doesn't have sufficient funds, is closed, or is frozen.
    */
-  failure_code: Treasury.ReceivedDebit.FailureCode | null;
+  failure_code: ReceivedDebit.FailureCode | null;
 
   /**
    * The FinancialAccount that funds were pulled from.
@@ -85,9 +85,9 @@ export interface ReceivedDebit {
    */
   hosted_regulatory_receipt_url: string | null;
 
-  initiating_payment_method_details?: Treasury.ReceivedDebit.InitiatingPaymentMethodDetails;
+  initiating_payment_method_details?: ReceivedDebit.InitiatingPaymentMethodDetails;
 
-  linked_flows: Treasury.ReceivedDebit.LinkedFlows;
+  linked_flows: ReceivedDebit.LinkedFlows;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -97,163 +97,161 @@ export interface ReceivedDebit {
   /**
    * The network used for the ReceivedDebit.
    */
-  network: Treasury.ReceivedDebit.Network;
+  network: ReceivedDebit.Network;
 
   /**
    * Details describing when a ReceivedDebit might be reversed.
    */
-  reversal_details: Treasury.ReceivedDebit.ReversalDetails | null;
+  reversal_details: ReceivedDebit.ReversalDetails | null;
 
   /**
    * Status of the ReceivedDebit. ReceivedDebits are created with a status of either `succeeded` (approved) or `failed` (declined). The failure reason can be found under the `failure_code`.
    */
-  status: Treasury.ReceivedDebit.Status;
+  status: ReceivedDebit.Status;
 
   /**
    * The Transaction associated with this object.
    */
   transaction: string | Transaction | null;
 }
-export namespace Treasury {
-  export namespace ReceivedDebit {
-    export type FailureCode =
-      | 'account_closed'
-      | 'account_frozen'
-      | 'insufficient_funds'
-      | 'international_transaction'
-      | 'other';
+export namespace ReceivedDebit {
+  export type FailureCode =
+    | 'account_closed'
+    | 'account_frozen'
+    | 'insufficient_funds'
+    | 'international_transaction'
+    | 'other';
 
-    export interface InitiatingPaymentMethodDetails {
+  export interface InitiatingPaymentMethodDetails {
+    /**
+     * Set when `type` is `balance`.
+     */
+    balance?: 'payments';
+
+    billing_details: InitiatingPaymentMethodDetails.BillingDetails;
+
+    financial_account?: InitiatingPaymentMethodDetails.FinancialAccount;
+
+    /**
+     * Set when `type` is `issuing_card`. This is an [Issuing Card](https://api.stripe.com#issuing_cards) ID.
+     */
+    issuing_card?: string;
+
+    /**
+     * Polymorphic type matching the originating money movement's source. This can be an external account, a Stripe balance, or a FinancialAccount.
+     */
+    type: InitiatingPaymentMethodDetails.Type;
+
+    us_bank_account?: InitiatingPaymentMethodDetails.UsBankAccount;
+  }
+
+  export interface LinkedFlows {
+    /**
+     * The DebitReversal created as a result of this ReceivedDebit being reversed.
+     */
+    debit_reversal: string | null;
+
+    /**
+     * Set if the ReceivedDebit is associated with an InboundTransfer's return of funds.
+     */
+    inbound_transfer: string | null;
+
+    /**
+     * Set if the ReceivedDebit was created due to an [Issuing Authorization](https://api.stripe.com#issuing_authorizations) object.
+     */
+    issuing_authorization: string | null;
+
+    /**
+     * Set if the ReceivedDebit is also viewable as an [Issuing Dispute](https://api.stripe.com#issuing_disputes) object.
+     */
+    issuing_transaction: string | null;
+
+    /**
+     * Set if the ReceivedDebit was created due to a [Payout](https://api.stripe.com#payouts) object.
+     */
+    payout: string | null;
+
+    /**
+     * Set if the ReceivedDebit was created due to a [Topup](https://api.stripe.com#topups) object.
+     */
+    topup: string | null;
+  }
+
+  export type Network = 'ach' | 'card' | 'stripe';
+
+  export interface ReversalDetails {
+    /**
+     * Time before which a ReceivedDebit can be reversed.
+     */
+    deadline: number | null;
+
+    /**
+     * Set if a ReceivedDebit can't be reversed.
+     */
+    restricted_reason: ReversalDetails.RestrictedReason | null;
+  }
+
+  export type Status = 'failed' | 'succeeded';
+
+  export namespace InitiatingPaymentMethodDetails {
+    export interface BillingDetails {
+      address: Address;
+
       /**
-       * Set when `type` is `balance`.
+       * Email address.
        */
-      balance?: 'payments';
-
-      billing_details: InitiatingPaymentMethodDetails.BillingDetails;
-
-      financial_account?: InitiatingPaymentMethodDetails.FinancialAccount;
+      email: string | null;
 
       /**
-       * Set when `type` is `issuing_card`. This is an [Issuing Card](https://api.stripe.com#issuing_cards) ID.
+       * Full name.
        */
-      issuing_card?: string;
-
-      /**
-       * Polymorphic type matching the originating money movement's source. This can be an external account, a Stripe balance, or a FinancialAccount.
-       */
-      type: InitiatingPaymentMethodDetails.Type;
-
-      us_bank_account?: InitiatingPaymentMethodDetails.UsBankAccount;
+      name: string | null;
     }
 
-    export interface LinkedFlows {
+    export interface FinancialAccount {
       /**
-       * The DebitReversal created as a result of this ReceivedDebit being reversed.
+       * The FinancialAccount ID.
        */
-      debit_reversal: string | null;
+      id: string;
 
       /**
-       * Set if the ReceivedDebit is associated with an InboundTransfer's return of funds.
+       * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over `stripe`.
        */
-      inbound_transfer: string | null;
-
-      /**
-       * Set if the ReceivedDebit was created due to an [Issuing Authorization](https://api.stripe.com#issuing_authorizations) object.
-       */
-      issuing_authorization: string | null;
-
-      /**
-       * Set if the ReceivedDebit is also viewable as an [Issuing Dispute](https://api.stripe.com#issuing_disputes) object.
-       */
-      issuing_transaction: string | null;
-
-      /**
-       * Set if the ReceivedDebit was created due to a [Payout](https://api.stripe.com#payouts) object.
-       */
-      payout: string | null;
-
-      /**
-       * Set if the ReceivedDebit was created due to a [Topup](https://api.stripe.com#topups) object.
-       */
-      topup: string | null;
+      network: 'stripe';
     }
 
-    export type Network = 'ach' | 'card' | 'stripe';
+    export type Type =
+      | 'balance'
+      | 'financial_account'
+      | 'issuing_card'
+      | 'stripe'
+      | 'us_bank_account';
 
-    export interface ReversalDetails {
+    export interface UsBankAccount {
       /**
-       * Time before which a ReceivedDebit can be reversed.
+       * Bank name.
        */
-      deadline: number | null;
+      bank_name: string | null;
 
       /**
-       * Set if a ReceivedDebit can't be reversed.
+       * The last four digits of the bank account number.
        */
-      restricted_reason: ReversalDetails.RestrictedReason | null;
+      last4: string | null;
+
+      /**
+       * The routing number for the bank account.
+       */
+      routing_number: string | null;
     }
+  }
 
-    export type Status = 'failed' | 'succeeded';
-
-    export namespace InitiatingPaymentMethodDetails {
-      export interface BillingDetails {
-        address: Address;
-
-        /**
-         * Email address.
-         */
-        email: string | null;
-
-        /**
-         * Full name.
-         */
-        name: string | null;
-      }
-
-      export interface FinancialAccount {
-        /**
-         * The FinancialAccount ID.
-         */
-        id: string;
-
-        /**
-         * The rails the ReceivedCredit was sent over. A FinancialAccount can only send funds over `stripe`.
-         */
-        network: 'stripe';
-      }
-
-      export type Type =
-        | 'balance'
-        | 'financial_account'
-        | 'issuing_card'
-        | 'stripe'
-        | 'us_bank_account';
-
-      export interface UsBankAccount {
-        /**
-         * Bank name.
-         */
-        bank_name: string | null;
-
-        /**
-         * The last four digits of the bank account number.
-         */
-        last4: string | null;
-
-        /**
-         * The routing number for the bank account.
-         */
-        routing_number: string | null;
-      }
-    }
-
-    export namespace ReversalDetails {
-      export type RestrictedReason =
-        | 'already_reversed'
-        | 'deadline_passed'
-        | 'network_restricted'
-        | 'other'
-        | 'source_flow_restricted';
-    }
+  export namespace ReversalDetails {
+    export type RestrictedReason =
+      | 'already_reversed'
+      | 'deadline_passed'
+      | 'network_restricted'
+      | 'other'
+      | 'source_flow_restricted';
   }
 }
 export namespace Treasury {

--- a/src/resources/Treasury/TransactionEntries.ts
+++ b/src/resources/Treasury/TransactionEntries.ts
@@ -445,7 +445,7 @@ export interface TransactionEntry {
   /**
    * Change to a FinancialAccount's balance
    */
-  balance_impact: Treasury.TransactionEntry.BalanceImpact;
+  balance_impact: TransactionEntry.BalanceImpact;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -475,12 +475,12 @@ export interface TransactionEntry {
   /**
    * Details of the flow associated with the TransactionEntry.
    */
-  flow_details?: Treasury.TransactionEntry.FlowDetails | null;
+  flow_details?: TransactionEntry.FlowDetails | null;
 
   /**
    * Type of the flow associated with the TransactionEntry.
    */
-  flow_type: Treasury.TransactionEntry.FlowType;
+  flow_type: TransactionEntry.FlowType;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -495,89 +495,122 @@ export interface TransactionEntry {
   /**
    * The specific money movement that generated the TransactionEntry.
    */
-  type: Treasury.TransactionEntry.Type;
+  type: TransactionEntry.Type;
 }
-export namespace Treasury {
-  export namespace TransactionEntry {
-    export interface BalanceImpact {
-      /**
-       * The change made to funds the user can spend right now.
-       */
-      cash: number;
+export namespace TransactionEntry {
+  export interface BalanceImpact {
+    /**
+     * The change made to funds the user can spend right now.
+     */
+    cash: number;
 
-      /**
-       * The change made to funds that are not spendable yet, but will become available at a later time.
-       */
-      inbound_pending: number;
+    /**
+     * The change made to funds that are not spendable yet, but will become available at a later time.
+     */
+    inbound_pending: number;
 
-      /**
-       * The change made to funds in the account, but not spendable because they are being held for pending outbound flows.
-       */
-      outbound_pending: number;
-    }
+    /**
+     * The change made to funds in the account, but not spendable because they are being held for pending outbound flows.
+     */
+    outbound_pending: number;
+  }
 
-    export interface FlowDetails {
-      /**
-       * You can reverse some [ReceivedCredits](https://api.stripe.com#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
-       */
-      credit_reversal?: CreditReversal;
+  export interface FlowDetails {
+    /**
+     * You can reverse some [ReceivedCredits](https://api.stripe.com#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
+     */
+    credit_reversal?: CreditReversal;
 
-      /**
-       * You can reverse some [ReceivedDebits](https://api.stripe.com#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
-       */
-      debit_reversal?: DebitReversal;
+    /**
+     * You can reverse some [ReceivedDebits](https://api.stripe.com#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
+     */
+    debit_reversal?: DebitReversal;
 
-      /**
-       * Use [InboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://api.stripe.com#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
-       *
-       * Related guide: [Moving money with Treasury using InboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers)
-       */
-      inbound_transfer?: InboundTransfer;
+    /**
+     * Use [InboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://api.stripe.com#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
+     *
+     * Related guide: [Moving money with Treasury using InboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers)
+     */
+    inbound_transfer?: InboundTransfer;
 
-      /**
-       * When an [issued card](https://docs.stripe.com/issuing) is used to make a purchase, an Issuing `Authorization`
-       * object is created. [Authorizations](https://docs.stripe.com/issuing/purchases/authorizations) must be approved for the
-       * purchase to be completed successfully.
-       *
-       * Related guide: [Issued card authorizations](https://docs.stripe.com/issuing/purchases/authorizations)
-       */
-      issuing_authorization?: Issuing.Authorization;
+    /**
+     * When an [issued card](https://docs.stripe.com/issuing) is used to make a purchase, an Issuing `Authorization`
+     * object is created. [Authorizations](https://docs.stripe.com/issuing/purchases/authorizations) must be approved for the
+     * purchase to be completed successfully.
+     *
+     * Related guide: [Issued card authorizations](https://docs.stripe.com/issuing/purchases/authorizations)
+     */
+    issuing_authorization?: Issuing.Authorization;
 
-      /**
-       * Use [OutboundPayments](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments) to send funds to another party's external bank account or [FinancialAccount](https://api.stripe.com#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://api.stripe.com#outbound_transfers).
-       *
-       * Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
-       *
-       * Related guide: [Moving money with Treasury using OutboundPayment objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments)
-       */
-      outbound_payment?: OutboundPayment;
+    /**
+     * Use [OutboundPayments](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments) to send funds to another party's external bank account or [FinancialAccount](https://api.stripe.com#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://api.stripe.com#outbound_transfers).
+     *
+     * Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
+     *
+     * Related guide: [Moving money with Treasury using OutboundPayment objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments)
+     */
+    outbound_payment?: OutboundPayment;
 
-      /**
-       * Use [OutboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers) to transfer funds from a [FinancialAccount](https://api.stripe.com#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://api.stripe.com#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
-       *
-       * Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
-       *
-       * Related guide: [Moving money with Treasury using OutboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers)
-       */
-      outbound_transfer?: OutboundTransfer;
+    /**
+     * Use [OutboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers) to transfer funds from a [FinancialAccount](https://api.stripe.com#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://api.stripe.com#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
+     *
+     * Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
+     *
+     * Related guide: [Moving money with Treasury using OutboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers)
+     */
+    outbound_transfer?: OutboundTransfer;
 
-      /**
-       * ReceivedCredits represent funds sent to a [FinancialAccount](https://api.stripe.com#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
-       */
-      received_credit?: ReceivedCredit;
+    /**
+     * ReceivedCredits represent funds sent to a [FinancialAccount](https://api.stripe.com#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
+     */
+    received_credit?: ReceivedCredit;
 
-      /**
-       * ReceivedDebits represent funds pulled from a [FinancialAccount](https://api.stripe.com#financial_accounts). These are not initiated from the FinancialAccount.
-       */
-      received_debit?: ReceivedDebit;
+    /**
+     * ReceivedDebits represent funds pulled from a [FinancialAccount](https://api.stripe.com#financial_accounts). These are not initiated from the FinancialAccount.
+     */
+    received_debit?: ReceivedDebit;
 
-      /**
-       * Type of the flow that created the Transaction. Set to the same value as `flow_type`.
-       */
-      type: FlowDetails.Type;
-    }
+    /**
+     * Type of the flow that created the Transaction. Set to the same value as `flow_type`.
+     */
+    type: FlowDetails.Type;
+  }
 
-    export type FlowType =
+  export type FlowType =
+    | 'credit_reversal'
+    | 'debit_reversal'
+    | 'inbound_transfer'
+    | 'issuing_authorization'
+    | 'other'
+    | 'outbound_payment'
+    | 'outbound_transfer'
+    | 'received_credit'
+    | 'received_debit';
+
+  export type Type =
+    | 'credit_reversal'
+    | 'credit_reversal_posting'
+    | 'debit_reversal'
+    | 'inbound_transfer'
+    | 'inbound_transfer_return'
+    | 'issuing_authorization_hold'
+    | 'issuing_authorization_release'
+    | 'other'
+    | 'outbound_payment'
+    | 'outbound_payment_cancellation'
+    | 'outbound_payment_failure'
+    | 'outbound_payment_posting'
+    | 'outbound_payment_return'
+    | 'outbound_transfer'
+    | 'outbound_transfer_cancellation'
+    | 'outbound_transfer_failure'
+    | 'outbound_transfer_posting'
+    | 'outbound_transfer_return'
+    | 'received_credit'
+    | 'received_debit';
+
+  export namespace FlowDetails {
+    export type Type =
       | 'credit_reversal'
       | 'debit_reversal'
       | 'inbound_transfer'
@@ -587,41 +620,6 @@ export namespace Treasury {
       | 'outbound_transfer'
       | 'received_credit'
       | 'received_debit';
-
-    export type Type =
-      | 'credit_reversal'
-      | 'credit_reversal_posting'
-      | 'debit_reversal'
-      | 'inbound_transfer'
-      | 'inbound_transfer_return'
-      | 'issuing_authorization_hold'
-      | 'issuing_authorization_release'
-      | 'other'
-      | 'outbound_payment'
-      | 'outbound_payment_cancellation'
-      | 'outbound_payment_failure'
-      | 'outbound_payment_posting'
-      | 'outbound_payment_return'
-      | 'outbound_transfer'
-      | 'outbound_transfer_cancellation'
-      | 'outbound_transfer_failure'
-      | 'outbound_transfer_posting'
-      | 'outbound_transfer_return'
-      | 'received_credit'
-      | 'received_debit';
-
-    export namespace FlowDetails {
-      export type Type =
-        | 'credit_reversal'
-        | 'debit_reversal'
-        | 'inbound_transfer'
-        | 'issuing_authorization'
-        | 'other'
-        | 'outbound_payment'
-        | 'outbound_transfer'
-        | 'received_credit'
-        | 'received_debit';
-    }
   }
 }
 export namespace Treasury {

--- a/src/resources/Treasury/Transactions.ts
+++ b/src/resources/Treasury/Transactions.ts
@@ -526,7 +526,7 @@ export interface Transaction {
   /**
    * Change to a FinancialAccount's balance
    */
-  balance_impact: Treasury.Transaction.BalanceImpact;
+  balance_impact: Transaction.BalanceImpact;
 
   /**
    * Time at which the object was created. Measured in seconds since the Unix epoch.
@@ -561,12 +561,12 @@ export interface Transaction {
   /**
    * Details of the flow that created the Transaction.
    */
-  flow_details?: Treasury.Transaction.FlowDetails | null;
+  flow_details?: Transaction.FlowDetails | null;
 
   /**
    * Type of the flow that created the Transaction.
    */
-  flow_type: Treasury.Transaction.FlowType;
+  flow_type: Transaction.FlowType;
 
   /**
    * If the object exists in live mode, the value is `true`. If the object exists in test mode, the value is `false`.
@@ -576,91 +576,116 @@ export interface Transaction {
   /**
    * Status of the Transaction.
    */
-  status: Treasury.Transaction.Status;
+  status: Transaction.Status;
 
-  status_transitions: Treasury.Transaction.StatusTransitions;
+  status_transitions: Transaction.StatusTransitions;
 }
-export namespace Treasury {
-  export namespace Transaction {
-    export interface BalanceImpact {
-      /**
-       * The change made to funds the user can spend right now.
-       */
-      cash: number;
+export namespace Transaction {
+  export interface BalanceImpact {
+    /**
+     * The change made to funds the user can spend right now.
+     */
+    cash: number;
 
-      /**
-       * The change made to funds that are not spendable yet, but will become available at a later time.
-       */
-      inbound_pending: number;
+    /**
+     * The change made to funds that are not spendable yet, but will become available at a later time.
+     */
+    inbound_pending: number;
 
-      /**
-       * The change made to funds in the account, but not spendable because they are being held for pending outbound flows.
-       */
-      outbound_pending: number;
-    }
+    /**
+     * The change made to funds in the account, but not spendable because they are being held for pending outbound flows.
+     */
+    outbound_pending: number;
+  }
 
-    export interface FlowDetails {
-      /**
-       * You can reverse some [ReceivedCredits](https://api.stripe.com#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
-       */
-      credit_reversal?: CreditReversal;
+  export interface FlowDetails {
+    /**
+     * You can reverse some [ReceivedCredits](https://api.stripe.com#received_credits) depending on their network and source flow. Reversing a ReceivedCredit leads to the creation of a new object known as a CreditReversal.
+     */
+    credit_reversal?: CreditReversal;
 
-      /**
-       * You can reverse some [ReceivedDebits](https://api.stripe.com#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
-       */
-      debit_reversal?: DebitReversal;
+    /**
+     * You can reverse some [ReceivedDebits](https://api.stripe.com#received_debits) depending on their network and source flow. Reversing a ReceivedDebit leads to the creation of a new object known as a DebitReversal.
+     */
+    debit_reversal?: DebitReversal;
 
-      /**
-       * Use [InboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://api.stripe.com#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
-       *
-       * Related guide: [Moving money with Treasury using InboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers)
-       */
-      inbound_transfer?: InboundTransfer;
+    /**
+     * Use [InboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers) to add funds to your [FinancialAccount](https://api.stripe.com#financial_accounts) via a PaymentMethod that is owned by you. The funds will be transferred via an ACH debit.
+     *
+     * Related guide: [Moving money with Treasury using InboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/into/inbound-transfers)
+     */
+    inbound_transfer?: InboundTransfer;
 
-      /**
-       * When an [issued card](https://docs.stripe.com/issuing) is used to make a purchase, an Issuing `Authorization`
-       * object is created. [Authorizations](https://docs.stripe.com/issuing/purchases/authorizations) must be approved for the
-       * purchase to be completed successfully.
-       *
-       * Related guide: [Issued card authorizations](https://docs.stripe.com/issuing/purchases/authorizations)
-       */
-      issuing_authorization?: Issuing.Authorization;
+    /**
+     * When an [issued card](https://docs.stripe.com/issuing) is used to make a purchase, an Issuing `Authorization`
+     * object is created. [Authorizations](https://docs.stripe.com/issuing/purchases/authorizations) must be approved for the
+     * purchase to be completed successfully.
+     *
+     * Related guide: [Issued card authorizations](https://docs.stripe.com/issuing/purchases/authorizations)
+     */
+    issuing_authorization?: Issuing.Authorization;
 
-      /**
-       * Use [OutboundPayments](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments) to send funds to another party's external bank account or [FinancialAccount](https://api.stripe.com#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://api.stripe.com#outbound_transfers).
-       *
-       * Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
-       *
-       * Related guide: [Moving money with Treasury using OutboundPayment objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments)
-       */
-      outbound_payment?: OutboundPayment;
+    /**
+     * Use [OutboundPayments](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments) to send funds to another party's external bank account or [FinancialAccount](https://api.stripe.com#financial_accounts). To send money to an account belonging to the same user, use an [OutboundTransfer](https://api.stripe.com#outbound_transfers).
+     *
+     * Simulate OutboundPayment state changes with the `/v1/test_helpers/treasury/outbound_payments` endpoints. These methods can only be called on test mode objects.
+     *
+     * Related guide: [Moving money with Treasury using OutboundPayment objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-payments)
+     */
+    outbound_payment?: OutboundPayment;
 
-      /**
-       * Use [OutboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers) to transfer funds from a [FinancialAccount](https://api.stripe.com#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://api.stripe.com#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
-       *
-       * Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
-       *
-       * Related guide: [Moving money with Treasury using OutboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers)
-       */
-      outbound_transfer?: OutboundTransfer;
+    /**
+     * Use [OutboundTransfers](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers) to transfer funds from a [FinancialAccount](https://api.stripe.com#financial_accounts) to a PaymentMethod belonging to the same entity. To send funds to a different party, use [OutboundPayments](https://api.stripe.com#outbound_payments) instead. You can send funds over ACH rails or through a domestic wire transfer to a user's own external bank account.
+     *
+     * Simulate OutboundTransfer state changes with the `/v1/test_helpers/treasury/outbound_transfers` endpoints. These methods can only be called on test mode objects.
+     *
+     * Related guide: [Moving money with Treasury using OutboundTransfer objects](https://docs.stripe.com/docs/treasury/moving-money/financial-accounts/out-of/outbound-transfers)
+     */
+    outbound_transfer?: OutboundTransfer;
 
-      /**
-       * ReceivedCredits represent funds sent to a [FinancialAccount](https://api.stripe.com#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
-       */
-      received_credit?: ReceivedCredit;
+    /**
+     * ReceivedCredits represent funds sent to a [FinancialAccount](https://api.stripe.com#financial_accounts) (for example, via ACH or wire). These money movements are not initiated from the FinancialAccount.
+     */
+    received_credit?: ReceivedCredit;
 
-      /**
-       * ReceivedDebits represent funds pulled from a [FinancialAccount](https://api.stripe.com#financial_accounts). These are not initiated from the FinancialAccount.
-       */
-      received_debit?: ReceivedDebit;
+    /**
+     * ReceivedDebits represent funds pulled from a [FinancialAccount](https://api.stripe.com#financial_accounts). These are not initiated from the FinancialAccount.
+     */
+    received_debit?: ReceivedDebit;
 
-      /**
-       * Type of the flow that created the Transaction. Set to the same value as `flow_type`.
-       */
-      type: FlowDetails.Type;
-    }
+    /**
+     * Type of the flow that created the Transaction. Set to the same value as `flow_type`.
+     */
+    type: FlowDetails.Type;
+  }
 
-    export type FlowType =
+  export type FlowType =
+    | 'credit_reversal'
+    | 'debit_reversal'
+    | 'inbound_transfer'
+    | 'issuing_authorization'
+    | 'other'
+    | 'outbound_payment'
+    | 'outbound_transfer'
+    | 'received_credit'
+    | 'received_debit';
+
+  export type Status = 'open' | 'posted' | 'void';
+
+  export interface StatusTransitions {
+    /**
+     * Timestamp describing when the Transaction changed status to `posted`.
+     */
+    posted_at: number | null;
+
+    /**
+     * Timestamp describing when the Transaction changed status to `void`.
+     */
+    void_at: number | null;
+  }
+
+  export namespace FlowDetails {
+    export type Type =
       | 'credit_reversal'
       | 'debit_reversal'
       | 'inbound_transfer'
@@ -670,33 +695,6 @@ export namespace Treasury {
       | 'outbound_transfer'
       | 'received_credit'
       | 'received_debit';
-
-    export type Status = 'open' | 'posted' | 'void';
-
-    export interface StatusTransitions {
-      /**
-       * Timestamp describing when the Transaction changed status to `posted`.
-       */
-      posted_at: number | null;
-
-      /**
-       * Timestamp describing when the Transaction changed status to `void`.
-       */
-      void_at: number | null;
-    }
-
-    export namespace FlowDetails {
-      export type Type =
-        | 'credit_reversal'
-        | 'debit_reversal'
-        | 'inbound_transfer'
-        | 'issuing_authorization'
-        | 'other'
-        | 'outbound_payment'
-        | 'outbound_transfer'
-        | 'received_credit'
-        | 'received_debit';
-    }
   }
 }
 export namespace Treasury {

--- a/src/resources/V2/Billing/MeterEventAdjustments.ts
+++ b/src/resources/V2/Billing/MeterEventAdjustments.ts
@@ -33,7 +33,7 @@ export interface MeterEventAdjustment {
   /**
    * Specifies which event to cancel.
    */
-  cancel: V2.Billing.MeterEventAdjustment.Cancel;
+  cancel: MeterEventAdjustment.Cancel;
 
   /**
    * The time the adjustment was created.
@@ -53,26 +53,22 @@ export interface MeterEventAdjustment {
   /**
    * Open Enum. The meter event adjustment's status.
    */
-  status: V2.Billing.MeterEventAdjustment.Status;
+  status: MeterEventAdjustment.Status;
 
   /**
    * Open Enum. Specifies the type of cancellation. Currently supports canceling a single event.
    */
   type: 'cancel';
 }
-export namespace V2 {
-  export namespace Billing {
-    export namespace MeterEventAdjustment {
-      export interface Cancel {
-        /**
-         * The identifier that was originally assigned to the meter event. You can only cancel events within 24 hours of Stripe receiving them.
-         */
-        identifier: string;
-      }
-
-      export type Status = 'complete' | 'pending';
-    }
+export namespace MeterEventAdjustment {
+  export interface Cancel {
+    /**
+     * The identifier that was originally assigned to the meter event. You can only cancel events within 24 hours of Stripe receiving them.
+     */
+    identifier: string;
   }
+
+  export type Status = 'complete' | 'pending';
 }
 export namespace V2 {
   export namespace Billing {

--- a/src/resources/V2/Commerce/ProductCatalogImports.ts
+++ b/src/resources/V2/Commerce/ProductCatalogImports.ts
@@ -21,7 +21,7 @@ export interface ProductCatalogImport {
   /**
    * The type of feed data being imported into the product catalog.
    */
-  feed_type: V2.Commerce.ProductCatalogImport.FeedType;
+  feed_type: ProductCatalogImport.FeedType;
 
   /**
    * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -36,194 +36,187 @@ export interface ProductCatalogImport {
   /**
    * The current status of this ProductCatalogImport.
    */
-  status: V2.Commerce.ProductCatalogImport.Status;
+  status: ProductCatalogImport.Status;
 
   /**
    * Details about the current import status.
    */
-  status_details?: V2.Commerce.ProductCatalogImport.StatusDetails;
+  status_details?: ProductCatalogImport.StatusDetails;
 }
-export namespace V2 {
-  export namespace Commerce {
-    export namespace ProductCatalogImport {
-      export type FeedType = 'inventory' | 'pricing' | 'product';
+export namespace ProductCatalogImport {
+  export type FeedType = 'inventory' | 'pricing' | 'product';
 
-      export type Status =
-        | 'awaiting_upload'
-        | 'failed'
-        | 'processing'
-        | 'succeeded'
-        | 'succeeded_with_errors';
+  export type Status =
+    | 'awaiting_upload'
+    | 'failed'
+    | 'processing'
+    | 'succeeded'
+    | 'succeeded_with_errors';
 
-      export interface StatusDetails {
+  export interface StatusDetails {
+    /**
+     * Details when the import is awaiting file upload.
+     */
+    awaiting_upload?: StatusDetails.AwaitingUpload;
+
+    /**
+     * Details when the import didn't complete.
+     */
+    failed?: StatusDetails.Failed;
+
+    /**
+     * Details when the import is processing.
+     */
+    processing?: StatusDetails.Processing;
+
+    /**
+     * Details when the import has succeeded.
+     */
+    succeeded?: StatusDetails.Succeeded;
+
+    /**
+     * Details when the import completed but some records failed to process.
+     */
+    succeeded_with_errors?: StatusDetails.SucceededWithErrors;
+  }
+
+  export namespace StatusDetails {
+    export interface AwaitingUpload {
+      /**
+       * The pre-signed URL information for uploading the catalog file.
+       */
+      upload_url: AwaitingUpload.UploadUrl;
+    }
+
+    export interface Failed {
+      /**
+       * The error code for this product catalog processing failure.
+       */
+      code: Failed.Code;
+
+      /**
+       * A message explaining why the import failed.
+       */
+      failure_message: string;
+
+      /**
+       * The error type for this product catalog processing failure.
+       */
+      type: Failed.Type;
+    }
+
+    export interface Processing {
+      /**
+       * The number of records that failed to process so far.
+       */
+      error_count: bigint;
+
+      /**
+       * The number of records processed so far.
+       */
+      success_count: bigint;
+    }
+
+    export interface Succeeded {
+      /**
+       * The total number of records processed.
+       */
+      success_count: bigint;
+    }
+
+    export interface SucceededWithErrors {
+      /**
+       * The total number of records that failed to process.
+       */
+      error_count: bigint;
+
+      /**
+       * A file containing details about all errors that occurred.
+       */
+      error_file: SucceededWithErrors.ErrorFile;
+
+      /**
+       * A sample of errors that occurred during processing.
+       */
+      samples: Array<SucceededWithErrors.Sample>;
+
+      /**
+       * The total number of records processed.
+       */
+      success_count: bigint;
+    }
+
+    export namespace AwaitingUpload {
+      export interface UploadUrl {
         /**
-         * Details when the import is awaiting file upload.
+         * The timestamp when the upload URL expires.
          */
-        awaiting_upload?: StatusDetails.AwaitingUpload;
+        expires_at: string;
 
         /**
-         * Details when the import didn't complete.
+         * The pre-signed URL for uploading the catalog file.
          */
-        failed?: StatusDetails.Failed;
+        url: string;
+      }
+    }
+
+    export namespace Failed {
+      export type Code = 'file_not_found' | 'internal_error' | 'invalid_file';
+
+      export type Type = 'cannot_proceed' | 'transient_failure';
+    }
+
+    export namespace SucceededWithErrors {
+      export interface ErrorFile {
+        /**
+         * The MIME type of the error file.
+         */
+        content_type: string;
 
         /**
-         * Details when the import is processing.
+         * The pre-signed URL information for downloading the error file.
          */
-        processing?: StatusDetails.Processing;
+        download_url: ErrorFile.DownloadUrl;
 
         /**
-         * Details when the import has succeeded.
+         * The size of the error file in bytes.
          */
-        succeeded?: StatusDetails.Succeeded;
-
-        /**
-         * Details when the import completed but some records failed to process.
-         */
-        succeeded_with_errors?: StatusDetails.SucceededWithErrors;
+        size: bigint;
       }
 
-      export namespace StatusDetails {
-        export interface AwaitingUpload {
-          /**
-           * The pre-signed URL information for uploading the catalog file.
-           */
-          upload_url: AwaitingUpload.UploadUrl;
-        }
+      export interface Sample {
+        /**
+         * A description of what went wrong with this record.
+         */
+        error_message: string;
 
-        export interface Failed {
-          /**
-           * The error code for this product catalog processing failure.
-           */
-          code: Failed.Code;
+        /**
+         * The name of the field that caused the error.
+         */
+        field: string;
 
-          /**
-           * A message explaining why the import failed.
-           */
-          failure_message: string;
+        /**
+         * The identifier of the record that failed to process.
+         */
+        id: string;
 
-          /**
-           * The error type for this product catalog processing failure.
-           */
-          type: Failed.Type;
-        }
+        /**
+         * The row number in the import file where the error occurred.
+         */
+        row: bigint;
+      }
 
-        export interface Processing {
+      export namespace ErrorFile {
+        export interface DownloadUrl {
           /**
-           * The number of records that failed to process so far.
+           * The timestamp when the download URL expires.
            */
-          error_count: bigint;
+          expires_at: string;
 
           /**
-           * The number of records processed so far.
+           * The pre-signed URL for downloading the error file.
            */
-          success_count: bigint;
-        }
-
-        export interface Succeeded {
-          /**
-           * The total number of records processed.
-           */
-          success_count: bigint;
-        }
-
-        export interface SucceededWithErrors {
-          /**
-           * The total number of records that failed to process.
-           */
-          error_count: bigint;
-
-          /**
-           * A file containing details about all errors that occurred.
-           */
-          error_file: SucceededWithErrors.ErrorFile;
-
-          /**
-           * A sample of errors that occurred during processing.
-           */
-          samples: Array<SucceededWithErrors.Sample>;
-
-          /**
-           * The total number of records processed.
-           */
-          success_count: bigint;
-        }
-
-        export namespace AwaitingUpload {
-          export interface UploadUrl {
-            /**
-             * The timestamp when the upload URL expires.
-             */
-            expires_at: string;
-
-            /**
-             * The pre-signed URL for uploading the catalog file.
-             */
-            url: string;
-          }
-        }
-
-        export namespace Failed {
-          export type Code =
-            | 'file_not_found'
-            | 'internal_error'
-            | 'invalid_file';
-
-          export type Type = 'cannot_proceed' | 'transient_failure';
-        }
-
-        export namespace SucceededWithErrors {
-          export interface ErrorFile {
-            /**
-             * The MIME type of the error file.
-             */
-            content_type: string;
-
-            /**
-             * The pre-signed URL information for downloading the error file.
-             */
-            download_url: ErrorFile.DownloadUrl;
-
-            /**
-             * The size of the error file in bytes.
-             */
-            size: bigint;
-          }
-
-          export interface Sample {
-            /**
-             * A description of what went wrong with this record.
-             */
-            error_message: string;
-
-            /**
-             * The name of the field that caused the error.
-             */
-            field: string;
-
-            /**
-             * The identifier of the record that failed to process.
-             */
-            id: string;
-
-            /**
-             * The row number in the import file where the error occurred.
-             */
-            row: bigint;
-          }
-
-          export namespace ErrorFile {
-            export interface DownloadUrl {
-              /**
-               * The timestamp when the download URL expires.
-               */
-              expires_at: string;
-
-              /**
-               * The pre-signed URL for downloading the error file.
-               */
-              url: string;
-            }
-          }
+          url: string;
         }
       }
     }

--- a/src/resources/V2/Core/AccountLinks.ts
+++ b/src/resources/V2/Core/AccountLinks.ts
@@ -54,118 +54,114 @@ export interface AccountLink {
   /**
    * Hash containing usage options.
    */
-  use_case: V2.Core.AccountLink.UseCase;
+  use_case: AccountLink.UseCase;
 }
-export namespace V2 {
-  export namespace Core {
-    export namespace AccountLink {
-      export interface UseCase {
+export namespace AccountLink {
+  export interface UseCase {
+    /**
+     * Hash containing configuration options for an Account Link object that onboards a new account.
+     */
+    account_onboarding?: UseCase.AccountOnboarding;
+
+    /**
+     * Hash containing configuration options for an Account Link that updates an existing account.
+     */
+    account_update?: UseCase.AccountUpdate;
+
+    /**
+     * Open Enum. The type of Account Link the user is requesting.
+     */
+    type: UseCase.Type;
+  }
+
+  export namespace UseCase {
+    export interface AccountOnboarding {
+      /**
+       * Specifies the requirements that Stripe collects from v2/core/accounts in the Onboarding flow.
+       */
+      collection_options?: AccountOnboarding.CollectionOptions;
+
+      /**
+       * Open Enum. A v2/core/account can be configured to enable certain functionality. The configuration param targets the v2/core/account_link to collect information for the specified v2/core/account configuration/s.
+       */
+      configurations: Array<AccountOnboarding.Configuration>;
+
+      /**
+       * The URL the user will be redirected to if the AccountLink is expired, has been used, or is otherwise invalid. The URL you specify should attempt to generate a new AccountLink with the same parameters used to create the original AccountLink, then redirect the user to the new AccountLink's URL so they can continue the flow. If a new AccountLink cannot be generated or the redirect fails you should display a useful error to the user. Please make sure to implement authentication before redirecting the user in case this URL is leaked to a third party.
+       */
+      refresh_url: string;
+
+      /**
+       * The URL that the user will be redirected to upon completing the linked flow.
+       */
+      return_url?: string;
+    }
+
+    export interface AccountUpdate {
+      /**
+       * Specifies the requirements that Stripe collects from v2/core/accounts in the Onboarding flow.
+       */
+      collection_options?: AccountUpdate.CollectionOptions;
+
+      /**
+       * Open Enum. A v2/account can be configured to enable certain functionality. The configuration param targets the v2/account_link to collect information for the specified v2/account configuration/s.
+       */
+      configurations: Array<AccountUpdate.Configuration>;
+
+      /**
+       * The URL the user will be redirected to if the Account Link is expired, has been used, or is otherwise invalid. The URL you specify should attempt to generate a new Account Link with the same parameters used to create the original Account Link, then redirect the user to the new Account Link URL so they can continue the flow. Make sure to authenticate the user before redirecting to the new Account Link, in case the URL leaks to a third party. If a new Account Link can't be generated, or if the redirect fails, you should display a useful error to the user.
+       */
+      refresh_url: string;
+
+      /**
+       * The URL that the user will be redirected to upon completing the linked flow.
+       */
+      return_url?: string;
+    }
+
+    export type Type = 'account_onboarding' | 'account_update';
+
+    export namespace AccountOnboarding {
+      export interface CollectionOptions {
         /**
-         * Hash containing configuration options for an Account Link object that onboards a new account.
+         * Specifies whether the platform collects only currently_due requirements (`currently_due`) or both currently_due and eventually_due requirements (`eventually_due`). If you don't specify collection_options, the default value is currently_due.
          */
-        account_onboarding?: UseCase.AccountOnboarding;
+        fields?: CollectionOptions.Fields;
 
         /**
-         * Hash containing configuration options for an Account Link that updates an existing account.
+         * Specifies whether the platform collects future_requirements in addition to requirements in Connect Onboarding. The default value is `omit`.
          */
-        account_update?: UseCase.AccountUpdate;
-
-        /**
-         * Open Enum. The type of Account Link the user is requesting.
-         */
-        type: UseCase.Type;
+        future_requirements?: CollectionOptions.FutureRequirements;
       }
 
-      export namespace UseCase {
-        export interface AccountOnboarding {
-          /**
-           * Specifies the requirements that Stripe collects from v2/core/accounts in the Onboarding flow.
-           */
-          collection_options?: AccountOnboarding.CollectionOptions;
+      export type Configuration = 'customer' | 'merchant' | 'recipient';
 
-          /**
-           * Open Enum. A v2/core/account can be configured to enable certain functionality. The configuration param targets the v2/core/account_link to collect information for the specified v2/core/account configuration/s.
-           */
-          configurations: Array<AccountOnboarding.Configuration>;
+      export namespace CollectionOptions {
+        export type Fields = 'currently_due' | 'eventually_due';
 
-          /**
-           * The URL the user will be redirected to if the AccountLink is expired, has been used, or is otherwise invalid. The URL you specify should attempt to generate a new AccountLink with the same parameters used to create the original AccountLink, then redirect the user to the new AccountLink's URL so they can continue the flow. If a new AccountLink cannot be generated or the redirect fails you should display a useful error to the user. Please make sure to implement authentication before redirecting the user in case this URL is leaked to a third party.
-           */
-          refresh_url: string;
+        export type FutureRequirements = 'include' | 'omit';
+      }
+    }
 
-          /**
-           * The URL that the user will be redirected to upon completing the linked flow.
-           */
-          return_url?: string;
-        }
+    export namespace AccountUpdate {
+      export interface CollectionOptions {
+        /**
+         * Specifies whether the platform collects only currently_due requirements (`currently_due`) or both currently_due and eventually_due requirements (`eventually_due`). The default value is `currently_due`.
+         */
+        fields?: CollectionOptions.Fields;
 
-        export interface AccountUpdate {
-          /**
-           * Specifies the requirements that Stripe collects from v2/core/accounts in the Onboarding flow.
-           */
-          collection_options?: AccountUpdate.CollectionOptions;
+        /**
+         * Specifies whether the platform collects future_requirements in addition to requirements in Connect Onboarding. The default value is `omit`.
+         */
+        future_requirements?: CollectionOptions.FutureRequirements;
+      }
 
-          /**
-           * Open Enum. A v2/account can be configured to enable certain functionality. The configuration param targets the v2/account_link to collect information for the specified v2/account configuration/s.
-           */
-          configurations: Array<AccountUpdate.Configuration>;
+      export type Configuration = 'customer' | 'merchant' | 'recipient';
 
-          /**
-           * The URL the user will be redirected to if the Account Link is expired, has been used, or is otherwise invalid. The URL you specify should attempt to generate a new Account Link with the same parameters used to create the original Account Link, then redirect the user to the new Account Link URL so they can continue the flow. Make sure to authenticate the user before redirecting to the new Account Link, in case the URL leaks to a third party. If a new Account Link can't be generated, or if the redirect fails, you should display a useful error to the user.
-           */
-          refresh_url: string;
+      export namespace CollectionOptions {
+        export type Fields = 'currently_due' | 'eventually_due';
 
-          /**
-           * The URL that the user will be redirected to upon completing the linked flow.
-           */
-          return_url?: string;
-        }
-
-        export type Type = 'account_onboarding' | 'account_update';
-
-        export namespace AccountOnboarding {
-          export interface CollectionOptions {
-            /**
-             * Specifies whether the platform collects only currently_due requirements (`currently_due`) or both currently_due and eventually_due requirements (`eventually_due`). If you don't specify collection_options, the default value is currently_due.
-             */
-            fields?: CollectionOptions.Fields;
-
-            /**
-             * Specifies whether the platform collects future_requirements in addition to requirements in Connect Onboarding. The default value is `omit`.
-             */
-            future_requirements?: CollectionOptions.FutureRequirements;
-          }
-
-          export type Configuration = 'customer' | 'merchant' | 'recipient';
-
-          export namespace CollectionOptions {
-            export type Fields = 'currently_due' | 'eventually_due';
-
-            export type FutureRequirements = 'include' | 'omit';
-          }
-        }
-
-        export namespace AccountUpdate {
-          export interface CollectionOptions {
-            /**
-             * Specifies whether the platform collects only currently_due requirements (`currently_due`) or both currently_due and eventually_due requirements (`eventually_due`). The default value is `currently_due`.
-             */
-            fields?: CollectionOptions.Fields;
-
-            /**
-             * Specifies whether the platform collects future_requirements in addition to requirements in Connect Onboarding. The default value is `omit`.
-             */
-            future_requirements?: CollectionOptions.FutureRequirements;
-          }
-
-          export type Configuration = 'customer' | 'merchant' | 'recipient';
-
-          export namespace CollectionOptions {
-            export type Fields = 'currently_due' | 'eventually_due';
-
-            export type FutureRequirements = 'include' | 'omit';
-          }
-        }
+        export type FutureRequirements = 'include' | 'omit';
       }
     }
   }

--- a/src/resources/V2/Core/AccountPersons.ts
+++ b/src/resources/V2/Core/AccountPersons.ts
@@ -21,22 +21,22 @@ export interface AccountPerson {
   /**
    * Additional addresses associated with the person.
    */
-  additional_addresses?: Array<V2.Core.AccountPerson.AdditionalAddress>;
+  additional_addresses?: Array<AccountPerson.AdditionalAddress>;
 
   /**
    * Additional names (e.g. aliases) associated with the person.
    */
-  additional_names?: Array<V2.Core.AccountPerson.AdditionalName>;
+  additional_names?: Array<AccountPerson.AdditionalName>;
 
   /**
    * Attestations of accepted terms of service agreements.
    */
-  additional_terms_of_service?: V2.Core.AccountPerson.AdditionalTermsOfService;
+  additional_terms_of_service?: AccountPerson.AdditionalTermsOfService;
 
   /**
    * The person's residential address.
    */
-  address?: V2.Core.AccountPerson.Address;
+  address?: AccountPerson.Address;
 
   /**
    * Time at which the object was created. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
@@ -46,12 +46,12 @@ export interface AccountPerson {
   /**
    * The person's date of birth.
    */
-  date_of_birth?: V2.Core.AccountPerson.DateOfBirth;
+  date_of_birth?: AccountPerson.DateOfBirth;
 
   /**
    * Documents that may be submitted to satisfy various informational requests.
    */
-  documents?: V2.Core.AccountPerson.Documents;
+  documents?: AccountPerson.Documents;
 
   /**
    * The person's email address.
@@ -66,12 +66,12 @@ export interface AccountPerson {
   /**
    * The identification numbers (e.g., SSN) associated with the person.
    */
-  id_numbers?: Array<V2.Core.AccountPerson.IdNumber>;
+  id_numbers?: Array<AccountPerson.IdNumber>;
 
   /**
    * The person's gender (International regulations require either "male" or "female").
    */
-  legal_gender?: V2.Core.AccountPerson.LegalGender;
+  legal_gender?: AccountPerson.LegalGender;
 
   /**
    * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -96,22 +96,22 @@ export interface AccountPerson {
   /**
    * The person's political exposure.
    */
-  political_exposure?: V2.Core.AccountPerson.PoliticalExposure;
+  political_exposure?: AccountPerson.PoliticalExposure;
 
   /**
    * The relationship that this person has with the Account's business or legal entity.
    */
-  relationship?: V2.Core.AccountPerson.Relationship;
+  relationship?: AccountPerson.Relationship;
 
   /**
    * The script addresses (e.g., non-Latin characters) associated with the person.
    */
-  script_addresses?: V2.Core.AccountPerson.ScriptAddresses;
+  script_addresses?: AccountPerson.ScriptAddresses;
 
   /**
    * The script names (e.g. non-Latin characters) associated with the person.
    */
-  script_names?: V2.Core.AccountPerson.ScriptNames;
+  script_names?: AccountPerson.ScriptNames;
 
   /**
    * The person's last name.
@@ -123,533 +123,529 @@ export interface AccountPerson {
    */
   updated: string;
 }
-export namespace V2 {
-  export namespace Core {
-    export namespace AccountPerson {
-      export interface AdditionalAddress {
+export namespace AccountPerson {
+  export interface AdditionalAddress {
+    /**
+     * City, district, suburb, town, or village.
+     */
+    city?: string;
+
+    /**
+     * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+     */
+    country?: string;
+
+    /**
+     * Address line 1 (e.g., street, PO Box, or company name).
+     */
+    line1?: string;
+
+    /**
+     * Address line 2 (e.g., apartment, suite, unit, or building).
+     */
+    line2?: string;
+
+    /**
+     * ZIP or postal code.
+     */
+    postal_code?: string;
+
+    /**
+     * Purpose of additional address.
+     */
+    purpose: 'registered';
+
+    /**
+     * State, county, province, or region.
+     */
+    state?: string;
+
+    /**
+     * Town or district.
+     */
+    town?: string;
+  }
+
+  export interface AdditionalName {
+    /**
+     * The individual's full name.
+     */
+    full_name?: string;
+
+    /**
+     * The individual's first or given name.
+     */
+    given_name?: string;
+
+    /**
+     * The purpose or type of the additional name.
+     */
+    purpose: AdditionalName.Purpose;
+
+    /**
+     * The individual's last or family name.
+     */
+    surname?: string;
+  }
+
+  export interface AdditionalTermsOfService {
+    /**
+     * Stripe terms of service agreement.
+     */
+    account?: AdditionalTermsOfService.Account;
+  }
+
+  export interface Address {
+    /**
+     * City, district, suburb, town, or village.
+     */
+    city?: string;
+
+    /**
+     * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+     */
+    country?: string;
+
+    /**
+     * Address line 1 (e.g., street, PO Box, or company name).
+     */
+    line1?: string;
+
+    /**
+     * Address line 2 (e.g., apartment, suite, unit, or building).
+     */
+    line2?: string;
+
+    /**
+     * ZIP or postal code.
+     */
+    postal_code?: string;
+
+    /**
+     * State, county, province, or region.
+     */
+    state?: string;
+
+    /**
+     * Town or district.
+     */
+    town?: string;
+  }
+
+  export interface DateOfBirth {
+    /**
+     * The day of birth, between 1 and 31.
+     */
+    day: number;
+
+    /**
+     * The month of birth, between 1 and 12.
+     */
+    month: number;
+
+    /**
+     * The four-digit year of birth.
+     */
+    year: number;
+  }
+
+  export interface Documents {
+    /**
+     * One or more documents that demonstrate proof that this person is authorized to represent the company.
+     */
+    company_authorization?: Documents.CompanyAuthorization;
+
+    /**
+     * One or more documents showing the person's passport page with photo and personal data.
+     */
+    passport?: Documents.Passport;
+
+    /**
+     * An identifying document showing the person's name, either a passport or local ID card.
+     */
+    primary_verification?: Documents.PrimaryVerification;
+
+    /**
+     * A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
+     */
+    secondary_verification?: Documents.SecondaryVerification;
+
+    /**
+     * One or more documents showing the person's visa required for living in the country where they are residing.
+     */
+    visa?: Documents.Visa;
+  }
+
+  export interface IdNumber {
+    /**
+     * The ID number type of an individual.
+     */
+    type: IdNumber.Type;
+  }
+
+  export type LegalGender = 'female' | 'male';
+
+  export type PoliticalExposure = 'existing' | 'none';
+
+  export interface Relationship {
+    /**
+     * Whether the individual is an authorizer of the Account's identity.
+     */
+    authorizer?: boolean;
+
+    /**
+     * Whether the individual is a director of the Account's identity. Directors are typically members of the governing board of the company or are responsible for making sure that the company meets its regulatory obligations.
+     */
+    director?: boolean;
+
+    /**
+     * Whether the individual has significant responsibility to control, manage, or direct the organization.
+     */
+    executive?: boolean;
+
+    /**
+     * Whether the individual is the legal guardian of the Account's representative.
+     */
+    legal_guardian?: boolean;
+
+    /**
+     * Whether the individual is an owner of the Account's identity.
+     */
+    owner?: boolean;
+
+    /**
+     * The percentage of the Account's identity that the individual owns.
+     */
+    percent_ownership?: Decimal;
+
+    /**
+     * Whether the individual is authorized as the primary representative of the Account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
+     */
+    representative?: boolean;
+
+    /**
+     * The individual's title (e.g., CEO, Support Engineer).
+     */
+    title?: string;
+  }
+
+  export interface ScriptAddresses {
+    /**
+     * Kana Address.
+     */
+    kana?: ScriptAddresses.Kana;
+
+    /**
+     * Kanji Address.
+     */
+    kanji?: ScriptAddresses.Kanji;
+  }
+
+  export interface ScriptNames {
+    /**
+     * Persons name in kana script.
+     */
+    kana?: ScriptNames.Kana;
+
+    /**
+     * Persons name in kanji script.
+     */
+    kanji?: ScriptNames.Kanji;
+  }
+
+  export namespace AdditionalName {
+    export type Purpose = 'alias' | 'maiden';
+  }
+
+  export namespace AdditionalTermsOfService {
+    export interface Account {
+      /**
+       * The time when the Account's representative accepted the terms of service. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+       */
+      date?: string;
+
+      /**
+       * The IP address from which the Account's representative accepted the terms of service.
+       */
+      ip?: string;
+
+      /**
+       * The user agent of the browser from which the Account's representative accepted the terms of service.
+       */
+      user_agent?: string;
+    }
+  }
+
+  export namespace Documents {
+    export interface CompanyAuthorization {
+      /**
+       * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+       */
+      files: Array<string>;
+
+      /**
+       * The format of the document. Currently supports `files` only.
+       */
+      type: 'files';
+    }
+
+    export interface Passport {
+      /**
+       * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+       */
+      files: Array<string>;
+
+      /**
+       * The format of the document. Currently supports `files` only.
+       */
+      type: 'files';
+    }
+
+    export interface PrimaryVerification {
+      /**
+       * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
+       */
+      front_back: PrimaryVerification.FrontBack;
+
+      /**
+       * The format of the verification document. Currently supports `front_back` only.
+       */
+      type: 'front_back';
+    }
+
+    export interface SecondaryVerification {
+      /**
+       * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
+       */
+      front_back: SecondaryVerification.FrontBack;
+
+      /**
+       * The format of the verification document. Currently supports `front_back` only.
+       */
+      type: 'front_back';
+    }
+
+    export interface Visa {
+      /**
+       * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+       */
+      files: Array<string>;
+
+      /**
+       * The format of the document. Currently supports `files` only.
+       */
+      type: 'files';
+    }
+
+    export namespace PrimaryVerification {
+      export interface FrontBack {
         /**
-         * City, district, suburb, town, or village.
+         * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
          */
-        city?: string;
+        back?: string;
 
         /**
-         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+         * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
          */
-        country?: string;
-
-        /**
-         * Address line 1 (e.g., street, PO Box, or company name).
-         */
-        line1?: string;
-
-        /**
-         * Address line 2 (e.g., apartment, suite, unit, or building).
-         */
-        line2?: string;
-
-        /**
-         * ZIP or postal code.
-         */
-        postal_code?: string;
-
-        /**
-         * Purpose of additional address.
-         */
-        purpose: 'registered';
-
-        /**
-         * State, county, province, or region.
-         */
-        state?: string;
-
-        /**
-         * Town or district.
-         */
-        town?: string;
+        front: string;
       }
+    }
 
-      export interface AdditionalName {
+    export namespace SecondaryVerification {
+      export interface FrontBack {
         /**
-         * The individual's full name.
+         * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
          */
-        full_name?: string;
-
-        /**
-         * The individual's first or given name.
-         */
-        given_name?: string;
+        back?: string;
 
         /**
-         * The purpose or type of the additional name.
+         * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
          */
-        purpose: AdditionalName.Purpose;
-
-        /**
-         * The individual's last or family name.
-         */
-        surname?: string;
+        front: string;
       }
-
-      export interface AdditionalTermsOfService {
-        /**
-         * Stripe terms of service agreement.
-         */
-        account?: AdditionalTermsOfService.Account;
-      }
-
-      export interface Address {
-        /**
-         * City, district, suburb, town, or village.
-         */
-        city?: string;
-
-        /**
-         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-         */
-        country?: string;
-
-        /**
-         * Address line 1 (e.g., street, PO Box, or company name).
-         */
-        line1?: string;
-
-        /**
-         * Address line 2 (e.g., apartment, suite, unit, or building).
-         */
-        line2?: string;
-
-        /**
-         * ZIP or postal code.
-         */
-        postal_code?: string;
-
-        /**
-         * State, county, province, or region.
-         */
-        state?: string;
-
-        /**
-         * Town or district.
-         */
-        town?: string;
-      }
-
-      export interface DateOfBirth {
-        /**
-         * The day of birth, between 1 and 31.
-         */
-        day: number;
-
-        /**
-         * The month of birth, between 1 and 12.
-         */
-        month: number;
-
-        /**
-         * The four-digit year of birth.
-         */
-        year: number;
-      }
-
-      export interface Documents {
-        /**
-         * One or more documents that demonstrate proof that this person is authorized to represent the company.
-         */
-        company_authorization?: Documents.CompanyAuthorization;
-
-        /**
-         * One or more documents showing the person's passport page with photo and personal data.
-         */
-        passport?: Documents.Passport;
-
-        /**
-         * An identifying document showing the person's name, either a passport or local ID card.
-         */
-        primary_verification?: Documents.PrimaryVerification;
-
-        /**
-         * A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
-         */
-        secondary_verification?: Documents.SecondaryVerification;
-
-        /**
-         * One or more documents showing the person's visa required for living in the country where they are residing.
-         */
-        visa?: Documents.Visa;
-      }
-
-      export interface IdNumber {
-        /**
-         * The ID number type of an individual.
-         */
-        type: IdNumber.Type;
-      }
-
-      export type LegalGender = 'female' | 'male';
-
-      export type PoliticalExposure = 'existing' | 'none';
-
-      export interface Relationship {
-        /**
-         * Whether the individual is an authorizer of the Account's identity.
-         */
-        authorizer?: boolean;
-
-        /**
-         * Whether the individual is a director of the Account's identity. Directors are typically members of the governing board of the company or are responsible for making sure that the company meets its regulatory obligations.
-         */
-        director?: boolean;
-
-        /**
-         * Whether the individual has significant responsibility to control, manage, or direct the organization.
-         */
-        executive?: boolean;
-
-        /**
-         * Whether the individual is the legal guardian of the Account's representative.
-         */
-        legal_guardian?: boolean;
-
-        /**
-         * Whether the individual is an owner of the Account's identity.
-         */
-        owner?: boolean;
-
-        /**
-         * The percentage of the Account's identity that the individual owns.
-         */
-        percent_ownership?: Decimal;
-
-        /**
-         * Whether the individual is authorized as the primary representative of the Account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
-         */
-        representative?: boolean;
-
-        /**
-         * The individual's title (e.g., CEO, Support Engineer).
-         */
-        title?: string;
-      }
-
-      export interface ScriptAddresses {
-        /**
-         * Kana Address.
-         */
-        kana?: ScriptAddresses.Kana;
-
-        /**
-         * Kanji Address.
-         */
-        kanji?: ScriptAddresses.Kanji;
-      }
-
-      export interface ScriptNames {
-        /**
-         * Persons name in kana script.
-         */
-        kana?: ScriptNames.Kana;
-
-        /**
-         * Persons name in kanji script.
-         */
-        kanji?: ScriptNames.Kanji;
-      }
-
-      export namespace AdditionalName {
-        export type Purpose = 'alias' | 'maiden';
-      }
-
-      export namespace AdditionalTermsOfService {
-        export interface Account {
-          /**
-           * The time when the Account's representative accepted the terms of service. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
-           */
-          date?: string;
-
-          /**
-           * The IP address from which the Account's representative accepted the terms of service.
-           */
-          ip?: string;
-
-          /**
-           * The user agent of the browser from which the Account's representative accepted the terms of service.
-           */
-          user_agent?: string;
-        }
-      }
-
-      export namespace Documents {
-        export interface CompanyAuthorization {
-          /**
-           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-           */
-          files: Array<string>;
-
-          /**
-           * The format of the document. Currently supports `files` only.
-           */
-          type: 'files';
-        }
-
-        export interface Passport {
-          /**
-           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-           */
-          files: Array<string>;
-
-          /**
-           * The format of the document. Currently supports `files` only.
-           */
-          type: 'files';
-        }
-
-        export interface PrimaryVerification {
-          /**
-           * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
-           */
-          front_back: PrimaryVerification.FrontBack;
-
-          /**
-           * The format of the verification document. Currently supports `front_back` only.
-           */
-          type: 'front_back';
-        }
-
-        export interface SecondaryVerification {
-          /**
-           * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
-           */
-          front_back: SecondaryVerification.FrontBack;
-
-          /**
-           * The format of the verification document. Currently supports `front_back` only.
-           */
-          type: 'front_back';
-        }
-
-        export interface Visa {
-          /**
-           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-           */
-          files: Array<string>;
-
-          /**
-           * The format of the document. Currently supports `files` only.
-           */
-          type: 'files';
-        }
-
-        export namespace PrimaryVerification {
-          export interface FrontBack {
-            /**
-             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-             */
-            back?: string;
-
-            /**
-             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-             */
-            front: string;
-          }
-        }
-
-        export namespace SecondaryVerification {
-          export interface FrontBack {
-            /**
-             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-             */
-            back?: string;
-
-            /**
-             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-             */
-            front: string;
-          }
-        }
-      }
-
-      export namespace IdNumber {
-        export type Type =
-          | 'ae_eid'
-          | 'ao_nif'
-          | 'ar_cuil'
-          | 'ar_dni'
-          | 'at_stn'
-          | 'az_tin'
-          | 'bd_brc'
-          | 'bd_etin'
-          | 'bd_nid'
-          | 'be_nrn'
-          | 'bg_ucn'
-          | 'bn_nric'
-          | 'br_cpf'
-          | 'ca_sin'
-          | 'ch_oasi'
-          | 'cl_rut'
-          | 'cn_pp'
-          | 'co_nuip'
-          | 'cr_ci'
-          | 'cr_cpf'
-          | 'cr_dimex'
-          | 'cr_nite'
-          | 'cy_tic'
-          | 'cz_rc'
-          | 'de_stn'
-          | 'dk_cpr'
-          | 'do_cie'
-          | 'do_rcn'
-          | 'ec_ci'
-          | 'ee_ik'
-          | 'es_nif'
-          | 'fi_hetu'
-          | 'fr_nir'
-          | 'gb_nino'
-          | 'gr_afm'
-          | 'gt_nit'
-          | 'hk_id'
-          | 'hr_oib'
-          | 'hu_ad'
-          | 'id_nik'
-          | 'ie_ppsn'
-          | 'is_kt'
-          | 'it_cf'
-          | 'jp_inc'
-          | 'ke_pin'
-          | 'kz_iin'
-          | 'li_peid'
-          | 'lt_ak'
-          | 'lu_nif'
-          | 'lv_pk'
-          | 'mx_rfc'
-          | 'my_nric'
-          | 'mz_nuit'
-          | 'ng_nin'
-          | 'nl_bsn'
-          | 'no_nin'
-          | 'nz_ird'
-          | 'pe_dni'
-          | 'pk_cnic'
-          | 'pk_snic'
-          | 'pl_pesel'
-          | 'pt_nif'
-          | 'ro_cnp'
-          | 'sa_tin'
-          | 'se_pin'
-          | 'sg_fin'
-          | 'sg_nric'
-          | 'sk_dic'
-          | 'th_lc'
-          | 'th_pin'
-          | 'tr_tin'
-          | 'us_itin'
-          | 'us_itin_last_4'
-          | 'us_ssn'
-          | 'us_ssn_last_4'
-          | 'uy_dni'
-          | 'za_id';
-      }
-
-      export namespace ScriptAddresses {
-        export interface Kana {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
-          line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
-
-          /**
-           * Town or district.
-           */
-          town?: string;
-        }
-
-        export interface Kanji {
-          /**
-           * City, district, suburb, town, or village.
-           */
-          city?: string;
-
-          /**
-           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          country?: string;
-
-          /**
-           * Address line 1 (e.g., street, PO Box, or company name).
-           */
-          line1?: string;
-
-          /**
-           * Address line 2 (e.g., apartment, suite, unit, or building).
-           */
-          line2?: string;
-
-          /**
-           * ZIP or postal code.
-           */
-          postal_code?: string;
-
-          /**
-           * State, county, province, or region.
-           */
-          state?: string;
-
-          /**
-           * Town or district.
-           */
-          town?: string;
-        }
-      }
-
-      export namespace ScriptNames {
-        export interface Kana {
-          /**
-           * The person's first or given name.
-           */
-          given_name?: string;
-
-          /**
-           * The person's last or family name.
-           */
-          surname?: string;
-        }
-
-        export interface Kanji {
-          /**
-           * The person's first or given name.
-           */
-          given_name?: string;
-
-          /**
-           * The person's last or family name.
-           */
-          surname?: string;
-        }
-      }
+    }
+  }
+
+  export namespace IdNumber {
+    export type Type =
+      | 'ae_eid'
+      | 'ao_nif'
+      | 'ar_cuil'
+      | 'ar_dni'
+      | 'at_stn'
+      | 'az_tin'
+      | 'bd_brc'
+      | 'bd_etin'
+      | 'bd_nid'
+      | 'be_nrn'
+      | 'bg_ucn'
+      | 'bn_nric'
+      | 'br_cpf'
+      | 'ca_sin'
+      | 'ch_oasi'
+      | 'cl_rut'
+      | 'cn_pp'
+      | 'co_nuip'
+      | 'cr_ci'
+      | 'cr_cpf'
+      | 'cr_dimex'
+      | 'cr_nite'
+      | 'cy_tic'
+      | 'cz_rc'
+      | 'de_stn'
+      | 'dk_cpr'
+      | 'do_cie'
+      | 'do_rcn'
+      | 'ec_ci'
+      | 'ee_ik'
+      | 'es_nif'
+      | 'fi_hetu'
+      | 'fr_nir'
+      | 'gb_nino'
+      | 'gr_afm'
+      | 'gt_nit'
+      | 'hk_id'
+      | 'hr_oib'
+      | 'hu_ad'
+      | 'id_nik'
+      | 'ie_ppsn'
+      | 'is_kt'
+      | 'it_cf'
+      | 'jp_inc'
+      | 'ke_pin'
+      | 'kz_iin'
+      | 'li_peid'
+      | 'lt_ak'
+      | 'lu_nif'
+      | 'lv_pk'
+      | 'mx_rfc'
+      | 'my_nric'
+      | 'mz_nuit'
+      | 'ng_nin'
+      | 'nl_bsn'
+      | 'no_nin'
+      | 'nz_ird'
+      | 'pe_dni'
+      | 'pk_cnic'
+      | 'pk_snic'
+      | 'pl_pesel'
+      | 'pt_nif'
+      | 'ro_cnp'
+      | 'sa_tin'
+      | 'se_pin'
+      | 'sg_fin'
+      | 'sg_nric'
+      | 'sk_dic'
+      | 'th_lc'
+      | 'th_pin'
+      | 'tr_tin'
+      | 'us_itin'
+      | 'us_itin_last_4'
+      | 'us_ssn'
+      | 'us_ssn_last_4'
+      | 'uy_dni'
+      | 'za_id';
+  }
+
+  export namespace ScriptAddresses {
+    export interface Kana {
+      /**
+       * City, district, suburb, town, or village.
+       */
+      city?: string;
+
+      /**
+       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+       */
+      country?: string;
+
+      /**
+       * Address line 1 (e.g., street, PO Box, or company name).
+       */
+      line1?: string;
+
+      /**
+       * Address line 2 (e.g., apartment, suite, unit, or building).
+       */
+      line2?: string;
+
+      /**
+       * ZIP or postal code.
+       */
+      postal_code?: string;
+
+      /**
+       * State, county, province, or region.
+       */
+      state?: string;
+
+      /**
+       * Town or district.
+       */
+      town?: string;
+    }
+
+    export interface Kanji {
+      /**
+       * City, district, suburb, town, or village.
+       */
+      city?: string;
+
+      /**
+       * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+       */
+      country?: string;
+
+      /**
+       * Address line 1 (e.g., street, PO Box, or company name).
+       */
+      line1?: string;
+
+      /**
+       * Address line 2 (e.g., apartment, suite, unit, or building).
+       */
+      line2?: string;
+
+      /**
+       * ZIP or postal code.
+       */
+      postal_code?: string;
+
+      /**
+       * State, county, province, or region.
+       */
+      state?: string;
+
+      /**
+       * Town or district.
+       */
+      town?: string;
+    }
+  }
+
+  export namespace ScriptNames {
+    export interface Kana {
+      /**
+       * The person's first or given name.
+       */
+      given_name?: string;
+
+      /**
+       * The person's last or family name.
+       */
+      surname?: string;
+    }
+
+    export interface Kanji {
+      /**
+       * The person's first or given name.
+       */
+      given_name?: string;
+
+      /**
+       * The person's last or family name.
+       */
+      surname?: string;
     }
   }
 }

--- a/src/resources/V2/Core/Accounts.ts
+++ b/src/resources/V2/Core/Accounts.ts
@@ -256,7 +256,7 @@ export interface Account {
   /**
    * The configurations that have been applied to this account.
    */
-  applied_configurations: Array<V2.Core.Account.AppliedConfiguration>;
+  applied_configurations: Array<Account.AppliedConfiguration>;
 
   /**
    * Indicates whether the account has been closed.
@@ -266,7 +266,7 @@ export interface Account {
   /**
    * An Account represents a company, individual, or other entity that a user interacts with. Accounts store identity information and one or more configurations that enable product-specific capabilities. You can assign configurations at creation or add them later.
    */
-  configuration?: V2.Core.Account.Configuration;
+  configuration?: Account.Configuration;
 
   /**
    * The primary contact email address for the Account.
@@ -286,12 +286,12 @@ export interface Account {
   /**
    * A value indicating the Stripe dashboard this Account has access to. This will depend on which configurations are enabled for this account.
    */
-  dashboard?: V2.Core.Account.Dashboard;
+  dashboard?: Account.Dashboard;
 
   /**
    * Default values for settings shared across Account configurations.
    */
-  defaults?: V2.Core.Account.Defaults;
+  defaults?: Account.Defaults;
 
   /**
    * A descriptive name for the Account. This name will be surfaced in the Stripe Dashboard and on any invoices sent to the Account.
@@ -301,12 +301,12 @@ export interface Account {
   /**
    * Information about the future requirements for the Account that will eventually come into effect, including what information needs to be collected, and by when.
    */
-  future_requirements?: V2.Core.Account.FutureRequirements;
+  future_requirements?: Account.FutureRequirements;
 
   /**
    * Information about the company, individual, and business represented by the Account.
    */
-  identity?: V2.Core.Account.Identity;
+  identity?: Account.Identity;
 
   /**
    * Has the value `true` if the object exists in live mode or the value `false` if the object exists in test mode.
@@ -321,5373 +321,5357 @@ export interface Account {
   /**
    * Information about the active requirements for the Account, including what information needs to be collected, and by when.
    */
-  requirements?: V2.Core.Account.Requirements;
+  requirements?: Account.Requirements;
 }
-export namespace V2 {
-  export namespace Core {
-    export namespace Account {
-      export type AppliedConfiguration = 'customer' | 'merchant' | 'recipient';
+export namespace Account {
+  export type AppliedConfiguration = 'customer' | 'merchant' | 'recipient';
 
-      export interface Configuration {
+  export interface Configuration {
+    /**
+     * The Customer Configuration allows the Account to be used in inbound payment flows (i.e. customer-facing payment and billing flows).
+     */
+    customer?: Configuration.Customer;
+
+    /**
+     * Enables the Account to act as a connected account and collect payments facilitated by a Connect platform. You must onboard your platform to Connect before you can add this configuration to your connected accounts. Utilize this configuration when the Account will be the Merchant of Record, like with Direct charges or Destination Charges with on_behalf_of set.
+     */
+    merchant?: Configuration.Merchant;
+
+    /**
+     * The Recipient Configuration allows the Account to receive funds. Utilize this configuration if the Account will not be the Merchant of Record, like with Separate Charges & Transfers, or Destination Charges without on_behalf_of set.
+     */
+    recipient?: Configuration.Recipient;
+  }
+
+  export type Dashboard = 'express' | 'full' | 'none';
+
+  export interface Defaults {
+    /**
+     * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+     */
+    currency?: string;
+
+    /**
+     * The Account's preferred locales (languages), ordered by preference.
+     */
+    locales?: Array<Defaults.Locale>;
+
+    /**
+     * Account profile information.
+     */
+    profile?: Defaults.Profile;
+
+    /**
+     * Default responsibilities held by either Stripe or the platform.
+     */
+    responsibilities: Defaults.Responsibilities;
+  }
+
+  export interface FutureRequirements {
+    /**
+     * A list of requirements for the Account.
+     */
+    entries?: Array<FutureRequirements.Entry>;
+
+    /**
+     * The time at which the future requirements become effective.
+     */
+    minimum_transition_date?: string;
+
+    /**
+     * An object containing an overview of requirements for the Account.
+     */
+    summary?: FutureRequirements.Summary;
+  }
+
+  export interface Identity {
+    /**
+     * Attestations from the identity's key people, e.g. owners, executives, directors, representatives.
+     */
+    attestations?: Identity.Attestations;
+
+    /**
+     * Information about the company or business.
+     */
+    business_details?: Identity.BusinessDetails;
+
+    /**
+     * The country in which the account holder resides, or in which the business is legally established. This should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
+     */
+    country?: string;
+
+    /**
+     * The entity type represented by the Account. Ensure this field is accurate before adding configurations that rely on identity information, as it determines which identity fields apply and how the Account is validated.
+     */
+    entity_type?: Identity.EntityType;
+
+    /**
+     * Information about the individual represented by the Account. This property is `null` unless `entity_type` is set to `individual`.
+     */
+    individual?: Identity.Individual;
+  }
+
+  export interface Requirements {
+    /**
+     * A list of requirements for the Account.
+     */
+    entries?: Array<Requirements.Entry>;
+
+    /**
+     * An object containing an overview of requirements for the Account.
+     */
+    summary?: Requirements.Summary;
+  }
+
+  export namespace Configuration {
+    export interface Customer {
+      /**
+       * Indicates whether the customer configuration is active. You can deactivate or reactivate the customer configuration by updating this property. Deactivating the configuration by setting this value to false will unrequest all capabilities within the configuration. It will not delete any of the configuration's other properties.
+       */
+      applied: boolean;
+
+      /**
+       * Settings for automatic indirect tax calculation on the customer's invoices, subscriptions, Checkout Sessions, and Payment Links. Available when automatic tax calculation is available for the customer account's location.
+       */
+      automatic_indirect_tax?: Customer.AutomaticIndirectTax;
+
+      /**
+       * Default Billing settings for the customer account, used in Invoices and Subscriptions.
+       */
+      billing?: Customer.Billing;
+
+      /**
+       * Capabilities that have been requested on the Customer Configuration.
+       */
+      capabilities?: Customer.Capabilities;
+
+      /**
+       * The customer's shipping information. Appears on invoices emailed to this customer.
+       */
+      shipping?: Customer.Shipping;
+
+      /**
+       * ID of the test clock to attach to the customer. Can only be set on testmode Accounts, and when the Customer Configuration is first set on an Account.
+       */
+      test_clock?: string;
+    }
+
+    export interface Merchant {
+      /**
+       * Indicates whether the merchant configuration is active. You can deactivate or reactivate the merchant configuration by updating this property. Deactivating the configuration by setting this value to false doesn't delete the configuration's properties.
+       */
+      applied: boolean;
+
+      /**
+       * Settings for Bacs Direct Debit payments.
+       */
+      bacs_debit_payments?: Merchant.BacsDebitPayments;
+
+      /**
+       * Settings used to apply the merchant's branding to email receipts, invoices, Checkout, and other products.
+       */
+      branding?: Merchant.Branding;
+
+      /**
+       * Capabilities that have been requested on the Merchant Configuration.
+       */
+      capabilities?: Merchant.Capabilities;
+
+      /**
+       * Card payments settings.
+       */
+      card_payments?: Merchant.CardPayments;
+
+      /**
+       * Settings specific to Konbini payments on the account.
+       */
+      konbini_payments?: Merchant.KonbiniPayments;
+
+      /**
+       * The Merchant Category Code (MCC) for the merchant. MCCs classify businesses based on the goods or services they provide.
+       */
+      mcc?: string;
+
+      /**
+       * Settings for the default text that appears on statements for language variations.
+       */
+      script_statement_descriptor?: Merchant.ScriptStatementDescriptor;
+
+      /**
+       * Settings for SEPA Direct Debit payments.
+       */
+      sepa_debit_payments?: Merchant.SepaDebitPayments;
+
+      /**
+       * Statement descriptor.
+       */
+      statement_descriptor?: Merchant.StatementDescriptor;
+
+      /**
+       * Publicly available contact information for sending support issues to.
+       */
+      support?: Merchant.Support;
+    }
+
+    export interface Recipient {
+      /**
+       * Indicates whether the recipient configuration is active. You can deactivate or reactivate the recipient configuration by updating this property. Deactivating the configuration by setting this value to false  unrequest all capabilities within the configuration. It will not delete any of the configuration's other properties.
+       */
+      applied: boolean;
+
+      /**
+       * Capabilities that have been requested on the Recipient Configuration.
+       */
+      capabilities?: Recipient.Capabilities;
+    }
+
+    export namespace Customer {
+      export interface AutomaticIndirectTax {
         /**
-         * The Customer Configuration allows the Account to be used in inbound payment flows (i.e. customer-facing payment and billing flows).
+         * The customer account's tax exemption status: `none`, `exempt`, or `reverse`. When `reverse`, invoice and receipt PDFs include "Reverse charge".
          */
-        customer?: Configuration.Customer;
+        exempt?: AutomaticIndirectTax.Exempt;
 
         /**
-         * Enables the Account to act as a connected account and collect payments facilitated by a Connect platform. You must onboard your platform to Connect before you can add this configuration to your connected accounts. Utilize this configuration when the Account will be the Merchant of Record, like with Direct charges or Destination Charges with on_behalf_of set.
+         * A recent IP address of the customer used for tax reporting and tax location inference.
          */
-        merchant?: Configuration.Merchant;
+        ip_address?: string;
 
         /**
-         * The Recipient Configuration allows the Account to receive funds. Utilize this configuration if the Account will not be the Merchant of Record, like with Separate Charges & Transfers, or Destination Charges without on_behalf_of set.
+         * The customer account's identified tax location, derived from `location_source`. Only rendered if the `automatic_indirect_tax` feature is requested and `active`.
          */
-        recipient?: Configuration.Recipient;
+        location?: AutomaticIndirectTax.Location;
+
+        /**
+         * Data source used to identify the customer account's tax location. Defaults to `identity_address`. Used for automatic indirect tax calculation.
+         */
+        location_source?: AutomaticIndirectTax.LocationSource;
       }
 
-      export type Dashboard = 'express' | 'full' | 'none';
-
-      export interface Defaults {
+      export interface Billing {
         /**
-         * Three-letter [ISO currency code](https://www.iso.org/iso-4217-currency-codes.html), in lowercase. Must be a [supported currency](https://stripe.com/docs/currencies).
+         * The ID of a `PaymentMethod` attached to this Account's `customer` configuration, used as the default payment method for invoices and subscriptions.
          */
-        currency?: string;
+        default_payment_method?: string;
 
         /**
-         * The Account's preferred locales (languages), ordered by preference.
+         * Default invoice settings for the customer account.
          */
-        locales?: Array<Defaults.Locale>;
-
-        /**
-         * Account profile information.
-         */
-        profile?: Defaults.Profile;
-
-        /**
-         * Default responsibilities held by either Stripe or the platform.
-         */
-        responsibilities: Defaults.Responsibilities;
+        invoice?: Billing.Invoice;
       }
 
-      export interface FutureRequirements {
+      export interface Capabilities {
         /**
-         * A list of requirements for the Account.
+         * Generates requirements for enabling automatic indirect tax calculation on this customer's invoices or subscriptions. Recommended to request this capability if planning to enable automatic tax calculation on this customer's invoices or subscriptions.
          */
-        entries?: Array<FutureRequirements.Entry>;
-
-        /**
-         * The time at which the future requirements become effective.
-         */
-        minimum_transition_date?: string;
-
-        /**
-         * An object containing an overview of requirements for the Account.
-         */
-        summary?: FutureRequirements.Summary;
+        automatic_indirect_tax?: Capabilities.AutomaticIndirectTax;
       }
 
-      export interface Identity {
+      export interface Shipping {
         /**
-         * Attestations from the identity's key people, e.g. owners, executives, directors, representatives.
+         * Customer shipping address.
          */
-        attestations?: Identity.Attestations;
+        address?: Shipping.Address;
 
         /**
-         * Information about the company or business.
+         * Customer name.
          */
-        business_details?: Identity.BusinessDetails;
+        name?: string;
 
         /**
-         * The country in which the account holder resides, or in which the business is legally established. This should be an [ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2) country code.
+         * Customer phone (including extension).
          */
-        country?: string;
-
-        /**
-         * The entity type represented by the Account. Ensure this field is accurate before adding configurations that rely on identity information, as it determines which identity fields apply and how the Account is validated.
-         */
-        entity_type?: Identity.EntityType;
-
-        /**
-         * Information about the individual represented by the Account. This property is `null` unless `entity_type` is set to `individual`.
-         */
-        individual?: Identity.Individual;
+        phone?: string;
       }
 
-      export interface Requirements {
-        /**
-         * A list of requirements for the Account.
-         */
-        entries?: Array<Requirements.Entry>;
+      export namespace AutomaticIndirectTax {
+        export type Exempt = 'exempt' | 'none' | 'reverse';
 
-        /**
-         * An object containing an overview of requirements for the Account.
-         */
-        summary?: Requirements.Summary;
+        export interface Location {
+          /**
+           * The identified tax country of the customer.
+           */
+          country?: string;
+
+          /**
+           * The identified tax state, county, province, or region of the customer.
+           */
+          state?: string;
+        }
+
+        export type LocationSource =
+          | 'identity_address'
+          | 'ip_address'
+          | 'payment_method'
+          | 'shipping_address';
       }
 
-      export namespace Configuration {
-        export interface Customer {
+      export namespace Billing {
+        export interface Invoice {
           /**
-           * Indicates whether the customer configuration is active. You can deactivate or reactivate the customer configuration by updating this property. Deactivating the configuration by setting this value to false will unrequest all capabilities within the configuration. It will not delete any of the configuration's other properties.
+           * The list of up to 4 default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
            */
-          applied: boolean;
+          custom_fields: Array<Invoice.CustomField>;
 
           /**
-           * Settings for automatic indirect tax calculation on the customer's invoices, subscriptions, Checkout Sessions, and Payment Links. Available when automatic tax calculation is available for the customer account's location.
+           * Default invoice footer.
            */
-          automatic_indirect_tax?: Customer.AutomaticIndirectTax;
+          footer?: string;
 
           /**
-           * Default Billing settings for the customer account, used in Invoices and Subscriptions.
+           * Sequence number to use on the customer account's next invoice. Defaults to 1.
            */
-          billing?: Customer.Billing;
+          next_sequence?: number;
 
           /**
-           * Capabilities that have been requested on the Customer Configuration.
+           * Prefix used to generate unique invoice numbers. Must be 3-12 uppercase letters or numbers.
            */
-          capabilities?: Customer.Capabilities;
+          prefix?: string;
 
           /**
-           * The customer's shipping information. Appears on invoices emailed to this customer.
+           * Default invoice PDF rendering options.
            */
-          shipping?: Customer.Shipping;
-
-          /**
-           * ID of the test clock to attach to the customer. Can only be set on testmode Accounts, and when the Customer Configuration is first set on an Account.
-           */
-          test_clock?: string;
+          rendering?: Invoice.Rendering;
         }
 
-        export interface Merchant {
-          /**
-           * Indicates whether the merchant configuration is active. You can deactivate or reactivate the merchant configuration by updating this property. Deactivating the configuration by setting this value to false doesn't delete the configuration's properties.
-           */
-          applied: boolean;
-
-          /**
-           * Settings for Bacs Direct Debit payments.
-           */
-          bacs_debit_payments?: Merchant.BacsDebitPayments;
-
-          /**
-           * Settings used to apply the merchant's branding to email receipts, invoices, Checkout, and other products.
-           */
-          branding?: Merchant.Branding;
-
-          /**
-           * Capabilities that have been requested on the Merchant Configuration.
-           */
-          capabilities?: Merchant.Capabilities;
-
-          /**
-           * Card payments settings.
-           */
-          card_payments?: Merchant.CardPayments;
-
-          /**
-           * Settings specific to Konbini payments on the account.
-           */
-          konbini_payments?: Merchant.KonbiniPayments;
-
-          /**
-           * The Merchant Category Code (MCC) for the merchant. MCCs classify businesses based on the goods or services they provide.
-           */
-          mcc?: string;
-
-          /**
-           * Settings for the default text that appears on statements for language variations.
-           */
-          script_statement_descriptor?: Merchant.ScriptStatementDescriptor;
-
-          /**
-           * Settings for SEPA Direct Debit payments.
-           */
-          sepa_debit_payments?: Merchant.SepaDebitPayments;
-
-          /**
-           * Statement descriptor.
-           */
-          statement_descriptor?: Merchant.StatementDescriptor;
-
-          /**
-           * Publicly available contact information for sending support issues to.
-           */
-          support?: Merchant.Support;
-        }
-
-        export interface Recipient {
-          /**
-           * Indicates whether the recipient configuration is active. You can deactivate or reactivate the recipient configuration by updating this property. Deactivating the configuration by setting this value to false  unrequest all capabilities within the configuration. It will not delete any of the configuration's other properties.
-           */
-          applied: boolean;
-
-          /**
-           * Capabilities that have been requested on the Recipient Configuration.
-           */
-          capabilities?: Recipient.Capabilities;
-        }
-
-        export namespace Customer {
-          export interface AutomaticIndirectTax {
+        export namespace Invoice {
+          export interface CustomField {
             /**
-             * The customer account's tax exemption status: `none`, `exempt`, or `reverse`. When `reverse`, invoice and receipt PDFs include "Reverse charge".
+             * The name of the custom field. This may be up to 40 characters.
              */
-            exempt?: AutomaticIndirectTax.Exempt;
+            name: string;
 
             /**
-             * A recent IP address of the customer used for tax reporting and tax location inference.
+             * The value of the custom field. This may be up to 140 characters. When updating, pass an empty string to remove previously-defined values.
              */
-            ip_address?: string;
-
-            /**
-             * The customer account's identified tax location, derived from `location_source`. Only rendered if the `automatic_indirect_tax` feature is requested and `active`.
-             */
-            location?: AutomaticIndirectTax.Location;
-
-            /**
-             * Data source used to identify the customer account's tax location. Defaults to `identity_address`. Used for automatic indirect tax calculation.
-             */
-            location_source?: AutomaticIndirectTax.LocationSource;
+            value: string;
           }
 
-          export interface Billing {
+          export interface Rendering {
             /**
-             * The ID of a `PaymentMethod` attached to this Account's `customer` configuration, used as the default payment method for invoices and subscriptions.
+             * Indicates whether displayed line item prices and amounts on invoice PDFs include inclusive tax amounts. Must be either `include_inclusive_tax` or `exclude_tax`.
              */
-            default_payment_method?: string;
+            amount_tax_display?: Rendering.AmountTaxDisplay;
 
             /**
-             * Default invoice settings for the customer account.
+             * ID of the invoice rendering template to use for future invoices.
              */
-            invoice?: Billing.Invoice;
+            template?: string;
           }
 
-          export interface Capabilities {
-            /**
-             * Generates requirements for enabling automatic indirect tax calculation on this customer's invoices or subscriptions. Recommended to request this capability if planning to enable automatic tax calculation on this customer's invoices or subscriptions.
-             */
-            automatic_indirect_tax?: Capabilities.AutomaticIndirectTax;
-          }
-
-          export interface Shipping {
-            /**
-             * Customer shipping address.
-             */
-            address?: Shipping.Address;
-
-            /**
-             * Customer name.
-             */
-            name?: string;
-
-            /**
-             * Customer phone (including extension).
-             */
-            phone?: string;
-          }
-
-          export namespace AutomaticIndirectTax {
-            export type Exempt = 'exempt' | 'none' | 'reverse';
-
-            export interface Location {
-              /**
-               * The identified tax country of the customer.
-               */
-              country?: string;
-
-              /**
-               * The identified tax state, county, province, or region of the customer.
-               */
-              state?: string;
-            }
-
-            export type LocationSource =
-              | 'identity_address'
-              | 'ip_address'
-              | 'payment_method'
-              | 'shipping_address';
-          }
-
-          export namespace Billing {
-            export interface Invoice {
-              /**
-               * The list of up to 4 default custom fields to be displayed on invoices for this customer. When updating, pass an empty string to remove previously-defined fields.
-               */
-              custom_fields: Array<Invoice.CustomField>;
-
-              /**
-               * Default invoice footer.
-               */
-              footer?: string;
-
-              /**
-               * Sequence number to use on the customer account's next invoice. Defaults to 1.
-               */
-              next_sequence?: number;
-
-              /**
-               * Prefix used to generate unique invoice numbers. Must be 3-12 uppercase letters or numbers.
-               */
-              prefix?: string;
-
-              /**
-               * Default invoice PDF rendering options.
-               */
-              rendering?: Invoice.Rendering;
-            }
-
-            export namespace Invoice {
-              export interface CustomField {
-                /**
-                 * The name of the custom field. This may be up to 40 characters.
-                 */
-                name: string;
-
-                /**
-                 * The value of the custom field. This may be up to 140 characters. When updating, pass an empty string to remove previously-defined values.
-                 */
-                value: string;
-              }
-
-              export interface Rendering {
-                /**
-                 * Indicates whether displayed line item prices and amounts on invoice PDFs include inclusive tax amounts. Must be either `include_inclusive_tax` or `exclude_tax`.
-                 */
-                amount_tax_display?: Rendering.AmountTaxDisplay;
-
-                /**
-                 * ID of the invoice rendering template to use for future invoices.
-                 */
-                template?: string;
-              }
-
-              export namespace Rendering {
-                export type AmountTaxDisplay =
-                  | 'exclude_tax'
-                  | 'include_inclusive_tax';
-              }
-            }
-          }
-
-          export namespace Capabilities {
-            export interface AutomaticIndirectTax {
-              /**
-               * The status of the Capability.
-               */
-              status: AutomaticIndirectTax.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AutomaticIndirectTax.StatusDetail>;
-            }
-
-            export namespace AutomaticIndirectTax {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-          }
-
-          export namespace Shipping {
-            export interface Address {
-              /**
-               * City, district, suburb, town, or village.
-               */
-              city?: string;
-
-              /**
-               * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-               */
-              country?: string;
-
-              /**
-               * Address line 1 (e.g., street, PO Box, or company name).
-               */
-              line1?: string;
-
-              /**
-               * Address line 2 (e.g., apartment, suite, unit, or building).
-               */
-              line2?: string;
-
-              /**
-               * ZIP or postal code.
-               */
-              postal_code?: string;
-
-              /**
-               * State, county, province, or region.
-               */
-              state?: string;
-            }
-          }
-        }
-
-        export namespace Merchant {
-          export interface BacsDebitPayments {
-            /**
-             * Display name for Bacs Direct Debit payments.
-             */
-            display_name?: string;
-
-            /**
-             * Service User Number (SUN) for Bacs Direct Debit payments.
-             */
-            service_user_number?: string;
-          }
-
-          export interface Branding {
-            /**
-             * ID of a [file upload](https://docs.stripe.com/api/persons/update#create_file): An icon for the merchant. Must be square and at least 128px x 128px.
-             */
-            icon?: string;
-
-            /**
-             * ID of a [file upload](https://docs.stripe.com/api/persons/update#create_file): A logo for the merchant that will be used in Checkout instead of the icon and without the merchant's name next to it if provided. Must be at least 128px x 128px.
-             */
-            logo?: string;
-
-            /**
-             * A CSS hex color value representing the primary branding color for the merchant.
-             */
-            primary_color?: string;
-
-            /**
-             * A CSS hex color value representing the secondary branding color for the merchant.
-             */
-            secondary_color?: string;
-          }
-
-          export interface Capabilities {
-            /**
-             * Allow the merchant to process ACH debit payments.
-             */
-            ach_debit_payments?: Capabilities.AchDebitPayments;
-
-            /**
-             * Allow the merchant to process ACSS debit payments.
-             */
-            acss_debit_payments?: Capabilities.AcssDebitPayments;
-
-            /**
-             * Allow the merchant to process Affirm payments.
-             */
-            affirm_payments?: Capabilities.AffirmPayments;
-
-            /**
-             * Allow the merchant to process Afterpay/Clearpay payments.
-             */
-            afterpay_clearpay_payments?: Capabilities.AfterpayClearpayPayments;
-
-            /**
-             * Allow the merchant to process Alma payments.
-             */
-            alma_payments?: Capabilities.AlmaPayments;
-
-            /**
-             * Allow the merchant to process Amazon Pay payments.
-             */
-            amazon_pay_payments?: Capabilities.AmazonPayPayments;
-
-            /**
-             * Allow the merchant to process Australian BECS Direct Debit payments.
-             */
-            au_becs_debit_payments?: Capabilities.AuBecsDebitPayments;
-
-            /**
-             * Allow the merchant to process BACS Direct Debit payments.
-             */
-            bacs_debit_payments?: Capabilities.BacsDebitPayments;
-
-            /**
-             * Allow the merchant to process Bancontact payments.
-             */
-            bancontact_payments?: Capabilities.BancontactPayments;
-
-            /**
-             * Allow the merchant to process BLIK payments.
-             */
-            blik_payments?: Capabilities.BlikPayments;
-
-            /**
-             * Allow the merchant to process Boleto payments.
-             */
-            boleto_payments?: Capabilities.BoletoPayments;
-
-            /**
-             * Allow the merchant to collect card payments.
-             */
-            card_payments?: Capabilities.CardPayments;
-
-            /**
-             * Allow the merchant to process Cartes Bancaires payments.
-             */
-            cartes_bancaires_payments?: Capabilities.CartesBancairesPayments;
-
-            /**
-             * Allow the merchant to process Cash App payments.
-             */
-            cashapp_payments?: Capabilities.CashappPayments;
-
-            /**
-             * Allow the merchant to process EPS payments.
-             */
-            eps_payments?: Capabilities.EpsPayments;
-
-            /**
-             * Allow the merchant to process FPX payments.
-             */
-            fpx_payments?: Capabilities.FpxPayments;
-
-            /**
-             * Allow the merchant to process UK bank transfer payments.
-             */
-            gb_bank_transfer_payments?: Capabilities.GbBankTransferPayments;
-
-            /**
-             * Allow the merchant to process GrabPay payments.
-             */
-            grabpay_payments?: Capabilities.GrabpayPayments;
-
-            /**
-             * Allow the merchant to process iDEAL payments.
-             */
-            ideal_payments?: Capabilities.IdealPayments;
-
-            /**
-             * Allow the merchant to process JCB card payments.
-             */
-            jcb_payments?: Capabilities.JcbPayments;
-
-            /**
-             * Allow the merchant to process Japanese bank transfer payments.
-             */
-            jp_bank_transfer_payments?: Capabilities.JpBankTransferPayments;
-
-            /**
-             * Allow the merchant to process Kakao Pay payments.
-             */
-            kakao_pay_payments?: Capabilities.KakaoPayPayments;
-
-            /**
-             * Allow the merchant to process Klarna payments.
-             */
-            klarna_payments?: Capabilities.KlarnaPayments;
-
-            /**
-             * Allow the merchant to process Konbini convenience store payments.
-             */
-            konbini_payments?: Capabilities.KonbiniPayments;
-
-            /**
-             * Allow the merchant to process Korean card payments.
-             */
-            kr_card_payments?: Capabilities.KrCardPayments;
-
-            /**
-             * Allow the merchant to process Link payments.
-             */
-            link_payments?: Capabilities.LinkPayments;
-
-            /**
-             * Allow the merchant to process MobilePay payments.
-             */
-            mobilepay_payments?: Capabilities.MobilepayPayments;
-
-            /**
-             * Allow the merchant to process Multibanco payments.
-             */
-            multibanco_payments?: Capabilities.MultibancoPayments;
-
-            /**
-             * Allow the merchant to process Mexican bank transfer payments.
-             */
-            mx_bank_transfer_payments?: Capabilities.MxBankTransferPayments;
-
-            /**
-             * Allow the merchant to process Naver Pay payments.
-             */
-            naver_pay_payments?: Capabilities.NaverPayPayments;
-
-            /**
-             * Allow the merchant to process OXXO payments.
-             */
-            oxxo_payments?: Capabilities.OxxoPayments;
-
-            /**
-             * Allow the merchant to process Przelewy24 (P24) payments.
-             */
-            p24_payments?: Capabilities.P24Payments;
-
-            /**
-             * Allow the merchant to process Pay by Bank payments.
-             */
-            pay_by_bank_payments?: Capabilities.PayByBankPayments;
-
-            /**
-             * Allow the merchant to process PAYCO payments.
-             */
-            payco_payments?: Capabilities.PaycoPayments;
-
-            /**
-             * Allow the merchant to process PayNow payments.
-             */
-            paynow_payments?: Capabilities.PaynowPayments;
-
-            /**
-             * Allow the merchant to process PromptPay payments.
-             */
-            promptpay_payments?: Capabilities.PromptpayPayments;
-
-            /**
-             * Allow the merchant to process Revolut Pay payments.
-             */
-            revolut_pay_payments?: Capabilities.RevolutPayPayments;
-
-            /**
-             * Allow the merchant to process Samsung Pay payments.
-             */
-            samsung_pay_payments?: Capabilities.SamsungPayPayments;
-
-            /**
-             * Allow the merchant to process SEPA bank transfer payments.
-             */
-            sepa_bank_transfer_payments?: Capabilities.SepaBankTransferPayments;
-
-            /**
-             * Allow the merchant to process SEPA Direct Debit payments.
-             */
-            sepa_debit_payments?: Capabilities.SepaDebitPayments;
-
-            /**
-             * Capabilities that enable the merchant to manage their Stripe Balance (/v1/balance).
-             */
-            stripe_balance?: Capabilities.StripeBalance;
-
-            /**
-             * Allow the merchant to process Swish payments.
-             */
-            swish_payments?: Capabilities.SwishPayments;
-
-            /**
-             * Allow the merchant to process TWINT payments.
-             */
-            twint_payments?: Capabilities.TwintPayments;
-
-            /**
-             * Allow the merchant to process US bank transfer payments.
-             */
-            us_bank_transfer_payments?: Capabilities.UsBankTransferPayments;
-
-            /**
-             * Allow the merchant to process Zip payments.
-             */
-            zip_payments?: Capabilities.ZipPayments;
-          }
-
-          export interface CardPayments {
-            /**
-             * Automatically declines certain charge types regardless of whether the card issuer accepted or declined the charge.
-             */
-            decline_on?: CardPayments.DeclineOn;
-          }
-
-          export interface KonbiniPayments {
-            /**
-             * Support for Konbini payments.
-             */
-            support?: KonbiniPayments.Support;
-          }
-
-          export interface ScriptStatementDescriptor {
-            /**
-             * The Kana variation of statement_descriptor used for charges in Japan. Japanese statement descriptors have [special requirements](https://docs.stripe.com/get-started/account/statement-descriptors#set-japanese-statement-descriptors).
-             */
-            kana?: ScriptStatementDescriptor.Kana;
-
-            /**
-             * The Kanji variation of statement_descriptor used for charges in Japan. Japanese statement descriptors have [special requirements](https://docs.stripe.com/get-started/account/statement-descriptors#set-japanese-statement-descriptors).
-             */
-            kanji?: ScriptStatementDescriptor.Kanji;
-          }
-
-          export interface SepaDebitPayments {
-            /**
-             * Creditor ID for SEPA Direct Debit payments.
-             */
-            creditor_id?: string;
-          }
-
-          export interface StatementDescriptor {
-            /**
-             * The default text that appears on statements for non-card charges outside of Japan. For card charges, if you don't set a statement_descriptor_prefix, this text is also used as the statement descriptor prefix. In that case, if concatenating the statement descriptor suffix causes the combined statement descriptor to exceed 22 characters, we truncate the statement_descriptor text to limit the full descriptor to 22 characters. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
-             */
-            descriptor?: string;
-
-            /**
-             * Default text that appears on statements for card charges outside of Japan, prefixing any dynamic statement_descriptor_suffix specified on the charge. To maximize space for the dynamic part of the descriptor, keep this text short. If you don't specify this value, statement_descriptor is used as the prefix. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
-             */
-            prefix?: string;
-          }
-
-          export interface Support {
-            /**
-             * A publicly available mailing address for sending support issues to.
-             */
-            address?: Support.Address;
-
-            /**
-             * A publicly available email address for sending support issues to.
-             */
-            email?: string;
-
-            /**
-             * A publicly available phone number to call with support issues.
-             */
-            phone?: string;
-
-            /**
-             * A publicly available website for handling support issues.
-             */
-            url?: string;
-          }
-
-          export namespace Capabilities {
-            export interface AchDebitPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AchDebitPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AchDebitPayments.StatusDetail>;
-            }
-
-            export interface AcssDebitPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AcssDebitPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AcssDebitPayments.StatusDetail>;
-            }
-
-            export interface AffirmPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AffirmPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AffirmPayments.StatusDetail>;
-            }
-
-            export interface AfterpayClearpayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AfterpayClearpayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AfterpayClearpayPayments.StatusDetail>;
-            }
-
-            export interface AlmaPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AlmaPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AlmaPayments.StatusDetail>;
-            }
-
-            export interface AmazonPayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AmazonPayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AmazonPayPayments.StatusDetail>;
-            }
-
-            export interface AuBecsDebitPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: AuBecsDebitPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<AuBecsDebitPayments.StatusDetail>;
-            }
-
-            export interface BacsDebitPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: BacsDebitPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<BacsDebitPayments.StatusDetail>;
-            }
-
-            export interface BancontactPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: BancontactPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<BancontactPayments.StatusDetail>;
-            }
-
-            export interface BlikPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: BlikPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<BlikPayments.StatusDetail>;
-            }
-
-            export interface BoletoPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: BoletoPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<BoletoPayments.StatusDetail>;
-            }
-
-            export interface CardPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: CardPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<CardPayments.StatusDetail>;
-            }
-
-            export interface CartesBancairesPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: CartesBancairesPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<CartesBancairesPayments.StatusDetail>;
-            }
-
-            export interface CashappPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: CashappPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<CashappPayments.StatusDetail>;
-            }
-
-            export interface EpsPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: EpsPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<EpsPayments.StatusDetail>;
-            }
-
-            export interface FpxPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: FpxPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<FpxPayments.StatusDetail>;
-            }
-
-            export interface GbBankTransferPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: GbBankTransferPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<GbBankTransferPayments.StatusDetail>;
-            }
-
-            export interface GrabpayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: GrabpayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<GrabpayPayments.StatusDetail>;
-            }
-
-            export interface IdealPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: IdealPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<IdealPayments.StatusDetail>;
-            }
-
-            export interface JcbPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: JcbPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<JcbPayments.StatusDetail>;
-            }
-
-            export interface JpBankTransferPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: JpBankTransferPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<JpBankTransferPayments.StatusDetail>;
-            }
-
-            export interface KakaoPayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: KakaoPayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<KakaoPayPayments.StatusDetail>;
-            }
-
-            export interface KlarnaPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: KlarnaPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<KlarnaPayments.StatusDetail>;
-            }
-
-            export interface KonbiniPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: KonbiniPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<KonbiniPayments.StatusDetail>;
-            }
-
-            export interface KrCardPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: KrCardPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<KrCardPayments.StatusDetail>;
-            }
-
-            export interface LinkPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: LinkPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<LinkPayments.StatusDetail>;
-            }
-
-            export interface MobilepayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: MobilepayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<MobilepayPayments.StatusDetail>;
-            }
-
-            export interface MultibancoPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: MultibancoPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<MultibancoPayments.StatusDetail>;
-            }
-
-            export interface MxBankTransferPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: MxBankTransferPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<MxBankTransferPayments.StatusDetail>;
-            }
-
-            export interface NaverPayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: NaverPayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<NaverPayPayments.StatusDetail>;
-            }
-
-            export interface OxxoPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: OxxoPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<OxxoPayments.StatusDetail>;
-            }
-
-            export interface P24Payments {
-              /**
-               * The status of the Capability.
-               */
-              status: P24Payments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<P24Payments.StatusDetail>;
-            }
-
-            export interface PayByBankPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: PayByBankPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<PayByBankPayments.StatusDetail>;
-            }
-
-            export interface PaycoPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: PaycoPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<PaycoPayments.StatusDetail>;
-            }
-
-            export interface PaynowPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: PaynowPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<PaynowPayments.StatusDetail>;
-            }
-
-            export interface PromptpayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: PromptpayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<PromptpayPayments.StatusDetail>;
-            }
-
-            export interface RevolutPayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: RevolutPayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<RevolutPayPayments.StatusDetail>;
-            }
-
-            export interface SamsungPayPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: SamsungPayPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<SamsungPayPayments.StatusDetail>;
-            }
-
-            export interface SepaBankTransferPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: SepaBankTransferPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<SepaBankTransferPayments.StatusDetail>;
-            }
-
-            export interface SepaDebitPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: SepaDebitPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<SepaDebitPayments.StatusDetail>;
-            }
-
-            export interface StripeBalance {
-              /**
-               * Enables this Account to complete payouts from their Stripe Balance (/v1/balance).
-               */
-              payouts?: StripeBalance.Payouts;
-            }
-
-            export interface SwishPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: SwishPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<SwishPayments.StatusDetail>;
-            }
-
-            export interface TwintPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: TwintPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<TwintPayments.StatusDetail>;
-            }
-
-            export interface UsBankTransferPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: UsBankTransferPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<UsBankTransferPayments.StatusDetail>;
-            }
-
-            export interface ZipPayments {
-              /**
-               * The status of the Capability.
-               */
-              status: ZipPayments.Status;
-
-              /**
-               * Additional details about the capability's status. This value is empty when `status` is `active`.
-               */
-              status_details: Array<ZipPayments.StatusDetail>;
-            }
-
-            export namespace AchDebitPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace AcssDebitPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace AffirmPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace AfterpayClearpayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace AlmaPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace AmazonPayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace AuBecsDebitPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace BacsDebitPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace BancontactPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace BlikPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace BoletoPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace CardPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace CartesBancairesPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace CashappPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace EpsPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace FpxPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace GbBankTransferPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace GrabpayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace IdealPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace JcbPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace JpBankTransferPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace KakaoPayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace KlarnaPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace KonbiniPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace KrCardPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace LinkPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace MobilepayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace MultibancoPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace MxBankTransferPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace NaverPayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace OxxoPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace P24Payments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace PayByBankPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace PaycoPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace PaynowPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace PromptpayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace RevolutPayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace SamsungPayPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace SepaBankTransferPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace SepaDebitPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace StripeBalance {
-              export interface Payouts {
-                /**
-                 * The status of the Capability.
-                 */
-                status: Payouts.Status;
-
-                /**
-                 * Additional details about the capability's status. This value is empty when `status` is `active`.
-                 */
-                status_details: Array<Payouts.StatusDetail>;
-              }
-
-              export namespace Payouts {
-                export type Status =
-                  | 'active'
-                  | 'pending'
-                  | 'restricted'
-                  | 'unsupported';
-
-                export interface StatusDetail {
-                  /**
-                   * Machine-readable code explaining the reason for the Capability to be in its current status.
-                   */
-                  code: StatusDetail.Code;
-
-                  /**
-                   * Machine-readable code explaining how to make the Capability active.
-                   */
-                  resolution: StatusDetail.Resolution;
-                }
-
-                export namespace StatusDetail {
-                  export type Code =
-                    | 'determining_status'
-                    | 'requirements_past_due'
-                    | 'requirements_pending_verification'
-                    | 'restricted_other'
-                    | 'unsupported_business'
-                    | 'unsupported_country'
-                    | 'unsupported_entity_type';
-
-                  export type Resolution =
-                    | 'contact_stripe'
-                    | 'no_resolution'
-                    | 'provide_info';
-                }
-              }
-            }
-
-            export namespace SwishPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace TwintPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace UsBankTransferPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-
-            export namespace ZipPayments {
-              export type Status =
-                | 'active'
-                | 'pending'
-                | 'restricted'
-                | 'unsupported';
-
-              export interface StatusDetail {
-                /**
-                 * Machine-readable code explaining the reason for the Capability to be in its current status.
-                 */
-                code: StatusDetail.Code;
-
-                /**
-                 * Machine-readable code explaining how to make the Capability active.
-                 */
-                resolution: StatusDetail.Resolution;
-              }
-
-              export namespace StatusDetail {
-                export type Code =
-                  | 'determining_status'
-                  | 'requirements_past_due'
-                  | 'requirements_pending_verification'
-                  | 'restricted_other'
-                  | 'unsupported_business'
-                  | 'unsupported_country'
-                  | 'unsupported_entity_type';
-
-                export type Resolution =
-                  | 'contact_stripe'
-                  | 'no_resolution'
-                  | 'provide_info';
-              }
-            }
-          }
-
-          export namespace CardPayments {
-            export interface DeclineOn {
-              /**
-               * Whether Stripe automatically declines charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and they fail bank verification.
-               */
-              avs_failure?: boolean;
-
-              /**
-               * Whether Stripe automatically declines charges with an incorrect CVC. This setting only applies when a CVC is provided and it fails bank verification.
-               */
-              cvc_failure?: boolean;
-            }
-          }
-
-          export namespace KonbiniPayments {
-            export interface Support {
-              /**
-               * Support email address for Konbini payments.
-               */
-              email?: string;
-
-              /**
-               * Support hours for Konbini payments.
-               */
-              hours?: Support.Hours;
-
-              /**
-               * Support phone number for Konbini payments.
-               */
-              phone?: string;
-            }
-
-            export namespace Support {
-              export interface Hours {
-                /**
-                 * Support hours end time (JST time of day) for in `HH:MM` format.
-                 */
-                end_time?: string;
-
-                /**
-                 * Support hours start time (JST time of day) for in `HH:MM` format.
-                 */
-                start_time?: string;
-              }
-            }
-          }
-
-          export namespace ScriptStatementDescriptor {
-            export interface Kana {
-              /**
-               * The default text that appears on statements for non-card charges outside of Japan. For card charges, if you don't set a statement_descriptor_prefix, this text is also used as the statement descriptor prefix. In that case, if concatenating the statement descriptor suffix causes the combined statement descriptor to exceed 22 characters, we truncate the statement_descriptor text to limit the full descriptor to 22 characters. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
-               */
-              descriptor?: string;
-
-              /**
-               * Default text that appears on statements for card charges outside of Japan, prefixing any dynamic statement_descriptor_suffix specified on the charge. To maximize space for the dynamic part of the descriptor, keep this text short. If you don't specify this value, statement_descriptor is used as the prefix. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
-               */
-              prefix?: string;
-            }
-
-            export interface Kanji {
-              /**
-               * The default text that appears on statements for non-card charges outside of Japan. For card charges, if you don't set a statement_descriptor_prefix, this text is also used as the statement descriptor prefix. In that case, if concatenating the statement descriptor suffix causes the combined statement descriptor to exceed 22 characters, we truncate the statement_descriptor text to limit the full descriptor to 22 characters. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
-               */
-              descriptor?: string;
-
-              /**
-               * Default text that appears on statements for card charges outside of Japan, prefixing any dynamic statement_descriptor_suffix specified on the charge. To maximize space for the dynamic part of the descriptor, keep this text short. If you don't specify this value, statement_descriptor is used as the prefix. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
-               */
-              prefix?: string;
-            }
-          }
-
-          export namespace Support {
-            export interface Address {
-              /**
-               * City, district, suburb, town, or village.
-               */
-              city?: string;
-
-              /**
-               * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-               */
-              country?: string;
-
-              /**
-               * Address line 1 (e.g., street, PO Box, or company name).
-               */
-              line1?: string;
-
-              /**
-               * Address line 2 (e.g., apartment, suite, unit, or building).
-               */
-              line2?: string;
-
-              /**
-               * ZIP or postal code.
-               */
-              postal_code?: string;
-
-              /**
-               * State, county, province, or region.
-               */
-              state?: string;
-
-              /**
-               * Town or district.
-               */
-              town?: string;
-            }
-          }
-        }
-
-        export namespace Recipient {
-          export interface Capabilities {
-            /**
-             * Capabilities that enable the recipient to manage their Stripe Balance (/v1/balance).
-             */
-            stripe_balance?: Capabilities.StripeBalance;
-          }
-
-          export namespace Capabilities {
-            export interface StripeBalance {
-              /**
-               * Enables this Account to complete payouts from their Stripe Balance (/v1/balance).
-               */
-              payouts?: StripeBalance.Payouts;
-
-              /**
-               * Enables this Account to receive /v1/transfers into their Stripe Balance (/v1/balance).
-               */
-              stripe_transfers?: StripeBalance.StripeTransfers;
-            }
-
-            export namespace StripeBalance {
-              export interface Payouts {
-                /**
-                 * The status of the Capability.
-                 */
-                status: Payouts.Status;
-
-                /**
-                 * Additional details about the capability's status. This value is empty when `status` is `active`.
-                 */
-                status_details: Array<Payouts.StatusDetail>;
-              }
-
-              export interface StripeTransfers {
-                /**
-                 * The status of the Capability.
-                 */
-                status: StripeTransfers.Status;
-
-                /**
-                 * Additional details about the capability's status. This value is empty when `status` is `active`.
-                 */
-                status_details: Array<StripeTransfers.StatusDetail>;
-              }
-
-              export namespace Payouts {
-                export type Status =
-                  | 'active'
-                  | 'pending'
-                  | 'restricted'
-                  | 'unsupported';
-
-                export interface StatusDetail {
-                  /**
-                   * Machine-readable code explaining the reason for the Capability to be in its current status.
-                   */
-                  code: StatusDetail.Code;
-
-                  /**
-                   * Machine-readable code explaining how to make the Capability active.
-                   */
-                  resolution: StatusDetail.Resolution;
-                }
-
-                export namespace StatusDetail {
-                  export type Code =
-                    | 'determining_status'
-                    | 'requirements_past_due'
-                    | 'requirements_pending_verification'
-                    | 'restricted_other'
-                    | 'unsupported_business'
-                    | 'unsupported_country'
-                    | 'unsupported_entity_type';
-
-                  export type Resolution =
-                    | 'contact_stripe'
-                    | 'no_resolution'
-                    | 'provide_info';
-                }
-              }
-
-              export namespace StripeTransfers {
-                export type Status =
-                  | 'active'
-                  | 'pending'
-                  | 'restricted'
-                  | 'unsupported';
-
-                export interface StatusDetail {
-                  /**
-                   * Machine-readable code explaining the reason for the Capability to be in its current status.
-                   */
-                  code: StatusDetail.Code;
-
-                  /**
-                   * Machine-readable code explaining how to make the Capability active.
-                   */
-                  resolution: StatusDetail.Resolution;
-                }
-
-                export namespace StatusDetail {
-                  export type Code =
-                    | 'determining_status'
-                    | 'requirements_past_due'
-                    | 'requirements_pending_verification'
-                    | 'restricted_other'
-                    | 'unsupported_business'
-                    | 'unsupported_country'
-                    | 'unsupported_entity_type';
-
-                  export type Resolution =
-                    | 'contact_stripe'
-                    | 'no_resolution'
-                    | 'provide_info';
-                }
-              }
-            }
+          export namespace Rendering {
+            export type AmountTaxDisplay =
+              | 'exclude_tax'
+              | 'include_inclusive_tax';
           }
         }
       }
 
-      export namespace Defaults {
-        export type Locale =
-          | 'ar-SA'
-          | 'bg'
-          | 'bg-BG'
-          | 'cs'
-          | 'cs-CZ'
-          | 'da'
-          | 'da-DK'
-          | 'de'
-          | 'de-DE'
-          | 'el'
-          | 'el-GR'
-          | 'en'
-          | 'en-AU'
-          | 'en-CA'
-          | 'en-GB'
-          | 'en-IE'
-          | 'en-IN'
-          | 'en-NZ'
-          | 'en-SG'
-          | 'en-US'
-          | 'es'
-          | 'es-419'
-          | 'es-ES'
-          | 'et'
-          | 'et-EE'
-          | 'fi'
-          | 'fil'
-          | 'fil-PH'
-          | 'fi-FI'
-          | 'fr'
-          | 'fr-CA'
-          | 'fr-FR'
-          | 'he-IL'
-          | 'hr'
-          | 'hr-HR'
-          | 'hu'
-          | 'hu-HU'
-          | 'id'
-          | 'id-ID'
-          | 'it'
-          | 'it-IT'
-          | 'ja'
-          | 'ja-JP'
-          | 'ko'
-          | 'ko-KR'
-          | 'lt'
-          | 'lt-LT'
-          | 'lv'
-          | 'lv-LV'
-          | 'ms'
-          | 'ms-MY'
-          | 'mt'
-          | 'mt-MT'
-          | 'nb'
-          | 'nb-NO'
-          | 'nl'
-          | 'nl-NL'
-          | 'pl'
-          | 'pl-PL'
-          | 'pt'
-          | 'pt-BR'
-          | 'pt-PT'
-          | 'ro'
-          | 'ro-RO'
-          | 'ru'
-          | 'ru-RU'
-          | 'sk'
-          | 'sk-SK'
-          | 'sl'
-          | 'sl-SI'
-          | 'sv'
-          | 'sv-SE'
-          | 'th'
-          | 'th-TH'
-          | 'tr'
-          | 'tr-TR'
-          | 'vi'
-          | 'vi-VN'
-          | 'zh'
-          | 'zh-Hans'
-          | 'zh-Hant-HK'
-          | 'zh-Hant-TW'
-          | 'zh-HK'
-          | 'zh-TW';
-
-        export interface Profile {
+      export namespace Capabilities {
+        export interface AutomaticIndirectTax {
           /**
-           * The business's publicly-available website.
+           * The status of the Capability.
            */
-          business_url?: string;
+          status: AutomaticIndirectTax.Status;
 
           /**
-           * The customer-facing business name.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
            */
-          doing_business_as?: string;
-
-          /**
-           * Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.
-           */
-          product_description?: string;
+          status_details: Array<AutomaticIndirectTax.StatusDetail>;
         }
 
-        export interface Responsibilities {
-          /**
-           * Indicates whether the platform or connected account is responsible for paying Stripe fees for pricing-control-eligible products.
-           */
-          fees_collector?: Responsibilities.FeesCollector;
+        export namespace AutomaticIndirectTax {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
 
-          /**
-           * A value indicating responsibility for collecting requirements on this account.
-           */
-          losses_collector?: Responsibilities.LossesCollector;
-
-          /**
-           * A value indicating responsibility for collecting requirements on this account.
-           */
-          requirements_collector: Responsibilities.RequirementsCollector;
-        }
-
-        export namespace Responsibilities {
-          export type FeesCollector =
-            | 'application'
-            | 'application_custom'
-            | 'application_express'
-            | 'stripe';
-
-          export type LossesCollector = 'application' | 'stripe';
-
-          export type RequirementsCollector = 'application' | 'stripe';
-        }
-      }
-
-      export namespace FutureRequirements {
-        export interface Entry {
-          /**
-           * Indicates whether the platform or Stripe is currently responsible for taking action on the requirement. Value can be `user` or `stripe`.
-           */
-          awaiting_action_from: Entry.AwaitingActionFrom;
-
-          /**
-           * Machine-readable string describing the requirement.
-           */
-          description: string;
-
-          /**
-           * Descriptions of why the requirement must be collected, or why the collected information isn't satisfactory to Stripe.
-           */
-          errors: Array<Entry.Error>;
-
-          /**
-           * A hash describing the impact of not collecting the requirement, or Stripe not being able to verify the collected information.
-           */
-          impact: Entry.Impact;
-
-          /**
-           * The soonest point when the account will be impacted by not providing the requirement.
-           */
-          minimum_deadline: Entry.MinimumDeadline;
-
-          /**
-           * A reference to the location of the requirement.
-           */
-          reference?: Entry.Reference;
-
-          /**
-           * A list of reasons why Stripe is collecting the requirement.
-           */
-          requested_reasons: Array<Entry.RequestedReason>;
-        }
-
-        export interface Summary {
-          /**
-           * The soonest date and time a requirement on the Account will become `past due`. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: `2022-09-18T13:22:18.123Z`.
-           */
-          minimum_deadline?: Summary.MinimumDeadline;
-        }
-
-        export namespace Entry {
-          export type AwaitingActionFrom = 'stripe' | 'user';
-
-          export interface Error {
+          export interface StatusDetail {
             /**
-             * Machine-readable code describing the error.
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
              */
-            code: Error.Code;
+            code: StatusDetail.Code;
 
             /**
-             * Human-readable description of the error.
+             * Machine-readable code explaining how to make the Capability active.
              */
-            description: string;
+            resolution: StatusDetail.Resolution;
           }
 
-          export interface Impact {
-            /**
-             * The Capabilities that will be restricted if the requirement is not collected and satisfactory to Stripe.
-             */
-            restricts_capabilities?: Array<Impact.RestrictsCapability>;
-          }
-
-          export interface MinimumDeadline {
-            /**
-             * The current status of the requirement's impact.
-             */
-            status: MinimumDeadline.Status;
-          }
-
-          export interface Reference {
-            /**
-             * If `inquiry` is the type, the inquiry token.
-             */
-            inquiry?: string;
-
-            /**
-             * If `resource` is the type, the resource token.
-             */
-            resource?: string;
-
-            /**
-             * The type of the reference. If the type is "inquiry", the inquiry token can be found in the "inquiry" field.
-             * Otherwise the type is an API resource, the token for which can be found in the "resource" field.
-             */
-            type: Reference.Type;
-          }
-
-          export interface RequestedReason {
-            /**
-             * Machine-readable description of Stripe's reason for collecting the requirement.
-             */
-            code: RequestedReason.Code;
-          }
-
-          export namespace Error {
+          export namespace StatusDetail {
             export type Code =
-              | 'invalid_address_city_state_postal_code'
-              | 'invalid_address_highway_contract_box'
-              | 'invalid_address_private_mailbox'
-              | 'invalid_business_profile_name'
-              | 'invalid_business_profile_name_denylisted'
-              | 'invalid_company_name_denylisted'
-              | 'invalid_dob_age_over_maximum'
-              | 'invalid_dob_age_under_18'
-              | 'invalid_dob_age_under_minimum'
-              | 'invalid_product_description_length'
-              | 'invalid_product_description_url_match'
-              | 'invalid_representative_country'
-              | 'invalid_statement_descriptor_business_mismatch'
-              | 'invalid_statement_descriptor_denylisted'
-              | 'invalid_statement_descriptor_length'
-              | 'invalid_statement_descriptor_prefix_denylisted'
-              | 'invalid_statement_descriptor_prefix_mismatch'
-              | 'invalid_street_address'
-              | 'invalid_tax_id'
-              | 'invalid_tax_id_format'
-              | 'invalid_tos_acceptance'
-              | 'invalid_url_denylisted'
-              | 'invalid_url_format'
-              | 'invalid_url_website_business_information_mismatch'
-              | 'invalid_url_website_empty'
-              | 'invalid_url_website_inaccessible'
-              | 'invalid_url_website_inaccessible_geoblocked'
-              | 'invalid_url_website_inaccessible_password_protected'
-              | 'invalid_url_website_incomplete'
-              | 'invalid_url_website_incomplete_cancellation_policy'
-              | 'invalid_url_website_incomplete_customer_service_details'
-              | 'invalid_url_website_incomplete_legal_restrictions'
-              | 'invalid_url_website_incomplete_refund_policy'
-              | 'invalid_url_website_incomplete_return_policy'
-              | 'invalid_url_website_incomplete_terms_and_conditions'
-              | 'invalid_url_website_incomplete_under_construction'
-              | 'invalid_url_website_other'
-              | 'invalid_url_web_presence_detected'
-              | 'invalid_value_other'
-              | 'unresolvable_ip_address'
-              | 'unresolvable_postal_code'
-              | 'verification_directors_mismatch'
-              | 'verification_document_address_mismatch'
-              | 'verification_document_address_missing'
-              | 'verification_document_corrupt'
-              | 'verification_document_country_not_supported'
-              | 'verification_document_directors_mismatch'
-              | 'verification_document_dob_mismatch'
-              | 'verification_document_duplicate_type'
-              | 'verification_document_expired'
-              | 'verification_document_failed_copy'
-              | 'verification_document_failed_greyscale'
-              | 'verification_document_failed_other'
-              | 'verification_document_failed_test_mode'
-              | 'verification_document_fraudulent'
-              | 'verification_document_id_number_mismatch'
-              | 'verification_document_id_number_missing'
-              | 'verification_document_incomplete'
-              | 'verification_document_invalid'
-              | 'verification_document_issue_or_expiry_date_missing'
-              | 'verification_document_manipulated'
-              | 'verification_document_missing_back'
-              | 'verification_document_missing_front'
-              | 'verification_document_name_mismatch'
-              | 'verification_document_name_missing'
-              | 'verification_document_nationality_mismatch'
-              | 'verification_document_not_readable'
-              | 'verification_document_not_signed'
-              | 'verification_document_not_uploaded'
-              | 'verification_document_photo_mismatch'
-              | 'verification_document_too_large'
-              | 'verification_document_type_not_supported'
-              | 'verification_extraneous_directors'
-              | 'verification_failed_address_match'
-              | 'verification_failed_business_iec_number'
-              | 'verification_failed_document_match'
-              | 'verification_failed_id_number_match'
-              | 'verification_failed_keyed_identity'
-              | 'verification_failed_keyed_match'
-              | 'verification_failed_name_match'
-              | 'verification_failed_other'
-              | 'verification_failed_representative_authority'
-              | 'verification_failed_residential_address'
-              | 'verification_failed_tax_id_match'
-              | 'verification_failed_tax_id_not_issued'
-              | 'verification_missing_directors'
-              | 'verification_missing_executives'
-              | 'verification_missing_owners'
-              | 'verification_requires_additional_memorandum_of_associations'
-              | 'verification_requires_additional_proof_of_registration'
-              | 'verification_selfie_document_missing_photo'
-              | 'verification_selfie_face_mismatch'
-              | 'verification_selfie_manipulated'
-              | 'verification_selfie_unverified_other'
-              | 'verification_supportability'
-              | 'verification_token_stale';
-          }
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
 
-          export namespace Impact {
-            export interface RestrictsCapability {
-              /**
-               * The name of the Capability which will be restricted.
-               */
-              capability: RestrictsCapability.Capability;
-
-              /**
-               * The configuration which specifies the Capability which will be restricted.
-               */
-              configuration: RestrictsCapability.Configuration;
-
-              /**
-               * Details about when in the account lifecycle the requirement must be collected by the avoid the Capability restriction.
-               */
-              deadline: RestrictsCapability.Deadline;
-            }
-
-            export namespace RestrictsCapability {
-              export type Capability =
-                | 'ach_debit_payments'
-                | 'acss_debit_payments'
-                | 'affirm_payments'
-                | 'afterpay_clearpay_payments'
-                | 'alma_payments'
-                | 'amazon_pay_payments'
-                | 'automatic_indirect_tax'
-                | 'au_becs_debit_payments'
-                | 'bacs_debit_payments'
-                | 'bancontact_payments'
-                | 'bank_accounts.local'
-                | 'bank_accounts.wire'
-                | 'blik_payments'
-                | 'boleto_payments'
-                | 'cards'
-                | 'card_payments'
-                | 'cartes_bancaires_payments'
-                | 'cashapp_payments'
-                | 'eps_payments'
-                | 'fpx_payments'
-                | 'gb_bank_transfer_payments'
-                | 'grabpay_payments'
-                | 'ideal_payments'
-                | 'jcb_payments'
-                | 'jp_bank_transfer_payments'
-                | 'kakao_pay_payments'
-                | 'klarna_payments'
-                | 'konbini_payments'
-                | 'kr_card_payments'
-                | 'link_payments'
-                | 'mobilepay_payments'
-                | 'multibanco_payments'
-                | 'mx_bank_transfer_payments'
-                | 'naver_pay_payments'
-                | 'oxxo_payments'
-                | 'p24_payments'
-                | 'payco_payments'
-                | 'paynow_payments'
-                | 'pay_by_bank_payments'
-                | 'promptpay_payments'
-                | 'revolut_pay_payments'
-                | 'samsung_pay_payments'
-                | 'sepa_bank_transfer_payments'
-                | 'sepa_debit_payments'
-                | 'stripe_balance.payouts'
-                | 'stripe_balance.stripe_transfers'
-                | 'swish_payments'
-                | 'twint_payments'
-                | 'us_bank_transfer_payments'
-                | 'zip_payments';
-
-              export type Configuration = 'customer' | 'merchant' | 'recipient';
-
-              export interface Deadline {
-                /**
-                 * The current status of the requirement's impact.
-                 */
-                status: Deadline.Status;
-              }
-
-              export namespace Deadline {
-                export type Status =
-                  | 'currently_due'
-                  | 'eventually_due'
-                  | 'past_due';
-              }
-            }
-          }
-
-          export namespace MinimumDeadline {
-            export type Status =
-              | 'currently_due'
-              | 'eventually_due'
-              | 'past_due';
-          }
-
-          export namespace Reference {
-            export type Type = 'inquiry' | 'payment_method' | 'person';
-          }
-
-          export namespace RequestedReason {
-            export type Code = 'routine_onboarding' | 'routine_verification';
-          }
-        }
-
-        export namespace Summary {
-          export interface MinimumDeadline {
-            /**
-             * The current strictest status of all requirements on the Account.
-             */
-            status: MinimumDeadline.Status;
-
-            /**
-             * The soonest RFC3339 date & time UTC value a requirement can impact the Account.
-             */
-            time?: string;
-          }
-
-          export namespace MinimumDeadline {
-            export type Status =
-              | 'currently_due'
-              | 'eventually_due'
-              | 'past_due';
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
           }
         }
       }
 
-      export namespace Identity {
-        export interface Attestations {
+      export namespace Shipping {
+        export interface Address {
           /**
-           * This hash is used to attest that the directors information provided to Stripe is both current and correct.
+           * City, district, suburb, town, or village.
            */
-          directorship_declaration?: Attestations.DirectorshipDeclaration;
+          city?: string;
 
           /**
-           * This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
            */
-          ownership_declaration?: Attestations.OwnershipDeclaration;
+          country?: string;
 
           /**
-           * Attestation that all Persons with a specific Relationship value have been provided.
+           * Address line 1 (e.g., street, PO Box, or company name).
            */
-          persons_provided?: Attestations.PersonsProvided;
+          line1?: string;
 
           /**
-           * This hash is used to attest that the representative is authorized to act as the representative of their legal entity.
+           * Address line 2 (e.g., apartment, suite, unit, or building).
            */
-          representative_declaration?: Attestations.RepresentativeDeclaration;
+          line2?: string;
 
           /**
-           * Attestations of accepted terms of service agreements.
+           * ZIP or postal code.
            */
-          terms_of_service?: Attestations.TermsOfService;
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+        }
+      }
+    }
+
+    export namespace Merchant {
+      export interface BacsDebitPayments {
+        /**
+         * Display name for Bacs Direct Debit payments.
+         */
+        display_name?: string;
+
+        /**
+         * Service User Number (SUN) for Bacs Direct Debit payments.
+         */
+        service_user_number?: string;
+      }
+
+      export interface Branding {
+        /**
+         * ID of a [file upload](https://docs.stripe.com/api/persons/update#create_file): An icon for the merchant. Must be square and at least 128px x 128px.
+         */
+        icon?: string;
+
+        /**
+         * ID of a [file upload](https://docs.stripe.com/api/persons/update#create_file): A logo for the merchant that will be used in Checkout instead of the icon and without the merchant's name next to it if provided. Must be at least 128px x 128px.
+         */
+        logo?: string;
+
+        /**
+         * A CSS hex color value representing the primary branding color for the merchant.
+         */
+        primary_color?: string;
+
+        /**
+         * A CSS hex color value representing the secondary branding color for the merchant.
+         */
+        secondary_color?: string;
+      }
+
+      export interface Capabilities {
+        /**
+         * Allow the merchant to process ACH debit payments.
+         */
+        ach_debit_payments?: Capabilities.AchDebitPayments;
+
+        /**
+         * Allow the merchant to process ACSS debit payments.
+         */
+        acss_debit_payments?: Capabilities.AcssDebitPayments;
+
+        /**
+         * Allow the merchant to process Affirm payments.
+         */
+        affirm_payments?: Capabilities.AffirmPayments;
+
+        /**
+         * Allow the merchant to process Afterpay/Clearpay payments.
+         */
+        afterpay_clearpay_payments?: Capabilities.AfterpayClearpayPayments;
+
+        /**
+         * Allow the merchant to process Alma payments.
+         */
+        alma_payments?: Capabilities.AlmaPayments;
+
+        /**
+         * Allow the merchant to process Amazon Pay payments.
+         */
+        amazon_pay_payments?: Capabilities.AmazonPayPayments;
+
+        /**
+         * Allow the merchant to process Australian BECS Direct Debit payments.
+         */
+        au_becs_debit_payments?: Capabilities.AuBecsDebitPayments;
+
+        /**
+         * Allow the merchant to process BACS Direct Debit payments.
+         */
+        bacs_debit_payments?: Capabilities.BacsDebitPayments;
+
+        /**
+         * Allow the merchant to process Bancontact payments.
+         */
+        bancontact_payments?: Capabilities.BancontactPayments;
+
+        /**
+         * Allow the merchant to process BLIK payments.
+         */
+        blik_payments?: Capabilities.BlikPayments;
+
+        /**
+         * Allow the merchant to process Boleto payments.
+         */
+        boleto_payments?: Capabilities.BoletoPayments;
+
+        /**
+         * Allow the merchant to collect card payments.
+         */
+        card_payments?: Capabilities.CardPayments;
+
+        /**
+         * Allow the merchant to process Cartes Bancaires payments.
+         */
+        cartes_bancaires_payments?: Capabilities.CartesBancairesPayments;
+
+        /**
+         * Allow the merchant to process Cash App payments.
+         */
+        cashapp_payments?: Capabilities.CashappPayments;
+
+        /**
+         * Allow the merchant to process EPS payments.
+         */
+        eps_payments?: Capabilities.EpsPayments;
+
+        /**
+         * Allow the merchant to process FPX payments.
+         */
+        fpx_payments?: Capabilities.FpxPayments;
+
+        /**
+         * Allow the merchant to process UK bank transfer payments.
+         */
+        gb_bank_transfer_payments?: Capabilities.GbBankTransferPayments;
+
+        /**
+         * Allow the merchant to process GrabPay payments.
+         */
+        grabpay_payments?: Capabilities.GrabpayPayments;
+
+        /**
+         * Allow the merchant to process iDEAL payments.
+         */
+        ideal_payments?: Capabilities.IdealPayments;
+
+        /**
+         * Allow the merchant to process JCB card payments.
+         */
+        jcb_payments?: Capabilities.JcbPayments;
+
+        /**
+         * Allow the merchant to process Japanese bank transfer payments.
+         */
+        jp_bank_transfer_payments?: Capabilities.JpBankTransferPayments;
+
+        /**
+         * Allow the merchant to process Kakao Pay payments.
+         */
+        kakao_pay_payments?: Capabilities.KakaoPayPayments;
+
+        /**
+         * Allow the merchant to process Klarna payments.
+         */
+        klarna_payments?: Capabilities.KlarnaPayments;
+
+        /**
+         * Allow the merchant to process Konbini convenience store payments.
+         */
+        konbini_payments?: Capabilities.KonbiniPayments;
+
+        /**
+         * Allow the merchant to process Korean card payments.
+         */
+        kr_card_payments?: Capabilities.KrCardPayments;
+
+        /**
+         * Allow the merchant to process Link payments.
+         */
+        link_payments?: Capabilities.LinkPayments;
+
+        /**
+         * Allow the merchant to process MobilePay payments.
+         */
+        mobilepay_payments?: Capabilities.MobilepayPayments;
+
+        /**
+         * Allow the merchant to process Multibanco payments.
+         */
+        multibanco_payments?: Capabilities.MultibancoPayments;
+
+        /**
+         * Allow the merchant to process Mexican bank transfer payments.
+         */
+        mx_bank_transfer_payments?: Capabilities.MxBankTransferPayments;
+
+        /**
+         * Allow the merchant to process Naver Pay payments.
+         */
+        naver_pay_payments?: Capabilities.NaverPayPayments;
+
+        /**
+         * Allow the merchant to process OXXO payments.
+         */
+        oxxo_payments?: Capabilities.OxxoPayments;
+
+        /**
+         * Allow the merchant to process Przelewy24 (P24) payments.
+         */
+        p24_payments?: Capabilities.P24Payments;
+
+        /**
+         * Allow the merchant to process Pay by Bank payments.
+         */
+        pay_by_bank_payments?: Capabilities.PayByBankPayments;
+
+        /**
+         * Allow the merchant to process PAYCO payments.
+         */
+        payco_payments?: Capabilities.PaycoPayments;
+
+        /**
+         * Allow the merchant to process PayNow payments.
+         */
+        paynow_payments?: Capabilities.PaynowPayments;
+
+        /**
+         * Allow the merchant to process PromptPay payments.
+         */
+        promptpay_payments?: Capabilities.PromptpayPayments;
+
+        /**
+         * Allow the merchant to process Revolut Pay payments.
+         */
+        revolut_pay_payments?: Capabilities.RevolutPayPayments;
+
+        /**
+         * Allow the merchant to process Samsung Pay payments.
+         */
+        samsung_pay_payments?: Capabilities.SamsungPayPayments;
+
+        /**
+         * Allow the merchant to process SEPA bank transfer payments.
+         */
+        sepa_bank_transfer_payments?: Capabilities.SepaBankTransferPayments;
+
+        /**
+         * Allow the merchant to process SEPA Direct Debit payments.
+         */
+        sepa_debit_payments?: Capabilities.SepaDebitPayments;
+
+        /**
+         * Capabilities that enable the merchant to manage their Stripe Balance (/v1/balance).
+         */
+        stripe_balance?: Capabilities.StripeBalance;
+
+        /**
+         * Allow the merchant to process Swish payments.
+         */
+        swish_payments?: Capabilities.SwishPayments;
+
+        /**
+         * Allow the merchant to process TWINT payments.
+         */
+        twint_payments?: Capabilities.TwintPayments;
+
+        /**
+         * Allow the merchant to process US bank transfer payments.
+         */
+        us_bank_transfer_payments?: Capabilities.UsBankTransferPayments;
+
+        /**
+         * Allow the merchant to process Zip payments.
+         */
+        zip_payments?: Capabilities.ZipPayments;
+      }
+
+      export interface CardPayments {
+        /**
+         * Automatically declines certain charge types regardless of whether the card issuer accepted or declined the charge.
+         */
+        decline_on?: CardPayments.DeclineOn;
+      }
+
+      export interface KonbiniPayments {
+        /**
+         * Support for Konbini payments.
+         */
+        support?: KonbiniPayments.Support;
+      }
+
+      export interface ScriptStatementDescriptor {
+        /**
+         * The Kana variation of statement_descriptor used for charges in Japan. Japanese statement descriptors have [special requirements](https://docs.stripe.com/get-started/account/statement-descriptors#set-japanese-statement-descriptors).
+         */
+        kana?: ScriptStatementDescriptor.Kana;
+
+        /**
+         * The Kanji variation of statement_descriptor used for charges in Japan. Japanese statement descriptors have [special requirements](https://docs.stripe.com/get-started/account/statement-descriptors#set-japanese-statement-descriptors).
+         */
+        kanji?: ScriptStatementDescriptor.Kanji;
+      }
+
+      export interface SepaDebitPayments {
+        /**
+         * Creditor ID for SEPA Direct Debit payments.
+         */
+        creditor_id?: string;
+      }
+
+      export interface StatementDescriptor {
+        /**
+         * The default text that appears on statements for non-card charges outside of Japan. For card charges, if you don't set a statement_descriptor_prefix, this text is also used as the statement descriptor prefix. In that case, if concatenating the statement descriptor suffix causes the combined statement descriptor to exceed 22 characters, we truncate the statement_descriptor text to limit the full descriptor to 22 characters. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
+         */
+        descriptor?: string;
+
+        /**
+         * Default text that appears on statements for card charges outside of Japan, prefixing any dynamic statement_descriptor_suffix specified on the charge. To maximize space for the dynamic part of the descriptor, keep this text short. If you don't specify this value, statement_descriptor is used as the prefix. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
+         */
+        prefix?: string;
+      }
+
+      export interface Support {
+        /**
+         * A publicly available mailing address for sending support issues to.
+         */
+        address?: Support.Address;
+
+        /**
+         * A publicly available email address for sending support issues to.
+         */
+        email?: string;
+
+        /**
+         * A publicly available phone number to call with support issues.
+         */
+        phone?: string;
+
+        /**
+         * A publicly available website for handling support issues.
+         */
+        url?: string;
+      }
+
+      export namespace Capabilities {
+        export interface AchDebitPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: AchDebitPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<AchDebitPayments.StatusDetail>;
         }
 
-        export interface BusinessDetails {
+        export interface AcssDebitPayments {
           /**
-           * The company's primary address.
+           * The status of the Capability.
            */
-          address?: BusinessDetails.Address;
+          status: AcssDebitPayments.Status;
 
           /**
-           * The business gross annual revenue for its preceding fiscal year.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
            */
-          annual_revenue?: BusinessDetails.AnnualRevenue;
-
-          /**
-           * Documents that may be submitted to satisfy various informational requests.
-           */
-          documents?: BusinessDetails.Documents;
-
-          /**
-           * Estimated maximum number of workers currently engaged by the business (including employees, contractors, and vendors).
-           */
-          estimated_worker_count?: number;
-
-          /**
-           * The provided ID numbers of a business entity.
-           */
-          id_numbers?: Array<BusinessDetails.IdNumber>;
-
-          /**
-           * An estimate of the monthly revenue of the business. Only accepted for accounts in Brazil and India.
-           */
-          monthly_estimated_revenue?: BusinessDetails.MonthlyEstimatedRevenue;
-
-          /**
-           * The company's phone number (used for verification).
-           */
-          phone?: string;
-
-          /**
-           * The business legal name.
-           */
-          registered_name?: string;
-
-          /**
-           * When the business was incorporated or registered.
-           */
-          registration_date?: BusinessDetails.RegistrationDate;
-
-          /**
-           * The business registration address of the business entity in non latin script.
-           */
-          script_addresses?: BusinessDetails.ScriptAddresses;
-
-          /**
-           * The business legal name in non latin script.
-           */
-          script_names?: BusinessDetails.ScriptNames;
-
-          /**
-           * The category identifying the legal structure of the business.
-           */
-          structure?: BusinessDetails.Structure;
+          status_details: Array<AcssDebitPayments.StatusDetail>;
         }
 
-        export type EntityType =
-          | 'company'
-          | 'government_entity'
-          | 'individual'
-          | 'non_profit';
-
-        export interface Individual {
+        export interface AffirmPayments {
           /**
-           * The account ID which the individual belongs to.
+           * The status of the Capability.
            */
-          account: string;
+          status: AffirmPayments.Status;
 
           /**
-           * Additional addresses associated with the individual.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
            */
-          additional_addresses?: Array<Individual.AdditionalAddress>;
+          status_details: Array<AffirmPayments.StatusDetail>;
+        }
 
+        export interface AfterpayClearpayPayments {
           /**
-           * Additional names (e.g. aliases) associated with the individual.
+           * The status of the Capability.
            */
-          additional_names?: Array<Individual.AdditionalName>;
+          status: AfterpayClearpayPayments.Status;
 
           /**
-           * Terms of service acceptances.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
            */
-          additional_terms_of_service?: Individual.AdditionalTermsOfService;
+          status_details: Array<AfterpayClearpayPayments.StatusDetail>;
+        }
 
+        export interface AlmaPayments {
           /**
-           * The individual's residential address.
+           * The status of the Capability.
            */
-          address?: Individual.Address;
+          status: AlmaPayments.Status;
 
           /**
-           * Time at which the object was created. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
            */
-          created: string;
+          status_details: Array<AlmaPayments.StatusDetail>;
+        }
 
+        export interface AmazonPayPayments {
           /**
-           * The individual's date of birth.
+           * The status of the Capability.
            */
-          date_of_birth?: Individual.DateOfBirth;
+          status: AmazonPayPayments.Status;
 
           /**
-           * Documents that may be submitted to satisfy various informational requests.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
            */
-          documents?: Individual.Documents;
+          status_details: Array<AmazonPayPayments.StatusDetail>;
+        }
+
+        export interface AuBecsDebitPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: AuBecsDebitPayments.Status;
 
           /**
-           * The individual's email address. You can only set this field when the Account is configured as a `merchant` or `recipient`. Use `contact_email` as the primary contact email for this Account.
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<AuBecsDebitPayments.StatusDetail>;
+        }
+
+        export interface BacsDebitPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: BacsDebitPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<BacsDebitPayments.StatusDetail>;
+        }
+
+        export interface BancontactPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: BancontactPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<BancontactPayments.StatusDetail>;
+        }
+
+        export interface BlikPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: BlikPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<BlikPayments.StatusDetail>;
+        }
+
+        export interface BoletoPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: BoletoPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<BoletoPayments.StatusDetail>;
+        }
+
+        export interface CardPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: CardPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<CardPayments.StatusDetail>;
+        }
+
+        export interface CartesBancairesPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: CartesBancairesPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<CartesBancairesPayments.StatusDetail>;
+        }
+
+        export interface CashappPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: CashappPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<CashappPayments.StatusDetail>;
+        }
+
+        export interface EpsPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: EpsPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<EpsPayments.StatusDetail>;
+        }
+
+        export interface FpxPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: FpxPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<FpxPayments.StatusDetail>;
+        }
+
+        export interface GbBankTransferPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: GbBankTransferPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<GbBankTransferPayments.StatusDetail>;
+        }
+
+        export interface GrabpayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: GrabpayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<GrabpayPayments.StatusDetail>;
+        }
+
+        export interface IdealPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: IdealPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<IdealPayments.StatusDetail>;
+        }
+
+        export interface JcbPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: JcbPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<JcbPayments.StatusDetail>;
+        }
+
+        export interface JpBankTransferPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: JpBankTransferPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<JpBankTransferPayments.StatusDetail>;
+        }
+
+        export interface KakaoPayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: KakaoPayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<KakaoPayPayments.StatusDetail>;
+        }
+
+        export interface KlarnaPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: KlarnaPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<KlarnaPayments.StatusDetail>;
+        }
+
+        export interface KonbiniPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: KonbiniPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<KonbiniPayments.StatusDetail>;
+        }
+
+        export interface KrCardPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: KrCardPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<KrCardPayments.StatusDetail>;
+        }
+
+        export interface LinkPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: LinkPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<LinkPayments.StatusDetail>;
+        }
+
+        export interface MobilepayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: MobilepayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<MobilepayPayments.StatusDetail>;
+        }
+
+        export interface MultibancoPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: MultibancoPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<MultibancoPayments.StatusDetail>;
+        }
+
+        export interface MxBankTransferPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: MxBankTransferPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<MxBankTransferPayments.StatusDetail>;
+        }
+
+        export interface NaverPayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: NaverPayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<NaverPayPayments.StatusDetail>;
+        }
+
+        export interface OxxoPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: OxxoPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<OxxoPayments.StatusDetail>;
+        }
+
+        export interface P24Payments {
+          /**
+           * The status of the Capability.
+           */
+          status: P24Payments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<P24Payments.StatusDetail>;
+        }
+
+        export interface PayByBankPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: PayByBankPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<PayByBankPayments.StatusDetail>;
+        }
+
+        export interface PaycoPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: PaycoPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<PaycoPayments.StatusDetail>;
+        }
+
+        export interface PaynowPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: PaynowPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<PaynowPayments.StatusDetail>;
+        }
+
+        export interface PromptpayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: PromptpayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<PromptpayPayments.StatusDetail>;
+        }
+
+        export interface RevolutPayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: RevolutPayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<RevolutPayPayments.StatusDetail>;
+        }
+
+        export interface SamsungPayPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: SamsungPayPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<SamsungPayPayments.StatusDetail>;
+        }
+
+        export interface SepaBankTransferPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: SepaBankTransferPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<SepaBankTransferPayments.StatusDetail>;
+        }
+
+        export interface SepaDebitPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: SepaDebitPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<SepaDebitPayments.StatusDetail>;
+        }
+
+        export interface StripeBalance {
+          /**
+           * Enables this Account to complete payouts from their Stripe Balance (/v1/balance).
+           */
+          payouts?: StripeBalance.Payouts;
+        }
+
+        export interface SwishPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: SwishPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<SwishPayments.StatusDetail>;
+        }
+
+        export interface TwintPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: TwintPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<TwintPayments.StatusDetail>;
+        }
+
+        export interface UsBankTransferPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: UsBankTransferPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<UsBankTransferPayments.StatusDetail>;
+        }
+
+        export interface ZipPayments {
+          /**
+           * The status of the Capability.
+           */
+          status: ZipPayments.Status;
+
+          /**
+           * Additional details about the capability's status. This value is empty when `status` is `active`.
+           */
+          status_details: Array<ZipPayments.StatusDetail>;
+        }
+
+        export namespace AchDebitPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace AcssDebitPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace AffirmPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace AfterpayClearpayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace AlmaPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace AmazonPayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace AuBecsDebitPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace BacsDebitPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace BancontactPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace BlikPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace BoletoPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace CardPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace CartesBancairesPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace CashappPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace EpsPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace FpxPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace GbBankTransferPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace GrabpayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace IdealPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace JcbPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace JpBankTransferPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace KakaoPayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace KlarnaPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace KonbiniPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace KrCardPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace LinkPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace MobilepayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace MultibancoPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace MxBankTransferPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace NaverPayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace OxxoPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace P24Payments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace PayByBankPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace PaycoPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace PaynowPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace PromptpayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace RevolutPayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace SamsungPayPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace SepaBankTransferPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace SepaDebitPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace StripeBalance {
+          export interface Payouts {
+            /**
+             * The status of the Capability.
+             */
+            status: Payouts.Status;
+
+            /**
+             * Additional details about the capability's status. This value is empty when `status` is `active`.
+             */
+            status_details: Array<Payouts.StatusDetail>;
+          }
+
+          export namespace Payouts {
+            export type Status =
+              | 'active'
+              | 'pending'
+              | 'restricted'
+              | 'unsupported';
+
+            export interface StatusDetail {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current status.
+               */
+              code: StatusDetail.Code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               */
+              resolution: StatusDetail.Resolution;
+            }
+
+            export namespace StatusDetail {
+              export type Code =
+                | 'determining_status'
+                | 'requirements_past_due'
+                | 'requirements_pending_verification'
+                | 'restricted_other'
+                | 'unsupported_business'
+                | 'unsupported_country'
+                | 'unsupported_entity_type';
+
+              export type Resolution =
+                | 'contact_stripe'
+                | 'no_resolution'
+                | 'provide_info';
+            }
+          }
+        }
+
+        export namespace SwishPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace TwintPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace UsBankTransferPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+
+        export namespace ZipPayments {
+          export type Status =
+            | 'active'
+            | 'pending'
+            | 'restricted'
+            | 'unsupported';
+
+          export interface StatusDetail {
+            /**
+             * Machine-readable code explaining the reason for the Capability to be in its current status.
+             */
+            code: StatusDetail.Code;
+
+            /**
+             * Machine-readable code explaining how to make the Capability active.
+             */
+            resolution: StatusDetail.Resolution;
+          }
+
+          export namespace StatusDetail {
+            export type Code =
+              | 'determining_status'
+              | 'requirements_past_due'
+              | 'requirements_pending_verification'
+              | 'restricted_other'
+              | 'unsupported_business'
+              | 'unsupported_country'
+              | 'unsupported_entity_type';
+
+            export type Resolution =
+              | 'contact_stripe'
+              | 'no_resolution'
+              | 'provide_info';
+          }
+        }
+      }
+
+      export namespace CardPayments {
+        export interface DeclineOn {
+          /**
+           * Whether Stripe automatically declines charges with an incorrect ZIP or postal code. This setting only applies when a ZIP or postal code is provided and they fail bank verification.
+           */
+          avs_failure?: boolean;
+
+          /**
+           * Whether Stripe automatically declines charges with an incorrect CVC. This setting only applies when a CVC is provided and it fails bank verification.
+           */
+          cvc_failure?: boolean;
+        }
+      }
+
+      export namespace KonbiniPayments {
+        export interface Support {
+          /**
+           * Support email address for Konbini payments.
            */
           email?: string;
 
           /**
-           * The individual's first name.
+           * Support hours for Konbini payments.
            */
-          given_name?: string;
+          hours?: Support.Hours;
 
           /**
-           * Unique identifier for the object.
-           */
-          id: string;
-
-          /**
-           * The identification numbers (e.g., SSN) associated with the individual.
-           */
-          id_numbers?: Array<Individual.IdNumber>;
-
-          /**
-           * The individual's gender (International regulations require either "male” or "female").
-           */
-          legal_gender?: Individual.LegalGender;
-
-          /**
-           * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
-           */
-          metadata?: Metadata;
-
-          /**
-           * The countries where the individual is a national. Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-           */
-          nationalities?: Array<string>;
-
-          /**
-           * String representing the object's type. Objects of the same type share the same value.
-           */
-          object: string;
-
-          /**
-           * The individual's phone number.
+           * Support phone number for Konbini payments.
            */
           phone?: string;
-
-          /**
-           * Indicates if the individual or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
-           */
-          political_exposure?: Individual.PoliticalExposure;
-
-          /**
-           * The relationship that this individual has with the Account's identity.
-           */
-          relationship?: Individual.Relationship;
-
-          /**
-           * The script addresses (e.g., non-Latin characters) associated with the individual.
-           */
-          script_addresses?: Individual.ScriptAddresses;
-
-          /**
-           * The script names (e.g. non-Latin characters) associated with the individual.
-           */
-          script_names?: Individual.ScriptNames;
-
-          /**
-           * The individual's last name.
-           */
-          surname?: string;
-
-          /**
-           * Time at which the object was last updated.
-           */
-          updated: string;
         }
 
-        export namespace Attestations {
-          export interface DirectorshipDeclaration {
+        export namespace Support {
+          export interface Hours {
             /**
-             * The time marking when the director attestation was made. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+             * Support hours end time (JST time of day) for in `HH:MM` format.
              */
-            date?: string;
+            end_time?: string;
 
             /**
-             * The IP address from which the director attestation was made.
+             * Support hours start time (JST time of day) for in `HH:MM` format.
              */
-            ip?: string;
-
-            /**
-             * The user agent of the browser from which the director attestation was made.
-             */
-            user_agent?: string;
-          }
-
-          export interface OwnershipDeclaration {
-            /**
-             * The time marking when the beneficial owner attestation was made. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
-             */
-            date?: string;
-
-            /**
-             * The IP address from which the beneficial owner attestation was made.
-             */
-            ip?: string;
-
-            /**
-             * The user agent of the browser from which the beneficial owner attestation was made.
-             */
-            user_agent?: string;
-          }
-
-          export interface PersonsProvided {
-            /**
-             * Whether the company's directors have been provided. Set this Boolean to true after creating all the company's directors with the [Persons API](https://docs.stripe.com/api/v2/core/accounts/createperson).
-             */
-            directors?: boolean;
-
-            /**
-             * Whether the company's executives have been provided. Set this Boolean to true after creating all the company's executives with the [Persons API](https://docs.stripe.com/api/v2/core/accounts/createperson).
-             */
-            executives?: boolean;
-
-            /**
-             * Whether the company's owners have been provided. Set this Boolean to true after creating all the company's owners with the [Persons API](https://docs.stripe.com/api/v2/core/accounts/createperson).
-             */
-            owners?: boolean;
-
-            /**
-             * Reason for why the company is exempt from providing ownership information.
-             */
-            ownership_exemption_reason?: PersonsProvided.OwnershipExemptionReason;
-          }
-
-          export interface RepresentativeDeclaration {
-            /**
-             * The time marking when the representative attestation was made. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
-             */
-            date?: string;
-
-            /**
-             * The IP address from which the representative attestation was made.
-             */
-            ip?: string;
-
-            /**
-             * The user agent of the browser from which the representative attestation was made.
-             */
-            user_agent?: string;
-          }
-
-          export interface TermsOfService {
-            /**
-             * Details on the Account's acceptance of the [Stripe Services Agreement](https://docs.stripe.com/connect/updating-accounts#tos-acceptance).
-             */
-            account?: TermsOfService.Account;
-          }
-
-          export namespace PersonsProvided {
-            export type OwnershipExemptionReason =
-              | 'qualified_entity_exceeds_ownership_threshold'
-              | 'qualifies_as_financial_institution';
-          }
-
-          export namespace TermsOfService {
-            export interface Account {
-              /**
-               * The time when the Account's representative accepted the terms of service. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
-               */
-              date?: string;
-
-              /**
-               * The IP address from which the Account's representative accepted the terms of service.
-               */
-              ip?: string;
-
-              /**
-               * The user agent of the browser from which the Account's representative accepted the terms of service.
-               */
-              user_agent?: string;
-            }
-          }
-        }
-
-        export namespace BusinessDetails {
-          export interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
-            line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
-
-            /**
-             * Town or district.
-             */
-            town?: string;
-          }
-
-          export interface AnnualRevenue {
-            /**
-             * Annual revenue amount in minor currency units (for example, '123' for 1.23 USD).
-             */
-            amount?: V2Amount;
-
-            /**
-             * The close-out date of the preceding fiscal year in ISO 8601 format. E.g. 2023-12-31 for the 31st of December, 2023.
-             */
-            fiscal_year_end?: string;
-          }
-
-          export interface Documents {
-            /**
-             * One or more documents that support the Bank account ownership verification requirement. Must be a document associated with the account's primary active bank account that displays the last 4 digits of the account number, either a statement or a check.
-             */
-            bank_account_ownership_verification?: Documents.BankAccountOwnershipVerification;
-
-            /**
-             * One or more documents that demonstrate proof of a company's license to operate.
-             */
-            company_license?: Documents.CompanyLicense;
-
-            /**
-             * One or more documents showing the company's Memorandum of Association.
-             */
-            company_memorandum_of_association?: Documents.CompanyMemorandumOfAssociation;
-
-            /**
-             * Certain countries only: One or more documents showing the ministerial decree legalizing the company's establishment.
-             */
-            company_ministerial_decree?: Documents.CompanyMinisterialDecree;
-
-            /**
-             * One or more documents that demonstrate proof of a company's registration with the appropriate local authorities.
-             */
-            company_registration_verification?: Documents.CompanyRegistrationVerification;
-
-            /**
-             * One or more documents that demonstrate proof of a company's tax ID.
-             */
-            company_tax_id_verification?: Documents.CompanyTaxIdVerification;
-
-            /**
-             * A document verifying the business.
-             */
-            primary_verification?: Documents.PrimaryVerification;
-
-            /**
-             * One or more documents that demonstrate proof of address.
-             */
-            proof_of_address?: Documents.ProofOfAddress;
-
-            /**
-             * One or more documents showing the company's proof of registration with the national business registry.
-             */
-            proof_of_registration?: Documents.ProofOfRegistration;
-
-            /**
-             * One or more documents that demonstrate proof of ultimate beneficial ownership.
-             */
-            proof_of_ultimate_beneficial_ownership?: Documents.ProofOfUltimateBeneficialOwnership;
-          }
-
-          export interface IdNumber {
-            /**
-             * The registrar of the ID number (Only valid for DE ID number types).
-             */
-            registrar?: string;
-
-            /**
-             * Open Enum. The ID number type of a business entity.
-             */
-            type: IdNumber.Type;
-          }
-
-          export interface MonthlyEstimatedRevenue {
-            /**
-             * Estimated monthly revenue amount in minor currency units (for example, '123' for 1.23 USD).
-             */
-            amount?: V2Amount;
-          }
-
-          export interface RegistrationDate {
-            /**
-             * The day of registration, between 1 and 31.
-             */
-            day: number;
-
-            /**
-             * The month of registration, between 1 and 12.
-             */
-            month: number;
-
-            /**
-             * The four-digit year of registration.
-             */
-            year: number;
-          }
-
-          export interface ScriptAddresses {
-            /**
-             * Kana Address.
-             */
-            kana?: ScriptAddresses.Kana;
-
-            /**
-             * Kanji Address.
-             */
-            kanji?: ScriptAddresses.Kanji;
-          }
-
-          export interface ScriptNames {
-            /**
-             * Kana name.
-             */
-            kana?: ScriptNames.Kana;
-
-            /**
-             * Kanji name.
-             */
-            kanji?: ScriptNames.Kanji;
-          }
-
-          export type Structure =
-            | 'cooperative'
-            | 'free_zone_establishment'
-            | 'free_zone_llc'
-            | 'governmental_unit'
-            | 'government_instrumentality'
-            | 'incorporated_association'
-            | 'incorporated_non_profit'
-            | 'incorporated_partnership'
-            | 'limited_liability_partnership'
-            | 'llc'
-            | 'multi_member_llc'
-            | 'private_company'
-            | 'private_corporation'
-            | 'private_partnership'
-            | 'public_company'
-            | 'public_corporation'
-            | 'public_listed_corporation'
-            | 'public_partnership'
-            | 'registered_charity'
-            | 'single_member_llc'
-            | 'sole_establishment'
-            | 'sole_proprietorship'
-            | 'tax_exempt_government_instrumentality'
-            | 'trust'
-            | 'unincorporated_association'
-            | 'unincorporated_non_profit'
-            | 'unincorporated_partnership';
-
-          export namespace Documents {
-            export interface BankAccountOwnershipVerification {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface CompanyLicense {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface CompanyMemorandumOfAssociation {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface CompanyMinisterialDecree {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface CompanyRegistrationVerification {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface CompanyTaxIdVerification {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface PrimaryVerification {
-              /**
-               * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
-               */
-              front_back: PrimaryVerification.FrontBack;
-
-              /**
-               * The format of the verification document. Currently supports `front_back` only.
-               */
-              type: 'front_back';
-            }
-
-            export interface ProofOfAddress {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface ProofOfRegistration {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * Person that is signing the document.
-               */
-              signer?: ProofOfRegistration.Signer;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface ProofOfUltimateBeneficialOwnership {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * Person that is signing the document.
-               */
-              signer?: ProofOfUltimateBeneficialOwnership.Signer;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export namespace PrimaryVerification {
-              export interface FrontBack {
-                /**
-                 * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-                 */
-                back?: string;
-
-                /**
-                 * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-                 */
-                front: string;
-              }
-            }
-
-            export namespace ProofOfRegistration {
-              export interface Signer {
-                /**
-                 * Person signing the document.
-                 */
-                person: string;
-              }
-            }
-
-            export namespace ProofOfUltimateBeneficialOwnership {
-              export interface Signer {
-                /**
-                 * Person signing the document.
-                 */
-                person: string;
-              }
-            }
-          }
-
-          export namespace IdNumber {
-            export type Type =
-              | 'ae_crn'
-              | 'ae_vat'
-              | 'ao_nif'
-              | 'ar_cuit'
-              | 'at_fn'
-              | 'at_stn'
-              | 'at_vat'
-              | 'au_abn'
-              | 'au_acn'
-              | 'au_in'
-              | 'az_tin'
-              | 'bd_etin'
-              | 'be_cbe'
-              | 'be_vat'
-              | 'bg_uic'
-              | 'bg_vat'
-              | 'br_cnpj'
-              | 'ca_cn'
-              | 'ca_crarr'
-              | 'ca_gst_hst'
-              | 'ca_neq'
-              | 'ca_rid'
-              | 'ch_chid'
-              | 'ch_uid'
-              | 'cr_cpj'
-              | 'cr_nite'
-              | 'cy_he'
-              | 'cy_tic'
-              | 'cy_vat'
-              | 'cz_ico'
-              | 'cz_vat'
-              | 'de_hrn'
-              | 'de_stn'
-              | 'de_vat'
-              | 'dk_cvr'
-              | 'dk_vat'
-              | 'do_rcn'
-              | 'ee_rk'
-              | 'ee_vat'
-              | 'es_cif'
-              | 'es_vat'
-              | 'fi_vat'
-              | 'fi_yt'
-              | 'fr_rna'
-              | 'fr_siren'
-              | 'fr_vat'
-              | 'gb_crn'
-              | 'gb_vat'
-              | 'gi_crn'
-              | 'gr_afm'
-              | 'gr_gemi'
-              | 'gr_vat'
-              | 'gt_nit'
-              | 'hk_br'
-              | 'hk_cr'
-              | 'hr_mbs'
-              | 'hr_oib'
-              | 'hr_vat'
-              | 'hu_cjs'
-              | 'hu_tin'
-              | 'hu_vat'
-              | 'ie_crn'
-              | 'ie_trn'
-              | 'ie_vat'
-              | 'it_rea'
-              | 'it_vat'
-              | 'jp_cn'
-              | 'kz_bin'
-              | 'li_uid'
-              | 'lt_ccrn'
-              | 'lt_vat'
-              | 'lu_nif'
-              | 'lu_rcs'
-              | 'lu_vat'
-              | 'lv_urn'
-              | 'lv_vat'
-              | 'mt_crn'
-              | 'mt_tin'
-              | 'mt_vat'
-              | 'mx_rfc'
-              | 'my_brn'
-              | 'my_coid'
-              | 'my_itn'
-              | 'my_sst'
-              | 'mz_nuit'
-              | 'nl_kvk'
-              | 'nl_rsin'
-              | 'nl_vat'
-              | 'no_orgnr'
-              | 'nz_bn'
-              | 'nz_ird'
-              | 'pe_ruc'
-              | 'pk_ntn'
-              | 'pl_nip'
-              | 'pl_regon'
-              | 'pl_vat'
-              | 'pt_vat'
-              | 'ro_cui'
-              | 'ro_orc'
-              | 'ro_vat'
-              | 'sa_crn'
-              | 'sa_tin'
-              | 'se_orgnr'
-              | 'se_vat'
-              | 'sg_uen'
-              | 'si_msp'
-              | 'si_tin'
-              | 'si_vat'
-              | 'sk_dic'
-              | 'sk_ico'
-              | 'sk_vat'
-              | 'th_crn'
-              | 'th_prn'
-              | 'th_tin'
-              | 'us_ein';
-          }
-
-          export namespace ScriptAddresses {
-            export interface Kana {
-              /**
-               * City, district, suburb, town, or village.
-               */
-              city?: string;
-
-              /**
-               * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-               */
-              country?: string;
-
-              /**
-               * Address line 1 (e.g., street, PO Box, or company name).
-               */
-              line1?: string;
-
-              /**
-               * Address line 2 (e.g., apartment, suite, unit, or building).
-               */
-              line2?: string;
-
-              /**
-               * ZIP or postal code.
-               */
-              postal_code?: string;
-
-              /**
-               * State, county, province, or region.
-               */
-              state?: string;
-
-              /**
-               * Town or district.
-               */
-              town?: string;
-            }
-
-            export interface Kanji {
-              /**
-               * City, district, suburb, town, or village.
-               */
-              city?: string;
-
-              /**
-               * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-               */
-              country?: string;
-
-              /**
-               * Address line 1 (e.g., street, PO Box, or company name).
-               */
-              line1?: string;
-
-              /**
-               * Address line 2 (e.g., apartment, suite, unit, or building).
-               */
-              line2?: string;
-
-              /**
-               * ZIP or postal code.
-               */
-              postal_code?: string;
-
-              /**
-               * State, county, province, or region.
-               */
-              state?: string;
-
-              /**
-               * Town or district.
-               */
-              town?: string;
-            }
-          }
-
-          export namespace ScriptNames {
-            export interface Kana {
-              /**
-               * Registered name of the business.
-               */
-              registered_name?: string;
-            }
-
-            export interface Kanji {
-              /**
-               * Registered name of the business.
-               */
-              registered_name?: string;
-            }
-          }
-        }
-
-        export namespace Individual {
-          export interface AdditionalAddress {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
-            line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * Purpose of additional address.
-             */
-            purpose: 'registered';
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
-
-            /**
-             * Town or district.
-             */
-            town?: string;
-          }
-
-          export interface AdditionalName {
-            /**
-             * The individual's full name.
-             */
-            full_name?: string;
-
-            /**
-             * The individual's first or given name.
-             */
-            given_name?: string;
-
-            /**
-             * The purpose or type of the additional name.
-             */
-            purpose: AdditionalName.Purpose;
-
-            /**
-             * The individual's last or family name.
-             */
-            surname?: string;
-          }
-
-          export interface AdditionalTermsOfService {
-            /**
-             * Stripe terms of service agreement.
-             */
-            account?: AdditionalTermsOfService.Account;
-          }
-
-          export interface Address {
-            /**
-             * City, district, suburb, town, or village.
-             */
-            city?: string;
-
-            /**
-             * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-             */
-            country?: string;
-
-            /**
-             * Address line 1 (e.g., street, PO Box, or company name).
-             */
-            line1?: string;
-
-            /**
-             * Address line 2 (e.g., apartment, suite, unit, or building).
-             */
-            line2?: string;
-
-            /**
-             * ZIP or postal code.
-             */
-            postal_code?: string;
-
-            /**
-             * State, county, province, or region.
-             */
-            state?: string;
-
-            /**
-             * Town or district.
-             */
-            town?: string;
-          }
-
-          export interface DateOfBirth {
-            /**
-             * The day of birth, between 1 and 31.
-             */
-            day: number;
-
-            /**
-             * The month of birth, between 1 and 12.
-             */
-            month: number;
-
-            /**
-             * The four-digit year of birth.
-             */
-            year: number;
-          }
-
-          export interface Documents {
-            /**
-             * One or more documents that demonstrate proof that this person is authorized to represent the company.
-             */
-            company_authorization?: Documents.CompanyAuthorization;
-
-            /**
-             * One or more documents showing the person's passport page with photo and personal data.
-             */
-            passport?: Documents.Passport;
-
-            /**
-             * An identifying document showing the person's name, either a passport or local ID card.
-             */
-            primary_verification?: Documents.PrimaryVerification;
-
-            /**
-             * A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
-             */
-            secondary_verification?: Documents.SecondaryVerification;
-
-            /**
-             * One or more documents showing the person's visa required for living in the country where they are residing.
-             */
-            visa?: Documents.Visa;
-          }
-
-          export interface IdNumber {
-            /**
-             * The ID number type of an individual.
-             */
-            type: IdNumber.Type;
-          }
-
-          export type LegalGender = 'female' | 'male';
-
-          export type PoliticalExposure = 'existing' | 'none';
-
-          export interface Relationship {
-            /**
-             * Whether the individual is an authorizer of the Account's identity.
-             */
-            authorizer?: boolean;
-
-            /**
-             * Whether the individual is a director of the Account's identity. Directors are typically members of the governing board of the company or are responsible for making sure that the company meets its regulatory obligations.
-             */
-            director?: boolean;
-
-            /**
-             * Whether the individual has significant responsibility to control, manage, or direct the organization.
-             */
-            executive?: boolean;
-
-            /**
-             * Whether the individual is the legal guardian of the Account's representative.
-             */
-            legal_guardian?: boolean;
-
-            /**
-             * Whether the individual is an owner of the Account's identity.
-             */
-            owner?: boolean;
-
-            /**
-             * The percentage of the Account's identity that the individual owns.
-             */
-            percent_ownership?: Decimal;
-
-            /**
-             * Whether the individual is authorized as the primary representative of the Account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
-             */
-            representative?: boolean;
-
-            /**
-             * The individual's title (e.g., CEO, Support Engineer).
-             */
-            title?: string;
-          }
-
-          export interface ScriptAddresses {
-            /**
-             * Kana Address.
-             */
-            kana?: ScriptAddresses.Kana;
-
-            /**
-             * Kanji Address.
-             */
-            kanji?: ScriptAddresses.Kanji;
-          }
-
-          export interface ScriptNames {
-            /**
-             * Persons name in kana script.
-             */
-            kana?: ScriptNames.Kana;
-
-            /**
-             * Persons name in kanji script.
-             */
-            kanji?: ScriptNames.Kanji;
-          }
-
-          export namespace AdditionalName {
-            export type Purpose = 'alias' | 'maiden';
-          }
-
-          export namespace AdditionalTermsOfService {
-            export interface Account {
-              /**
-               * The time when the Account's representative accepted the terms of service. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
-               */
-              date?: string;
-
-              /**
-               * The IP address from which the Account's representative accepted the terms of service.
-               */
-              ip?: string;
-
-              /**
-               * The user agent of the browser from which the Account's representative accepted the terms of service.
-               */
-              user_agent?: string;
-            }
-          }
-
-          export namespace Documents {
-            export interface CompanyAuthorization {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface Passport {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export interface PrimaryVerification {
-              /**
-               * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
-               */
-              front_back: PrimaryVerification.FrontBack;
-
-              /**
-               * The format of the verification document. Currently supports `front_back` only.
-               */
-              type: 'front_back';
-            }
-
-            export interface SecondaryVerification {
-              /**
-               * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
-               */
-              front_back: SecondaryVerification.FrontBack;
-
-              /**
-               * The format of the verification document. Currently supports `front_back` only.
-               */
-              type: 'front_back';
-            }
-
-            export interface Visa {
-              /**
-               * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
-               */
-              files: Array<string>;
-
-              /**
-               * The format of the document. Currently supports `files` only.
-               */
-              type: 'files';
-            }
-
-            export namespace PrimaryVerification {
-              export interface FrontBack {
-                /**
-                 * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-                 */
-                back?: string;
-
-                /**
-                 * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-                 */
-                front: string;
-              }
-            }
-
-            export namespace SecondaryVerification {
-              export interface FrontBack {
-                /**
-                 * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-                 */
-                back?: string;
-
-                /**
-                 * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
-                 */
-                front: string;
-              }
-            }
-          }
-
-          export namespace IdNumber {
-            export type Type =
-              | 'ae_eid'
-              | 'ao_nif'
-              | 'ar_cuil'
-              | 'ar_dni'
-              | 'at_stn'
-              | 'az_tin'
-              | 'bd_brc'
-              | 'bd_etin'
-              | 'bd_nid'
-              | 'be_nrn'
-              | 'bg_ucn'
-              | 'bn_nric'
-              | 'br_cpf'
-              | 'ca_sin'
-              | 'ch_oasi'
-              | 'cl_rut'
-              | 'cn_pp'
-              | 'co_nuip'
-              | 'cr_ci'
-              | 'cr_cpf'
-              | 'cr_dimex'
-              | 'cr_nite'
-              | 'cy_tic'
-              | 'cz_rc'
-              | 'de_stn'
-              | 'dk_cpr'
-              | 'do_cie'
-              | 'do_rcn'
-              | 'ec_ci'
-              | 'ee_ik'
-              | 'es_nif'
-              | 'fi_hetu'
-              | 'fr_nir'
-              | 'gb_nino'
-              | 'gr_afm'
-              | 'gt_nit'
-              | 'hk_id'
-              | 'hr_oib'
-              | 'hu_ad'
-              | 'id_nik'
-              | 'ie_ppsn'
-              | 'is_kt'
-              | 'it_cf'
-              | 'jp_inc'
-              | 'ke_pin'
-              | 'kz_iin'
-              | 'li_peid'
-              | 'lt_ak'
-              | 'lu_nif'
-              | 'lv_pk'
-              | 'mx_rfc'
-              | 'my_nric'
-              | 'mz_nuit'
-              | 'ng_nin'
-              | 'nl_bsn'
-              | 'no_nin'
-              | 'nz_ird'
-              | 'pe_dni'
-              | 'pk_cnic'
-              | 'pk_snic'
-              | 'pl_pesel'
-              | 'pt_nif'
-              | 'ro_cnp'
-              | 'sa_tin'
-              | 'se_pin'
-              | 'sg_fin'
-              | 'sg_nric'
-              | 'sk_dic'
-              | 'th_lc'
-              | 'th_pin'
-              | 'tr_tin'
-              | 'us_itin'
-              | 'us_itin_last_4'
-              | 'us_ssn'
-              | 'us_ssn_last_4'
-              | 'uy_dni'
-              | 'za_id';
-          }
-
-          export namespace ScriptAddresses {
-            export interface Kana {
-              /**
-               * City, district, suburb, town, or village.
-               */
-              city?: string;
-
-              /**
-               * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-               */
-              country?: string;
-
-              /**
-               * Address line 1 (e.g., street, PO Box, or company name).
-               */
-              line1?: string;
-
-              /**
-               * Address line 2 (e.g., apartment, suite, unit, or building).
-               */
-              line2?: string;
-
-              /**
-               * ZIP or postal code.
-               */
-              postal_code?: string;
-
-              /**
-               * State, county, province, or region.
-               */
-              state?: string;
-
-              /**
-               * Town or district.
-               */
-              town?: string;
-            }
-
-            export interface Kanji {
-              /**
-               * City, district, suburb, town, or village.
-               */
-              city?: string;
-
-              /**
-               * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
-               */
-              country?: string;
-
-              /**
-               * Address line 1 (e.g., street, PO Box, or company name).
-               */
-              line1?: string;
-
-              /**
-               * Address line 2 (e.g., apartment, suite, unit, or building).
-               */
-              line2?: string;
-
-              /**
-               * ZIP or postal code.
-               */
-              postal_code?: string;
-
-              /**
-               * State, county, province, or region.
-               */
-              state?: string;
-
-              /**
-               * Town or district.
-               */
-              town?: string;
-            }
-          }
-
-          export namespace ScriptNames {
-            export interface Kana {
-              /**
-               * The person's first or given name.
-               */
-              given_name?: string;
-
-              /**
-               * The person's last or family name.
-               */
-              surname?: string;
-            }
-
-            export interface Kanji {
-              /**
-               * The person's first or given name.
-               */
-              given_name?: string;
-
-              /**
-               * The person's last or family name.
-               */
-              surname?: string;
-            }
+            start_time?: string;
           }
         }
       }
 
-      export namespace Requirements {
-        export interface Entry {
+      export namespace ScriptStatementDescriptor {
+        export interface Kana {
           /**
-           * Indicates whether the platform or Stripe is currently responsible for taking action on the requirement. Value can be `user` or `stripe`.
+           * The default text that appears on statements for non-card charges outside of Japan. For card charges, if you don't set a statement_descriptor_prefix, this text is also used as the statement descriptor prefix. In that case, if concatenating the statement descriptor suffix causes the combined statement descriptor to exceed 22 characters, we truncate the statement_descriptor text to limit the full descriptor to 22 characters. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
            */
-          awaiting_action_from: Entry.AwaitingActionFrom;
+          descriptor?: string;
 
           /**
-           * Machine-readable string describing the requirement.
+           * Default text that appears on statements for card charges outside of Japan, prefixing any dynamic statement_descriptor_suffix specified on the charge. To maximize space for the dynamic part of the descriptor, keep this text short. If you don't specify this value, statement_descriptor is used as the prefix. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
            */
-          description: string;
-
-          /**
-           * Descriptions of why the requirement must be collected, or why the collected information isn't satisfactory to Stripe.
-           */
-          errors: Array<Entry.Error>;
-
-          /**
-           * A hash describing the impact of not collecting the requirement, or Stripe not being able to verify the collected information.
-           */
-          impact: Entry.Impact;
-
-          /**
-           * The soonest point when the account will be impacted by not providing the requirement.
-           */
-          minimum_deadline: Entry.MinimumDeadline;
-
-          /**
-           * A reference to the location of the requirement.
-           */
-          reference?: Entry.Reference;
-
-          /**
-           * A list of reasons why Stripe is collecting the requirement.
-           */
-          requested_reasons: Array<Entry.RequestedReason>;
+          prefix?: string;
         }
 
-        export interface Summary {
+        export interface Kanji {
           /**
-           * The soonest date and time a requirement on the Account will become `past due`. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: `2022-09-18T13:22:18.123Z`.
+           * The default text that appears on statements for non-card charges outside of Japan. For card charges, if you don't set a statement_descriptor_prefix, this text is also used as the statement descriptor prefix. In that case, if concatenating the statement descriptor suffix causes the combined statement descriptor to exceed 22 characters, we truncate the statement_descriptor text to limit the full descriptor to 22 characters. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
            */
-          minimum_deadline?: Summary.MinimumDeadline;
+          descriptor?: string;
+
+          /**
+           * Default text that appears on statements for card charges outside of Japan, prefixing any dynamic statement_descriptor_suffix specified on the charge. To maximize space for the dynamic part of the descriptor, keep this text short. If you don't specify this value, statement_descriptor is used as the prefix. For more information about statement descriptors and their requirements, see the Merchant Configuration settings documentation.
+           */
+          prefix?: string;
+        }
+      }
+
+      export namespace Support {
+        export interface Address {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+
+          /**
+           * Town or district.
+           */
+          town?: string;
+        }
+      }
+    }
+
+    export namespace Recipient {
+      export interface Capabilities {
+        /**
+         * Capabilities that enable the recipient to manage their Stripe Balance (/v1/balance).
+         */
+        stripe_balance?: Capabilities.StripeBalance;
+      }
+
+      export namespace Capabilities {
+        export interface StripeBalance {
+          /**
+           * Enables this Account to complete payouts from their Stripe Balance (/v1/balance).
+           */
+          payouts?: StripeBalance.Payouts;
+
+          /**
+           * Enables this Account to receive /v1/transfers into their Stripe Balance (/v1/balance).
+           */
+          stripe_transfers?: StripeBalance.StripeTransfers;
         }
 
-        export namespace Entry {
-          export type AwaitingActionFrom = 'stripe' | 'user';
-
-          export interface Error {
+        export namespace StripeBalance {
+          export interface Payouts {
             /**
-             * Machine-readable code describing the error.
+             * The status of the Capability.
              */
-            code: Error.Code;
+            status: Payouts.Status;
 
             /**
-             * Human-readable description of the error.
+             * Additional details about the capability's status. This value is empty when `status` is `active`.
              */
-            description: string;
+            status_details: Array<Payouts.StatusDetail>;
           }
 
-          export interface Impact {
+          export interface StripeTransfers {
             /**
-             * The Capabilities that will be restricted if the requirement is not collected and satisfactory to Stripe.
+             * The status of the Capability.
              */
-            restricts_capabilities?: Array<Impact.RestrictsCapability>;
+            status: StripeTransfers.Status;
+
+            /**
+             * Additional details about the capability's status. This value is empty when `status` is `active`.
+             */
+            status_details: Array<StripeTransfers.StatusDetail>;
           }
 
-          export interface MinimumDeadline {
+          export namespace Payouts {
+            export type Status =
+              | 'active'
+              | 'pending'
+              | 'restricted'
+              | 'unsupported';
+
+            export interface StatusDetail {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current status.
+               */
+              code: StatusDetail.Code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               */
+              resolution: StatusDetail.Resolution;
+            }
+
+            export namespace StatusDetail {
+              export type Code =
+                | 'determining_status'
+                | 'requirements_past_due'
+                | 'requirements_pending_verification'
+                | 'restricted_other'
+                | 'unsupported_business'
+                | 'unsupported_country'
+                | 'unsupported_entity_type';
+
+              export type Resolution =
+                | 'contact_stripe'
+                | 'no_resolution'
+                | 'provide_info';
+            }
+          }
+
+          export namespace StripeTransfers {
+            export type Status =
+              | 'active'
+              | 'pending'
+              | 'restricted'
+              | 'unsupported';
+
+            export interface StatusDetail {
+              /**
+               * Machine-readable code explaining the reason for the Capability to be in its current status.
+               */
+              code: StatusDetail.Code;
+
+              /**
+               * Machine-readable code explaining how to make the Capability active.
+               */
+              resolution: StatusDetail.Resolution;
+            }
+
+            export namespace StatusDetail {
+              export type Code =
+                | 'determining_status'
+                | 'requirements_past_due'
+                | 'requirements_pending_verification'
+                | 'restricted_other'
+                | 'unsupported_business'
+                | 'unsupported_country'
+                | 'unsupported_entity_type';
+
+              export type Resolution =
+                | 'contact_stripe'
+                | 'no_resolution'
+                | 'provide_info';
+            }
+          }
+        }
+      }
+    }
+  }
+
+  export namespace Defaults {
+    export type Locale =
+      | 'ar-SA'
+      | 'bg'
+      | 'bg-BG'
+      | 'cs'
+      | 'cs-CZ'
+      | 'da'
+      | 'da-DK'
+      | 'de'
+      | 'de-DE'
+      | 'el'
+      | 'el-GR'
+      | 'en'
+      | 'en-AU'
+      | 'en-CA'
+      | 'en-GB'
+      | 'en-IE'
+      | 'en-IN'
+      | 'en-NZ'
+      | 'en-SG'
+      | 'en-US'
+      | 'es'
+      | 'es-419'
+      | 'es-ES'
+      | 'et'
+      | 'et-EE'
+      | 'fi'
+      | 'fil'
+      | 'fil-PH'
+      | 'fi-FI'
+      | 'fr'
+      | 'fr-CA'
+      | 'fr-FR'
+      | 'he-IL'
+      | 'hr'
+      | 'hr-HR'
+      | 'hu'
+      | 'hu-HU'
+      | 'id'
+      | 'id-ID'
+      | 'it'
+      | 'it-IT'
+      | 'ja'
+      | 'ja-JP'
+      | 'ko'
+      | 'ko-KR'
+      | 'lt'
+      | 'lt-LT'
+      | 'lv'
+      | 'lv-LV'
+      | 'ms'
+      | 'ms-MY'
+      | 'mt'
+      | 'mt-MT'
+      | 'nb'
+      | 'nb-NO'
+      | 'nl'
+      | 'nl-NL'
+      | 'pl'
+      | 'pl-PL'
+      | 'pt'
+      | 'pt-BR'
+      | 'pt-PT'
+      | 'ro'
+      | 'ro-RO'
+      | 'ru'
+      | 'ru-RU'
+      | 'sk'
+      | 'sk-SK'
+      | 'sl'
+      | 'sl-SI'
+      | 'sv'
+      | 'sv-SE'
+      | 'th'
+      | 'th-TH'
+      | 'tr'
+      | 'tr-TR'
+      | 'vi'
+      | 'vi-VN'
+      | 'zh'
+      | 'zh-Hans'
+      | 'zh-Hant-HK'
+      | 'zh-Hant-TW'
+      | 'zh-HK'
+      | 'zh-TW';
+
+    export interface Profile {
+      /**
+       * The business's publicly-available website.
+       */
+      business_url?: string;
+
+      /**
+       * The customer-facing business name.
+       */
+      doing_business_as?: string;
+
+      /**
+       * Internal-only description of the product sold or service provided by the business. It's used by Stripe for risk and underwriting purposes.
+       */
+      product_description?: string;
+    }
+
+    export interface Responsibilities {
+      /**
+       * Indicates whether the platform or connected account is responsible for paying Stripe fees for pricing-control-eligible products.
+       */
+      fees_collector?: Responsibilities.FeesCollector;
+
+      /**
+       * A value indicating responsibility for collecting requirements on this account.
+       */
+      losses_collector?: Responsibilities.LossesCollector;
+
+      /**
+       * A value indicating responsibility for collecting requirements on this account.
+       */
+      requirements_collector: Responsibilities.RequirementsCollector;
+    }
+
+    export namespace Responsibilities {
+      export type FeesCollector =
+        | 'application'
+        | 'application_custom'
+        | 'application_express'
+        | 'stripe';
+
+      export type LossesCollector = 'application' | 'stripe';
+
+      export type RequirementsCollector = 'application' | 'stripe';
+    }
+  }
+
+  export namespace FutureRequirements {
+    export interface Entry {
+      /**
+       * Indicates whether the platform or Stripe is currently responsible for taking action on the requirement. Value can be `user` or `stripe`.
+       */
+      awaiting_action_from: Entry.AwaitingActionFrom;
+
+      /**
+       * Machine-readable string describing the requirement.
+       */
+      description: string;
+
+      /**
+       * Descriptions of why the requirement must be collected, or why the collected information isn't satisfactory to Stripe.
+       */
+      errors: Array<Entry.Error>;
+
+      /**
+       * A hash describing the impact of not collecting the requirement, or Stripe not being able to verify the collected information.
+       */
+      impact: Entry.Impact;
+
+      /**
+       * The soonest point when the account will be impacted by not providing the requirement.
+       */
+      minimum_deadline: Entry.MinimumDeadline;
+
+      /**
+       * A reference to the location of the requirement.
+       */
+      reference?: Entry.Reference;
+
+      /**
+       * A list of reasons why Stripe is collecting the requirement.
+       */
+      requested_reasons: Array<Entry.RequestedReason>;
+    }
+
+    export interface Summary {
+      /**
+       * The soonest date and time a requirement on the Account will become `past due`. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: `2022-09-18T13:22:18.123Z`.
+       */
+      minimum_deadline?: Summary.MinimumDeadline;
+    }
+
+    export namespace Entry {
+      export type AwaitingActionFrom = 'stripe' | 'user';
+
+      export interface Error {
+        /**
+         * Machine-readable code describing the error.
+         */
+        code: Error.Code;
+
+        /**
+         * Human-readable description of the error.
+         */
+        description: string;
+      }
+
+      export interface Impact {
+        /**
+         * The Capabilities that will be restricted if the requirement is not collected and satisfactory to Stripe.
+         */
+        restricts_capabilities?: Array<Impact.RestrictsCapability>;
+      }
+
+      export interface MinimumDeadline {
+        /**
+         * The current status of the requirement's impact.
+         */
+        status: MinimumDeadline.Status;
+      }
+
+      export interface Reference {
+        /**
+         * If `inquiry` is the type, the inquiry token.
+         */
+        inquiry?: string;
+
+        /**
+         * If `resource` is the type, the resource token.
+         */
+        resource?: string;
+
+        /**
+         * The type of the reference. If the type is "inquiry", the inquiry token can be found in the "inquiry" field.
+         * Otherwise the type is an API resource, the token for which can be found in the "resource" field.
+         */
+        type: Reference.Type;
+      }
+
+      export interface RequestedReason {
+        /**
+         * Machine-readable description of Stripe's reason for collecting the requirement.
+         */
+        code: RequestedReason.Code;
+      }
+
+      export namespace Error {
+        export type Code =
+          | 'invalid_address_city_state_postal_code'
+          | 'invalid_address_highway_contract_box'
+          | 'invalid_address_private_mailbox'
+          | 'invalid_business_profile_name'
+          | 'invalid_business_profile_name_denylisted'
+          | 'invalid_company_name_denylisted'
+          | 'invalid_dob_age_over_maximum'
+          | 'invalid_dob_age_under_18'
+          | 'invalid_dob_age_under_minimum'
+          | 'invalid_product_description_length'
+          | 'invalid_product_description_url_match'
+          | 'invalid_representative_country'
+          | 'invalid_statement_descriptor_business_mismatch'
+          | 'invalid_statement_descriptor_denylisted'
+          | 'invalid_statement_descriptor_length'
+          | 'invalid_statement_descriptor_prefix_denylisted'
+          | 'invalid_statement_descriptor_prefix_mismatch'
+          | 'invalid_street_address'
+          | 'invalid_tax_id'
+          | 'invalid_tax_id_format'
+          | 'invalid_tos_acceptance'
+          | 'invalid_url_denylisted'
+          | 'invalid_url_format'
+          | 'invalid_url_website_business_information_mismatch'
+          | 'invalid_url_website_empty'
+          | 'invalid_url_website_inaccessible'
+          | 'invalid_url_website_inaccessible_geoblocked'
+          | 'invalid_url_website_inaccessible_password_protected'
+          | 'invalid_url_website_incomplete'
+          | 'invalid_url_website_incomplete_cancellation_policy'
+          | 'invalid_url_website_incomplete_customer_service_details'
+          | 'invalid_url_website_incomplete_legal_restrictions'
+          | 'invalid_url_website_incomplete_refund_policy'
+          | 'invalid_url_website_incomplete_return_policy'
+          | 'invalid_url_website_incomplete_terms_and_conditions'
+          | 'invalid_url_website_incomplete_under_construction'
+          | 'invalid_url_website_other'
+          | 'invalid_url_web_presence_detected'
+          | 'invalid_value_other'
+          | 'unresolvable_ip_address'
+          | 'unresolvable_postal_code'
+          | 'verification_directors_mismatch'
+          | 'verification_document_address_mismatch'
+          | 'verification_document_address_missing'
+          | 'verification_document_corrupt'
+          | 'verification_document_country_not_supported'
+          | 'verification_document_directors_mismatch'
+          | 'verification_document_dob_mismatch'
+          | 'verification_document_duplicate_type'
+          | 'verification_document_expired'
+          | 'verification_document_failed_copy'
+          | 'verification_document_failed_greyscale'
+          | 'verification_document_failed_other'
+          | 'verification_document_failed_test_mode'
+          | 'verification_document_fraudulent'
+          | 'verification_document_id_number_mismatch'
+          | 'verification_document_id_number_missing'
+          | 'verification_document_incomplete'
+          | 'verification_document_invalid'
+          | 'verification_document_issue_or_expiry_date_missing'
+          | 'verification_document_manipulated'
+          | 'verification_document_missing_back'
+          | 'verification_document_missing_front'
+          | 'verification_document_name_mismatch'
+          | 'verification_document_name_missing'
+          | 'verification_document_nationality_mismatch'
+          | 'verification_document_not_readable'
+          | 'verification_document_not_signed'
+          | 'verification_document_not_uploaded'
+          | 'verification_document_photo_mismatch'
+          | 'verification_document_too_large'
+          | 'verification_document_type_not_supported'
+          | 'verification_extraneous_directors'
+          | 'verification_failed_address_match'
+          | 'verification_failed_business_iec_number'
+          | 'verification_failed_document_match'
+          | 'verification_failed_id_number_match'
+          | 'verification_failed_keyed_identity'
+          | 'verification_failed_keyed_match'
+          | 'verification_failed_name_match'
+          | 'verification_failed_other'
+          | 'verification_failed_representative_authority'
+          | 'verification_failed_residential_address'
+          | 'verification_failed_tax_id_match'
+          | 'verification_failed_tax_id_not_issued'
+          | 'verification_missing_directors'
+          | 'verification_missing_executives'
+          | 'verification_missing_owners'
+          | 'verification_requires_additional_memorandum_of_associations'
+          | 'verification_requires_additional_proof_of_registration'
+          | 'verification_selfie_document_missing_photo'
+          | 'verification_selfie_face_mismatch'
+          | 'verification_selfie_manipulated'
+          | 'verification_selfie_unverified_other'
+          | 'verification_supportability'
+          | 'verification_token_stale';
+      }
+
+      export namespace Impact {
+        export interface RestrictsCapability {
+          /**
+           * The name of the Capability which will be restricted.
+           */
+          capability: RestrictsCapability.Capability;
+
+          /**
+           * The configuration which specifies the Capability which will be restricted.
+           */
+          configuration: RestrictsCapability.Configuration;
+
+          /**
+           * Details about when in the account lifecycle the requirement must be collected by the avoid the Capability restriction.
+           */
+          deadline: RestrictsCapability.Deadline;
+        }
+
+        export namespace RestrictsCapability {
+          export type Capability =
+            | 'ach_debit_payments'
+            | 'acss_debit_payments'
+            | 'affirm_payments'
+            | 'afterpay_clearpay_payments'
+            | 'alma_payments'
+            | 'amazon_pay_payments'
+            | 'automatic_indirect_tax'
+            | 'au_becs_debit_payments'
+            | 'bacs_debit_payments'
+            | 'bancontact_payments'
+            | 'bank_accounts.local'
+            | 'bank_accounts.wire'
+            | 'blik_payments'
+            | 'boleto_payments'
+            | 'cards'
+            | 'card_payments'
+            | 'cartes_bancaires_payments'
+            | 'cashapp_payments'
+            | 'eps_payments'
+            | 'fpx_payments'
+            | 'gb_bank_transfer_payments'
+            | 'grabpay_payments'
+            | 'ideal_payments'
+            | 'jcb_payments'
+            | 'jp_bank_transfer_payments'
+            | 'kakao_pay_payments'
+            | 'klarna_payments'
+            | 'konbini_payments'
+            | 'kr_card_payments'
+            | 'link_payments'
+            | 'mobilepay_payments'
+            | 'multibanco_payments'
+            | 'mx_bank_transfer_payments'
+            | 'naver_pay_payments'
+            | 'oxxo_payments'
+            | 'p24_payments'
+            | 'payco_payments'
+            | 'paynow_payments'
+            | 'pay_by_bank_payments'
+            | 'promptpay_payments'
+            | 'revolut_pay_payments'
+            | 'samsung_pay_payments'
+            | 'sepa_bank_transfer_payments'
+            | 'sepa_debit_payments'
+            | 'stripe_balance.payouts'
+            | 'stripe_balance.stripe_transfers'
+            | 'swish_payments'
+            | 'twint_payments'
+            | 'us_bank_transfer_payments'
+            | 'zip_payments';
+
+          export type Configuration = 'customer' | 'merchant' | 'recipient';
+
+          export interface Deadline {
             /**
              * The current status of the requirement's impact.
              */
-            status: MinimumDeadline.Status;
+            status: Deadline.Status;
           }
 
-          export interface Reference {
-            /**
-             * If `inquiry` is the type, the inquiry token.
-             */
-            inquiry?: string;
-
-            /**
-             * If `resource` is the type, the resource token.
-             */
-            resource?: string;
-
-            /**
-             * The type of the reference. If the type is "inquiry", the inquiry token can be found in the "inquiry" field.
-             * Otherwise the type is an API resource, the token for which can be found in the "resource" field.
-             */
-            type: Reference.Type;
-          }
-
-          export interface RequestedReason {
-            /**
-             * Machine-readable description of Stripe's reason for collecting the requirement.
-             */
-            code: RequestedReason.Code;
-          }
-
-          export namespace Error {
-            export type Code =
-              | 'invalid_address_city_state_postal_code'
-              | 'invalid_address_highway_contract_box'
-              | 'invalid_address_private_mailbox'
-              | 'invalid_business_profile_name'
-              | 'invalid_business_profile_name_denylisted'
-              | 'invalid_company_name_denylisted'
-              | 'invalid_dob_age_over_maximum'
-              | 'invalid_dob_age_under_18'
-              | 'invalid_dob_age_under_minimum'
-              | 'invalid_product_description_length'
-              | 'invalid_product_description_url_match'
-              | 'invalid_representative_country'
-              | 'invalid_statement_descriptor_business_mismatch'
-              | 'invalid_statement_descriptor_denylisted'
-              | 'invalid_statement_descriptor_length'
-              | 'invalid_statement_descriptor_prefix_denylisted'
-              | 'invalid_statement_descriptor_prefix_mismatch'
-              | 'invalid_street_address'
-              | 'invalid_tax_id'
-              | 'invalid_tax_id_format'
-              | 'invalid_tos_acceptance'
-              | 'invalid_url_denylisted'
-              | 'invalid_url_format'
-              | 'invalid_url_website_business_information_mismatch'
-              | 'invalid_url_website_empty'
-              | 'invalid_url_website_inaccessible'
-              | 'invalid_url_website_inaccessible_geoblocked'
-              | 'invalid_url_website_inaccessible_password_protected'
-              | 'invalid_url_website_incomplete'
-              | 'invalid_url_website_incomplete_cancellation_policy'
-              | 'invalid_url_website_incomplete_customer_service_details'
-              | 'invalid_url_website_incomplete_legal_restrictions'
-              | 'invalid_url_website_incomplete_refund_policy'
-              | 'invalid_url_website_incomplete_return_policy'
-              | 'invalid_url_website_incomplete_terms_and_conditions'
-              | 'invalid_url_website_incomplete_under_construction'
-              | 'invalid_url_website_other'
-              | 'invalid_url_web_presence_detected'
-              | 'invalid_value_other'
-              | 'unresolvable_ip_address'
-              | 'unresolvable_postal_code'
-              | 'verification_directors_mismatch'
-              | 'verification_document_address_mismatch'
-              | 'verification_document_address_missing'
-              | 'verification_document_corrupt'
-              | 'verification_document_country_not_supported'
-              | 'verification_document_directors_mismatch'
-              | 'verification_document_dob_mismatch'
-              | 'verification_document_duplicate_type'
-              | 'verification_document_expired'
-              | 'verification_document_failed_copy'
-              | 'verification_document_failed_greyscale'
-              | 'verification_document_failed_other'
-              | 'verification_document_failed_test_mode'
-              | 'verification_document_fraudulent'
-              | 'verification_document_id_number_mismatch'
-              | 'verification_document_id_number_missing'
-              | 'verification_document_incomplete'
-              | 'verification_document_invalid'
-              | 'verification_document_issue_or_expiry_date_missing'
-              | 'verification_document_manipulated'
-              | 'verification_document_missing_back'
-              | 'verification_document_missing_front'
-              | 'verification_document_name_mismatch'
-              | 'verification_document_name_missing'
-              | 'verification_document_nationality_mismatch'
-              | 'verification_document_not_readable'
-              | 'verification_document_not_signed'
-              | 'verification_document_not_uploaded'
-              | 'verification_document_photo_mismatch'
-              | 'verification_document_too_large'
-              | 'verification_document_type_not_supported'
-              | 'verification_extraneous_directors'
-              | 'verification_failed_address_match'
-              | 'verification_failed_business_iec_number'
-              | 'verification_failed_document_match'
-              | 'verification_failed_id_number_match'
-              | 'verification_failed_keyed_identity'
-              | 'verification_failed_keyed_match'
-              | 'verification_failed_name_match'
-              | 'verification_failed_other'
-              | 'verification_failed_representative_authority'
-              | 'verification_failed_residential_address'
-              | 'verification_failed_tax_id_match'
-              | 'verification_failed_tax_id_not_issued'
-              | 'verification_missing_directors'
-              | 'verification_missing_executives'
-              | 'verification_missing_owners'
-              | 'verification_requires_additional_memorandum_of_associations'
-              | 'verification_requires_additional_proof_of_registration'
-              | 'verification_selfie_document_missing_photo'
-              | 'verification_selfie_face_mismatch'
-              | 'verification_selfie_manipulated'
-              | 'verification_selfie_unverified_other'
-              | 'verification_supportability'
-              | 'verification_token_stale';
-          }
-
-          export namespace Impact {
-            export interface RestrictsCapability {
-              /**
-               * The name of the Capability which will be restricted.
-               */
-              capability: RestrictsCapability.Capability;
-
-              /**
-               * The configuration which specifies the Capability which will be restricted.
-               */
-              configuration: RestrictsCapability.Configuration;
-
-              /**
-               * Details about when in the account lifecycle the requirement must be collected by the avoid the Capability restriction.
-               */
-              deadline: RestrictsCapability.Deadline;
-            }
-
-            export namespace RestrictsCapability {
-              export type Capability =
-                | 'ach_debit_payments'
-                | 'acss_debit_payments'
-                | 'affirm_payments'
-                | 'afterpay_clearpay_payments'
-                | 'alma_payments'
-                | 'amazon_pay_payments'
-                | 'automatic_indirect_tax'
-                | 'au_becs_debit_payments'
-                | 'bacs_debit_payments'
-                | 'bancontact_payments'
-                | 'bank_accounts.local'
-                | 'bank_accounts.wire'
-                | 'blik_payments'
-                | 'boleto_payments'
-                | 'cards'
-                | 'card_payments'
-                | 'cartes_bancaires_payments'
-                | 'cashapp_payments'
-                | 'eps_payments'
-                | 'fpx_payments'
-                | 'gb_bank_transfer_payments'
-                | 'grabpay_payments'
-                | 'ideal_payments'
-                | 'jcb_payments'
-                | 'jp_bank_transfer_payments'
-                | 'kakao_pay_payments'
-                | 'klarna_payments'
-                | 'konbini_payments'
-                | 'kr_card_payments'
-                | 'link_payments'
-                | 'mobilepay_payments'
-                | 'multibanco_payments'
-                | 'mx_bank_transfer_payments'
-                | 'naver_pay_payments'
-                | 'oxxo_payments'
-                | 'p24_payments'
-                | 'payco_payments'
-                | 'paynow_payments'
-                | 'pay_by_bank_payments'
-                | 'promptpay_payments'
-                | 'revolut_pay_payments'
-                | 'samsung_pay_payments'
-                | 'sepa_bank_transfer_payments'
-                | 'sepa_debit_payments'
-                | 'stripe_balance.payouts'
-                | 'stripe_balance.stripe_transfers'
-                | 'swish_payments'
-                | 'twint_payments'
-                | 'us_bank_transfer_payments'
-                | 'zip_payments';
-
-              export type Configuration = 'customer' | 'merchant' | 'recipient';
-
-              export interface Deadline {
-                /**
-                 * The current status of the requirement's impact.
-                 */
-                status: Deadline.Status;
-              }
-
-              export namespace Deadline {
-                export type Status =
-                  | 'currently_due'
-                  | 'eventually_due'
-                  | 'past_due';
-              }
-            }
-          }
-
-          export namespace MinimumDeadline {
-            export type Status =
-              | 'currently_due'
-              | 'eventually_due'
-              | 'past_due';
-          }
-
-          export namespace Reference {
-            export type Type = 'inquiry' | 'payment_method' | 'person';
-          }
-
-          export namespace RequestedReason {
-            export type Code = 'routine_onboarding' | 'routine_verification';
-          }
-        }
-
-        export namespace Summary {
-          export interface MinimumDeadline {
-            /**
-             * The current strictest status of all requirements on the Account.
-             */
-            status: MinimumDeadline.Status;
-
-            /**
-             * The soonest RFC3339 date & time UTC value a requirement can impact the Account.
-             */
-            time?: string;
-          }
-
-          export namespace MinimumDeadline {
+          export namespace Deadline {
             export type Status =
               | 'currently_due'
               | 'eventually_due'
               | 'past_due';
           }
         }
+      }
+
+      export namespace MinimumDeadline {
+        export type Status = 'currently_due' | 'eventually_due' | 'past_due';
+      }
+
+      export namespace Reference {
+        export type Type = 'inquiry' | 'payment_method' | 'person';
+      }
+
+      export namespace RequestedReason {
+        export type Code = 'routine_onboarding' | 'routine_verification';
+      }
+    }
+
+    export namespace Summary {
+      export interface MinimumDeadline {
+        /**
+         * The current strictest status of all requirements on the Account.
+         */
+        status: MinimumDeadline.Status;
+
+        /**
+         * The soonest RFC3339 date & time UTC value a requirement can impact the Account.
+         */
+        time?: string;
+      }
+
+      export namespace MinimumDeadline {
+        export type Status = 'currently_due' | 'eventually_due' | 'past_due';
+      }
+    }
+  }
+
+  export namespace Identity {
+    export interface Attestations {
+      /**
+       * This hash is used to attest that the directors information provided to Stripe is both current and correct.
+       */
+      directorship_declaration?: Attestations.DirectorshipDeclaration;
+
+      /**
+       * This hash is used to attest that the beneficial owner information provided to Stripe is both current and correct.
+       */
+      ownership_declaration?: Attestations.OwnershipDeclaration;
+
+      /**
+       * Attestation that all Persons with a specific Relationship value have been provided.
+       */
+      persons_provided?: Attestations.PersonsProvided;
+
+      /**
+       * This hash is used to attest that the representative is authorized to act as the representative of their legal entity.
+       */
+      representative_declaration?: Attestations.RepresentativeDeclaration;
+
+      /**
+       * Attestations of accepted terms of service agreements.
+       */
+      terms_of_service?: Attestations.TermsOfService;
+    }
+
+    export interface BusinessDetails {
+      /**
+       * The company's primary address.
+       */
+      address?: BusinessDetails.Address;
+
+      /**
+       * The business gross annual revenue for its preceding fiscal year.
+       */
+      annual_revenue?: BusinessDetails.AnnualRevenue;
+
+      /**
+       * Documents that may be submitted to satisfy various informational requests.
+       */
+      documents?: BusinessDetails.Documents;
+
+      /**
+       * Estimated maximum number of workers currently engaged by the business (including employees, contractors, and vendors).
+       */
+      estimated_worker_count?: number;
+
+      /**
+       * The provided ID numbers of a business entity.
+       */
+      id_numbers?: Array<BusinessDetails.IdNumber>;
+
+      /**
+       * An estimate of the monthly revenue of the business. Only accepted for accounts in Brazil and India.
+       */
+      monthly_estimated_revenue?: BusinessDetails.MonthlyEstimatedRevenue;
+
+      /**
+       * The company's phone number (used for verification).
+       */
+      phone?: string;
+
+      /**
+       * The business legal name.
+       */
+      registered_name?: string;
+
+      /**
+       * When the business was incorporated or registered.
+       */
+      registration_date?: BusinessDetails.RegistrationDate;
+
+      /**
+       * The business registration address of the business entity in non latin script.
+       */
+      script_addresses?: BusinessDetails.ScriptAddresses;
+
+      /**
+       * The business legal name in non latin script.
+       */
+      script_names?: BusinessDetails.ScriptNames;
+
+      /**
+       * The category identifying the legal structure of the business.
+       */
+      structure?: BusinessDetails.Structure;
+    }
+
+    export type EntityType =
+      | 'company'
+      | 'government_entity'
+      | 'individual'
+      | 'non_profit';
+
+    export interface Individual {
+      /**
+       * The account ID which the individual belongs to.
+       */
+      account: string;
+
+      /**
+       * Additional addresses associated with the individual.
+       */
+      additional_addresses?: Array<Individual.AdditionalAddress>;
+
+      /**
+       * Additional names (e.g. aliases) associated with the individual.
+       */
+      additional_names?: Array<Individual.AdditionalName>;
+
+      /**
+       * Terms of service acceptances.
+       */
+      additional_terms_of_service?: Individual.AdditionalTermsOfService;
+
+      /**
+       * The individual's residential address.
+       */
+      address?: Individual.Address;
+
+      /**
+       * Time at which the object was created. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+       */
+      created: string;
+
+      /**
+       * The individual's date of birth.
+       */
+      date_of_birth?: Individual.DateOfBirth;
+
+      /**
+       * Documents that may be submitted to satisfy various informational requests.
+       */
+      documents?: Individual.Documents;
+
+      /**
+       * The individual's email address. You can only set this field when the Account is configured as a `merchant` or `recipient`. Use `contact_email` as the primary contact email for this Account.
+       */
+      email?: string;
+
+      /**
+       * The individual's first name.
+       */
+      given_name?: string;
+
+      /**
+       * Unique identifier for the object.
+       */
+      id: string;
+
+      /**
+       * The identification numbers (e.g., SSN) associated with the individual.
+       */
+      id_numbers?: Array<Individual.IdNumber>;
+
+      /**
+       * The individual's gender (International regulations require either "male” or "female").
+       */
+      legal_gender?: Individual.LegalGender;
+
+      /**
+       * Set of key-value pairs that you can attach to an object. This can be useful for storing additional information about the object in a structured format.
+       */
+      metadata?: Metadata;
+
+      /**
+       * The countries where the individual is a national. Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+       */
+      nationalities?: Array<string>;
+
+      /**
+       * String representing the object's type. Objects of the same type share the same value.
+       */
+      object: string;
+
+      /**
+       * The individual's phone number.
+       */
+      phone?: string;
+
+      /**
+       * Indicates if the individual or any of their representatives, family members, or other closely related persons, declares that they hold or have held an important public job or function, in any jurisdiction.
+       */
+      political_exposure?: Individual.PoliticalExposure;
+
+      /**
+       * The relationship that this individual has with the Account's identity.
+       */
+      relationship?: Individual.Relationship;
+
+      /**
+       * The script addresses (e.g., non-Latin characters) associated with the individual.
+       */
+      script_addresses?: Individual.ScriptAddresses;
+
+      /**
+       * The script names (e.g. non-Latin characters) associated with the individual.
+       */
+      script_names?: Individual.ScriptNames;
+
+      /**
+       * The individual's last name.
+       */
+      surname?: string;
+
+      /**
+       * Time at which the object was last updated.
+       */
+      updated: string;
+    }
+
+    export namespace Attestations {
+      export interface DirectorshipDeclaration {
+        /**
+         * The time marking when the director attestation was made. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+         */
+        date?: string;
+
+        /**
+         * The IP address from which the director attestation was made.
+         */
+        ip?: string;
+
+        /**
+         * The user agent of the browser from which the director attestation was made.
+         */
+        user_agent?: string;
+      }
+
+      export interface OwnershipDeclaration {
+        /**
+         * The time marking when the beneficial owner attestation was made. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+         */
+        date?: string;
+
+        /**
+         * The IP address from which the beneficial owner attestation was made.
+         */
+        ip?: string;
+
+        /**
+         * The user agent of the browser from which the beneficial owner attestation was made.
+         */
+        user_agent?: string;
+      }
+
+      export interface PersonsProvided {
+        /**
+         * Whether the company's directors have been provided. Set this Boolean to true after creating all the company's directors with the [Persons API](https://docs.stripe.com/api/v2/core/accounts/createperson).
+         */
+        directors?: boolean;
+
+        /**
+         * Whether the company's executives have been provided. Set this Boolean to true after creating all the company's executives with the [Persons API](https://docs.stripe.com/api/v2/core/accounts/createperson).
+         */
+        executives?: boolean;
+
+        /**
+         * Whether the company's owners have been provided. Set this Boolean to true after creating all the company's owners with the [Persons API](https://docs.stripe.com/api/v2/core/accounts/createperson).
+         */
+        owners?: boolean;
+
+        /**
+         * Reason for why the company is exempt from providing ownership information.
+         */
+        ownership_exemption_reason?: PersonsProvided.OwnershipExemptionReason;
+      }
+
+      export interface RepresentativeDeclaration {
+        /**
+         * The time marking when the representative attestation was made. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+         */
+        date?: string;
+
+        /**
+         * The IP address from which the representative attestation was made.
+         */
+        ip?: string;
+
+        /**
+         * The user agent of the browser from which the representative attestation was made.
+         */
+        user_agent?: string;
+      }
+
+      export interface TermsOfService {
+        /**
+         * Details on the Account's acceptance of the [Stripe Services Agreement](https://docs.stripe.com/connect/updating-accounts#tos-acceptance).
+         */
+        account?: TermsOfService.Account;
+      }
+
+      export namespace PersonsProvided {
+        export type OwnershipExemptionReason =
+          | 'qualified_entity_exceeds_ownership_threshold'
+          | 'qualifies_as_financial_institution';
+      }
+
+      export namespace TermsOfService {
+        export interface Account {
+          /**
+           * The time when the Account's representative accepted the terms of service. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+           */
+          date?: string;
+
+          /**
+           * The IP address from which the Account's representative accepted the terms of service.
+           */
+          ip?: string;
+
+          /**
+           * The user agent of the browser from which the Account's representative accepted the terms of service.
+           */
+          user_agent?: string;
+        }
+      }
+    }
+
+    export namespace BusinessDetails {
+      export interface Address {
+        /**
+         * City, district, suburb, town, or village.
+         */
+        city?: string;
+
+        /**
+         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+         */
+        country?: string;
+
+        /**
+         * Address line 1 (e.g., street, PO Box, or company name).
+         */
+        line1?: string;
+
+        /**
+         * Address line 2 (e.g., apartment, suite, unit, or building).
+         */
+        line2?: string;
+
+        /**
+         * ZIP or postal code.
+         */
+        postal_code?: string;
+
+        /**
+         * State, county, province, or region.
+         */
+        state?: string;
+
+        /**
+         * Town or district.
+         */
+        town?: string;
+      }
+
+      export interface AnnualRevenue {
+        /**
+         * Annual revenue amount in minor currency units (for example, '123' for 1.23 USD).
+         */
+        amount?: V2Amount;
+
+        /**
+         * The close-out date of the preceding fiscal year in ISO 8601 format. E.g. 2023-12-31 for the 31st of December, 2023.
+         */
+        fiscal_year_end?: string;
+      }
+
+      export interface Documents {
+        /**
+         * One or more documents that support the Bank account ownership verification requirement. Must be a document associated with the account's primary active bank account that displays the last 4 digits of the account number, either a statement or a check.
+         */
+        bank_account_ownership_verification?: Documents.BankAccountOwnershipVerification;
+
+        /**
+         * One or more documents that demonstrate proof of a company's license to operate.
+         */
+        company_license?: Documents.CompanyLicense;
+
+        /**
+         * One or more documents showing the company's Memorandum of Association.
+         */
+        company_memorandum_of_association?: Documents.CompanyMemorandumOfAssociation;
+
+        /**
+         * Certain countries only: One or more documents showing the ministerial decree legalizing the company's establishment.
+         */
+        company_ministerial_decree?: Documents.CompanyMinisterialDecree;
+
+        /**
+         * One or more documents that demonstrate proof of a company's registration with the appropriate local authorities.
+         */
+        company_registration_verification?: Documents.CompanyRegistrationVerification;
+
+        /**
+         * One or more documents that demonstrate proof of a company's tax ID.
+         */
+        company_tax_id_verification?: Documents.CompanyTaxIdVerification;
+
+        /**
+         * A document verifying the business.
+         */
+        primary_verification?: Documents.PrimaryVerification;
+
+        /**
+         * One or more documents that demonstrate proof of address.
+         */
+        proof_of_address?: Documents.ProofOfAddress;
+
+        /**
+         * One or more documents showing the company's proof of registration with the national business registry.
+         */
+        proof_of_registration?: Documents.ProofOfRegistration;
+
+        /**
+         * One or more documents that demonstrate proof of ultimate beneficial ownership.
+         */
+        proof_of_ultimate_beneficial_ownership?: Documents.ProofOfUltimateBeneficialOwnership;
+      }
+
+      export interface IdNumber {
+        /**
+         * The registrar of the ID number (Only valid for DE ID number types).
+         */
+        registrar?: string;
+
+        /**
+         * Open Enum. The ID number type of a business entity.
+         */
+        type: IdNumber.Type;
+      }
+
+      export interface MonthlyEstimatedRevenue {
+        /**
+         * Estimated monthly revenue amount in minor currency units (for example, '123' for 1.23 USD).
+         */
+        amount?: V2Amount;
+      }
+
+      export interface RegistrationDate {
+        /**
+         * The day of registration, between 1 and 31.
+         */
+        day: number;
+
+        /**
+         * The month of registration, between 1 and 12.
+         */
+        month: number;
+
+        /**
+         * The four-digit year of registration.
+         */
+        year: number;
+      }
+
+      export interface ScriptAddresses {
+        /**
+         * Kana Address.
+         */
+        kana?: ScriptAddresses.Kana;
+
+        /**
+         * Kanji Address.
+         */
+        kanji?: ScriptAddresses.Kanji;
+      }
+
+      export interface ScriptNames {
+        /**
+         * Kana name.
+         */
+        kana?: ScriptNames.Kana;
+
+        /**
+         * Kanji name.
+         */
+        kanji?: ScriptNames.Kanji;
+      }
+
+      export type Structure =
+        | 'cooperative'
+        | 'free_zone_establishment'
+        | 'free_zone_llc'
+        | 'governmental_unit'
+        | 'government_instrumentality'
+        | 'incorporated_association'
+        | 'incorporated_non_profit'
+        | 'incorporated_partnership'
+        | 'limited_liability_partnership'
+        | 'llc'
+        | 'multi_member_llc'
+        | 'private_company'
+        | 'private_corporation'
+        | 'private_partnership'
+        | 'public_company'
+        | 'public_corporation'
+        | 'public_listed_corporation'
+        | 'public_partnership'
+        | 'registered_charity'
+        | 'single_member_llc'
+        | 'sole_establishment'
+        | 'sole_proprietorship'
+        | 'tax_exempt_government_instrumentality'
+        | 'trust'
+        | 'unincorporated_association'
+        | 'unincorporated_non_profit'
+        | 'unincorporated_partnership';
+
+      export namespace Documents {
+        export interface BankAccountOwnershipVerification {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface CompanyLicense {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface CompanyMemorandumOfAssociation {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface CompanyMinisterialDecree {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface CompanyRegistrationVerification {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface CompanyTaxIdVerification {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface PrimaryVerification {
+          /**
+           * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
+           */
+          front_back: PrimaryVerification.FrontBack;
+
+          /**
+           * The format of the verification document. Currently supports `front_back` only.
+           */
+          type: 'front_back';
+        }
+
+        export interface ProofOfAddress {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface ProofOfRegistration {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * Person that is signing the document.
+           */
+          signer?: ProofOfRegistration.Signer;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface ProofOfUltimateBeneficialOwnership {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * Person that is signing the document.
+           */
+          signer?: ProofOfUltimateBeneficialOwnership.Signer;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export namespace PrimaryVerification {
+          export interface FrontBack {
+            /**
+             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
+             */
+            back?: string;
+
+            /**
+             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
+             */
+            front: string;
+          }
+        }
+
+        export namespace ProofOfRegistration {
+          export interface Signer {
+            /**
+             * Person signing the document.
+             */
+            person: string;
+          }
+        }
+
+        export namespace ProofOfUltimateBeneficialOwnership {
+          export interface Signer {
+            /**
+             * Person signing the document.
+             */
+            person: string;
+          }
+        }
+      }
+
+      export namespace IdNumber {
+        export type Type =
+          | 'ae_crn'
+          | 'ae_vat'
+          | 'ao_nif'
+          | 'ar_cuit'
+          | 'at_fn'
+          | 'at_stn'
+          | 'at_vat'
+          | 'au_abn'
+          | 'au_acn'
+          | 'au_in'
+          | 'az_tin'
+          | 'bd_etin'
+          | 'be_cbe'
+          | 'be_vat'
+          | 'bg_uic'
+          | 'bg_vat'
+          | 'br_cnpj'
+          | 'ca_cn'
+          | 'ca_crarr'
+          | 'ca_gst_hst'
+          | 'ca_neq'
+          | 'ca_rid'
+          | 'ch_chid'
+          | 'ch_uid'
+          | 'cr_cpj'
+          | 'cr_nite'
+          | 'cy_he'
+          | 'cy_tic'
+          | 'cy_vat'
+          | 'cz_ico'
+          | 'cz_vat'
+          | 'de_hrn'
+          | 'de_stn'
+          | 'de_vat'
+          | 'dk_cvr'
+          | 'dk_vat'
+          | 'do_rcn'
+          | 'ee_rk'
+          | 'ee_vat'
+          | 'es_cif'
+          | 'es_vat'
+          | 'fi_vat'
+          | 'fi_yt'
+          | 'fr_rna'
+          | 'fr_siren'
+          | 'fr_vat'
+          | 'gb_crn'
+          | 'gb_vat'
+          | 'gi_crn'
+          | 'gr_afm'
+          | 'gr_gemi'
+          | 'gr_vat'
+          | 'gt_nit'
+          | 'hk_br'
+          | 'hk_cr'
+          | 'hr_mbs'
+          | 'hr_oib'
+          | 'hr_vat'
+          | 'hu_cjs'
+          | 'hu_tin'
+          | 'hu_vat'
+          | 'ie_crn'
+          | 'ie_trn'
+          | 'ie_vat'
+          | 'it_rea'
+          | 'it_vat'
+          | 'jp_cn'
+          | 'kz_bin'
+          | 'li_uid'
+          | 'lt_ccrn'
+          | 'lt_vat'
+          | 'lu_nif'
+          | 'lu_rcs'
+          | 'lu_vat'
+          | 'lv_urn'
+          | 'lv_vat'
+          | 'mt_crn'
+          | 'mt_tin'
+          | 'mt_vat'
+          | 'mx_rfc'
+          | 'my_brn'
+          | 'my_coid'
+          | 'my_itn'
+          | 'my_sst'
+          | 'mz_nuit'
+          | 'nl_kvk'
+          | 'nl_rsin'
+          | 'nl_vat'
+          | 'no_orgnr'
+          | 'nz_bn'
+          | 'nz_ird'
+          | 'pe_ruc'
+          | 'pk_ntn'
+          | 'pl_nip'
+          | 'pl_regon'
+          | 'pl_vat'
+          | 'pt_vat'
+          | 'ro_cui'
+          | 'ro_orc'
+          | 'ro_vat'
+          | 'sa_crn'
+          | 'sa_tin'
+          | 'se_orgnr'
+          | 'se_vat'
+          | 'sg_uen'
+          | 'si_msp'
+          | 'si_tin'
+          | 'si_vat'
+          | 'sk_dic'
+          | 'sk_ico'
+          | 'sk_vat'
+          | 'th_crn'
+          | 'th_prn'
+          | 'th_tin'
+          | 'us_ein';
+      }
+
+      export namespace ScriptAddresses {
+        export interface Kana {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+
+          /**
+           * Town or district.
+           */
+          town?: string;
+        }
+
+        export interface Kanji {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+
+          /**
+           * Town or district.
+           */
+          town?: string;
+        }
+      }
+
+      export namespace ScriptNames {
+        export interface Kana {
+          /**
+           * Registered name of the business.
+           */
+          registered_name?: string;
+        }
+
+        export interface Kanji {
+          /**
+           * Registered name of the business.
+           */
+          registered_name?: string;
+        }
+      }
+    }
+
+    export namespace Individual {
+      export interface AdditionalAddress {
+        /**
+         * City, district, suburb, town, or village.
+         */
+        city?: string;
+
+        /**
+         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+         */
+        country?: string;
+
+        /**
+         * Address line 1 (e.g., street, PO Box, or company name).
+         */
+        line1?: string;
+
+        /**
+         * Address line 2 (e.g., apartment, suite, unit, or building).
+         */
+        line2?: string;
+
+        /**
+         * ZIP or postal code.
+         */
+        postal_code?: string;
+
+        /**
+         * Purpose of additional address.
+         */
+        purpose: 'registered';
+
+        /**
+         * State, county, province, or region.
+         */
+        state?: string;
+
+        /**
+         * Town or district.
+         */
+        town?: string;
+      }
+
+      export interface AdditionalName {
+        /**
+         * The individual's full name.
+         */
+        full_name?: string;
+
+        /**
+         * The individual's first or given name.
+         */
+        given_name?: string;
+
+        /**
+         * The purpose or type of the additional name.
+         */
+        purpose: AdditionalName.Purpose;
+
+        /**
+         * The individual's last or family name.
+         */
+        surname?: string;
+      }
+
+      export interface AdditionalTermsOfService {
+        /**
+         * Stripe terms of service agreement.
+         */
+        account?: AdditionalTermsOfService.Account;
+      }
+
+      export interface Address {
+        /**
+         * City, district, suburb, town, or village.
+         */
+        city?: string;
+
+        /**
+         * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+         */
+        country?: string;
+
+        /**
+         * Address line 1 (e.g., street, PO Box, or company name).
+         */
+        line1?: string;
+
+        /**
+         * Address line 2 (e.g., apartment, suite, unit, or building).
+         */
+        line2?: string;
+
+        /**
+         * ZIP or postal code.
+         */
+        postal_code?: string;
+
+        /**
+         * State, county, province, or region.
+         */
+        state?: string;
+
+        /**
+         * Town or district.
+         */
+        town?: string;
+      }
+
+      export interface DateOfBirth {
+        /**
+         * The day of birth, between 1 and 31.
+         */
+        day: number;
+
+        /**
+         * The month of birth, between 1 and 12.
+         */
+        month: number;
+
+        /**
+         * The four-digit year of birth.
+         */
+        year: number;
+      }
+
+      export interface Documents {
+        /**
+         * One or more documents that demonstrate proof that this person is authorized to represent the company.
+         */
+        company_authorization?: Documents.CompanyAuthorization;
+
+        /**
+         * One or more documents showing the person's passport page with photo and personal data.
+         */
+        passport?: Documents.Passport;
+
+        /**
+         * An identifying document showing the person's name, either a passport or local ID card.
+         */
+        primary_verification?: Documents.PrimaryVerification;
+
+        /**
+         * A document showing address, either a passport, local ID card, or utility bill from a well-known utility company.
+         */
+        secondary_verification?: Documents.SecondaryVerification;
+
+        /**
+         * One or more documents showing the person's visa required for living in the country where they are residing.
+         */
+        visa?: Documents.Visa;
+      }
+
+      export interface IdNumber {
+        /**
+         * The ID number type of an individual.
+         */
+        type: IdNumber.Type;
+      }
+
+      export type LegalGender = 'female' | 'male';
+
+      export type PoliticalExposure = 'existing' | 'none';
+
+      export interface Relationship {
+        /**
+         * Whether the individual is an authorizer of the Account's identity.
+         */
+        authorizer?: boolean;
+
+        /**
+         * Whether the individual is a director of the Account's identity. Directors are typically members of the governing board of the company or are responsible for making sure that the company meets its regulatory obligations.
+         */
+        director?: boolean;
+
+        /**
+         * Whether the individual has significant responsibility to control, manage, or direct the organization.
+         */
+        executive?: boolean;
+
+        /**
+         * Whether the individual is the legal guardian of the Account's representative.
+         */
+        legal_guardian?: boolean;
+
+        /**
+         * Whether the individual is an owner of the Account's identity.
+         */
+        owner?: boolean;
+
+        /**
+         * The percentage of the Account's identity that the individual owns.
+         */
+        percent_ownership?: Decimal;
+
+        /**
+         * Whether the individual is authorized as the primary representative of the Account. This is the person nominated by the business to provide information about themselves, and general information about the account. There can only be one representative at any given time. At the time the account is created, this person should be set to the person responsible for opening the account.
+         */
+        representative?: boolean;
+
+        /**
+         * The individual's title (e.g., CEO, Support Engineer).
+         */
+        title?: string;
+      }
+
+      export interface ScriptAddresses {
+        /**
+         * Kana Address.
+         */
+        kana?: ScriptAddresses.Kana;
+
+        /**
+         * Kanji Address.
+         */
+        kanji?: ScriptAddresses.Kanji;
+      }
+
+      export interface ScriptNames {
+        /**
+         * Persons name in kana script.
+         */
+        kana?: ScriptNames.Kana;
+
+        /**
+         * Persons name in kanji script.
+         */
+        kanji?: ScriptNames.Kanji;
+      }
+
+      export namespace AdditionalName {
+        export type Purpose = 'alias' | 'maiden';
+      }
+
+      export namespace AdditionalTermsOfService {
+        export interface Account {
+          /**
+           * The time when the Account's representative accepted the terms of service. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: 2022-09-18T13:22:18.123Z.
+           */
+          date?: string;
+
+          /**
+           * The IP address from which the Account's representative accepted the terms of service.
+           */
+          ip?: string;
+
+          /**
+           * The user agent of the browser from which the Account's representative accepted the terms of service.
+           */
+          user_agent?: string;
+        }
+      }
+
+      export namespace Documents {
+        export interface CompanyAuthorization {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface Passport {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export interface PrimaryVerification {
+          /**
+           * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
+           */
+          front_back: PrimaryVerification.FrontBack;
+
+          /**
+           * The format of the verification document. Currently supports `front_back` only.
+           */
+          type: 'front_back';
+        }
+
+        export interface SecondaryVerification {
+          /**
+           * The [file upload](https://docs.stripe.com/api/persons/update#create_file) tokens for the front and back of the verification document.
+           */
+          front_back: SecondaryVerification.FrontBack;
+
+          /**
+           * The format of the verification document. Currently supports `front_back` only.
+           */
+          type: 'front_back';
+        }
+
+        export interface Visa {
+          /**
+           * One or more document IDs returned by a [file upload](https://docs.stripe.com/api/persons/update#create_file) with a purpose value of `account_requirement`.
+           */
+          files: Array<string>;
+
+          /**
+           * The format of the document. Currently supports `files` only.
+           */
+          type: 'files';
+        }
+
+        export namespace PrimaryVerification {
+          export interface FrontBack {
+            /**
+             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
+             */
+            back?: string;
+
+            /**
+             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
+             */
+            front: string;
+          }
+        }
+
+        export namespace SecondaryVerification {
+          export interface FrontBack {
+            /**
+             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the back of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
+             */
+            back?: string;
+
+            /**
+             * A [file upload](https://docs.stripe.com/api/persons/update#create_file) token representing the front of the verification document. The purpose of the uploaded file should be 'identity_document'. The uploaded file needs to be a color image (smaller than 8,000px by 8,000px), in JPG, PNG, or PDF format, and less than 10 MB in size.
+             */
+            front: string;
+          }
+        }
+      }
+
+      export namespace IdNumber {
+        export type Type =
+          | 'ae_eid'
+          | 'ao_nif'
+          | 'ar_cuil'
+          | 'ar_dni'
+          | 'at_stn'
+          | 'az_tin'
+          | 'bd_brc'
+          | 'bd_etin'
+          | 'bd_nid'
+          | 'be_nrn'
+          | 'bg_ucn'
+          | 'bn_nric'
+          | 'br_cpf'
+          | 'ca_sin'
+          | 'ch_oasi'
+          | 'cl_rut'
+          | 'cn_pp'
+          | 'co_nuip'
+          | 'cr_ci'
+          | 'cr_cpf'
+          | 'cr_dimex'
+          | 'cr_nite'
+          | 'cy_tic'
+          | 'cz_rc'
+          | 'de_stn'
+          | 'dk_cpr'
+          | 'do_cie'
+          | 'do_rcn'
+          | 'ec_ci'
+          | 'ee_ik'
+          | 'es_nif'
+          | 'fi_hetu'
+          | 'fr_nir'
+          | 'gb_nino'
+          | 'gr_afm'
+          | 'gt_nit'
+          | 'hk_id'
+          | 'hr_oib'
+          | 'hu_ad'
+          | 'id_nik'
+          | 'ie_ppsn'
+          | 'is_kt'
+          | 'it_cf'
+          | 'jp_inc'
+          | 'ke_pin'
+          | 'kz_iin'
+          | 'li_peid'
+          | 'lt_ak'
+          | 'lu_nif'
+          | 'lv_pk'
+          | 'mx_rfc'
+          | 'my_nric'
+          | 'mz_nuit'
+          | 'ng_nin'
+          | 'nl_bsn'
+          | 'no_nin'
+          | 'nz_ird'
+          | 'pe_dni'
+          | 'pk_cnic'
+          | 'pk_snic'
+          | 'pl_pesel'
+          | 'pt_nif'
+          | 'ro_cnp'
+          | 'sa_tin'
+          | 'se_pin'
+          | 'sg_fin'
+          | 'sg_nric'
+          | 'sk_dic'
+          | 'th_lc'
+          | 'th_pin'
+          | 'tr_tin'
+          | 'us_itin'
+          | 'us_itin_last_4'
+          | 'us_ssn'
+          | 'us_ssn_last_4'
+          | 'uy_dni'
+          | 'za_id';
+      }
+
+      export namespace ScriptAddresses {
+        export interface Kana {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+
+          /**
+           * Town or district.
+           */
+          town?: string;
+        }
+
+        export interface Kanji {
+          /**
+           * City, district, suburb, town, or village.
+           */
+          city?: string;
+
+          /**
+           * Two-letter country code ([ISO 3166-1 alpha-2](https://en.wikipedia.org/wiki/ISO_3166-1_alpha-2)).
+           */
+          country?: string;
+
+          /**
+           * Address line 1 (e.g., street, PO Box, or company name).
+           */
+          line1?: string;
+
+          /**
+           * Address line 2 (e.g., apartment, suite, unit, or building).
+           */
+          line2?: string;
+
+          /**
+           * ZIP or postal code.
+           */
+          postal_code?: string;
+
+          /**
+           * State, county, province, or region.
+           */
+          state?: string;
+
+          /**
+           * Town or district.
+           */
+          town?: string;
+        }
+      }
+
+      export namespace ScriptNames {
+        export interface Kana {
+          /**
+           * The person's first or given name.
+           */
+          given_name?: string;
+
+          /**
+           * The person's last or family name.
+           */
+          surname?: string;
+        }
+
+        export interface Kanji {
+          /**
+           * The person's first or given name.
+           */
+          given_name?: string;
+
+          /**
+           * The person's last or family name.
+           */
+          surname?: string;
+        }
+      }
+    }
+  }
+
+  export namespace Requirements {
+    export interface Entry {
+      /**
+       * Indicates whether the platform or Stripe is currently responsible for taking action on the requirement. Value can be `user` or `stripe`.
+       */
+      awaiting_action_from: Entry.AwaitingActionFrom;
+
+      /**
+       * Machine-readable string describing the requirement.
+       */
+      description: string;
+
+      /**
+       * Descriptions of why the requirement must be collected, or why the collected information isn't satisfactory to Stripe.
+       */
+      errors: Array<Entry.Error>;
+
+      /**
+       * A hash describing the impact of not collecting the requirement, or Stripe not being able to verify the collected information.
+       */
+      impact: Entry.Impact;
+
+      /**
+       * The soonest point when the account will be impacted by not providing the requirement.
+       */
+      minimum_deadline: Entry.MinimumDeadline;
+
+      /**
+       * A reference to the location of the requirement.
+       */
+      reference?: Entry.Reference;
+
+      /**
+       * A list of reasons why Stripe is collecting the requirement.
+       */
+      requested_reasons: Array<Entry.RequestedReason>;
+    }
+
+    export interface Summary {
+      /**
+       * The soonest date and time a requirement on the Account will become `past due`. Represented as a RFC 3339 date & time UTC value in millisecond precision, for example: `2022-09-18T13:22:18.123Z`.
+       */
+      minimum_deadline?: Summary.MinimumDeadline;
+    }
+
+    export namespace Entry {
+      export type AwaitingActionFrom = 'stripe' | 'user';
+
+      export interface Error {
+        /**
+         * Machine-readable code describing the error.
+         */
+        code: Error.Code;
+
+        /**
+         * Human-readable description of the error.
+         */
+        description: string;
+      }
+
+      export interface Impact {
+        /**
+         * The Capabilities that will be restricted if the requirement is not collected and satisfactory to Stripe.
+         */
+        restricts_capabilities?: Array<Impact.RestrictsCapability>;
+      }
+
+      export interface MinimumDeadline {
+        /**
+         * The current status of the requirement's impact.
+         */
+        status: MinimumDeadline.Status;
+      }
+
+      export interface Reference {
+        /**
+         * If `inquiry` is the type, the inquiry token.
+         */
+        inquiry?: string;
+
+        /**
+         * If `resource` is the type, the resource token.
+         */
+        resource?: string;
+
+        /**
+         * The type of the reference. If the type is "inquiry", the inquiry token can be found in the "inquiry" field.
+         * Otherwise the type is an API resource, the token for which can be found in the "resource" field.
+         */
+        type: Reference.Type;
+      }
+
+      export interface RequestedReason {
+        /**
+         * Machine-readable description of Stripe's reason for collecting the requirement.
+         */
+        code: RequestedReason.Code;
+      }
+
+      export namespace Error {
+        export type Code =
+          | 'invalid_address_city_state_postal_code'
+          | 'invalid_address_highway_contract_box'
+          | 'invalid_address_private_mailbox'
+          | 'invalid_business_profile_name'
+          | 'invalid_business_profile_name_denylisted'
+          | 'invalid_company_name_denylisted'
+          | 'invalid_dob_age_over_maximum'
+          | 'invalid_dob_age_under_18'
+          | 'invalid_dob_age_under_minimum'
+          | 'invalid_product_description_length'
+          | 'invalid_product_description_url_match'
+          | 'invalid_representative_country'
+          | 'invalid_statement_descriptor_business_mismatch'
+          | 'invalid_statement_descriptor_denylisted'
+          | 'invalid_statement_descriptor_length'
+          | 'invalid_statement_descriptor_prefix_denylisted'
+          | 'invalid_statement_descriptor_prefix_mismatch'
+          | 'invalid_street_address'
+          | 'invalid_tax_id'
+          | 'invalid_tax_id_format'
+          | 'invalid_tos_acceptance'
+          | 'invalid_url_denylisted'
+          | 'invalid_url_format'
+          | 'invalid_url_website_business_information_mismatch'
+          | 'invalid_url_website_empty'
+          | 'invalid_url_website_inaccessible'
+          | 'invalid_url_website_inaccessible_geoblocked'
+          | 'invalid_url_website_inaccessible_password_protected'
+          | 'invalid_url_website_incomplete'
+          | 'invalid_url_website_incomplete_cancellation_policy'
+          | 'invalid_url_website_incomplete_customer_service_details'
+          | 'invalid_url_website_incomplete_legal_restrictions'
+          | 'invalid_url_website_incomplete_refund_policy'
+          | 'invalid_url_website_incomplete_return_policy'
+          | 'invalid_url_website_incomplete_terms_and_conditions'
+          | 'invalid_url_website_incomplete_under_construction'
+          | 'invalid_url_website_other'
+          | 'invalid_url_web_presence_detected'
+          | 'invalid_value_other'
+          | 'unresolvable_ip_address'
+          | 'unresolvable_postal_code'
+          | 'verification_directors_mismatch'
+          | 'verification_document_address_mismatch'
+          | 'verification_document_address_missing'
+          | 'verification_document_corrupt'
+          | 'verification_document_country_not_supported'
+          | 'verification_document_directors_mismatch'
+          | 'verification_document_dob_mismatch'
+          | 'verification_document_duplicate_type'
+          | 'verification_document_expired'
+          | 'verification_document_failed_copy'
+          | 'verification_document_failed_greyscale'
+          | 'verification_document_failed_other'
+          | 'verification_document_failed_test_mode'
+          | 'verification_document_fraudulent'
+          | 'verification_document_id_number_mismatch'
+          | 'verification_document_id_number_missing'
+          | 'verification_document_incomplete'
+          | 'verification_document_invalid'
+          | 'verification_document_issue_or_expiry_date_missing'
+          | 'verification_document_manipulated'
+          | 'verification_document_missing_back'
+          | 'verification_document_missing_front'
+          | 'verification_document_name_mismatch'
+          | 'verification_document_name_missing'
+          | 'verification_document_nationality_mismatch'
+          | 'verification_document_not_readable'
+          | 'verification_document_not_signed'
+          | 'verification_document_not_uploaded'
+          | 'verification_document_photo_mismatch'
+          | 'verification_document_too_large'
+          | 'verification_document_type_not_supported'
+          | 'verification_extraneous_directors'
+          | 'verification_failed_address_match'
+          | 'verification_failed_business_iec_number'
+          | 'verification_failed_document_match'
+          | 'verification_failed_id_number_match'
+          | 'verification_failed_keyed_identity'
+          | 'verification_failed_keyed_match'
+          | 'verification_failed_name_match'
+          | 'verification_failed_other'
+          | 'verification_failed_representative_authority'
+          | 'verification_failed_residential_address'
+          | 'verification_failed_tax_id_match'
+          | 'verification_failed_tax_id_not_issued'
+          | 'verification_missing_directors'
+          | 'verification_missing_executives'
+          | 'verification_missing_owners'
+          | 'verification_requires_additional_memorandum_of_associations'
+          | 'verification_requires_additional_proof_of_registration'
+          | 'verification_selfie_document_missing_photo'
+          | 'verification_selfie_face_mismatch'
+          | 'verification_selfie_manipulated'
+          | 'verification_selfie_unverified_other'
+          | 'verification_supportability'
+          | 'verification_token_stale';
+      }
+
+      export namespace Impact {
+        export interface RestrictsCapability {
+          /**
+           * The name of the Capability which will be restricted.
+           */
+          capability: RestrictsCapability.Capability;
+
+          /**
+           * The configuration which specifies the Capability which will be restricted.
+           */
+          configuration: RestrictsCapability.Configuration;
+
+          /**
+           * Details about when in the account lifecycle the requirement must be collected by the avoid the Capability restriction.
+           */
+          deadline: RestrictsCapability.Deadline;
+        }
+
+        export namespace RestrictsCapability {
+          export type Capability =
+            | 'ach_debit_payments'
+            | 'acss_debit_payments'
+            | 'affirm_payments'
+            | 'afterpay_clearpay_payments'
+            | 'alma_payments'
+            | 'amazon_pay_payments'
+            | 'automatic_indirect_tax'
+            | 'au_becs_debit_payments'
+            | 'bacs_debit_payments'
+            | 'bancontact_payments'
+            | 'bank_accounts.local'
+            | 'bank_accounts.wire'
+            | 'blik_payments'
+            | 'boleto_payments'
+            | 'cards'
+            | 'card_payments'
+            | 'cartes_bancaires_payments'
+            | 'cashapp_payments'
+            | 'eps_payments'
+            | 'fpx_payments'
+            | 'gb_bank_transfer_payments'
+            | 'grabpay_payments'
+            | 'ideal_payments'
+            | 'jcb_payments'
+            | 'jp_bank_transfer_payments'
+            | 'kakao_pay_payments'
+            | 'klarna_payments'
+            | 'konbini_payments'
+            | 'kr_card_payments'
+            | 'link_payments'
+            | 'mobilepay_payments'
+            | 'multibanco_payments'
+            | 'mx_bank_transfer_payments'
+            | 'naver_pay_payments'
+            | 'oxxo_payments'
+            | 'p24_payments'
+            | 'payco_payments'
+            | 'paynow_payments'
+            | 'pay_by_bank_payments'
+            | 'promptpay_payments'
+            | 'revolut_pay_payments'
+            | 'samsung_pay_payments'
+            | 'sepa_bank_transfer_payments'
+            | 'sepa_debit_payments'
+            | 'stripe_balance.payouts'
+            | 'stripe_balance.stripe_transfers'
+            | 'swish_payments'
+            | 'twint_payments'
+            | 'us_bank_transfer_payments'
+            | 'zip_payments';
+
+          export type Configuration = 'customer' | 'merchant' | 'recipient';
+
+          export interface Deadline {
+            /**
+             * The current status of the requirement's impact.
+             */
+            status: Deadline.Status;
+          }
+
+          export namespace Deadline {
+            export type Status =
+              | 'currently_due'
+              | 'eventually_due'
+              | 'past_due';
+          }
+        }
+      }
+
+      export namespace MinimumDeadline {
+        export type Status = 'currently_due' | 'eventually_due' | 'past_due';
+      }
+
+      export namespace Reference {
+        export type Type = 'inquiry' | 'payment_method' | 'person';
+      }
+
+      export namespace RequestedReason {
+        export type Code = 'routine_onboarding' | 'routine_verification';
+      }
+    }
+
+    export namespace Summary {
+      export interface MinimumDeadline {
+        /**
+         * The current strictest status of all requirements on the Account.
+         */
+        status: MinimumDeadline.Status;
+
+        /**
+         * The soonest RFC3339 date & time UTC value a requirement can impact the Account.
+         */
+        time?: string;
+      }
+
+      export namespace MinimumDeadline {
+        export type Status = 'currently_due' | 'eventually_due' | 'past_due';
       }
     }
   }

--- a/src/resources/V2/Core/EventDestinations.ts
+++ b/src/resources/V2/Core/EventDestinations.ts
@@ -143,12 +143,12 @@ export interface EventDestination {
   /**
    * Amazon EventBridge configuration.
    */
-  amazon_eventbridge?: V2.Core.EventDestination.AmazonEventbridge;
+  amazon_eventbridge?: EventDestination.AmazonEventbridge;
 
   /**
    * Azure Event Grid configuration.
    */
-  azure_event_grid?: V2.Core.EventDestination.AzureEventGrid;
+  azure_event_grid?: EventDestination.AzureEventGrid;
 
   /**
    * Time at which the object was created.
@@ -168,7 +168,7 @@ export interface EventDestination {
   /**
    * Payload type of events being subscribed to.
    */
-  event_payload: V2.Core.EventDestination.EventPayload;
+  event_payload: EventDestination.EventPayload;
 
   /**
    * Specifies which accounts' events route to this destination.
@@ -202,17 +202,17 @@ export interface EventDestination {
   /**
    * Status. It can be set to either enabled or disabled.
    */
-  status: V2.Core.EventDestination.Status;
+  status: EventDestination.Status;
 
   /**
    * Additional information about event destination status.
    */
-  status_details?: V2.Core.EventDestination.StatusDetails;
+  status_details?: EventDestination.StatusDetails;
 
   /**
    * Event destination type.
    */
-  type: V2.Core.EventDestination.Type;
+  type: EventDestination.Type;
 
   /**
    * Time at which the object was last updated.
@@ -222,114 +222,110 @@ export interface EventDestination {
   /**
    * Webhook endpoint configuration.
    */
-  webhook_endpoint?: V2.Core.EventDestination.WebhookEndpoint;
+  webhook_endpoint?: EventDestination.WebhookEndpoint;
 }
-export namespace V2 {
-  export namespace Core {
-    export namespace EventDestination {
-      export interface AmazonEventbridge {
-        /**
-         * The AWS account ID.
-         */
-        aws_account_id: string;
+export namespace EventDestination {
+  export interface AmazonEventbridge {
+    /**
+     * The AWS account ID.
+     */
+    aws_account_id: string;
 
-        /**
-         * The ARN of the AWS event source.
-         */
-        aws_event_source_arn: string;
+    /**
+     * The ARN of the AWS event source.
+     */
+    aws_event_source_arn: string;
 
-        /**
-         * The state of the AWS event source.
-         */
-        aws_event_source_status: AmazonEventbridge.AwsEventSourceStatus;
-      }
+    /**
+     * The state of the AWS event source.
+     */
+    aws_event_source_status: AmazonEventbridge.AwsEventSourceStatus;
+  }
 
-      export interface AzureEventGrid {
-        /**
-         * The name of the Azure partner topic.
-         */
-        azure_partner_topic_name: string;
+  export interface AzureEventGrid {
+    /**
+     * The name of the Azure partner topic.
+     */
+    azure_partner_topic_name: string;
 
-        /**
-         * The status of the Azure partner topic.
-         */
-        azure_partner_topic_status: AzureEventGrid.AzurePartnerTopicStatus;
+    /**
+     * The status of the Azure partner topic.
+     */
+    azure_partner_topic_status: AzureEventGrid.AzurePartnerTopicStatus;
 
-        /**
-         * The Azure region.
-         */
-        azure_region: string;
+    /**
+     * The Azure region.
+     */
+    azure_region: string;
 
-        /**
-         * The name of the Azure resource group.
-         */
-        azure_resource_group_name: string;
+    /**
+     * The name of the Azure resource group.
+     */
+    azure_resource_group_name: string;
 
-        /**
-         * The Azure subscription ID.
-         */
-        azure_subscription_id: string;
-      }
+    /**
+     * The Azure subscription ID.
+     */
+    azure_subscription_id: string;
+  }
 
-      export type EventPayload = 'snapshot' | 'thin';
+  export type EventPayload = 'snapshot' | 'thin';
 
-      export type Status = 'disabled' | 'enabled';
+  export type Status = 'disabled' | 'enabled';
 
-      export interface StatusDetails {
-        /**
-         * Details about why the event destination has been disabled.
-         */
-        disabled?: StatusDetails.Disabled;
-      }
+  export interface StatusDetails {
+    /**
+     * Details about why the event destination has been disabled.
+     */
+    disabled?: StatusDetails.Disabled;
+  }
 
-      export type Type =
-        | 'amazon_eventbridge'
-        | 'azure_event_grid'
-        | 'webhook_endpoint';
+  export type Type =
+    | 'amazon_eventbridge'
+    | 'azure_event_grid'
+    | 'webhook_endpoint';
 
-      export interface WebhookEndpoint {
-        /**
-         * The signing secret of the webhook endpoint, only includable on creation.
-         */
-        signing_secret?: string;
+  export interface WebhookEndpoint {
+    /**
+     * The signing secret of the webhook endpoint, only includable on creation.
+     */
+    signing_secret?: string;
 
-        /**
-         * The URL of the webhook endpoint, includable.
-         */
-        url?: string;
-      }
+    /**
+     * The URL of the webhook endpoint, includable.
+     */
+    url?: string;
+  }
 
-      export namespace AmazonEventbridge {
-        export type AwsEventSourceStatus =
-          | 'active'
-          | 'deleted'
-          | 'pending'
-          | 'unknown';
-      }
+  export namespace AmazonEventbridge {
+    export type AwsEventSourceStatus =
+      | 'active'
+      | 'deleted'
+      | 'pending'
+      | 'unknown';
+  }
 
-      export namespace AzureEventGrid {
-        export type AzurePartnerTopicStatus =
-          | 'activated'
-          | 'deleted'
-          | 'never_activated'
-          | 'unknown';
-      }
+  export namespace AzureEventGrid {
+    export type AzurePartnerTopicStatus =
+      | 'activated'
+      | 'deleted'
+      | 'never_activated'
+      | 'unknown';
+  }
 
-      export namespace StatusDetails {
-        export interface Disabled {
-          /**
-           * Reason event destination has been disabled.
-           */
-          reason: Disabled.Reason;
-        }
+  export namespace StatusDetails {
+    export interface Disabled {
+      /**
+       * Reason event destination has been disabled.
+       */
+      reason: Disabled.Reason;
+    }
 
-        export namespace Disabled {
-          export type Reason =
-            | 'no_aws_event_source_exists'
-            | 'no_azure_partner_topic_exists'
-            | 'user';
-        }
-      }
+    export namespace Disabled {
+      export type Reason =
+        | 'no_aws_event_source_exists'
+        | 'no_azure_partner_topic_exists'
+        | 'user';
     }
   }
 }

--- a/src/resources/V2/Core/Events.ts
+++ b/src/resources/V2/Core/Events.ts
@@ -84,7 +84,7 @@ export interface EventBase {
   /**
    * Before and after changes for the primary related object.
    */
-  changes?: V2.Core.Event.Changes;
+  changes?: Event.Changes;
 
   /**
    * Authentication context needed to fetch the event or related object.
@@ -104,45 +104,41 @@ export interface EventBase {
   /**
    * Reason for the event.
    */
-  reason?: V2.Core.Event.Reason;
+  reason?: Event.Reason;
 
   /**
    * The type of the event.
    */
   type: string;
 }
-export namespace V2 {
-  export namespace Core {
-    export namespace Event {
-      export type Changes = {
-        [key: string]: unknown;
-      };
+export namespace Event {
+  export type Changes = {
+    [key: string]: unknown;
+  };
 
-      export interface Reason {
-        /**
-         * Information on the API request that instigated the event.
-         */
-        request?: Reason.Request;
+  export interface Reason {
+    /**
+     * Information on the API request that instigated the event.
+     */
+    request?: Reason.Request;
 
-        /**
-         * Event reason type.
-         */
-        type: 'request';
-      }
+    /**
+     * Event reason type.
+     */
+    type: 'request';
+  }
 
-      export namespace Reason {
-        export interface Request {
-          /**
-           * ID of the API request that caused the event.
-           */
-          id: string;
+  export namespace Reason {
+    export interface Request {
+      /**
+       * ID of the API request that caused the event.
+       */
+      id: string;
 
-          /**
-           * The idempotency key transmitted during the request.
-           */
-          idempotency_key: string;
-        }
-      }
+      /**
+       * The idempotency key transmitted during the request.
+       */
+      idempotency_key: string;
     }
   }
 }

--- a/src/stripe.cjs.node.ts
+++ b/src/stripe.cjs.node.ts
@@ -513,6 +513,163 @@ declare namespace StripeConstructor {
     export type Settings = Stripe.AccountCreateParams.Settings;
     export type TosAcceptance = Stripe.AccountCreateParams.TosAcceptance;
     export type Type = Stripe.AccountCreateParams.Type;
+    export namespace BusinessProfile {
+      export type AnnualRevenue = Stripe.AccountCreateParams.BusinessProfile.AnnualRevenue;
+      export type MinorityOwnedBusinessDesignation = Stripe.AccountCreateParams.BusinessProfile.MinorityOwnedBusinessDesignation;
+      export type MonthlyEstimatedRevenue = Stripe.AccountCreateParams.BusinessProfile.MonthlyEstimatedRevenue;
+    }
+    export namespace Capabilities {
+      export type AcssDebitPayments = Stripe.AccountCreateParams.Capabilities.AcssDebitPayments;
+      export type AffirmPayments = Stripe.AccountCreateParams.Capabilities.AffirmPayments;
+      export type AfterpayClearpayPayments = Stripe.AccountCreateParams.Capabilities.AfterpayClearpayPayments;
+      export type AlmaPayments = Stripe.AccountCreateParams.Capabilities.AlmaPayments;
+      export type AmazonPayPayments = Stripe.AccountCreateParams.Capabilities.AmazonPayPayments;
+      export type AppDistribution = Stripe.AccountCreateParams.Capabilities.AppDistribution;
+      export type AuBecsDebitPayments = Stripe.AccountCreateParams.Capabilities.AuBecsDebitPayments;
+      export type BacsDebitPayments = Stripe.AccountCreateParams.Capabilities.BacsDebitPayments;
+      export type BancontactPayments = Stripe.AccountCreateParams.Capabilities.BancontactPayments;
+      export type BankTransferPayments = Stripe.AccountCreateParams.Capabilities.BankTransferPayments;
+      export type BilliePayments = Stripe.AccountCreateParams.Capabilities.BilliePayments;
+      export type BizumPayments = Stripe.AccountCreateParams.Capabilities.BizumPayments;
+      export type BlikPayments = Stripe.AccountCreateParams.Capabilities.BlikPayments;
+      export type BoletoPayments = Stripe.AccountCreateParams.Capabilities.BoletoPayments;
+      export type CardIssuing = Stripe.AccountCreateParams.Capabilities.CardIssuing;
+      export type CardPayments = Stripe.AccountCreateParams.Capabilities.CardPayments;
+      export type CartesBancairesPayments = Stripe.AccountCreateParams.Capabilities.CartesBancairesPayments;
+      export type CashappPayments = Stripe.AccountCreateParams.Capabilities.CashappPayments;
+      export type CryptoPayments = Stripe.AccountCreateParams.Capabilities.CryptoPayments;
+      export type EpsPayments = Stripe.AccountCreateParams.Capabilities.EpsPayments;
+      export type FpxPayments = Stripe.AccountCreateParams.Capabilities.FpxPayments;
+      export type GbBankTransferPayments = Stripe.AccountCreateParams.Capabilities.GbBankTransferPayments;
+      export type GiropayPayments = Stripe.AccountCreateParams.Capabilities.GiropayPayments;
+      export type GrabpayPayments = Stripe.AccountCreateParams.Capabilities.GrabpayPayments;
+      export type IdealPayments = Stripe.AccountCreateParams.Capabilities.IdealPayments;
+      export type IndiaInternationalPayments = Stripe.AccountCreateParams.Capabilities.IndiaInternationalPayments;
+      export type JcbPayments = Stripe.AccountCreateParams.Capabilities.JcbPayments;
+      export type JpBankTransferPayments = Stripe.AccountCreateParams.Capabilities.JpBankTransferPayments;
+      export type KakaoPayPayments = Stripe.AccountCreateParams.Capabilities.KakaoPayPayments;
+      export type KlarnaPayments = Stripe.AccountCreateParams.Capabilities.KlarnaPayments;
+      export type KonbiniPayments = Stripe.AccountCreateParams.Capabilities.KonbiniPayments;
+      export type KrCardPayments = Stripe.AccountCreateParams.Capabilities.KrCardPayments;
+      export type LegacyPayments = Stripe.AccountCreateParams.Capabilities.LegacyPayments;
+      export type LinkPayments = Stripe.AccountCreateParams.Capabilities.LinkPayments;
+      export type MbWayPayments = Stripe.AccountCreateParams.Capabilities.MbWayPayments;
+      export type MobilepayPayments = Stripe.AccountCreateParams.Capabilities.MobilepayPayments;
+      export type MultibancoPayments = Stripe.AccountCreateParams.Capabilities.MultibancoPayments;
+      export type MxBankTransferPayments = Stripe.AccountCreateParams.Capabilities.MxBankTransferPayments;
+      export type NaverPayPayments = Stripe.AccountCreateParams.Capabilities.NaverPayPayments;
+      export type NzBankAccountBecsDebitPayments = Stripe.AccountCreateParams.Capabilities.NzBankAccountBecsDebitPayments;
+      export type OxxoPayments = Stripe.AccountCreateParams.Capabilities.OxxoPayments;
+      export type P24Payments = Stripe.AccountCreateParams.Capabilities.P24Payments;
+      export type PayByBankPayments = Stripe.AccountCreateParams.Capabilities.PayByBankPayments;
+      export type PaycoPayments = Stripe.AccountCreateParams.Capabilities.PaycoPayments;
+      export type PaynowPayments = Stripe.AccountCreateParams.Capabilities.PaynowPayments;
+      export type PaytoPayments = Stripe.AccountCreateParams.Capabilities.PaytoPayments;
+      export type PixPayments = Stripe.AccountCreateParams.Capabilities.PixPayments;
+      export type PromptpayPayments = Stripe.AccountCreateParams.Capabilities.PromptpayPayments;
+      export type RevolutPayPayments = Stripe.AccountCreateParams.Capabilities.RevolutPayPayments;
+      export type SamsungPayPayments = Stripe.AccountCreateParams.Capabilities.SamsungPayPayments;
+      export type SatispayPayments = Stripe.AccountCreateParams.Capabilities.SatispayPayments;
+      export type ScalapayPayments = Stripe.AccountCreateParams.Capabilities.ScalapayPayments;
+      export type SepaBankTransferPayments = Stripe.AccountCreateParams.Capabilities.SepaBankTransferPayments;
+      export type SepaDebitPayments = Stripe.AccountCreateParams.Capabilities.SepaDebitPayments;
+      export type SofortPayments = Stripe.AccountCreateParams.Capabilities.SofortPayments;
+      export type SunbitPayments = Stripe.AccountCreateParams.Capabilities.SunbitPayments;
+      export type SwishPayments = Stripe.AccountCreateParams.Capabilities.SwishPayments;
+      export type TaxReportingUs1099K = Stripe.AccountCreateParams.Capabilities.TaxReportingUs1099K;
+      export type TaxReportingUs1099Misc = Stripe.AccountCreateParams.Capabilities.TaxReportingUs1099Misc;
+      export type Transfers = Stripe.AccountCreateParams.Capabilities.Transfers;
+      export type Treasury = Stripe.AccountCreateParams.Capabilities.Treasury;
+      export type TwintPayments = Stripe.AccountCreateParams.Capabilities.TwintPayments;
+      export type UpiPayments = Stripe.AccountCreateParams.Capabilities.UpiPayments;
+      export type UsBankAccountAchPayments = Stripe.AccountCreateParams.Capabilities.UsBankAccountAchPayments;
+      export type UsBankTransferPayments = Stripe.AccountCreateParams.Capabilities.UsBankTransferPayments;
+      export type ZipPayments = Stripe.AccountCreateParams.Capabilities.ZipPayments;
+    }
+    export namespace Company {
+      export type DirectorshipDeclaration = Stripe.AccountCreateParams.Company.DirectorshipDeclaration;
+      export type OwnershipDeclaration = Stripe.AccountCreateParams.Company.OwnershipDeclaration;
+      export type OwnershipExemptionReason = Stripe.AccountCreateParams.Company.OwnershipExemptionReason;
+      export type RegistrationDate = Stripe.AccountCreateParams.Company.RegistrationDate;
+      export type RepresentativeDeclaration = Stripe.AccountCreateParams.Company.RepresentativeDeclaration;
+      export type Structure = Stripe.AccountCreateParams.Company.Structure;
+      export type Verification = Stripe.AccountCreateParams.Company.Verification;
+      export namespace Verification {
+        export type Document = Stripe.AccountCreateParams.Company.Verification.Document;
+      }
+    }
+    export namespace Controller {
+      export type Fees = Stripe.AccountCreateParams.Controller.Fees;
+      export type Losses = Stripe.AccountCreateParams.Controller.Losses;
+      export type RequirementCollection = Stripe.AccountCreateParams.Controller.RequirementCollection;
+      export type StripeDashboard = Stripe.AccountCreateParams.Controller.StripeDashboard;
+      export namespace Fees {
+        export type Payer = Stripe.AccountCreateParams.Controller.Fees.Payer;
+      }
+      export namespace Losses {
+        export type Payments = Stripe.AccountCreateParams.Controller.Losses.Payments;
+      }
+      export namespace StripeDashboard {
+        export type Type = Stripe.AccountCreateParams.Controller.StripeDashboard.Type;
+      }
+    }
+    export namespace Documents {
+      export type BankAccountOwnershipVerification = Stripe.AccountCreateParams.Documents.BankAccountOwnershipVerification;
+      export type CompanyLicense = Stripe.AccountCreateParams.Documents.CompanyLicense;
+      export type CompanyMemorandumOfAssociation = Stripe.AccountCreateParams.Documents.CompanyMemorandumOfAssociation;
+      export type CompanyMinisterialDecree = Stripe.AccountCreateParams.Documents.CompanyMinisterialDecree;
+      export type CompanyRegistrationVerification = Stripe.AccountCreateParams.Documents.CompanyRegistrationVerification;
+      export type CompanyTaxIdVerification = Stripe.AccountCreateParams.Documents.CompanyTaxIdVerification;
+      export type ProofOfAddress = Stripe.AccountCreateParams.Documents.ProofOfAddress;
+      export type ProofOfRegistration = Stripe.AccountCreateParams.Documents.ProofOfRegistration;
+      export type ProofOfUltimateBeneficialOwnership = Stripe.AccountCreateParams.Documents.ProofOfUltimateBeneficialOwnership;
+      export namespace ProofOfRegistration {
+        export type Signer = Stripe.AccountCreateParams.Documents.ProofOfRegistration.Signer;
+      }
+      export namespace ProofOfUltimateBeneficialOwnership {
+        export type Signer = Stripe.AccountCreateParams.Documents.ProofOfUltimateBeneficialOwnership.Signer;
+      }
+    }
+    export namespace Individual {
+      export type Dob = Stripe.AccountCreateParams.Individual.Dob;
+      export type PoliticalExposure = Stripe.AccountCreateParams.Individual.PoliticalExposure;
+      export type Relationship = Stripe.AccountCreateParams.Individual.Relationship;
+      export type Verification = Stripe.AccountCreateParams.Individual.Verification;
+      export namespace Verification {
+        export type AdditionalDocument = Stripe.AccountCreateParams.Individual.Verification.AdditionalDocument;
+        export type Document = Stripe.AccountCreateParams.Individual.Verification.Document;
+      }
+    }
+    export namespace Settings {
+      export type BacsDebitPayments = Stripe.AccountCreateParams.Settings.BacsDebitPayments;
+      export type Branding = Stripe.AccountCreateParams.Settings.Branding;
+      export type CardIssuing = Stripe.AccountCreateParams.Settings.CardIssuing;
+      export type CardPayments = Stripe.AccountCreateParams.Settings.CardPayments;
+      export type Invoices = Stripe.AccountCreateParams.Settings.Invoices;
+      export type Payments = Stripe.AccountCreateParams.Settings.Payments;
+      export type Payouts = Stripe.AccountCreateParams.Settings.Payouts;
+      export type Treasury = Stripe.AccountCreateParams.Settings.Treasury;
+      export namespace CardIssuing {
+        export type TosAcceptance = Stripe.AccountCreateParams.Settings.CardIssuing.TosAcceptance;
+      }
+      export namespace CardPayments {
+        export type DeclineOn = Stripe.AccountCreateParams.Settings.CardPayments.DeclineOn;
+      }
+      export namespace Invoices {
+        export type HostedPaymentMethodSave = Stripe.AccountCreateParams.Settings.Invoices.HostedPaymentMethodSave;
+      }
+      export namespace Payouts {
+        export type Schedule = Stripe.AccountCreateParams.Settings.Payouts.Schedule;
+        export namespace Schedule {
+          export type Interval = Stripe.AccountCreateParams.Settings.Payouts.Schedule.Interval;
+          export type WeeklyAnchor = Stripe.AccountCreateParams.Settings.Payouts.Schedule.WeeklyAnchor;
+          export type WeeklyPayoutDay = Stripe.AccountCreateParams.Settings.Payouts.Schedule.WeeklyPayoutDay;
+        }
+      }
+      export namespace Treasury {
+        export type TosAcceptance = Stripe.AccountCreateParams.Settings.Treasury.TosAcceptance;
+      }
+    }
   }
   export namespace AccountUpdateParams {
     export type BusinessProfile = Stripe.AccountUpdateParams.BusinessProfile;
@@ -527,11 +684,159 @@ declare namespace StripeConstructor {
     export type Individual = Stripe.AccountUpdateParams.Individual;
     export type Settings = Stripe.AccountUpdateParams.Settings;
     export type TosAcceptance = Stripe.AccountUpdateParams.TosAcceptance;
+    export namespace BankAccount {
+      export type AccountHolderType = Stripe.AccountUpdateParams.BankAccount.AccountHolderType;
+    }
+    export namespace BusinessProfile {
+      export type AnnualRevenue = Stripe.AccountUpdateParams.BusinessProfile.AnnualRevenue;
+      export type MinorityOwnedBusinessDesignation = Stripe.AccountUpdateParams.BusinessProfile.MinorityOwnedBusinessDesignation;
+      export type MonthlyEstimatedRevenue = Stripe.AccountUpdateParams.BusinessProfile.MonthlyEstimatedRevenue;
+    }
+    export namespace Capabilities {
+      export type AcssDebitPayments = Stripe.AccountUpdateParams.Capabilities.AcssDebitPayments;
+      export type AffirmPayments = Stripe.AccountUpdateParams.Capabilities.AffirmPayments;
+      export type AfterpayClearpayPayments = Stripe.AccountUpdateParams.Capabilities.AfterpayClearpayPayments;
+      export type AlmaPayments = Stripe.AccountUpdateParams.Capabilities.AlmaPayments;
+      export type AmazonPayPayments = Stripe.AccountUpdateParams.Capabilities.AmazonPayPayments;
+      export type AppDistribution = Stripe.AccountUpdateParams.Capabilities.AppDistribution;
+      export type AuBecsDebitPayments = Stripe.AccountUpdateParams.Capabilities.AuBecsDebitPayments;
+      export type BacsDebitPayments = Stripe.AccountUpdateParams.Capabilities.BacsDebitPayments;
+      export type BancontactPayments = Stripe.AccountUpdateParams.Capabilities.BancontactPayments;
+      export type BankTransferPayments = Stripe.AccountUpdateParams.Capabilities.BankTransferPayments;
+      export type BilliePayments = Stripe.AccountUpdateParams.Capabilities.BilliePayments;
+      export type BizumPayments = Stripe.AccountUpdateParams.Capabilities.BizumPayments;
+      export type BlikPayments = Stripe.AccountUpdateParams.Capabilities.BlikPayments;
+      export type BoletoPayments = Stripe.AccountUpdateParams.Capabilities.BoletoPayments;
+      export type CardIssuing = Stripe.AccountUpdateParams.Capabilities.CardIssuing;
+      export type CardPayments = Stripe.AccountUpdateParams.Capabilities.CardPayments;
+      export type CartesBancairesPayments = Stripe.AccountUpdateParams.Capabilities.CartesBancairesPayments;
+      export type CashappPayments = Stripe.AccountUpdateParams.Capabilities.CashappPayments;
+      export type CryptoPayments = Stripe.AccountUpdateParams.Capabilities.CryptoPayments;
+      export type EpsPayments = Stripe.AccountUpdateParams.Capabilities.EpsPayments;
+      export type FpxPayments = Stripe.AccountUpdateParams.Capabilities.FpxPayments;
+      export type GbBankTransferPayments = Stripe.AccountUpdateParams.Capabilities.GbBankTransferPayments;
+      export type GiropayPayments = Stripe.AccountUpdateParams.Capabilities.GiropayPayments;
+      export type GrabpayPayments = Stripe.AccountUpdateParams.Capabilities.GrabpayPayments;
+      export type IdealPayments = Stripe.AccountUpdateParams.Capabilities.IdealPayments;
+      export type IndiaInternationalPayments = Stripe.AccountUpdateParams.Capabilities.IndiaInternationalPayments;
+      export type JcbPayments = Stripe.AccountUpdateParams.Capabilities.JcbPayments;
+      export type JpBankTransferPayments = Stripe.AccountUpdateParams.Capabilities.JpBankTransferPayments;
+      export type KakaoPayPayments = Stripe.AccountUpdateParams.Capabilities.KakaoPayPayments;
+      export type KlarnaPayments = Stripe.AccountUpdateParams.Capabilities.KlarnaPayments;
+      export type KonbiniPayments = Stripe.AccountUpdateParams.Capabilities.KonbiniPayments;
+      export type KrCardPayments = Stripe.AccountUpdateParams.Capabilities.KrCardPayments;
+      export type LegacyPayments = Stripe.AccountUpdateParams.Capabilities.LegacyPayments;
+      export type LinkPayments = Stripe.AccountUpdateParams.Capabilities.LinkPayments;
+      export type MbWayPayments = Stripe.AccountUpdateParams.Capabilities.MbWayPayments;
+      export type MobilepayPayments = Stripe.AccountUpdateParams.Capabilities.MobilepayPayments;
+      export type MultibancoPayments = Stripe.AccountUpdateParams.Capabilities.MultibancoPayments;
+      export type MxBankTransferPayments = Stripe.AccountUpdateParams.Capabilities.MxBankTransferPayments;
+      export type NaverPayPayments = Stripe.AccountUpdateParams.Capabilities.NaverPayPayments;
+      export type NzBankAccountBecsDebitPayments = Stripe.AccountUpdateParams.Capabilities.NzBankAccountBecsDebitPayments;
+      export type OxxoPayments = Stripe.AccountUpdateParams.Capabilities.OxxoPayments;
+      export type P24Payments = Stripe.AccountUpdateParams.Capabilities.P24Payments;
+      export type PayByBankPayments = Stripe.AccountUpdateParams.Capabilities.PayByBankPayments;
+      export type PaycoPayments = Stripe.AccountUpdateParams.Capabilities.PaycoPayments;
+      export type PaynowPayments = Stripe.AccountUpdateParams.Capabilities.PaynowPayments;
+      export type PaytoPayments = Stripe.AccountUpdateParams.Capabilities.PaytoPayments;
+      export type PixPayments = Stripe.AccountUpdateParams.Capabilities.PixPayments;
+      export type PromptpayPayments = Stripe.AccountUpdateParams.Capabilities.PromptpayPayments;
+      export type RevolutPayPayments = Stripe.AccountUpdateParams.Capabilities.RevolutPayPayments;
+      export type SamsungPayPayments = Stripe.AccountUpdateParams.Capabilities.SamsungPayPayments;
+      export type SatispayPayments = Stripe.AccountUpdateParams.Capabilities.SatispayPayments;
+      export type ScalapayPayments = Stripe.AccountUpdateParams.Capabilities.ScalapayPayments;
+      export type SepaBankTransferPayments = Stripe.AccountUpdateParams.Capabilities.SepaBankTransferPayments;
+      export type SepaDebitPayments = Stripe.AccountUpdateParams.Capabilities.SepaDebitPayments;
+      export type SofortPayments = Stripe.AccountUpdateParams.Capabilities.SofortPayments;
+      export type SunbitPayments = Stripe.AccountUpdateParams.Capabilities.SunbitPayments;
+      export type SwishPayments = Stripe.AccountUpdateParams.Capabilities.SwishPayments;
+      export type TaxReportingUs1099K = Stripe.AccountUpdateParams.Capabilities.TaxReportingUs1099K;
+      export type TaxReportingUs1099Misc = Stripe.AccountUpdateParams.Capabilities.TaxReportingUs1099Misc;
+      export type Transfers = Stripe.AccountUpdateParams.Capabilities.Transfers;
+      export type Treasury = Stripe.AccountUpdateParams.Capabilities.Treasury;
+      export type TwintPayments = Stripe.AccountUpdateParams.Capabilities.TwintPayments;
+      export type UpiPayments = Stripe.AccountUpdateParams.Capabilities.UpiPayments;
+      export type UsBankAccountAchPayments = Stripe.AccountUpdateParams.Capabilities.UsBankAccountAchPayments;
+      export type UsBankTransferPayments = Stripe.AccountUpdateParams.Capabilities.UsBankTransferPayments;
+      export type ZipPayments = Stripe.AccountUpdateParams.Capabilities.ZipPayments;
+    }
+    export namespace Company {
+      export type DirectorshipDeclaration = Stripe.AccountUpdateParams.Company.DirectorshipDeclaration;
+      export type OwnershipDeclaration = Stripe.AccountUpdateParams.Company.OwnershipDeclaration;
+      export type OwnershipExemptionReason = Stripe.AccountUpdateParams.Company.OwnershipExemptionReason;
+      export type RegistrationDate = Stripe.AccountUpdateParams.Company.RegistrationDate;
+      export type RepresentativeDeclaration = Stripe.AccountUpdateParams.Company.RepresentativeDeclaration;
+      export type Structure = Stripe.AccountUpdateParams.Company.Structure;
+      export type Verification = Stripe.AccountUpdateParams.Company.Verification;
+      export namespace Verification {
+        export type Document = Stripe.AccountUpdateParams.Company.Verification.Document;
+      }
+    }
+    export namespace Documents {
+      export type BankAccountOwnershipVerification = Stripe.AccountUpdateParams.Documents.BankAccountOwnershipVerification;
+      export type CompanyLicense = Stripe.AccountUpdateParams.Documents.CompanyLicense;
+      export type CompanyMemorandumOfAssociation = Stripe.AccountUpdateParams.Documents.CompanyMemorandumOfAssociation;
+      export type CompanyMinisterialDecree = Stripe.AccountUpdateParams.Documents.CompanyMinisterialDecree;
+      export type CompanyRegistrationVerification = Stripe.AccountUpdateParams.Documents.CompanyRegistrationVerification;
+      export type CompanyTaxIdVerification = Stripe.AccountUpdateParams.Documents.CompanyTaxIdVerification;
+      export type ProofOfAddress = Stripe.AccountUpdateParams.Documents.ProofOfAddress;
+      export type ProofOfRegistration = Stripe.AccountUpdateParams.Documents.ProofOfRegistration;
+      export type ProofOfUltimateBeneficialOwnership = Stripe.AccountUpdateParams.Documents.ProofOfUltimateBeneficialOwnership;
+      export namespace ProofOfRegistration {
+        export type Signer = Stripe.AccountUpdateParams.Documents.ProofOfRegistration.Signer;
+      }
+      export namespace ProofOfUltimateBeneficialOwnership {
+        export type Signer = Stripe.AccountUpdateParams.Documents.ProofOfUltimateBeneficialOwnership.Signer;
+      }
+    }
+    export namespace Individual {
+      export type Dob = Stripe.AccountUpdateParams.Individual.Dob;
+      export type PoliticalExposure = Stripe.AccountUpdateParams.Individual.PoliticalExposure;
+      export type Relationship = Stripe.AccountUpdateParams.Individual.Relationship;
+      export type Verification = Stripe.AccountUpdateParams.Individual.Verification;
+      export namespace Verification {
+        export type AdditionalDocument = Stripe.AccountUpdateParams.Individual.Verification.AdditionalDocument;
+        export type Document = Stripe.AccountUpdateParams.Individual.Verification.Document;
+      }
+    }
+    export namespace Settings {
+      export type BacsDebitPayments = Stripe.AccountUpdateParams.Settings.BacsDebitPayments;
+      export type Branding = Stripe.AccountUpdateParams.Settings.Branding;
+      export type CardIssuing = Stripe.AccountUpdateParams.Settings.CardIssuing;
+      export type CardPayments = Stripe.AccountUpdateParams.Settings.CardPayments;
+      export type Invoices = Stripe.AccountUpdateParams.Settings.Invoices;
+      export type Payments = Stripe.AccountUpdateParams.Settings.Payments;
+      export type Payouts = Stripe.AccountUpdateParams.Settings.Payouts;
+      export type Treasury = Stripe.AccountUpdateParams.Settings.Treasury;
+      export namespace CardIssuing {
+        export type TosAcceptance = Stripe.AccountUpdateParams.Settings.CardIssuing.TosAcceptance;
+      }
+      export namespace CardPayments {
+        export type DeclineOn = Stripe.AccountUpdateParams.Settings.CardPayments.DeclineOn;
+      }
+      export namespace Invoices {
+        export type HostedPaymentMethodSave = Stripe.AccountUpdateParams.Settings.Invoices.HostedPaymentMethodSave;
+      }
+      export namespace Payouts {
+        export type Schedule = Stripe.AccountUpdateParams.Settings.Payouts.Schedule;
+        export namespace Schedule {
+          export type Interval = Stripe.AccountUpdateParams.Settings.Payouts.Schedule.Interval;
+          export type WeeklyAnchor = Stripe.AccountUpdateParams.Settings.Payouts.Schedule.WeeklyAnchor;
+          export type WeeklyPayoutDay = Stripe.AccountUpdateParams.Settings.Payouts.Schedule.WeeklyPayoutDay;
+        }
+      }
+      export namespace Treasury {
+        export type TosAcceptance = Stripe.AccountUpdateParams.Settings.Treasury.TosAcceptance;
+      }
+    }
   }
   export namespace AccountCreateExternalAccountParams {
     export type Card = Stripe.AccountCreateExternalAccountParams.Card;
     export type BankAccount = Stripe.AccountCreateExternalAccountParams.BankAccount;
     export type CardToken = Stripe.AccountCreateExternalAccountParams.CardToken;
+    export namespace BankAccount {
+      export type AccountHolderType = Stripe.AccountCreateExternalAccountParams.BankAccount.AccountHolderType;
+    }
   }
   export namespace AccountCreatePersonParams {
     export type AdditionalTosAcceptances = Stripe.AccountCreatePersonParams.AdditionalTosAcceptances;
@@ -541,6 +846,28 @@ declare namespace StripeConstructor {
     export type Relationship = Stripe.AccountCreatePersonParams.Relationship;
     export type UsCfpbData = Stripe.AccountCreatePersonParams.UsCfpbData;
     export type Verification = Stripe.AccountCreatePersonParams.Verification;
+    export namespace AdditionalTosAcceptances {
+      export type Account = Stripe.AccountCreatePersonParams.AdditionalTosAcceptances.Account;
+    }
+    export namespace Documents {
+      export type CompanyAuthorization = Stripe.AccountCreatePersonParams.Documents.CompanyAuthorization;
+      export type Passport = Stripe.AccountCreatePersonParams.Documents.Passport;
+      export type Visa = Stripe.AccountCreatePersonParams.Documents.Visa;
+    }
+    export namespace UsCfpbData {
+      export type EthnicityDetails = Stripe.AccountCreatePersonParams.UsCfpbData.EthnicityDetails;
+      export type RaceDetails = Stripe.AccountCreatePersonParams.UsCfpbData.RaceDetails;
+      export namespace EthnicityDetails {
+        export type Ethnicity = Stripe.AccountCreatePersonParams.UsCfpbData.EthnicityDetails.Ethnicity;
+      }
+      export namespace RaceDetails {
+        export type Race = Stripe.AccountCreatePersonParams.UsCfpbData.RaceDetails.Race;
+      }
+    }
+    export namespace Verification {
+      export type AdditionalDocument = Stripe.AccountCreatePersonParams.Verification.AdditionalDocument;
+      export type Document = Stripe.AccountCreatePersonParams.Verification.Document;
+    }
   }
   export namespace AccountListExternalAccountsParams {
     export type Object = Stripe.AccountListExternalAccountsParams.Object;
@@ -552,6 +879,9 @@ declare namespace StripeConstructor {
     export type AccountHolderType = Stripe.AccountUpdateExternalAccountParams.AccountHolderType;
     export type AccountType = Stripe.AccountUpdateExternalAccountParams.AccountType;
     export type Documents = Stripe.AccountUpdateExternalAccountParams.Documents;
+    export namespace Documents {
+      export type BankAccountOwnershipVerification = Stripe.AccountUpdateExternalAccountParams.Documents.BankAccountOwnershipVerification;
+    }
   }
   export namespace AccountUpdatePersonParams {
     export type AdditionalTosAcceptances = Stripe.AccountUpdatePersonParams.AdditionalTosAcceptances;
@@ -561,17 +891,471 @@ declare namespace StripeConstructor {
     export type Relationship = Stripe.AccountUpdatePersonParams.Relationship;
     export type UsCfpbData = Stripe.AccountUpdatePersonParams.UsCfpbData;
     export type Verification = Stripe.AccountUpdatePersonParams.Verification;
+    export namespace AdditionalTosAcceptances {
+      export type Account = Stripe.AccountUpdatePersonParams.AdditionalTosAcceptances.Account;
+    }
+    export namespace Documents {
+      export type CompanyAuthorization = Stripe.AccountUpdatePersonParams.Documents.CompanyAuthorization;
+      export type Passport = Stripe.AccountUpdatePersonParams.Documents.Passport;
+      export type Visa = Stripe.AccountUpdatePersonParams.Documents.Visa;
+    }
+    export namespace UsCfpbData {
+      export type EthnicityDetails = Stripe.AccountUpdatePersonParams.UsCfpbData.EthnicityDetails;
+      export type RaceDetails = Stripe.AccountUpdatePersonParams.UsCfpbData.RaceDetails;
+      export namespace EthnicityDetails {
+        export type Ethnicity = Stripe.AccountUpdatePersonParams.UsCfpbData.EthnicityDetails.Ethnicity;
+      }
+      export namespace RaceDetails {
+        export type Race = Stripe.AccountUpdatePersonParams.UsCfpbData.RaceDetails.Race;
+      }
+    }
+    export namespace Verification {
+      export type AdditionalDocument = Stripe.AccountUpdatePersonParams.Verification.AdditionalDocument;
+      export type Document = Stripe.AccountUpdatePersonParams.Verification.Document;
+    }
+  }
+  export namespace Account {
+    export type BusinessProfile = Stripe.Account.BusinessProfile;
+    export type BusinessType = Stripe.Account.BusinessType;
+    export type Capabilities = Stripe.Account.Capabilities;
+    export type Company = Stripe.Account.Company;
+    export type Controller = Stripe.Account.Controller;
+    export type FutureRequirements = Stripe.Account.FutureRequirements;
+    export type Groups = Stripe.Account.Groups;
+    export type Requirements = Stripe.Account.Requirements;
+    export type Settings = Stripe.Account.Settings;
+    export type TosAcceptance = Stripe.Account.TosAcceptance;
+    export type Type = Stripe.Account.Type;
+    export namespace BusinessProfile {
+      export type AnnualRevenue = Stripe.Account.BusinessProfile.AnnualRevenue;
+      export type MinorityOwnedBusinessDesignation = Stripe.Account.BusinessProfile.MinorityOwnedBusinessDesignation;
+      export type MonthlyEstimatedRevenue = Stripe.Account.BusinessProfile.MonthlyEstimatedRevenue;
+    }
+    export namespace Capabilities {
+      export type AcssDebitPayments = Stripe.Account.Capabilities.AcssDebitPayments;
+      export type AffirmPayments = Stripe.Account.Capabilities.AffirmPayments;
+      export type AfterpayClearpayPayments = Stripe.Account.Capabilities.AfterpayClearpayPayments;
+      export type AlmaPayments = Stripe.Account.Capabilities.AlmaPayments;
+      export type AmazonPayPayments = Stripe.Account.Capabilities.AmazonPayPayments;
+      export type AppDistribution = Stripe.Account.Capabilities.AppDistribution;
+      export type AuBecsDebitPayments = Stripe.Account.Capabilities.AuBecsDebitPayments;
+      export type BacsDebitPayments = Stripe.Account.Capabilities.BacsDebitPayments;
+      export type BancontactPayments = Stripe.Account.Capabilities.BancontactPayments;
+      export type BankTransferPayments = Stripe.Account.Capabilities.BankTransferPayments;
+      export type BilliePayments = Stripe.Account.Capabilities.BilliePayments;
+      export type BizumPayments = Stripe.Account.Capabilities.BizumPayments;
+      export type BlikPayments = Stripe.Account.Capabilities.BlikPayments;
+      export type BoletoPayments = Stripe.Account.Capabilities.BoletoPayments;
+      export type CardIssuing = Stripe.Account.Capabilities.CardIssuing;
+      export type CardPayments = Stripe.Account.Capabilities.CardPayments;
+      export type CartesBancairesPayments = Stripe.Account.Capabilities.CartesBancairesPayments;
+      export type CashappPayments = Stripe.Account.Capabilities.CashappPayments;
+      export type CryptoPayments = Stripe.Account.Capabilities.CryptoPayments;
+      export type EpsPayments = Stripe.Account.Capabilities.EpsPayments;
+      export type FpxPayments = Stripe.Account.Capabilities.FpxPayments;
+      export type GbBankTransferPayments = Stripe.Account.Capabilities.GbBankTransferPayments;
+      export type GiropayPayments = Stripe.Account.Capabilities.GiropayPayments;
+      export type GrabpayPayments = Stripe.Account.Capabilities.GrabpayPayments;
+      export type IdealPayments = Stripe.Account.Capabilities.IdealPayments;
+      export type IndiaInternationalPayments = Stripe.Account.Capabilities.IndiaInternationalPayments;
+      export type JcbPayments = Stripe.Account.Capabilities.JcbPayments;
+      export type JpBankTransferPayments = Stripe.Account.Capabilities.JpBankTransferPayments;
+      export type KakaoPayPayments = Stripe.Account.Capabilities.KakaoPayPayments;
+      export type KlarnaPayments = Stripe.Account.Capabilities.KlarnaPayments;
+      export type KonbiniPayments = Stripe.Account.Capabilities.KonbiniPayments;
+      export type KrCardPayments = Stripe.Account.Capabilities.KrCardPayments;
+      export type LegacyPayments = Stripe.Account.Capabilities.LegacyPayments;
+      export type LinkPayments = Stripe.Account.Capabilities.LinkPayments;
+      export type MbWayPayments = Stripe.Account.Capabilities.MbWayPayments;
+      export type MobilepayPayments = Stripe.Account.Capabilities.MobilepayPayments;
+      export type MultibancoPayments = Stripe.Account.Capabilities.MultibancoPayments;
+      export type MxBankTransferPayments = Stripe.Account.Capabilities.MxBankTransferPayments;
+      export type NaverPayPayments = Stripe.Account.Capabilities.NaverPayPayments;
+      export type NzBankAccountBecsDebitPayments = Stripe.Account.Capabilities.NzBankAccountBecsDebitPayments;
+      export type OxxoPayments = Stripe.Account.Capabilities.OxxoPayments;
+      export type P24Payments = Stripe.Account.Capabilities.P24Payments;
+      export type PayByBankPayments = Stripe.Account.Capabilities.PayByBankPayments;
+      export type PaycoPayments = Stripe.Account.Capabilities.PaycoPayments;
+      export type PaynowPayments = Stripe.Account.Capabilities.PaynowPayments;
+      export type PaytoPayments = Stripe.Account.Capabilities.PaytoPayments;
+      export type PixPayments = Stripe.Account.Capabilities.PixPayments;
+      export type PromptpayPayments = Stripe.Account.Capabilities.PromptpayPayments;
+      export type RevolutPayPayments = Stripe.Account.Capabilities.RevolutPayPayments;
+      export type SamsungPayPayments = Stripe.Account.Capabilities.SamsungPayPayments;
+      export type SatispayPayments = Stripe.Account.Capabilities.SatispayPayments;
+      export type ScalapayPayments = Stripe.Account.Capabilities.ScalapayPayments;
+      export type SepaBankTransferPayments = Stripe.Account.Capabilities.SepaBankTransferPayments;
+      export type SepaDebitPayments = Stripe.Account.Capabilities.SepaDebitPayments;
+      export type SofortPayments = Stripe.Account.Capabilities.SofortPayments;
+      export type SunbitPayments = Stripe.Account.Capabilities.SunbitPayments;
+      export type SwishPayments = Stripe.Account.Capabilities.SwishPayments;
+      export type TaxReportingUs1099K = Stripe.Account.Capabilities.TaxReportingUs1099K;
+      export type TaxReportingUs1099Misc = Stripe.Account.Capabilities.TaxReportingUs1099Misc;
+      export type Transfers = Stripe.Account.Capabilities.Transfers;
+      export type Treasury = Stripe.Account.Capabilities.Treasury;
+      export type TwintPayments = Stripe.Account.Capabilities.TwintPayments;
+      export type UpiPayments = Stripe.Account.Capabilities.UpiPayments;
+      export type UsBankAccountAchPayments = Stripe.Account.Capabilities.UsBankAccountAchPayments;
+      export type UsBankTransferPayments = Stripe.Account.Capabilities.UsBankTransferPayments;
+      export type ZipPayments = Stripe.Account.Capabilities.ZipPayments;
+    }
+    export namespace Company {
+      export type AddressKana = Stripe.Account.Company.AddressKana;
+      export type AddressKanji = Stripe.Account.Company.AddressKanji;
+      export type DirectorshipDeclaration = Stripe.Account.Company.DirectorshipDeclaration;
+      export type OwnershipDeclaration = Stripe.Account.Company.OwnershipDeclaration;
+      export type OwnershipExemptionReason = Stripe.Account.Company.OwnershipExemptionReason;
+      export type RegistrationDate = Stripe.Account.Company.RegistrationDate;
+      export type RepresentativeDeclaration = Stripe.Account.Company.RepresentativeDeclaration;
+      export type Structure = Stripe.Account.Company.Structure;
+      export type Verification = Stripe.Account.Company.Verification;
+      export namespace Verification {
+        export type Document = Stripe.Account.Company.Verification.Document;
+      }
+    }
+    export namespace Controller {
+      export type Fees = Stripe.Account.Controller.Fees;
+      export type Losses = Stripe.Account.Controller.Losses;
+      export type RequirementCollection = Stripe.Account.Controller.RequirementCollection;
+      export type StripeDashboard = Stripe.Account.Controller.StripeDashboard;
+      export type Type = Stripe.Account.Controller.Type;
+      export namespace Fees {
+        export type Payer = Stripe.Account.Controller.Fees.Payer;
+      }
+      export namespace Losses {
+        export type Payments = Stripe.Account.Controller.Losses.Payments;
+      }
+      export namespace StripeDashboard {
+        export type Type = Stripe.Account.Controller.StripeDashboard.Type;
+      }
+    }
+    export namespace FutureRequirements {
+      export type Alternative = Stripe.Account.FutureRequirements.Alternative;
+      export type DisabledReason = Stripe.Account.FutureRequirements.DisabledReason;
+      export type Error = Stripe.Account.FutureRequirements.Error;
+      export namespace Error {
+        export type Code = Stripe.Account.FutureRequirements.Error.Code;
+      }
+    }
+    export namespace Requirements {
+      export type Alternative = Stripe.Account.Requirements.Alternative;
+      export type DisabledReason = Stripe.Account.Requirements.DisabledReason;
+      export type Error = Stripe.Account.Requirements.Error;
+      export namespace Error {
+        export type Code = Stripe.Account.Requirements.Error.Code;
+      }
+    }
+    export namespace Settings {
+      export type BacsDebitPayments = Stripe.Account.Settings.BacsDebitPayments;
+      export type Branding = Stripe.Account.Settings.Branding;
+      export type CardIssuing = Stripe.Account.Settings.CardIssuing;
+      export type CardPayments = Stripe.Account.Settings.CardPayments;
+      export type Dashboard = Stripe.Account.Settings.Dashboard;
+      export type Invoices = Stripe.Account.Settings.Invoices;
+      export type Payments = Stripe.Account.Settings.Payments;
+      export type Payouts = Stripe.Account.Settings.Payouts;
+      export type SepaDebitPayments = Stripe.Account.Settings.SepaDebitPayments;
+      export type Treasury = Stripe.Account.Settings.Treasury;
+      export namespace CardIssuing {
+        export type TosAcceptance = Stripe.Account.Settings.CardIssuing.TosAcceptance;
+      }
+      export namespace CardPayments {
+        export type DeclineOn = Stripe.Account.Settings.CardPayments.DeclineOn;
+      }
+      export namespace Invoices {
+        export type HostedPaymentMethodSave = Stripe.Account.Settings.Invoices.HostedPaymentMethodSave;
+      }
+      export namespace Payouts {
+        export type Schedule = Stripe.Account.Settings.Payouts.Schedule;
+        export namespace Schedule {
+          export type WeeklyPayoutDay = Stripe.Account.Settings.Payouts.Schedule.WeeklyPayoutDay;
+        }
+      }
+      export namespace Treasury {
+        export type TosAcceptance = Stripe.Account.Settings.Treasury.TosAcceptance;
+      }
+    }
   }
   export namespace AccountLinkCreateParams {
     export type Type = Stripe.AccountLinkCreateParams.Type;
     export type Collect = Stripe.AccountLinkCreateParams.Collect;
     export type CollectionOptions = Stripe.AccountLinkCreateParams.CollectionOptions;
+    export namespace CollectionOptions {
+      export type Fields = Stripe.AccountLinkCreateParams.CollectionOptions.Fields;
+      export type FutureRequirements = Stripe.AccountLinkCreateParams.CollectionOptions.FutureRequirements;
+    }
   }
   export namespace AccountSessionCreateParams {
     export type Components = Stripe.AccountSessionCreateParams.Components;
+    export namespace Components {
+      export type AccountManagement = Stripe.AccountSessionCreateParams.Components.AccountManagement;
+      export type AccountOnboarding = Stripe.AccountSessionCreateParams.Components.AccountOnboarding;
+      export type BalanceReport = Stripe.AccountSessionCreateParams.Components.BalanceReport;
+      export type Balances = Stripe.AccountSessionCreateParams.Components.Balances;
+      export type DisputesList = Stripe.AccountSessionCreateParams.Components.DisputesList;
+      export type Documents = Stripe.AccountSessionCreateParams.Components.Documents;
+      export type FinancialAccount = Stripe.AccountSessionCreateParams.Components.FinancialAccount;
+      export type FinancialAccountTransactions = Stripe.AccountSessionCreateParams.Components.FinancialAccountTransactions;
+      export type InstantPayoutsPromotion = Stripe.AccountSessionCreateParams.Components.InstantPayoutsPromotion;
+      export type IssuingCard = Stripe.AccountSessionCreateParams.Components.IssuingCard;
+      export type IssuingCardsList = Stripe.AccountSessionCreateParams.Components.IssuingCardsList;
+      export type NotificationBanner = Stripe.AccountSessionCreateParams.Components.NotificationBanner;
+      export type PaymentDetails = Stripe.AccountSessionCreateParams.Components.PaymentDetails;
+      export type PaymentDisputes = Stripe.AccountSessionCreateParams.Components.PaymentDisputes;
+      export type Payments = Stripe.AccountSessionCreateParams.Components.Payments;
+      export type PayoutDetails = Stripe.AccountSessionCreateParams.Components.PayoutDetails;
+      export type PayoutReconciliationReport = Stripe.AccountSessionCreateParams.Components.PayoutReconciliationReport;
+      export type Payouts = Stripe.AccountSessionCreateParams.Components.Payouts;
+      export type PayoutsList = Stripe.AccountSessionCreateParams.Components.PayoutsList;
+      export type TaxRegistrations = Stripe.AccountSessionCreateParams.Components.TaxRegistrations;
+      export type TaxSettings = Stripe.AccountSessionCreateParams.Components.TaxSettings;
+      export namespace AccountManagement {
+        export type Features = Stripe.AccountSessionCreateParams.Components.AccountManagement.Features;
+      }
+      export namespace AccountOnboarding {
+        export type Features = Stripe.AccountSessionCreateParams.Components.AccountOnboarding.Features;
+      }
+      export namespace BalanceReport {
+        export type Features = Stripe.AccountSessionCreateParams.Components.BalanceReport.Features;
+      }
+      export namespace Balances {
+        export type Features = Stripe.AccountSessionCreateParams.Components.Balances.Features;
+      }
+      export namespace DisputesList {
+        export type Features = Stripe.AccountSessionCreateParams.Components.DisputesList.Features;
+      }
+      export namespace Documents {
+        export type Features = Stripe.AccountSessionCreateParams.Components.Documents.Features;
+      }
+      export namespace FinancialAccount {
+        export type Features = Stripe.AccountSessionCreateParams.Components.FinancialAccount.Features;
+      }
+      export namespace FinancialAccountTransactions {
+        export type Features = Stripe.AccountSessionCreateParams.Components.FinancialAccountTransactions.Features;
+      }
+      export namespace InstantPayoutsPromotion {
+        export type Features = Stripe.AccountSessionCreateParams.Components.InstantPayoutsPromotion.Features;
+      }
+      export namespace IssuingCard {
+        export type Features = Stripe.AccountSessionCreateParams.Components.IssuingCard.Features;
+      }
+      export namespace IssuingCardsList {
+        export type Features = Stripe.AccountSessionCreateParams.Components.IssuingCardsList.Features;
+      }
+      export namespace NotificationBanner {
+        export type Features = Stripe.AccountSessionCreateParams.Components.NotificationBanner.Features;
+      }
+      export namespace PaymentDetails {
+        export type Features = Stripe.AccountSessionCreateParams.Components.PaymentDetails.Features;
+      }
+      export namespace PaymentDisputes {
+        export type Features = Stripe.AccountSessionCreateParams.Components.PaymentDisputes.Features;
+      }
+      export namespace Payments {
+        export type Features = Stripe.AccountSessionCreateParams.Components.Payments.Features;
+      }
+      export namespace PayoutDetails {
+        export type Features = Stripe.AccountSessionCreateParams.Components.PayoutDetails.Features;
+      }
+      export namespace PayoutReconciliationReport {
+        export type Features = Stripe.AccountSessionCreateParams.Components.PayoutReconciliationReport.Features;
+      }
+      export namespace Payouts {
+        export type Features = Stripe.AccountSessionCreateParams.Components.Payouts.Features;
+      }
+      export namespace PayoutsList {
+        export type Features = Stripe.AccountSessionCreateParams.Components.PayoutsList.Features;
+      }
+      export namespace TaxRegistrations {
+        export type Features = Stripe.AccountSessionCreateParams.Components.TaxRegistrations.Features;
+      }
+      export namespace TaxSettings {
+        export type Features = Stripe.AccountSessionCreateParams.Components.TaxSettings.Features;
+      }
+    }
+  }
+  export namespace AccountSession {
+    export type Components = Stripe.AccountSession.Components;
+    export namespace Components {
+      export type AccountManagement = Stripe.AccountSession.Components.AccountManagement;
+      export type AccountOnboarding = Stripe.AccountSession.Components.AccountOnboarding;
+      export type BalanceReport = Stripe.AccountSession.Components.BalanceReport;
+      export type Balances = Stripe.AccountSession.Components.Balances;
+      export type DisputesList = Stripe.AccountSession.Components.DisputesList;
+      export type Documents = Stripe.AccountSession.Components.Documents;
+      export type FinancialAccount = Stripe.AccountSession.Components.FinancialAccount;
+      export type FinancialAccountTransactions = Stripe.AccountSession.Components.FinancialAccountTransactions;
+      export type InstantPayoutsPromotion = Stripe.AccountSession.Components.InstantPayoutsPromotion;
+      export type IssuingCard = Stripe.AccountSession.Components.IssuingCard;
+      export type IssuingCardsList = Stripe.AccountSession.Components.IssuingCardsList;
+      export type NotificationBanner = Stripe.AccountSession.Components.NotificationBanner;
+      export type PaymentDetails = Stripe.AccountSession.Components.PaymentDetails;
+      export type PaymentDisputes = Stripe.AccountSession.Components.PaymentDisputes;
+      export type Payments = Stripe.AccountSession.Components.Payments;
+      export type PayoutDetails = Stripe.AccountSession.Components.PayoutDetails;
+      export type PayoutReconciliationReport = Stripe.AccountSession.Components.PayoutReconciliationReport;
+      export type Payouts = Stripe.AccountSession.Components.Payouts;
+      export type PayoutsList = Stripe.AccountSession.Components.PayoutsList;
+      export type TaxRegistrations = Stripe.AccountSession.Components.TaxRegistrations;
+      export type TaxSettings = Stripe.AccountSession.Components.TaxSettings;
+      export namespace AccountManagement {
+        export type Features = Stripe.AccountSession.Components.AccountManagement.Features;
+      }
+      export namespace AccountOnboarding {
+        export type Features = Stripe.AccountSession.Components.AccountOnboarding.Features;
+      }
+      export namespace BalanceReport {
+        export type Features = Stripe.AccountSession.Components.BalanceReport.Features;
+      }
+      export namespace Balances {
+        export type Features = Stripe.AccountSession.Components.Balances.Features;
+      }
+      export namespace DisputesList {
+        export type Features = Stripe.AccountSession.Components.DisputesList.Features;
+      }
+      export namespace Documents {
+        export type Features = Stripe.AccountSession.Components.Documents.Features;
+      }
+      export namespace FinancialAccount {
+        export type Features = Stripe.AccountSession.Components.FinancialAccount.Features;
+      }
+      export namespace FinancialAccountTransactions {
+        export type Features = Stripe.AccountSession.Components.FinancialAccountTransactions.Features;
+      }
+      export namespace InstantPayoutsPromotion {
+        export type Features = Stripe.AccountSession.Components.InstantPayoutsPromotion.Features;
+      }
+      export namespace IssuingCard {
+        export type Features = Stripe.AccountSession.Components.IssuingCard.Features;
+      }
+      export namespace IssuingCardsList {
+        export type Features = Stripe.AccountSession.Components.IssuingCardsList.Features;
+      }
+      export namespace NotificationBanner {
+        export type Features = Stripe.AccountSession.Components.NotificationBanner.Features;
+      }
+      export namespace PaymentDetails {
+        export type Features = Stripe.AccountSession.Components.PaymentDetails.Features;
+      }
+      export namespace PaymentDisputes {
+        export type Features = Stripe.AccountSession.Components.PaymentDisputes.Features;
+      }
+      export namespace Payments {
+        export type Features = Stripe.AccountSession.Components.Payments.Features;
+      }
+      export namespace PayoutDetails {
+        export type Features = Stripe.AccountSession.Components.PayoutDetails.Features;
+      }
+      export namespace PayoutReconciliationReport {
+        export type Features = Stripe.AccountSession.Components.PayoutReconciliationReport.Features;
+      }
+      export namespace Payouts {
+        export type Features = Stripe.AccountSession.Components.Payouts.Features;
+      }
+      export namespace PayoutsList {
+        export type Features = Stripe.AccountSession.Components.PayoutsList.Features;
+      }
+      export namespace TaxRegistrations {
+        export type Features = Stripe.AccountSession.Components.TaxRegistrations.Features;
+      }
+      export namespace TaxSettings {
+        export type Features = Stripe.AccountSession.Components.TaxSettings.Features;
+      }
+    }
+  }
+  export namespace ApplicationFee {
+    export type FeeSource = Stripe.ApplicationFee.FeeSource;
+    export namespace FeeSource {
+      export type Type = Stripe.ApplicationFee.FeeSource.Type;
+    }
+  }
+  export namespace Balance {
+    export type Available = Stripe.Balance.Available;
+    export type ConnectReserved = Stripe.Balance.ConnectReserved;
+    export type InstantAvailable = Stripe.Balance.InstantAvailable;
+    export type Issuing = Stripe.Balance.Issuing;
+    export type Pending = Stripe.Balance.Pending;
+    export type RefundAndDisputePrefunding = Stripe.Balance.RefundAndDisputePrefunding;
+    export namespace Available {
+      export type SourceTypes = Stripe.Balance.Available.SourceTypes;
+    }
+    export namespace ConnectReserved {
+      export type SourceTypes = Stripe.Balance.ConnectReserved.SourceTypes;
+    }
+    export namespace InstantAvailable {
+      export type NetAvailable = Stripe.Balance.InstantAvailable.NetAvailable;
+      export type SourceTypes = Stripe.Balance.InstantAvailable.SourceTypes;
+      export namespace NetAvailable {
+        export type SourceTypes = Stripe.Balance.InstantAvailable.NetAvailable.SourceTypes;
+      }
+    }
+    export namespace Issuing {
+      export type Available = Stripe.Balance.Issuing.Available;
+      export namespace Available {
+        export type SourceTypes = Stripe.Balance.Issuing.Available.SourceTypes;
+      }
+    }
+    export namespace Pending {
+      export type SourceTypes = Stripe.Balance.Pending.SourceTypes;
+    }
+    export namespace RefundAndDisputePrefunding {
+      export type Available = Stripe.Balance.RefundAndDisputePrefunding.Available;
+      export type Pending = Stripe.Balance.RefundAndDisputePrefunding.Pending;
+      export namespace Available {
+        export type SourceTypes = Stripe.Balance.RefundAndDisputePrefunding.Available.SourceTypes;
+      }
+      export namespace Pending {
+        export type SourceTypes = Stripe.Balance.RefundAndDisputePrefunding.Pending.SourceTypes;
+      }
+    }
   }
   export namespace BalanceSettingsUpdateParams {
     export type Payments = Stripe.BalanceSettingsUpdateParams.Payments;
+    export namespace Payments {
+      export type Payouts = Stripe.BalanceSettingsUpdateParams.Payments.Payouts;
+      export type SettlementTiming = Stripe.BalanceSettingsUpdateParams.Payments.SettlementTiming;
+      export namespace Payouts {
+        export type AutomaticTransferRulesByCurrency = Stripe.BalanceSettingsUpdateParams.Payments.Payouts.AutomaticTransferRulesByCurrency;
+        export type Schedule = Stripe.BalanceSettingsUpdateParams.Payments.Payouts.Schedule;
+        export namespace AutomaticTransferRulesByCurrency {
+          export type Type = Stripe.BalanceSettingsUpdateParams.Payments.Payouts.AutomaticTransferRulesByCurrency.Type;
+        }
+        export namespace Schedule {
+          export type Interval = Stripe.BalanceSettingsUpdateParams.Payments.Payouts.Schedule.Interval;
+          export type WeeklyPayoutDay = Stripe.BalanceSettingsUpdateParams.Payments.Payouts.Schedule.WeeklyPayoutDay;
+        }
+      }
+      export namespace SettlementTiming {
+        export type StartOfDay = Stripe.BalanceSettingsUpdateParams.Payments.SettlementTiming.StartOfDay;
+      }
+    }
+  }
+  export namespace BalanceSettings {
+    export type Payments = Stripe.BalanceSettings.Payments;
+    export namespace Payments {
+      export type Payouts = Stripe.BalanceSettings.Payments.Payouts;
+      export type SettlementTiming = Stripe.BalanceSettings.Payments.SettlementTiming;
+      export namespace Payouts {
+        export type AutomaticTransferRulesByCurrency = Stripe.BalanceSettings.Payments.Payouts.AutomaticTransferRulesByCurrency;
+        export type Schedule = Stripe.BalanceSettings.Payments.Payouts.Schedule;
+        export type Status = Stripe.BalanceSettings.Payments.Payouts.Status;
+        export namespace AutomaticTransferRulesByCurrency {
+          export type Type = Stripe.BalanceSettings.Payments.Payouts.AutomaticTransferRulesByCurrency.Type;
+        }
+        export namespace Schedule {
+          export type Interval = Stripe.BalanceSettings.Payments.Payouts.Schedule.Interval;
+          export type WeeklyPayoutDay = Stripe.BalanceSettings.Payments.Payouts.Schedule.WeeklyPayoutDay;
+        }
+      }
+      export namespace SettlementTiming {
+        export type StartOfDay = Stripe.BalanceSettings.Payments.SettlementTiming.StartOfDay;
+      }
+    }
+  }
+  export namespace BalanceTransaction {
+    export type BalanceType = Stripe.BalanceTransaction.BalanceType;
+    export type FeeDetail = Stripe.BalanceTransaction.FeeDetail;
+    export type Type = Stripe.BalanceTransaction.Type;
   }
   export namespace ChargeCreateParams {
     export type Destination = Stripe.ChargeCreateParams.Destination;
@@ -582,9 +1366,416 @@ declare namespace StripeConstructor {
   export namespace ChargeUpdateParams {
     export type FraudDetails = Stripe.ChargeUpdateParams.FraudDetails;
     export type Shipping = Stripe.ChargeUpdateParams.Shipping;
+    export namespace FraudDetails {
+      export type UserReport = Stripe.ChargeUpdateParams.FraudDetails.UserReport;
+    }
   }
   export namespace ChargeCaptureParams {
     export type TransferData = Stripe.ChargeCaptureParams.TransferData;
+  }
+  export namespace Charge {
+    export type BillingDetails = Stripe.Charge.BillingDetails;
+    export type FraudDetails = Stripe.Charge.FraudDetails;
+    export type Level3 = Stripe.Charge.Level3;
+    export type Outcome = Stripe.Charge.Outcome;
+    export type PaymentMethodDetails = Stripe.Charge.PaymentMethodDetails;
+    export type PresentmentDetails = Stripe.Charge.PresentmentDetails;
+    export type RadarOptions = Stripe.Charge.RadarOptions;
+    export type Shipping = Stripe.Charge.Shipping;
+    export type Status = Stripe.Charge.Status;
+    export type TransferData = Stripe.Charge.TransferData;
+    export namespace Level3 {
+      export type LineItem = Stripe.Charge.Level3.LineItem;
+    }
+    export namespace Outcome {
+      export type AdviceCode = Stripe.Charge.Outcome.AdviceCode;
+      export type Rule = Stripe.Charge.Outcome.Rule;
+    }
+    export namespace PaymentMethodDetails {
+      export type AchCreditTransfer = Stripe.Charge.PaymentMethodDetails.AchCreditTransfer;
+      export type AchDebit = Stripe.Charge.PaymentMethodDetails.AchDebit;
+      export type AcssDebit = Stripe.Charge.PaymentMethodDetails.AcssDebit;
+      export type Affirm = Stripe.Charge.PaymentMethodDetails.Affirm;
+      export type AfterpayClearpay = Stripe.Charge.PaymentMethodDetails.AfterpayClearpay;
+      export type Alipay = Stripe.Charge.PaymentMethodDetails.Alipay;
+      export type Alma = Stripe.Charge.PaymentMethodDetails.Alma;
+      export type AmazonPay = Stripe.Charge.PaymentMethodDetails.AmazonPay;
+      export type AuBecsDebit = Stripe.Charge.PaymentMethodDetails.AuBecsDebit;
+      export type BacsDebit = Stripe.Charge.PaymentMethodDetails.BacsDebit;
+      export type Bancontact = Stripe.Charge.PaymentMethodDetails.Bancontact;
+      export type Billie = Stripe.Charge.PaymentMethodDetails.Billie;
+      export type Bizum = Stripe.Charge.PaymentMethodDetails.Bizum;
+      export type Blik = Stripe.Charge.PaymentMethodDetails.Blik;
+      export type Boleto = Stripe.Charge.PaymentMethodDetails.Boleto;
+      export type Card = Stripe.Charge.PaymentMethodDetails.Card;
+      export type CardPresent = Stripe.Charge.PaymentMethodDetails.CardPresent;
+      export type Cashapp = Stripe.Charge.PaymentMethodDetails.Cashapp;
+      export type Crypto = Stripe.Charge.PaymentMethodDetails.Crypto;
+      export type CustomerBalance = Stripe.Charge.PaymentMethodDetails.CustomerBalance;
+      export type Eps = Stripe.Charge.PaymentMethodDetails.Eps;
+      export type Fpx = Stripe.Charge.PaymentMethodDetails.Fpx;
+      export type Giropay = Stripe.Charge.PaymentMethodDetails.Giropay;
+      export type Grabpay = Stripe.Charge.PaymentMethodDetails.Grabpay;
+      export type Ideal = Stripe.Charge.PaymentMethodDetails.Ideal;
+      export type InteracPresent = Stripe.Charge.PaymentMethodDetails.InteracPresent;
+      export type KakaoPay = Stripe.Charge.PaymentMethodDetails.KakaoPay;
+      export type Klarna = Stripe.Charge.PaymentMethodDetails.Klarna;
+      export type Konbini = Stripe.Charge.PaymentMethodDetails.Konbini;
+      export type KrCard = Stripe.Charge.PaymentMethodDetails.KrCard;
+      export type Link = Stripe.Charge.PaymentMethodDetails.Link;
+      export type MbWay = Stripe.Charge.PaymentMethodDetails.MbWay;
+      export type Mobilepay = Stripe.Charge.PaymentMethodDetails.Mobilepay;
+      export type Multibanco = Stripe.Charge.PaymentMethodDetails.Multibanco;
+      export type NaverPay = Stripe.Charge.PaymentMethodDetails.NaverPay;
+      export type NzBankAccount = Stripe.Charge.PaymentMethodDetails.NzBankAccount;
+      export type Oxxo = Stripe.Charge.PaymentMethodDetails.Oxxo;
+      export type P24 = Stripe.Charge.PaymentMethodDetails.P24;
+      export type PayByBank = Stripe.Charge.PaymentMethodDetails.PayByBank;
+      export type Payco = Stripe.Charge.PaymentMethodDetails.Payco;
+      export type Paynow = Stripe.Charge.PaymentMethodDetails.Paynow;
+      export type Paypal = Stripe.Charge.PaymentMethodDetails.Paypal;
+      export type Payto = Stripe.Charge.PaymentMethodDetails.Payto;
+      export type Pix = Stripe.Charge.PaymentMethodDetails.Pix;
+      export type Promptpay = Stripe.Charge.PaymentMethodDetails.Promptpay;
+      export type RevolutPay = Stripe.Charge.PaymentMethodDetails.RevolutPay;
+      export type SamsungPay = Stripe.Charge.PaymentMethodDetails.SamsungPay;
+      export type Satispay = Stripe.Charge.PaymentMethodDetails.Satispay;
+      export type Scalapay = Stripe.Charge.PaymentMethodDetails.Scalapay;
+      export type SepaCreditTransfer = Stripe.Charge.PaymentMethodDetails.SepaCreditTransfer;
+      export type SepaDebit = Stripe.Charge.PaymentMethodDetails.SepaDebit;
+      export type Sofort = Stripe.Charge.PaymentMethodDetails.Sofort;
+      export type StripeAccount = Stripe.Charge.PaymentMethodDetails.StripeAccount;
+      export type Sunbit = Stripe.Charge.PaymentMethodDetails.Sunbit;
+      export type Swish = Stripe.Charge.PaymentMethodDetails.Swish;
+      export type Twint = Stripe.Charge.PaymentMethodDetails.Twint;
+      export type Upi = Stripe.Charge.PaymentMethodDetails.Upi;
+      export type UsBankAccount = Stripe.Charge.PaymentMethodDetails.UsBankAccount;
+      export type Wechat = Stripe.Charge.PaymentMethodDetails.Wechat;
+      export type WechatPay = Stripe.Charge.PaymentMethodDetails.WechatPay;
+      export type Zip = Stripe.Charge.PaymentMethodDetails.Zip;
+      export namespace AchDebit {
+        export type AccountHolderType = Stripe.Charge.PaymentMethodDetails.AchDebit.AccountHolderType;
+      }
+      export namespace Alma {
+        export type Installments = Stripe.Charge.PaymentMethodDetails.Alma.Installments;
+      }
+      export namespace AmazonPay {
+        export type Funding = Stripe.Charge.PaymentMethodDetails.AmazonPay.Funding;
+        export namespace Funding {
+          export type Card = Stripe.Charge.PaymentMethodDetails.AmazonPay.Funding.Card;
+        }
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.Charge.PaymentMethodDetails.Bancontact.PreferredLanguage;
+      }
+      export namespace Card {
+        export type Checks = Stripe.Charge.PaymentMethodDetails.Card.Checks;
+        export type ExtendedAuthorization = Stripe.Charge.PaymentMethodDetails.Card.ExtendedAuthorization;
+        export type IncrementalAuthorization = Stripe.Charge.PaymentMethodDetails.Card.IncrementalAuthorization;
+        export type Installments = Stripe.Charge.PaymentMethodDetails.Card.Installments;
+        export type Multicapture = Stripe.Charge.PaymentMethodDetails.Card.Multicapture;
+        export type NetworkToken = Stripe.Charge.PaymentMethodDetails.Card.NetworkToken;
+        export type Overcapture = Stripe.Charge.PaymentMethodDetails.Card.Overcapture;
+        export type RegulatedStatus = Stripe.Charge.PaymentMethodDetails.Card.RegulatedStatus;
+        export type ThreeDSecure = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure;
+        export type Wallet = Stripe.Charge.PaymentMethodDetails.Card.Wallet;
+        export namespace ExtendedAuthorization {
+          export type Status = Stripe.Charge.PaymentMethodDetails.Card.ExtendedAuthorization.Status;
+        }
+        export namespace IncrementalAuthorization {
+          export type Status = Stripe.Charge.PaymentMethodDetails.Card.IncrementalAuthorization.Status;
+        }
+        export namespace Installments {
+          export type Plan = Stripe.Charge.PaymentMethodDetails.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.Charge.PaymentMethodDetails.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace Multicapture {
+          export type Status = Stripe.Charge.PaymentMethodDetails.Card.Multicapture.Status;
+        }
+        export namespace Overcapture {
+          export type Status = Stripe.Charge.PaymentMethodDetails.Card.Overcapture.Status;
+        }
+        export namespace ThreeDSecure {
+          export type AuthenticationFlow = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure.AuthenticationFlow;
+          export type ElectronicCommerceIndicator = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type ExemptionIndicator = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure.ExemptionIndicator;
+          export type Result = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure.Result;
+          export type ResultReason = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure.ResultReason;
+          export type Version = Stripe.Charge.PaymentMethodDetails.Card.ThreeDSecure.Version;
+        }
+        export namespace Wallet {
+          export type AmexExpressCheckout = Stripe.Charge.PaymentMethodDetails.Card.Wallet.AmexExpressCheckout;
+          export type ApplePay = Stripe.Charge.PaymentMethodDetails.Card.Wallet.ApplePay;
+          export type GooglePay = Stripe.Charge.PaymentMethodDetails.Card.Wallet.GooglePay;
+          export type Link = Stripe.Charge.PaymentMethodDetails.Card.Wallet.Link;
+          export type Masterpass = Stripe.Charge.PaymentMethodDetails.Card.Wallet.Masterpass;
+          export type SamsungPay = Stripe.Charge.PaymentMethodDetails.Card.Wallet.SamsungPay;
+          export type Type = Stripe.Charge.PaymentMethodDetails.Card.Wallet.Type;
+          export type VisaCheckout = Stripe.Charge.PaymentMethodDetails.Card.Wallet.VisaCheckout;
+        }
+      }
+      export namespace CardPresent {
+        export type Offline = Stripe.Charge.PaymentMethodDetails.CardPresent.Offline;
+        export type ReadMethod = Stripe.Charge.PaymentMethodDetails.CardPresent.ReadMethod;
+        export type Receipt = Stripe.Charge.PaymentMethodDetails.CardPresent.Receipt;
+        export type Wallet = Stripe.Charge.PaymentMethodDetails.CardPresent.Wallet;
+        export namespace Receipt {
+          export type AccountType = Stripe.Charge.PaymentMethodDetails.CardPresent.Receipt.AccountType;
+        }
+        export namespace Wallet {
+          export type Type = Stripe.Charge.PaymentMethodDetails.CardPresent.Wallet.Type;
+        }
+      }
+      export namespace Crypto {
+        export type Network = Stripe.Charge.PaymentMethodDetails.Crypto.Network;
+        export type TokenCurrency = Stripe.Charge.PaymentMethodDetails.Crypto.TokenCurrency;
+      }
+      export namespace Eps {
+        export type Bank = Stripe.Charge.PaymentMethodDetails.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.Charge.PaymentMethodDetails.Fpx.AccountHolderType;
+        export type Bank = Stripe.Charge.PaymentMethodDetails.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.Charge.PaymentMethodDetails.Ideal.Bank;
+        export type Bic = Stripe.Charge.PaymentMethodDetails.Ideal.Bic;
+      }
+      export namespace InteracPresent {
+        export type ReadMethod = Stripe.Charge.PaymentMethodDetails.InteracPresent.ReadMethod;
+        export type Receipt = Stripe.Charge.PaymentMethodDetails.InteracPresent.Receipt;
+        export namespace Receipt {
+          export type AccountType = Stripe.Charge.PaymentMethodDetails.InteracPresent.Receipt.AccountType;
+        }
+      }
+      export namespace Klarna {
+        export type PayerDetails = Stripe.Charge.PaymentMethodDetails.Klarna.PayerDetails;
+        export namespace PayerDetails {
+          export type Address = Stripe.Charge.PaymentMethodDetails.Klarna.PayerDetails.Address;
+        }
+      }
+      export namespace Konbini {
+        export type Store = Stripe.Charge.PaymentMethodDetails.Konbini.Store;
+        export namespace Store {
+          export type Chain = Stripe.Charge.PaymentMethodDetails.Konbini.Store.Chain;
+        }
+      }
+      export namespace KrCard {
+        export type Brand = Stripe.Charge.PaymentMethodDetails.KrCard.Brand;
+      }
+      export namespace Mobilepay {
+        export type Card = Stripe.Charge.PaymentMethodDetails.Mobilepay.Card;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.Charge.PaymentMethodDetails.P24.Bank;
+      }
+      export namespace Paypal {
+        export type SellerProtection = Stripe.Charge.PaymentMethodDetails.Paypal.SellerProtection;
+        export namespace SellerProtection {
+          export type DisputeCategory = Stripe.Charge.PaymentMethodDetails.Paypal.SellerProtection.DisputeCategory;
+          export type Status = Stripe.Charge.PaymentMethodDetails.Paypal.SellerProtection.Status;
+        }
+      }
+      export namespace RevolutPay {
+        export type Funding = Stripe.Charge.PaymentMethodDetails.RevolutPay.Funding;
+        export namespace Funding {
+          export type Card = Stripe.Charge.PaymentMethodDetails.RevolutPay.Funding.Card;
+        }
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.Charge.PaymentMethodDetails.Sofort.PreferredLanguage;
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.Charge.PaymentMethodDetails.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.Charge.PaymentMethodDetails.UsBankAccount.AccountType;
+      }
+    }
+  }
+  export namespace ConfirmationToken {
+    export type MandateData = Stripe.ConfirmationToken.MandateData;
+    export type PaymentMethodOptions = Stripe.ConfirmationToken.PaymentMethodOptions;
+    export type PaymentMethodPreview = Stripe.ConfirmationToken.PaymentMethodPreview;
+    export type SetupFutureUsage = Stripe.ConfirmationToken.SetupFutureUsage;
+    export type Shipping = Stripe.ConfirmationToken.Shipping;
+    export namespace MandateData {
+      export type CustomerAcceptance = Stripe.ConfirmationToken.MandateData.CustomerAcceptance;
+      export namespace CustomerAcceptance {
+        export type Online = Stripe.ConfirmationToken.MandateData.CustomerAcceptance.Online;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type Card = Stripe.ConfirmationToken.PaymentMethodOptions.Card;
+      export namespace Card {
+        export type Installments = Stripe.ConfirmationToken.PaymentMethodOptions.Card.Installments;
+        export namespace Installments {
+          export type Plan = Stripe.ConfirmationToken.PaymentMethodOptions.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.ConfirmationToken.PaymentMethodOptions.Card.Installments.Plan.Type;
+          }
+        }
+      }
+    }
+    export namespace PaymentMethodPreview {
+      export type AcssDebit = Stripe.ConfirmationToken.PaymentMethodPreview.AcssDebit;
+      export type Affirm = Stripe.ConfirmationToken.PaymentMethodPreview.Affirm;
+      export type AfterpayClearpay = Stripe.ConfirmationToken.PaymentMethodPreview.AfterpayClearpay;
+      export type Alipay = Stripe.ConfirmationToken.PaymentMethodPreview.Alipay;
+      export type AllowRedisplay = Stripe.ConfirmationToken.PaymentMethodPreview.AllowRedisplay;
+      export type Alma = Stripe.ConfirmationToken.PaymentMethodPreview.Alma;
+      export type AmazonPay = Stripe.ConfirmationToken.PaymentMethodPreview.AmazonPay;
+      export type AuBecsDebit = Stripe.ConfirmationToken.PaymentMethodPreview.AuBecsDebit;
+      export type BacsDebit = Stripe.ConfirmationToken.PaymentMethodPreview.BacsDebit;
+      export type Bancontact = Stripe.ConfirmationToken.PaymentMethodPreview.Bancontact;
+      export type Billie = Stripe.ConfirmationToken.PaymentMethodPreview.Billie;
+      export type BillingDetails = Stripe.ConfirmationToken.PaymentMethodPreview.BillingDetails;
+      export type Bizum = Stripe.ConfirmationToken.PaymentMethodPreview.Bizum;
+      export type Blik = Stripe.ConfirmationToken.PaymentMethodPreview.Blik;
+      export type Boleto = Stripe.ConfirmationToken.PaymentMethodPreview.Boleto;
+      export type Card = Stripe.ConfirmationToken.PaymentMethodPreview.Card;
+      export type CardPresent = Stripe.ConfirmationToken.PaymentMethodPreview.CardPresent;
+      export type Cashapp = Stripe.ConfirmationToken.PaymentMethodPreview.Cashapp;
+      export type Crypto = Stripe.ConfirmationToken.PaymentMethodPreview.Crypto;
+      export type CustomerBalance = Stripe.ConfirmationToken.PaymentMethodPreview.CustomerBalance;
+      export type Eps = Stripe.ConfirmationToken.PaymentMethodPreview.Eps;
+      export type Fpx = Stripe.ConfirmationToken.PaymentMethodPreview.Fpx;
+      export type Giropay = Stripe.ConfirmationToken.PaymentMethodPreview.Giropay;
+      export type Grabpay = Stripe.ConfirmationToken.PaymentMethodPreview.Grabpay;
+      export type Ideal = Stripe.ConfirmationToken.PaymentMethodPreview.Ideal;
+      export type InteracPresent = Stripe.ConfirmationToken.PaymentMethodPreview.InteracPresent;
+      export type KakaoPay = Stripe.ConfirmationToken.PaymentMethodPreview.KakaoPay;
+      export type Klarna = Stripe.ConfirmationToken.PaymentMethodPreview.Klarna;
+      export type Konbini = Stripe.ConfirmationToken.PaymentMethodPreview.Konbini;
+      export type KrCard = Stripe.ConfirmationToken.PaymentMethodPreview.KrCard;
+      export type Link = Stripe.ConfirmationToken.PaymentMethodPreview.Link;
+      export type MbWay = Stripe.ConfirmationToken.PaymentMethodPreview.MbWay;
+      export type Mobilepay = Stripe.ConfirmationToken.PaymentMethodPreview.Mobilepay;
+      export type Multibanco = Stripe.ConfirmationToken.PaymentMethodPreview.Multibanco;
+      export type NaverPay = Stripe.ConfirmationToken.PaymentMethodPreview.NaverPay;
+      export type NzBankAccount = Stripe.ConfirmationToken.PaymentMethodPreview.NzBankAccount;
+      export type Oxxo = Stripe.ConfirmationToken.PaymentMethodPreview.Oxxo;
+      export type P24 = Stripe.ConfirmationToken.PaymentMethodPreview.P24;
+      export type PayByBank = Stripe.ConfirmationToken.PaymentMethodPreview.PayByBank;
+      export type Payco = Stripe.ConfirmationToken.PaymentMethodPreview.Payco;
+      export type Paynow = Stripe.ConfirmationToken.PaymentMethodPreview.Paynow;
+      export type Paypal = Stripe.ConfirmationToken.PaymentMethodPreview.Paypal;
+      export type Payto = Stripe.ConfirmationToken.PaymentMethodPreview.Payto;
+      export type Pix = Stripe.ConfirmationToken.PaymentMethodPreview.Pix;
+      export type Promptpay = Stripe.ConfirmationToken.PaymentMethodPreview.Promptpay;
+      export type RevolutPay = Stripe.ConfirmationToken.PaymentMethodPreview.RevolutPay;
+      export type SamsungPay = Stripe.ConfirmationToken.PaymentMethodPreview.SamsungPay;
+      export type Satispay = Stripe.ConfirmationToken.PaymentMethodPreview.Satispay;
+      export type Scalapay = Stripe.ConfirmationToken.PaymentMethodPreview.Scalapay;
+      export type SepaDebit = Stripe.ConfirmationToken.PaymentMethodPreview.SepaDebit;
+      export type Sofort = Stripe.ConfirmationToken.PaymentMethodPreview.Sofort;
+      export type Sunbit = Stripe.ConfirmationToken.PaymentMethodPreview.Sunbit;
+      export type Swish = Stripe.ConfirmationToken.PaymentMethodPreview.Swish;
+      export type Twint = Stripe.ConfirmationToken.PaymentMethodPreview.Twint;
+      export type Type = Stripe.ConfirmationToken.PaymentMethodPreview.Type;
+      export type Upi = Stripe.ConfirmationToken.PaymentMethodPreview.Upi;
+      export type UsBankAccount = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount;
+      export type WechatPay = Stripe.ConfirmationToken.PaymentMethodPreview.WechatPay;
+      export type Zip = Stripe.ConfirmationToken.PaymentMethodPreview.Zip;
+      export namespace Card {
+        export type Checks = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Checks;
+        export type GeneratedFrom = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom;
+        export type Networks = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Networks;
+        export type RegulatedStatus = Stripe.ConfirmationToken.PaymentMethodPreview.Card.RegulatedStatus;
+        export type ThreeDSecureUsage = Stripe.ConfirmationToken.PaymentMethodPreview.Card.ThreeDSecureUsage;
+        export type Wallet = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet;
+        export namespace GeneratedFrom {
+          export type PaymentMethodDetails = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails;
+          export namespace PaymentMethodDetails {
+            export type CardPresent = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent;
+            export namespace CardPresent {
+              export type Offline = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Offline;
+              export type ReadMethod = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.ReadMethod;
+              export type Receipt = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Receipt;
+              export type Wallet = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Wallet;
+              export namespace Receipt {
+                export type AccountType = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Receipt.AccountType;
+              }
+              export namespace Wallet {
+                export type Type = Stripe.ConfirmationToken.PaymentMethodPreview.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Wallet.Type;
+              }
+            }
+          }
+        }
+        export namespace Wallet {
+          export type AmexExpressCheckout = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.AmexExpressCheckout;
+          export type ApplePay = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.ApplePay;
+          export type GooglePay = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.GooglePay;
+          export type Link = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.Link;
+          export type Masterpass = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.Masterpass;
+          export type SamsungPay = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.SamsungPay;
+          export type Type = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.Type;
+          export type VisaCheckout = Stripe.ConfirmationToken.PaymentMethodPreview.Card.Wallet.VisaCheckout;
+        }
+      }
+      export namespace CardPresent {
+        export type Networks = Stripe.ConfirmationToken.PaymentMethodPreview.CardPresent.Networks;
+        export type Offline = Stripe.ConfirmationToken.PaymentMethodPreview.CardPresent.Offline;
+        export type ReadMethod = Stripe.ConfirmationToken.PaymentMethodPreview.CardPresent.ReadMethod;
+        export type Wallet = Stripe.ConfirmationToken.PaymentMethodPreview.CardPresent.Wallet;
+        export namespace Wallet {
+          export type Type = Stripe.ConfirmationToken.PaymentMethodPreview.CardPresent.Wallet.Type;
+        }
+      }
+      export namespace Eps {
+        export type Bank = Stripe.ConfirmationToken.PaymentMethodPreview.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.ConfirmationToken.PaymentMethodPreview.Fpx.AccountHolderType;
+        export type Bank = Stripe.ConfirmationToken.PaymentMethodPreview.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.ConfirmationToken.PaymentMethodPreview.Ideal.Bank;
+        export type Bic = Stripe.ConfirmationToken.PaymentMethodPreview.Ideal.Bic;
+      }
+      export namespace InteracPresent {
+        export type Networks = Stripe.ConfirmationToken.PaymentMethodPreview.InteracPresent.Networks;
+        export type ReadMethod = Stripe.ConfirmationToken.PaymentMethodPreview.InteracPresent.ReadMethod;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.ConfirmationToken.PaymentMethodPreview.Klarna.Dob;
+      }
+      export namespace KrCard {
+        export type Brand = Stripe.ConfirmationToken.PaymentMethodPreview.KrCard.Brand;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.ConfirmationToken.PaymentMethodPreview.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.ConfirmationToken.PaymentMethodPreview.P24.Bank;
+      }
+      export namespace SepaDebit {
+        export type GeneratedFrom = Stripe.ConfirmationToken.PaymentMethodPreview.SepaDebit.GeneratedFrom;
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.AccountType;
+        export type Networks = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.Networks;
+        export type StatusDetails = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.StatusDetails;
+        export namespace Networks {
+          export type Supported = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.Networks.Supported;
+        }
+        export namespace StatusDetails {
+          export type Blocked = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.StatusDetails.Blocked;
+          export namespace Blocked {
+            export type NetworkCode = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.StatusDetails.Blocked.NetworkCode;
+            export type Reason = Stripe.ConfirmationToken.PaymentMethodPreview.UsBankAccount.StatusDetails.Blocked.Reason;
+          }
+        }
+      }
+    }
+  }
+  export namespace CountrySpec {
+    export type VerificationFields = Stripe.CountrySpec.VerificationFields;
+    export namespace VerificationFields {
+      export type Company = Stripe.CountrySpec.VerificationFields.Company;
+      export type Individual = Stripe.CountrySpec.VerificationFields.Individual;
+    }
   }
   export namespace CouponCreateParams {
     export type AppliesTo = Stripe.CouponCreateParams.AppliesTo;
@@ -594,12 +1785,25 @@ declare namespace StripeConstructor {
   export namespace CouponUpdateParams {
     export type CurrencyOptions = Stripe.CouponUpdateParams.CurrencyOptions;
   }
+  export namespace Coupon {
+    export type AppliesTo = Stripe.Coupon.AppliesTo;
+    export type CurrencyOptions = Stripe.Coupon.CurrencyOptions;
+    export type Duration = Stripe.Coupon.Duration;
+  }
   export namespace CreditNoteCreateParams {
     export type EmailType = Stripe.CreditNoteCreateParams.EmailType;
     export type Line = Stripe.CreditNoteCreateParams.Line;
     export type Reason = Stripe.CreditNoteCreateParams.Reason;
     export type Refund = Stripe.CreditNoteCreateParams.Refund;
     export type ShippingCost = Stripe.CreditNoteCreateParams.ShippingCost;
+    export namespace Line {
+      export type TaxAmount = Stripe.CreditNoteCreateParams.Line.TaxAmount;
+      export type Type = Stripe.CreditNoteCreateParams.Line.Type;
+    }
+    export namespace Refund {
+      export type PaymentRecordRefund = Stripe.CreditNoteCreateParams.Refund.PaymentRecordRefund;
+      export type Type = Stripe.CreditNoteCreateParams.Refund.Type;
+    }
   }
   export namespace CreditNoteListPreviewLineItemsParams {
     export type EmailType = Stripe.CreditNoteListPreviewLineItemsParams.EmailType;
@@ -607,6 +1811,14 @@ declare namespace StripeConstructor {
     export type Reason = Stripe.CreditNoteListPreviewLineItemsParams.Reason;
     export type Refund = Stripe.CreditNoteListPreviewLineItemsParams.Refund;
     export type ShippingCost = Stripe.CreditNoteListPreviewLineItemsParams.ShippingCost;
+    export namespace Line {
+      export type TaxAmount = Stripe.CreditNoteListPreviewLineItemsParams.Line.TaxAmount;
+      export type Type = Stripe.CreditNoteListPreviewLineItemsParams.Line.Type;
+    }
+    export namespace Refund {
+      export type PaymentRecordRefund = Stripe.CreditNoteListPreviewLineItemsParams.Refund.PaymentRecordRefund;
+      export type Type = Stripe.CreditNoteListPreviewLineItemsParams.Refund.Type;
+    }
   }
   export namespace CreditNotePreviewParams {
     export type EmailType = Stripe.CreditNotePreviewParams.EmailType;
@@ -614,6 +1826,42 @@ declare namespace StripeConstructor {
     export type Reason = Stripe.CreditNotePreviewParams.Reason;
     export type Refund = Stripe.CreditNotePreviewParams.Refund;
     export type ShippingCost = Stripe.CreditNotePreviewParams.ShippingCost;
+    export namespace Line {
+      export type TaxAmount = Stripe.CreditNotePreviewParams.Line.TaxAmount;
+      export type Type = Stripe.CreditNotePreviewParams.Line.Type;
+    }
+    export namespace Refund {
+      export type PaymentRecordRefund = Stripe.CreditNotePreviewParams.Refund.PaymentRecordRefund;
+      export type Type = Stripe.CreditNotePreviewParams.Refund.Type;
+    }
+  }
+  export namespace CreditNote {
+    export type DiscountAmount = Stripe.CreditNote.DiscountAmount;
+    export type PretaxCreditAmount = Stripe.CreditNote.PretaxCreditAmount;
+    export type Reason = Stripe.CreditNote.Reason;
+    export type Refund = Stripe.CreditNote.Refund;
+    export type ShippingCost = Stripe.CreditNote.ShippingCost;
+    export type Status = Stripe.CreditNote.Status;
+    export type TotalTax = Stripe.CreditNote.TotalTax;
+    export type Type = Stripe.CreditNote.Type;
+    export namespace PretaxCreditAmount {
+      export type Type = Stripe.CreditNote.PretaxCreditAmount.Type;
+    }
+    export namespace Refund {
+      export type PaymentRecordRefund = Stripe.CreditNote.Refund.PaymentRecordRefund;
+      export type Type = Stripe.CreditNote.Refund.Type;
+    }
+    export namespace ShippingCost {
+      export type Tax = Stripe.CreditNote.ShippingCost.Tax;
+      export namespace Tax {
+        export type TaxabilityReason = Stripe.CreditNote.ShippingCost.Tax.TaxabilityReason;
+      }
+    }
+    export namespace TotalTax {
+      export type TaxBehavior = Stripe.CreditNote.TotalTax.TaxBehavior;
+      export type TaxRateDetails = Stripe.CreditNote.TotalTax.TaxRateDetails;
+      export type TaxabilityReason = Stripe.CreditNote.TotalTax.TaxabilityReason;
+    }
   }
   export namespace CustomerCreateParams {
     export type CashBalance = Stripe.CustomerCreateParams.CashBalance;
@@ -622,6 +1870,25 @@ declare namespace StripeConstructor {
     export type Tax = Stripe.CustomerCreateParams.Tax;
     export type TaxExempt = Stripe.CustomerCreateParams.TaxExempt;
     export type TaxIdDatum = Stripe.CustomerCreateParams.TaxIdDatum;
+    export namespace CashBalance {
+      export type Settings = Stripe.CustomerCreateParams.CashBalance.Settings;
+      export namespace Settings {
+        export type ReconciliationMode = Stripe.CustomerCreateParams.CashBalance.Settings.ReconciliationMode;
+      }
+    }
+    export namespace InvoiceSettings {
+      export type CustomField = Stripe.CustomerCreateParams.InvoiceSettings.CustomField;
+      export type RenderingOptions = Stripe.CustomerCreateParams.InvoiceSettings.RenderingOptions;
+      export namespace RenderingOptions {
+        export type AmountTaxDisplay = Stripe.CustomerCreateParams.InvoiceSettings.RenderingOptions.AmountTaxDisplay;
+      }
+    }
+    export namespace Tax {
+      export type ValidateLocation = Stripe.CustomerCreateParams.Tax.ValidateLocation;
+    }
+    export namespace TaxIdDatum {
+      export type Type = Stripe.CustomerCreateParams.TaxIdDatum.Type;
+    }
   }
   export namespace CustomerUpdateParams {
     export type CashBalance = Stripe.CustomerUpdateParams.CashBalance;
@@ -629,9 +1896,30 @@ declare namespace StripeConstructor {
     export type Shipping = Stripe.CustomerUpdateParams.Shipping;
     export type Tax = Stripe.CustomerUpdateParams.Tax;
     export type TaxExempt = Stripe.CustomerUpdateParams.TaxExempt;
+    export namespace CashBalance {
+      export type Settings = Stripe.CustomerUpdateParams.CashBalance.Settings;
+      export namespace Settings {
+        export type ReconciliationMode = Stripe.CustomerUpdateParams.CashBalance.Settings.ReconciliationMode;
+      }
+    }
+    export namespace InvoiceSettings {
+      export type CustomField = Stripe.CustomerUpdateParams.InvoiceSettings.CustomField;
+      export type RenderingOptions = Stripe.CustomerUpdateParams.InvoiceSettings.RenderingOptions;
+      export namespace RenderingOptions {
+        export type AmountTaxDisplay = Stripe.CustomerUpdateParams.InvoiceSettings.RenderingOptions.AmountTaxDisplay;
+      }
+    }
+    export namespace Tax {
+      export type ValidateLocation = Stripe.CustomerUpdateParams.Tax.ValidateLocation;
+    }
   }
   export namespace CustomerCreateFundingInstructionsParams {
     export type BankTransfer = Stripe.CustomerCreateFundingInstructionsParams.BankTransfer;
+    export namespace BankTransfer {
+      export type EuBankTransfer = Stripe.CustomerCreateFundingInstructionsParams.BankTransfer.EuBankTransfer;
+      export type RequestedAddressType = Stripe.CustomerCreateFundingInstructionsParams.BankTransfer.RequestedAddressType;
+      export type Type = Stripe.CustomerCreateFundingInstructionsParams.BankTransfer.Type;
+    }
   }
   export namespace CustomerCreateTaxIdParams {
     export type Type = Stripe.CustomerCreateTaxIdParams.Type;
@@ -642,16 +1930,179 @@ declare namespace StripeConstructor {
   }
   export namespace CustomerUpdateCashBalanceParams {
     export type Settings = Stripe.CustomerUpdateCashBalanceParams.Settings;
+    export namespace Settings {
+      export type ReconciliationMode = Stripe.CustomerUpdateCashBalanceParams.Settings.ReconciliationMode;
+    }
   }
   export namespace CustomerUpdateSourceParams {
     export type AccountHolderType = Stripe.CustomerUpdateSourceParams.AccountHolderType;
     export type Owner = Stripe.CustomerUpdateSourceParams.Owner;
   }
+  export namespace Customer {
+    export type InvoiceSettings = Stripe.Customer.InvoiceSettings;
+    export type Shipping = Stripe.Customer.Shipping;
+    export type Tax = Stripe.Customer.Tax;
+    export type TaxExempt = Stripe.Customer.TaxExempt;
+    export namespace InvoiceSettings {
+      export type CustomField = Stripe.Customer.InvoiceSettings.CustomField;
+      export type RenderingOptions = Stripe.Customer.InvoiceSettings.RenderingOptions;
+    }
+    export namespace Tax {
+      export type AutomaticTax = Stripe.Customer.Tax.AutomaticTax;
+      export type Location = Stripe.Customer.Tax.Location;
+      export type Provider = Stripe.Customer.Tax.Provider;
+      export namespace Location {
+        export type Source = Stripe.Customer.Tax.Location.Source;
+      }
+    }
+  }
   export namespace CustomerSessionCreateParams {
     export type Components = Stripe.CustomerSessionCreateParams.Components;
+    export namespace Components {
+      export type BuyButton = Stripe.CustomerSessionCreateParams.Components.BuyButton;
+      export type CustomerSheet = Stripe.CustomerSessionCreateParams.Components.CustomerSheet;
+      export type MobilePaymentElement = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement;
+      export type PaymentElement = Stripe.CustomerSessionCreateParams.Components.PaymentElement;
+      export type PricingTable = Stripe.CustomerSessionCreateParams.Components.PricingTable;
+      export namespace CustomerSheet {
+        export type Features = Stripe.CustomerSessionCreateParams.Components.CustomerSheet.Features;
+        export namespace Features {
+          export type PaymentMethodAllowRedisplayFilter = Stripe.CustomerSessionCreateParams.Components.CustomerSheet.Features.PaymentMethodAllowRedisplayFilter;
+          export type PaymentMethodRemove = Stripe.CustomerSessionCreateParams.Components.CustomerSheet.Features.PaymentMethodRemove;
+        }
+      }
+      export namespace MobilePaymentElement {
+        export type Features = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement.Features;
+        export namespace Features {
+          export type PaymentMethodAllowRedisplayFilter = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement.Features.PaymentMethodAllowRedisplayFilter;
+          export type PaymentMethodRedisplay = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement.Features.PaymentMethodRedisplay;
+          export type PaymentMethodRemove = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement.Features.PaymentMethodRemove;
+          export type PaymentMethodSave = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement.Features.PaymentMethodSave;
+          export type PaymentMethodSaveAllowRedisplayOverride = Stripe.CustomerSessionCreateParams.Components.MobilePaymentElement.Features.PaymentMethodSaveAllowRedisplayOverride;
+        }
+      }
+      export namespace PaymentElement {
+        export type Features = Stripe.CustomerSessionCreateParams.Components.PaymentElement.Features;
+        export namespace Features {
+          export type PaymentMethodAllowRedisplayFilter = Stripe.CustomerSessionCreateParams.Components.PaymentElement.Features.PaymentMethodAllowRedisplayFilter;
+          export type PaymentMethodRedisplay = Stripe.CustomerSessionCreateParams.Components.PaymentElement.Features.PaymentMethodRedisplay;
+          export type PaymentMethodRemove = Stripe.CustomerSessionCreateParams.Components.PaymentElement.Features.PaymentMethodRemove;
+          export type PaymentMethodSave = Stripe.CustomerSessionCreateParams.Components.PaymentElement.Features.PaymentMethodSave;
+          export type PaymentMethodSaveUsage = Stripe.CustomerSessionCreateParams.Components.PaymentElement.Features.PaymentMethodSaveUsage;
+        }
+      }
+    }
+  }
+  export namespace CustomerSession {
+    export type Components = Stripe.CustomerSession.Components;
+    export namespace Components {
+      export type BuyButton = Stripe.CustomerSession.Components.BuyButton;
+      export type CustomerSheet = Stripe.CustomerSession.Components.CustomerSheet;
+      export type MobilePaymentElement = Stripe.CustomerSession.Components.MobilePaymentElement;
+      export type PaymentElement = Stripe.CustomerSession.Components.PaymentElement;
+      export type PricingTable = Stripe.CustomerSession.Components.PricingTable;
+      export namespace CustomerSheet {
+        export type Features = Stripe.CustomerSession.Components.CustomerSheet.Features;
+        export namespace Features {
+          export type PaymentMethodAllowRedisplayFilter = Stripe.CustomerSession.Components.CustomerSheet.Features.PaymentMethodAllowRedisplayFilter;
+          export type PaymentMethodRemove = Stripe.CustomerSession.Components.CustomerSheet.Features.PaymentMethodRemove;
+        }
+      }
+      export namespace MobilePaymentElement {
+        export type Features = Stripe.CustomerSession.Components.MobilePaymentElement.Features;
+        export namespace Features {
+          export type PaymentMethodAllowRedisplayFilter = Stripe.CustomerSession.Components.MobilePaymentElement.Features.PaymentMethodAllowRedisplayFilter;
+          export type PaymentMethodRedisplay = Stripe.CustomerSession.Components.MobilePaymentElement.Features.PaymentMethodRedisplay;
+          export type PaymentMethodRemove = Stripe.CustomerSession.Components.MobilePaymentElement.Features.PaymentMethodRemove;
+          export type PaymentMethodSave = Stripe.CustomerSession.Components.MobilePaymentElement.Features.PaymentMethodSave;
+          export type PaymentMethodSaveAllowRedisplayOverride = Stripe.CustomerSession.Components.MobilePaymentElement.Features.PaymentMethodSaveAllowRedisplayOverride;
+        }
+      }
+      export namespace PaymentElement {
+        export type Features = Stripe.CustomerSession.Components.PaymentElement.Features;
+        export namespace Features {
+          export type PaymentMethodAllowRedisplayFilter = Stripe.CustomerSession.Components.PaymentElement.Features.PaymentMethodAllowRedisplayFilter;
+          export type PaymentMethodRedisplay = Stripe.CustomerSession.Components.PaymentElement.Features.PaymentMethodRedisplay;
+          export type PaymentMethodRemove = Stripe.CustomerSession.Components.PaymentElement.Features.PaymentMethodRemove;
+          export type PaymentMethodSave = Stripe.CustomerSession.Components.PaymentElement.Features.PaymentMethodSave;
+          export type PaymentMethodSaveUsage = Stripe.CustomerSession.Components.PaymentElement.Features.PaymentMethodSaveUsage;
+        }
+      }
+    }
   }
   export namespace DisputeUpdateParams {
     export type Evidence = Stripe.DisputeUpdateParams.Evidence;
+    export namespace Evidence {
+      export type EnhancedEvidence = Stripe.DisputeUpdateParams.Evidence.EnhancedEvidence;
+      export namespace EnhancedEvidence {
+        export type VisaCompellingEvidence3 = Stripe.DisputeUpdateParams.Evidence.EnhancedEvidence.VisaCompellingEvidence3;
+        export type VisaCompliance = Stripe.DisputeUpdateParams.Evidence.EnhancedEvidence.VisaCompliance;
+        export namespace VisaCompellingEvidence3 {
+          export type DisputedTransaction = Stripe.DisputeUpdateParams.Evidence.EnhancedEvidence.VisaCompellingEvidence3.DisputedTransaction;
+          export type PriorUndisputedTransaction = Stripe.DisputeUpdateParams.Evidence.EnhancedEvidence.VisaCompellingEvidence3.PriorUndisputedTransaction;
+          export namespace DisputedTransaction {
+            export type MerchandiseOrServices = Stripe.DisputeUpdateParams.Evidence.EnhancedEvidence.VisaCompellingEvidence3.DisputedTransaction.MerchandiseOrServices;
+          }
+        }
+      }
+    }
+  }
+  export namespace Dispute {
+    export type EnhancedEligibilityType = Stripe.Dispute.EnhancedEligibilityType;
+    export type Evidence = Stripe.Dispute.Evidence;
+    export type EvidenceDetails = Stripe.Dispute.EvidenceDetails;
+    export type PaymentMethodDetails = Stripe.Dispute.PaymentMethodDetails;
+    export type Status = Stripe.Dispute.Status;
+    export namespace Evidence {
+      export type EnhancedEvidence = Stripe.Dispute.Evidence.EnhancedEvidence;
+      export namespace EnhancedEvidence {
+        export type VisaCompellingEvidence3 = Stripe.Dispute.Evidence.EnhancedEvidence.VisaCompellingEvidence3;
+        export type VisaCompliance = Stripe.Dispute.Evidence.EnhancedEvidence.VisaCompliance;
+        export namespace VisaCompellingEvidence3 {
+          export type DisputedTransaction = Stripe.Dispute.Evidence.EnhancedEvidence.VisaCompellingEvidence3.DisputedTransaction;
+          export type PriorUndisputedTransaction = Stripe.Dispute.Evidence.EnhancedEvidence.VisaCompellingEvidence3.PriorUndisputedTransaction;
+          export namespace DisputedTransaction {
+            export type MerchandiseOrServices = Stripe.Dispute.Evidence.EnhancedEvidence.VisaCompellingEvidence3.DisputedTransaction.MerchandiseOrServices;
+          }
+        }
+      }
+    }
+    export namespace EvidenceDetails {
+      export type EnhancedEligibility = Stripe.Dispute.EvidenceDetails.EnhancedEligibility;
+      export namespace EnhancedEligibility {
+        export type VisaCompellingEvidence3 = Stripe.Dispute.EvidenceDetails.EnhancedEligibility.VisaCompellingEvidence3;
+        export type VisaCompliance = Stripe.Dispute.EvidenceDetails.EnhancedEligibility.VisaCompliance;
+        export namespace VisaCompellingEvidence3 {
+          export type RequiredAction = Stripe.Dispute.EvidenceDetails.EnhancedEligibility.VisaCompellingEvidence3.RequiredAction;
+          export type Status = Stripe.Dispute.EvidenceDetails.EnhancedEligibility.VisaCompellingEvidence3.Status;
+        }
+        export namespace VisaCompliance {
+          export type Status = Stripe.Dispute.EvidenceDetails.EnhancedEligibility.VisaCompliance.Status;
+        }
+      }
+    }
+    export namespace PaymentMethodDetails {
+      export type AmazonPay = Stripe.Dispute.PaymentMethodDetails.AmazonPay;
+      export type Card = Stripe.Dispute.PaymentMethodDetails.Card;
+      export type Klarna = Stripe.Dispute.PaymentMethodDetails.Klarna;
+      export type Paypal = Stripe.Dispute.PaymentMethodDetails.Paypal;
+      export type Type = Stripe.Dispute.PaymentMethodDetails.Type;
+      export namespace AmazonPay {
+        export type DisputeType = Stripe.Dispute.PaymentMethodDetails.AmazonPay.DisputeType;
+      }
+      export namespace Card {
+        export type CaseType = Stripe.Dispute.PaymentMethodDetails.Card.CaseType;
+      }
+    }
+  }
+  export namespace Event {
+    export type Data = Stripe.Event.Data;
+    export type Request = Stripe.Event.Request;
+    export type Type = Stripe.Event.Type;
+    export namespace Data {
+      export type Object = Stripe.Event.Data.Object;
+      export type PreviousAttributes = Stripe.Event.Data.PreviousAttributes;
+    }
   }
   export namespace FileCreateParams {
     export type Purpose = Stripe.FileCreateParams.Purpose;
@@ -659,6 +2110,9 @@ declare namespace StripeConstructor {
   }
   export namespace FileListParams {
     export type Purpose = Stripe.FileListParams.Purpose;
+  }
+  export namespace File {
+    export type Purpose = Stripe.File.Purpose;
   }
   export namespace InvoiceCreateParams {
     export type AutomaticTax = Stripe.InvoiceCreateParams.AutomaticTax;
@@ -673,6 +2127,115 @@ declare namespace StripeConstructor {
     export type ShippingCost = Stripe.InvoiceCreateParams.ShippingCost;
     export type ShippingDetails = Stripe.InvoiceCreateParams.ShippingDetails;
     export type TransferData = Stripe.InvoiceCreateParams.TransferData;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.InvoiceCreateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.InvoiceCreateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace Issuer {
+      export type Type = Stripe.InvoiceCreateParams.Issuer.Type;
+    }
+    export namespace PaymentSettings {
+      export type PaymentMethodOptions = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions;
+      export type PaymentMethodType = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodType;
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit;
+        export type Bancontact = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Bancontact;
+        export type Card = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card;
+        export type CustomerBalance = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance;
+        export type Konbini = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Konbini;
+        export type Payto = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Pix;
+        export type SepaDebit = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.SepaDebit;
+        export type Upi = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type MandateOptions = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type VerificationMethod = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type TransactionType = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace Bancontact {
+          export type PreferredLanguage = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        }
+        export namespace Card {
+          export type Installments = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card.Installments;
+          export type RequestThreeDSecure = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export namespace Installments {
+            export type Plan = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card.Installments.Plan;
+            export namespace Plan {
+              export type Type = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Card.Installments.Plan.Type;
+            }
+          }
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          }
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions;
+          export namespace MandateOptions {
+            export type Purpose = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type AmountIncludesIof = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Pix.AmountIncludesIof;
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type VerificationMethod = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.InvoiceCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+    }
+    export namespace Rendering {
+      export type AmountTaxDisplay = Stripe.InvoiceCreateParams.Rendering.AmountTaxDisplay;
+      export type Pdf = Stripe.InvoiceCreateParams.Rendering.Pdf;
+      export namespace Pdf {
+        export type PageSize = Stripe.InvoiceCreateParams.Rendering.Pdf.PageSize;
+      }
+    }
+    export namespace ShippingCost {
+      export type ShippingRateData = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData;
+      export namespace ShippingRateData {
+        export type DeliveryEstimate = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.DeliveryEstimate;
+        export type FixedAmount = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.FixedAmount;
+        export type TaxBehavior = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.TaxBehavior;
+        export namespace DeliveryEstimate {
+          export type Maximum = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Maximum;
+          export type Minimum = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Minimum;
+          export namespace Maximum {
+            export type Unit = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Maximum.Unit;
+          }
+          export namespace Minimum {
+            export type Unit = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Minimum.Unit;
+          }
+        }
+        export namespace FixedAmount {
+          export type CurrencyOptions = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.FixedAmount.CurrencyOptions;
+          export namespace CurrencyOptions {
+            export type TaxBehavior = Stripe.InvoiceCreateParams.ShippingCost.ShippingRateData.FixedAmount.CurrencyOptions.TaxBehavior;
+          }
+        }
+      }
+    }
   }
   export namespace InvoiceUpdateParams {
     export type AutomaticTax = Stripe.InvoiceUpdateParams.AutomaticTax;
@@ -685,6 +2248,115 @@ declare namespace StripeConstructor {
     export type ShippingCost = Stripe.InvoiceUpdateParams.ShippingCost;
     export type ShippingDetails = Stripe.InvoiceUpdateParams.ShippingDetails;
     export type TransferData = Stripe.InvoiceUpdateParams.TransferData;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.InvoiceUpdateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.InvoiceUpdateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace Issuer {
+      export type Type = Stripe.InvoiceUpdateParams.Issuer.Type;
+    }
+    export namespace PaymentSettings {
+      export type PaymentMethodOptions = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions;
+      export type PaymentMethodType = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodType;
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit;
+        export type Bancontact = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Bancontact;
+        export type Card = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Card;
+        export type CustomerBalance = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance;
+        export type Konbini = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Konbini;
+        export type Payto = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Pix;
+        export type SepaDebit = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.SepaDebit;
+        export type Upi = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type MandateOptions = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type VerificationMethod = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type TransactionType = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace Bancontact {
+          export type PreferredLanguage = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        }
+        export namespace Card {
+          export type Installments = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Card.Installments;
+          export type RequestThreeDSecure = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export namespace Installments {
+            export type Plan = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Card.Installments.Plan;
+            export namespace Plan {
+              export type Type = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Card.Installments.Plan.Type;
+            }
+          }
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          }
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions;
+          export namespace MandateOptions {
+            export type Purpose = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type AmountIncludesIof = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Pix.AmountIncludesIof;
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type VerificationMethod = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.InvoiceUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+    }
+    export namespace Rendering {
+      export type AmountTaxDisplay = Stripe.InvoiceUpdateParams.Rendering.AmountTaxDisplay;
+      export type Pdf = Stripe.InvoiceUpdateParams.Rendering.Pdf;
+      export namespace Pdf {
+        export type PageSize = Stripe.InvoiceUpdateParams.Rendering.Pdf.PageSize;
+      }
+    }
+    export namespace ShippingCost {
+      export type ShippingRateData = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData;
+      export namespace ShippingRateData {
+        export type DeliveryEstimate = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.DeliveryEstimate;
+        export type FixedAmount = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.FixedAmount;
+        export type TaxBehavior = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.TaxBehavior;
+        export namespace DeliveryEstimate {
+          export type Maximum = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Maximum;
+          export type Minimum = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Minimum;
+          export namespace Maximum {
+            export type Unit = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Maximum.Unit;
+          }
+          export namespace Minimum {
+            export type Unit = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.DeliveryEstimate.Minimum.Unit;
+          }
+        }
+        export namespace FixedAmount {
+          export type CurrencyOptions = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.FixedAmount.CurrencyOptions;
+          export namespace CurrencyOptions {
+            export type TaxBehavior = Stripe.InvoiceUpdateParams.ShippingCost.ShippingRateData.FixedAmount.CurrencyOptions.TaxBehavior;
+          }
+        }
+      }
+    }
   }
   export namespace InvoiceListParams {
     export type CollectionMethod = Stripe.InvoiceListParams.CollectionMethod;
@@ -692,6 +2364,25 @@ declare namespace StripeConstructor {
   }
   export namespace InvoiceAddLinesParams {
     export type Line = Stripe.InvoiceAddLinesParams.Line;
+    export namespace Line {
+      export type Discount = Stripe.InvoiceAddLinesParams.Line.Discount;
+      export type Period = Stripe.InvoiceAddLinesParams.Line.Period;
+      export type PriceData = Stripe.InvoiceAddLinesParams.Line.PriceData;
+      export type Pricing = Stripe.InvoiceAddLinesParams.Line.Pricing;
+      export type TaxAmount = Stripe.InvoiceAddLinesParams.Line.TaxAmount;
+      export namespace PriceData {
+        export type ProductData = Stripe.InvoiceAddLinesParams.Line.PriceData.ProductData;
+        export type TaxBehavior = Stripe.InvoiceAddLinesParams.Line.PriceData.TaxBehavior;
+      }
+      export namespace TaxAmount {
+        export type TaxRateData = Stripe.InvoiceAddLinesParams.Line.TaxAmount.TaxRateData;
+        export type TaxabilityReason = Stripe.InvoiceAddLinesParams.Line.TaxAmount.TaxabilityReason;
+        export namespace TaxRateData {
+          export type JurisdictionLevel = Stripe.InvoiceAddLinesParams.Line.TaxAmount.TaxRateData.JurisdictionLevel;
+          export type TaxType = Stripe.InvoiceAddLinesParams.Line.TaxAmount.TaxRateData.TaxType;
+        }
+      }
+    }
   }
   export namespace InvoiceCreatePreviewParams {
     export type AutomaticTax = Stripe.InvoiceCreatePreviewParams.AutomaticTax;
@@ -702,12 +2393,170 @@ declare namespace StripeConstructor {
     export type PreviewMode = Stripe.InvoiceCreatePreviewParams.PreviewMode;
     export type ScheduleDetails = Stripe.InvoiceCreatePreviewParams.ScheduleDetails;
     export type SubscriptionDetails = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.InvoiceCreatePreviewParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.InvoiceCreatePreviewParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace CustomerDetails {
+      export type Shipping = Stripe.InvoiceCreatePreviewParams.CustomerDetails.Shipping;
+      export type Tax = Stripe.InvoiceCreatePreviewParams.CustomerDetails.Tax;
+      export type TaxExempt = Stripe.InvoiceCreatePreviewParams.CustomerDetails.TaxExempt;
+      export type TaxId = Stripe.InvoiceCreatePreviewParams.CustomerDetails.TaxId;
+      export namespace TaxId {
+        export type Type = Stripe.InvoiceCreatePreviewParams.CustomerDetails.TaxId.Type;
+      }
+    }
+    export namespace InvoiceItem {
+      export type Discount = Stripe.InvoiceCreatePreviewParams.InvoiceItem.Discount;
+      export type Period = Stripe.InvoiceCreatePreviewParams.InvoiceItem.Period;
+      export type PriceData = Stripe.InvoiceCreatePreviewParams.InvoiceItem.PriceData;
+      export type TaxBehavior = Stripe.InvoiceCreatePreviewParams.InvoiceItem.TaxBehavior;
+      export namespace PriceData {
+        export type TaxBehavior = Stripe.InvoiceCreatePreviewParams.InvoiceItem.PriceData.TaxBehavior;
+      }
+    }
+    export namespace Issuer {
+      export type Type = Stripe.InvoiceCreatePreviewParams.Issuer.Type;
+    }
+    export namespace ScheduleDetails {
+      export type BillingMode = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.BillingMode;
+      export type EndBehavior = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.EndBehavior;
+      export type Phase = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase;
+      export type ProrationBehavior = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.ProrationBehavior;
+      export namespace BillingMode {
+        export type Flexible = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.BillingMode.Flexible;
+        export type Type = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.BillingMode.Type;
+        export namespace Flexible {
+          export type ProrationDiscounts = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.BillingMode.Flexible.ProrationDiscounts;
+        }
+      }
+      export namespace Phase {
+        export type AddInvoiceItem = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem;
+        export type AutomaticTax = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AutomaticTax;
+        export type BillingCycleAnchor = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.BillingCycleAnchor;
+        export type BillingThresholds = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.BillingThresholds;
+        export type CollectionMethod = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.CollectionMethod;
+        export type Discount = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Discount;
+        export type Duration = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Duration;
+        export type InvoiceSettings = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.InvoiceSettings;
+        export type Item = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item;
+        export type ProrationBehavior = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.ProrationBehavior;
+        export type TransferData = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.TransferData;
+        export namespace AddInvoiceItem {
+          export type Discount = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.Discount;
+          export type Period = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.Period;
+          export type PriceData = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.PriceData;
+          export namespace Period {
+            export type End = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.Period.End;
+            export type Start = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.Period.Start;
+            export namespace End {
+              export type Type = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.Period.End.Type;
+            }
+            export namespace Start {
+              export type Type = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.Period.Start.Type;
+            }
+          }
+          export namespace PriceData {
+            export type TaxBehavior = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AddInvoiceItem.PriceData.TaxBehavior;
+          }
+        }
+        export namespace AutomaticTax {
+          export type Liability = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AutomaticTax.Liability;
+          export namespace Liability {
+            export type Type = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.AutomaticTax.Liability.Type;
+          }
+        }
+        export namespace Duration {
+          export type Interval = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Duration.Interval;
+        }
+        export namespace InvoiceSettings {
+          export type Issuer = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.InvoiceSettings.Issuer;
+          export namespace Issuer {
+            export type Type = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.InvoiceSettings.Issuer.Type;
+          }
+        }
+        export namespace Item {
+          export type BillingThresholds = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item.BillingThresholds;
+          export type Discount = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item.Discount;
+          export type PriceData = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item.PriceData;
+          export namespace PriceData {
+            export type Recurring = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item.PriceData.Recurring;
+            export type TaxBehavior = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item.PriceData.TaxBehavior;
+            export namespace Recurring {
+              export type Interval = Stripe.InvoiceCreatePreviewParams.ScheduleDetails.Phase.Item.PriceData.Recurring.Interval;
+            }
+          }
+        }
+      }
+    }
+    export namespace SubscriptionDetails {
+      export type BillingCycleAnchor = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingCycleAnchor;
+      export type BillingMode = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingMode;
+      export type BillingSchedule = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingSchedule;
+      export type CancelAt = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.CancelAt;
+      export type Item = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item;
+      export type ProrationBehavior = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.ProrationBehavior;
+      export namespace BillingMode {
+        export type Flexible = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingMode.Flexible;
+        export type Type = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingMode.Type;
+        export namespace Flexible {
+          export type ProrationDiscounts = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingMode.Flexible.ProrationDiscounts;
+        }
+      }
+      export namespace BillingSchedule {
+        export type AppliesTo = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingSchedule.AppliesTo;
+        export type BillUntil = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingSchedule.BillUntil;
+        export namespace BillUntil {
+          export type Duration = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingSchedule.BillUntil.Duration;
+          export type Type = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingSchedule.BillUntil.Type;
+          export namespace Duration {
+            export type Interval = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.BillingSchedule.BillUntil.Duration.Interval;
+          }
+        }
+      }
+      export namespace Item {
+        export type BillingThresholds = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item.BillingThresholds;
+        export type Discount = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item.Discount;
+        export type PriceData = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item.PriceData;
+        export namespace PriceData {
+          export type Recurring = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item.PriceData.Recurring;
+          export type TaxBehavior = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item.PriceData.TaxBehavior;
+          export namespace Recurring {
+            export type Interval = Stripe.InvoiceCreatePreviewParams.SubscriptionDetails.Item.PriceData.Recurring.Interval;
+          }
+        }
+      }
+    }
   }
   export namespace InvoiceRemoveLinesParams {
     export type Line = Stripe.InvoiceRemoveLinesParams.Line;
+    export namespace Line {
+      export type Behavior = Stripe.InvoiceRemoveLinesParams.Line.Behavior;
+    }
   }
   export namespace InvoiceUpdateLinesParams {
     export type Line = Stripe.InvoiceUpdateLinesParams.Line;
+    export namespace Line {
+      export type Discount = Stripe.InvoiceUpdateLinesParams.Line.Discount;
+      export type Period = Stripe.InvoiceUpdateLinesParams.Line.Period;
+      export type PriceData = Stripe.InvoiceUpdateLinesParams.Line.PriceData;
+      export type Pricing = Stripe.InvoiceUpdateLinesParams.Line.Pricing;
+      export type TaxAmount = Stripe.InvoiceUpdateLinesParams.Line.TaxAmount;
+      export namespace PriceData {
+        export type ProductData = Stripe.InvoiceUpdateLinesParams.Line.PriceData.ProductData;
+        export type TaxBehavior = Stripe.InvoiceUpdateLinesParams.Line.PriceData.TaxBehavior;
+      }
+      export namespace TaxAmount {
+        export type TaxRateData = Stripe.InvoiceUpdateLinesParams.Line.TaxAmount.TaxRateData;
+        export type TaxabilityReason = Stripe.InvoiceUpdateLinesParams.Line.TaxAmount.TaxabilityReason;
+        export namespace TaxRateData {
+          export type JurisdictionLevel = Stripe.InvoiceUpdateLinesParams.Line.TaxAmount.TaxRateData.JurisdictionLevel;
+          export type TaxType = Stripe.InvoiceUpdateLinesParams.Line.TaxAmount.TaxRateData.TaxType;
+        }
+      }
+    }
   }
   export namespace InvoiceUpdateLineItemParams {
     export type Discount = Stripe.InvoiceUpdateLineItemParams.Discount;
@@ -715,6 +2564,155 @@ declare namespace StripeConstructor {
     export type PriceData = Stripe.InvoiceUpdateLineItemParams.PriceData;
     export type Pricing = Stripe.InvoiceUpdateLineItemParams.Pricing;
     export type TaxAmount = Stripe.InvoiceUpdateLineItemParams.TaxAmount;
+    export namespace PriceData {
+      export type ProductData = Stripe.InvoiceUpdateLineItemParams.PriceData.ProductData;
+      export type TaxBehavior = Stripe.InvoiceUpdateLineItemParams.PriceData.TaxBehavior;
+    }
+    export namespace TaxAmount {
+      export type TaxRateData = Stripe.InvoiceUpdateLineItemParams.TaxAmount.TaxRateData;
+      export type TaxabilityReason = Stripe.InvoiceUpdateLineItemParams.TaxAmount.TaxabilityReason;
+      export namespace TaxRateData {
+        export type JurisdictionLevel = Stripe.InvoiceUpdateLineItemParams.TaxAmount.TaxRateData.JurisdictionLevel;
+        export type TaxType = Stripe.InvoiceUpdateLineItemParams.TaxAmount.TaxRateData.TaxType;
+      }
+    }
+  }
+  export namespace Invoice {
+    export type AutomaticTax = Stripe.Invoice.AutomaticTax;
+    export type BillingReason = Stripe.Invoice.BillingReason;
+    export type CollectionMethod = Stripe.Invoice.CollectionMethod;
+    export type ConfirmationSecret = Stripe.Invoice.ConfirmationSecret;
+    export type CustomField = Stripe.Invoice.CustomField;
+    export type CustomerShipping = Stripe.Invoice.CustomerShipping;
+    export type CustomerTaxExempt = Stripe.Invoice.CustomerTaxExempt;
+    export type CustomerTaxId = Stripe.Invoice.CustomerTaxId;
+    export type FromInvoice = Stripe.Invoice.FromInvoice;
+    export type Issuer = Stripe.Invoice.Issuer;
+    export type LastFinalizationError = Stripe.Invoice.LastFinalizationError;
+    export type Parent = Stripe.Invoice.Parent;
+    export type PaymentSettings = Stripe.Invoice.PaymentSettings;
+    export type Rendering = Stripe.Invoice.Rendering;
+    export type ShippingCost = Stripe.Invoice.ShippingCost;
+    export type ShippingDetails = Stripe.Invoice.ShippingDetails;
+    export type Status = Stripe.Invoice.Status;
+    export type StatusTransitions = Stripe.Invoice.StatusTransitions;
+    export type ThresholdReason = Stripe.Invoice.ThresholdReason;
+    export type TotalDiscountAmount = Stripe.Invoice.TotalDiscountAmount;
+    export type TotalPretaxCreditAmount = Stripe.Invoice.TotalPretaxCreditAmount;
+    export type TotalTax = Stripe.Invoice.TotalTax;
+    export namespace AutomaticTax {
+      export type DisabledReason = Stripe.Invoice.AutomaticTax.DisabledReason;
+      export type Liability = Stripe.Invoice.AutomaticTax.Liability;
+      export type Status = Stripe.Invoice.AutomaticTax.Status;
+      export namespace Liability {
+        export type Type = Stripe.Invoice.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace CustomerTaxId {
+      export type Type = Stripe.Invoice.CustomerTaxId.Type;
+    }
+    export namespace Issuer {
+      export type Type = Stripe.Invoice.Issuer.Type;
+    }
+    export namespace LastFinalizationError {
+      export type Code = Stripe.Invoice.LastFinalizationError.Code;
+      export type Type = Stripe.Invoice.LastFinalizationError.Type;
+    }
+    export namespace Parent {
+      export type QuoteDetails = Stripe.Invoice.Parent.QuoteDetails;
+      export type SubscriptionDetails = Stripe.Invoice.Parent.SubscriptionDetails;
+      export type Type = Stripe.Invoice.Parent.Type;
+    }
+    export namespace PaymentSettings {
+      export type PaymentMethodOptions = Stripe.Invoice.PaymentSettings.PaymentMethodOptions;
+      export type PaymentMethodType = Stripe.Invoice.PaymentSettings.PaymentMethodType;
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.AcssDebit;
+        export type Bancontact = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Bancontact;
+        export type Card = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Card;
+        export type CustomerBalance = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.CustomerBalance;
+        export type Konbini = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Konbini;
+        export type Payto = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Pix;
+        export type SepaDebit = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.SepaDebit;
+        export type Upi = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type MandateOptions = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type VerificationMethod = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type TransactionType = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace Bancontact {
+          export type PreferredLanguage = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        }
+        export namespace Card {
+          export type Installments = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Card.Installments;
+          export type RequestThreeDSecure = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure;
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+            export namespace EuBankTransfer {
+              export type Country = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer.Country;
+            }
+          }
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+            export type Purpose = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type AmountIncludesIof = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Pix.AmountIncludesIof;
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type VerificationMethod = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.Invoice.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+    }
+    export namespace Rendering {
+      export type Pdf = Stripe.Invoice.Rendering.Pdf;
+      export namespace Pdf {
+        export type PageSize = Stripe.Invoice.Rendering.Pdf.PageSize;
+      }
+    }
+    export namespace ShippingCost {
+      export type Tax = Stripe.Invoice.ShippingCost.Tax;
+      export namespace Tax {
+        export type TaxabilityReason = Stripe.Invoice.ShippingCost.Tax.TaxabilityReason;
+      }
+    }
+    export namespace ThresholdReason {
+      export type ItemReason = Stripe.Invoice.ThresholdReason.ItemReason;
+    }
+    export namespace TotalPretaxCreditAmount {
+      export type Type = Stripe.Invoice.TotalPretaxCreditAmount.Type;
+    }
+    export namespace TotalTax {
+      export type TaxBehavior = Stripe.Invoice.TotalTax.TaxBehavior;
+      export type TaxRateDetails = Stripe.Invoice.TotalTax.TaxRateDetails;
+      export type TaxabilityReason = Stripe.Invoice.TotalTax.TaxabilityReason;
+    }
   }
   export namespace InvoiceItemCreateParams {
     export type Discount = Stripe.InvoiceItemCreateParams.Discount;
@@ -722,6 +2720,9 @@ declare namespace StripeConstructor {
     export type PriceData = Stripe.InvoiceItemCreateParams.PriceData;
     export type Pricing = Stripe.InvoiceItemCreateParams.Pricing;
     export type TaxBehavior = Stripe.InvoiceItemCreateParams.TaxBehavior;
+    export namespace PriceData {
+      export type TaxBehavior = Stripe.InvoiceItemCreateParams.PriceData.TaxBehavior;
+    }
   }
   export namespace InvoiceItemUpdateParams {
     export type Discount = Stripe.InvoiceItemUpdateParams.Discount;
@@ -729,13 +2730,313 @@ declare namespace StripeConstructor {
     export type PriceData = Stripe.InvoiceItemUpdateParams.PriceData;
     export type Pricing = Stripe.InvoiceItemUpdateParams.Pricing;
     export type TaxBehavior = Stripe.InvoiceItemUpdateParams.TaxBehavior;
+    export namespace PriceData {
+      export type TaxBehavior = Stripe.InvoiceItemUpdateParams.PriceData.TaxBehavior;
+    }
+  }
+  export namespace InvoiceItem {
+    export type Parent = Stripe.InvoiceItem.Parent;
+    export type Period = Stripe.InvoiceItem.Period;
+    export type Pricing = Stripe.InvoiceItem.Pricing;
+    export type ProrationDetails = Stripe.InvoiceItem.ProrationDetails;
+    export namespace Parent {
+      export type SubscriptionDetails = Stripe.InvoiceItem.Parent.SubscriptionDetails;
+    }
+    export namespace Pricing {
+      export type PriceDetails = Stripe.InvoiceItem.Pricing.PriceDetails;
+    }
+    export namespace ProrationDetails {
+      export type CreditedItems = Stripe.InvoiceItem.ProrationDetails.CreditedItems;
+      export type DiscountAmount = Stripe.InvoiceItem.ProrationDetails.DiscountAmount;
+      export namespace CreditedItems {
+        export type InvoiceLineItemDetails = Stripe.InvoiceItem.ProrationDetails.CreditedItems.InvoiceLineItemDetails;
+        export type Type = Stripe.InvoiceItem.ProrationDetails.CreditedItems.Type;
+      }
+    }
   }
   export namespace InvoicePaymentListParams {
     export type Payment = Stripe.InvoicePaymentListParams.Payment;
     export type Status = Stripe.InvoicePaymentListParams.Status;
+    export namespace Payment {
+      export type Type = Stripe.InvoicePaymentListParams.Payment.Type;
+    }
+  }
+  export namespace InvoicePayment {
+    export type Payment = Stripe.InvoicePayment.Payment;
+    export type StatusTransitions = Stripe.InvoicePayment.StatusTransitions;
+    export namespace Payment {
+      export type Type = Stripe.InvoicePayment.Payment.Type;
+    }
   }
   export namespace InvoiceRenderingTemplateListParams {
     export type Status = Stripe.InvoiceRenderingTemplateListParams.Status;
+  }
+  export namespace InvoiceRenderingTemplate {
+    export type Status = Stripe.InvoiceRenderingTemplate.Status;
+  }
+  export namespace Mandate {
+    export type CustomerAcceptance = Stripe.Mandate.CustomerAcceptance;
+    export type MultiUse = Stripe.Mandate.MultiUse;
+    export type PaymentMethodDetails = Stripe.Mandate.PaymentMethodDetails;
+    export type SingleUse = Stripe.Mandate.SingleUse;
+    export type Status = Stripe.Mandate.Status;
+    export type Type = Stripe.Mandate.Type;
+    export namespace CustomerAcceptance {
+      export type Offline = Stripe.Mandate.CustomerAcceptance.Offline;
+      export type Online = Stripe.Mandate.CustomerAcceptance.Online;
+      export type Type = Stripe.Mandate.CustomerAcceptance.Type;
+    }
+    export namespace PaymentMethodDetails {
+      export type AcssDebit = Stripe.Mandate.PaymentMethodDetails.AcssDebit;
+      export type AmazonPay = Stripe.Mandate.PaymentMethodDetails.AmazonPay;
+      export type AuBecsDebit = Stripe.Mandate.PaymentMethodDetails.AuBecsDebit;
+      export type BacsDebit = Stripe.Mandate.PaymentMethodDetails.BacsDebit;
+      export type Card = Stripe.Mandate.PaymentMethodDetails.Card;
+      export type Cashapp = Stripe.Mandate.PaymentMethodDetails.Cashapp;
+      export type KakaoPay = Stripe.Mandate.PaymentMethodDetails.KakaoPay;
+      export type Klarna = Stripe.Mandate.PaymentMethodDetails.Klarna;
+      export type KrCard = Stripe.Mandate.PaymentMethodDetails.KrCard;
+      export type Link = Stripe.Mandate.PaymentMethodDetails.Link;
+      export type NaverPay = Stripe.Mandate.PaymentMethodDetails.NaverPay;
+      export type NzBankAccount = Stripe.Mandate.PaymentMethodDetails.NzBankAccount;
+      export type Paypal = Stripe.Mandate.PaymentMethodDetails.Paypal;
+      export type Payto = Stripe.Mandate.PaymentMethodDetails.Payto;
+      export type Pix = Stripe.Mandate.PaymentMethodDetails.Pix;
+      export type RevolutPay = Stripe.Mandate.PaymentMethodDetails.RevolutPay;
+      export type SepaDebit = Stripe.Mandate.PaymentMethodDetails.SepaDebit;
+      export type Twint = Stripe.Mandate.PaymentMethodDetails.Twint;
+      export type Upi = Stripe.Mandate.PaymentMethodDetails.Upi;
+      export type UsBankAccount = Stripe.Mandate.PaymentMethodDetails.UsBankAccount;
+      export namespace AcssDebit {
+        export type DefaultFor = Stripe.Mandate.PaymentMethodDetails.AcssDebit.DefaultFor;
+        export type PaymentSchedule = Stripe.Mandate.PaymentMethodDetails.AcssDebit.PaymentSchedule;
+        export type TransactionType = Stripe.Mandate.PaymentMethodDetails.AcssDebit.TransactionType;
+      }
+      export namespace BacsDebit {
+        export type NetworkStatus = Stripe.Mandate.PaymentMethodDetails.BacsDebit.NetworkStatus;
+        export type RevocationReason = Stripe.Mandate.PaymentMethodDetails.BacsDebit.RevocationReason;
+      }
+      export namespace Payto {
+        export type AmountType = Stripe.Mandate.PaymentMethodDetails.Payto.AmountType;
+        export type PaymentSchedule = Stripe.Mandate.PaymentMethodDetails.Payto.PaymentSchedule;
+        export type Purpose = Stripe.Mandate.PaymentMethodDetails.Payto.Purpose;
+      }
+      export namespace Pix {
+        export type AmountIncludesIof = Stripe.Mandate.PaymentMethodDetails.Pix.AmountIncludesIof;
+        export type AmountType = Stripe.Mandate.PaymentMethodDetails.Pix.AmountType;
+        export type PaymentSchedule = Stripe.Mandate.PaymentMethodDetails.Pix.PaymentSchedule;
+      }
+      export namespace Upi {
+        export type AmountType = Stripe.Mandate.PaymentMethodDetails.Upi.AmountType;
+      }
+    }
+  }
+  export namespace PaymentAttemptRecord {
+    export type Amount = Stripe.PaymentAttemptRecord.Amount;
+    export type AmountAuthorized = Stripe.PaymentAttemptRecord.AmountAuthorized;
+    export type AmountCanceled = Stripe.PaymentAttemptRecord.AmountCanceled;
+    export type AmountFailed = Stripe.PaymentAttemptRecord.AmountFailed;
+    export type AmountGuaranteed = Stripe.PaymentAttemptRecord.AmountGuaranteed;
+    export type AmountRefunded = Stripe.PaymentAttemptRecord.AmountRefunded;
+    export type AmountRequested = Stripe.PaymentAttemptRecord.AmountRequested;
+    export type CustomerDetails = Stripe.PaymentAttemptRecord.CustomerDetails;
+    export type CustomerPresence = Stripe.PaymentAttemptRecord.CustomerPresence;
+    export type PaymentMethodDetails = Stripe.PaymentAttemptRecord.PaymentMethodDetails;
+    export type ProcessorDetails = Stripe.PaymentAttemptRecord.ProcessorDetails;
+    export type ReportedBy = Stripe.PaymentAttemptRecord.ReportedBy;
+    export type ShippingDetails = Stripe.PaymentAttemptRecord.ShippingDetails;
+    export namespace PaymentMethodDetails {
+      export type AchCreditTransfer = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AchCreditTransfer;
+      export type AchDebit = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AchDebit;
+      export type AcssDebit = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AcssDebit;
+      export type Affirm = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Alipay;
+      export type Alma = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Alma;
+      export type AmazonPay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentAttemptRecord.PaymentMethodDetails.BacsDebit;
+      export type Bancontact = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Bancontact;
+      export type Billie = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Billie;
+      export type BillingDetails = Stripe.PaymentAttemptRecord.PaymentMethodDetails.BillingDetails;
+      export type Bizum = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Bizum;
+      export type Blik = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Blik;
+      export type Boleto = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Boleto;
+      export type Card = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card;
+      export type CardPresent = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent;
+      export type Cashapp = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Cashapp;
+      export type Crypto = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Crypto;
+      export type Custom = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Custom;
+      export type CustomerBalance = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CustomerBalance;
+      export type Eps = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Eps;
+      export type Fpx = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Fpx;
+      export type Giropay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Giropay;
+      export type Grabpay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Grabpay;
+      export type Ideal = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Ideal;
+      export type InteracPresent = Stripe.PaymentAttemptRecord.PaymentMethodDetails.InteracPresent;
+      export type KakaoPay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.KakaoPay;
+      export type Klarna = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Klarna;
+      export type Konbini = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Konbini;
+      export type KrCard = Stripe.PaymentAttemptRecord.PaymentMethodDetails.KrCard;
+      export type Link = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Link;
+      export type MbWay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.MbWay;
+      export type Mobilepay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Mobilepay;
+      export type Multibanco = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Multibanco;
+      export type NaverPay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.NaverPay;
+      export type NzBankAccount = Stripe.PaymentAttemptRecord.PaymentMethodDetails.NzBankAccount;
+      export type Oxxo = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Oxxo;
+      export type P24 = Stripe.PaymentAttemptRecord.PaymentMethodDetails.P24;
+      export type PayByBank = Stripe.PaymentAttemptRecord.PaymentMethodDetails.PayByBank;
+      export type Payco = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Payco;
+      export type Paynow = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Paynow;
+      export type Paypal = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Paypal;
+      export type Payto = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Payto;
+      export type Pix = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Pix;
+      export type Promptpay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Promptpay;
+      export type RevolutPay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.RevolutPay;
+      export type SamsungPay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.SamsungPay;
+      export type Satispay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Satispay;
+      export type Scalapay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Scalapay;
+      export type SepaCreditTransfer = Stripe.PaymentAttemptRecord.PaymentMethodDetails.SepaCreditTransfer;
+      export type SepaDebit = Stripe.PaymentAttemptRecord.PaymentMethodDetails.SepaDebit;
+      export type Sofort = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Sofort;
+      export type StripeAccount = Stripe.PaymentAttemptRecord.PaymentMethodDetails.StripeAccount;
+      export type Sunbit = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Sunbit;
+      export type Swish = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Swish;
+      export type Twint = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Twint;
+      export type Upi = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Upi;
+      export type UsBankAccount = Stripe.PaymentAttemptRecord.PaymentMethodDetails.UsBankAccount;
+      export type Wechat = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Wechat;
+      export type WechatPay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.WechatPay;
+      export type Zip = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Zip;
+      export namespace AchDebit {
+        export type AccountHolderType = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AchDebit.AccountHolderType;
+      }
+      export namespace Alma {
+        export type Installments = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Alma.Installments;
+      }
+      export namespace AmazonPay {
+        export type Funding = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AmazonPay.Funding;
+        export namespace Funding {
+          export type Card = Stripe.PaymentAttemptRecord.PaymentMethodDetails.AmazonPay.Funding.Card;
+        }
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Bancontact.PreferredLanguage;
+      }
+      export namespace Card {
+        export type Brand = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Brand;
+        export type Checks = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Checks;
+        export type Funding = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Funding;
+        export type Installments = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Installments;
+        export type Network = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Network;
+        export type NetworkToken = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.NetworkToken;
+        export type StoredCredentialUsage = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.StoredCredentialUsage;
+        export type ThreeDSecure = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure;
+        export type Wallet = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Wallet;
+        export namespace Checks {
+          export type AddressLine1Check = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Checks.AddressLine1Check;
+          export type AddressPostalCodeCheck = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Checks.AddressPostalCodeCheck;
+          export type CvcCheck = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Checks.CvcCheck;
+        }
+        export namespace Installments {
+          export type Plan = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace ThreeDSecure {
+          export type AuthenticationFlow = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure.AuthenticationFlow;
+          export type ElectronicCommerceIndicator = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type ExemptionIndicator = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure.ExemptionIndicator;
+          export type Result = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure.Result;
+          export type ResultReason = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure.ResultReason;
+          export type Version = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.ThreeDSecure.Version;
+        }
+        export namespace Wallet {
+          export type ApplePay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Wallet.ApplePay;
+          export type GooglePay = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Card.Wallet.GooglePay;
+        }
+      }
+      export namespace CardPresent {
+        export type Offline = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent.Offline;
+        export type ReadMethod = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent.ReadMethod;
+        export type Receipt = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent.Receipt;
+        export type Wallet = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent.Wallet;
+        export namespace Receipt {
+          export type AccountType = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent.Receipt.AccountType;
+        }
+        export namespace Wallet {
+          export type Type = Stripe.PaymentAttemptRecord.PaymentMethodDetails.CardPresent.Wallet.Type;
+        }
+      }
+      export namespace Crypto {
+        export type Network = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Crypto.Network;
+        export type TokenCurrency = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Crypto.TokenCurrency;
+      }
+      export namespace Eps {
+        export type Bank = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Fpx.AccountHolderType;
+        export type Bank = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Ideal.Bank;
+        export type Bic = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Ideal.Bic;
+      }
+      export namespace InteracPresent {
+        export type ReadMethod = Stripe.PaymentAttemptRecord.PaymentMethodDetails.InteracPresent.ReadMethod;
+        export type Receipt = Stripe.PaymentAttemptRecord.PaymentMethodDetails.InteracPresent.Receipt;
+        export namespace Receipt {
+          export type AccountType = Stripe.PaymentAttemptRecord.PaymentMethodDetails.InteracPresent.Receipt.AccountType;
+        }
+      }
+      export namespace Klarna {
+        export type PayerDetails = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Klarna.PayerDetails;
+        export namespace PayerDetails {
+          export type Address = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Klarna.PayerDetails.Address;
+        }
+      }
+      export namespace Konbini {
+        export type Store = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Konbini.Store;
+        export namespace Store {
+          export type Chain = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Konbini.Store.Chain;
+        }
+      }
+      export namespace KrCard {
+        export type Brand = Stripe.PaymentAttemptRecord.PaymentMethodDetails.KrCard.Brand;
+      }
+      export namespace Mobilepay {
+        export type Card = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Mobilepay.Card;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.PaymentAttemptRecord.PaymentMethodDetails.P24.Bank;
+      }
+      export namespace Paypal {
+        export type SellerProtection = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Paypal.SellerProtection;
+        export namespace SellerProtection {
+          export type DisputeCategory = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Paypal.SellerProtection.DisputeCategory;
+          export type Status = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Paypal.SellerProtection.Status;
+        }
+      }
+      export namespace RevolutPay {
+        export type Funding = Stripe.PaymentAttemptRecord.PaymentMethodDetails.RevolutPay.Funding;
+        export namespace Funding {
+          export type Card = Stripe.PaymentAttemptRecord.PaymentMethodDetails.RevolutPay.Funding.Card;
+        }
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.PaymentAttemptRecord.PaymentMethodDetails.Sofort.PreferredLanguage;
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.PaymentAttemptRecord.PaymentMethodDetails.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.PaymentAttemptRecord.PaymentMethodDetails.UsBankAccount.AccountType;
+      }
+    }
+    export namespace ProcessorDetails {
+      export type Custom = Stripe.PaymentAttemptRecord.ProcessorDetails.Custom;
+    }
   }
   export namespace PaymentIntentCreateParams {
     export type AmountDetails = Stripe.PaymentIntentCreateParams.AmountDetails;
@@ -753,6 +3054,372 @@ declare namespace StripeConstructor {
     export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.SetupFutureUsage;
     export type Shipping = Stripe.PaymentIntentCreateParams.Shipping;
     export type TransferData = Stripe.PaymentIntentCreateParams.TransferData;
+    export namespace AmountDetails {
+      export type LineItem = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem;
+      export type Shipping = Stripe.PaymentIntentCreateParams.AmountDetails.Shipping;
+      export type Tax = Stripe.PaymentIntentCreateParams.AmountDetails.Tax;
+      export namespace LineItem {
+        export type PaymentMethodOptions = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.PaymentMethodOptions;
+        export type Tax = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.Tax;
+        export namespace PaymentMethodOptions {
+          export type Card = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.PaymentMethodOptions.Card;
+          export type CardPresent = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.PaymentMethodOptions.CardPresent;
+          export type Klarna = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.PaymentMethodOptions.Klarna;
+          export type Paypal = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal;
+          export namespace Paypal {
+            export type Category = Stripe.PaymentIntentCreateParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal.Category;
+          }
+        }
+      }
+    }
+    export namespace AutomaticPaymentMethods {
+      export type AllowRedirects = Stripe.PaymentIntentCreateParams.AutomaticPaymentMethods.AllowRedirects;
+    }
+    export namespace Hooks {
+      export type Inputs = Stripe.PaymentIntentCreateParams.Hooks.Inputs;
+      export namespace Inputs {
+        export type Tax = Stripe.PaymentIntentCreateParams.Hooks.Inputs.Tax;
+      }
+    }
+    export namespace MandateData {
+      export type CustomerAcceptance = Stripe.PaymentIntentCreateParams.MandateData.CustomerAcceptance;
+      export namespace CustomerAcceptance {
+        export type Offline = Stripe.PaymentIntentCreateParams.MandateData.CustomerAcceptance.Offline;
+        export type Online = Stripe.PaymentIntentCreateParams.MandateData.CustomerAcceptance.Online;
+        export type Type = Stripe.PaymentIntentCreateParams.MandateData.CustomerAcceptance.Type;
+      }
+    }
+    export namespace PaymentMethodData {
+      export type AcssDebit = Stripe.PaymentIntentCreateParams.PaymentMethodData.AcssDebit;
+      export type Affirm = Stripe.PaymentIntentCreateParams.PaymentMethodData.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntentCreateParams.PaymentMethodData.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Alipay;
+      export type AllowRedisplay = Stripe.PaymentIntentCreateParams.PaymentMethodData.AllowRedisplay;
+      export type Alma = Stripe.PaymentIntentCreateParams.PaymentMethodData.Alma;
+      export type AmazonPay = Stripe.PaymentIntentCreateParams.PaymentMethodData.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntentCreateParams.PaymentMethodData.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntentCreateParams.PaymentMethodData.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntentCreateParams.PaymentMethodData.Bancontact;
+      export type Billie = Stripe.PaymentIntentCreateParams.PaymentMethodData.Billie;
+      export type BillingDetails = Stripe.PaymentIntentCreateParams.PaymentMethodData.BillingDetails;
+      export type Bizum = Stripe.PaymentIntentCreateParams.PaymentMethodData.Bizum;
+      export type Blik = Stripe.PaymentIntentCreateParams.PaymentMethodData.Blik;
+      export type Boleto = Stripe.PaymentIntentCreateParams.PaymentMethodData.Boleto;
+      export type Cashapp = Stripe.PaymentIntentCreateParams.PaymentMethodData.Cashapp;
+      export type Crypto = Stripe.PaymentIntentCreateParams.PaymentMethodData.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntentCreateParams.PaymentMethodData.CustomerBalance;
+      export type Eps = Stripe.PaymentIntentCreateParams.PaymentMethodData.Eps;
+      export type Fpx = Stripe.PaymentIntentCreateParams.PaymentMethodData.Fpx;
+      export type Giropay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Giropay;
+      export type Grabpay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Grabpay;
+      export type Ideal = Stripe.PaymentIntentCreateParams.PaymentMethodData.Ideal;
+      export type InteracPresent = Stripe.PaymentIntentCreateParams.PaymentMethodData.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntentCreateParams.PaymentMethodData.KakaoPay;
+      export type Klarna = Stripe.PaymentIntentCreateParams.PaymentMethodData.Klarna;
+      export type Konbini = Stripe.PaymentIntentCreateParams.PaymentMethodData.Konbini;
+      export type KrCard = Stripe.PaymentIntentCreateParams.PaymentMethodData.KrCard;
+      export type Link = Stripe.PaymentIntentCreateParams.PaymentMethodData.Link;
+      export type MbWay = Stripe.PaymentIntentCreateParams.PaymentMethodData.MbWay;
+      export type Mobilepay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntentCreateParams.PaymentMethodData.Multibanco;
+      export type NaverPay = Stripe.PaymentIntentCreateParams.PaymentMethodData.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntentCreateParams.PaymentMethodData.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntentCreateParams.PaymentMethodData.Oxxo;
+      export type P24 = Stripe.PaymentIntentCreateParams.PaymentMethodData.P24;
+      export type PayByBank = Stripe.PaymentIntentCreateParams.PaymentMethodData.PayByBank;
+      export type Payco = Stripe.PaymentIntentCreateParams.PaymentMethodData.Payco;
+      export type Paynow = Stripe.PaymentIntentCreateParams.PaymentMethodData.Paynow;
+      export type Paypal = Stripe.PaymentIntentCreateParams.PaymentMethodData.Paypal;
+      export type Payto = Stripe.PaymentIntentCreateParams.PaymentMethodData.Payto;
+      export type Pix = Stripe.PaymentIntentCreateParams.PaymentMethodData.Pix;
+      export type Promptpay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Promptpay;
+      export type RadarOptions = Stripe.PaymentIntentCreateParams.PaymentMethodData.RadarOptions;
+      export type RevolutPay = Stripe.PaymentIntentCreateParams.PaymentMethodData.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntentCreateParams.PaymentMethodData.SamsungPay;
+      export type Satispay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Satispay;
+      export type Scalapay = Stripe.PaymentIntentCreateParams.PaymentMethodData.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntentCreateParams.PaymentMethodData.SepaDebit;
+      export type Sofort = Stripe.PaymentIntentCreateParams.PaymentMethodData.Sofort;
+      export type Sunbit = Stripe.PaymentIntentCreateParams.PaymentMethodData.Sunbit;
+      export type Swish = Stripe.PaymentIntentCreateParams.PaymentMethodData.Swish;
+      export type Twint = Stripe.PaymentIntentCreateParams.PaymentMethodData.Twint;
+      export type Type = Stripe.PaymentIntentCreateParams.PaymentMethodData.Type;
+      export type Upi = Stripe.PaymentIntentCreateParams.PaymentMethodData.Upi;
+      export type UsBankAccount = Stripe.PaymentIntentCreateParams.PaymentMethodData.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntentCreateParams.PaymentMethodData.WechatPay;
+      export type Zip = Stripe.PaymentIntentCreateParams.PaymentMethodData.Zip;
+      export namespace Eps {
+        export type Bank = Stripe.PaymentIntentCreateParams.PaymentMethodData.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.PaymentIntentCreateParams.PaymentMethodData.Fpx.AccountHolderType;
+        export type Bank = Stripe.PaymentIntentCreateParams.PaymentMethodData.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.PaymentIntentCreateParams.PaymentMethodData.Ideal.Bank;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.PaymentIntentCreateParams.PaymentMethodData.Klarna.Dob;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.PaymentIntentCreateParams.PaymentMethodData.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.PaymentIntentCreateParams.PaymentMethodData.P24.Bank;
+      }
+      export namespace Sofort {
+        export type Country = Stripe.PaymentIntentCreateParams.PaymentMethodData.Sofort.Country;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodData.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentCreateParams.PaymentMethodData.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.PaymentIntentCreateParams.PaymentMethodData.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.PaymentIntentCreateParams.PaymentMethodData.UsBankAccount.AccountType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AcssDebit;
+      export type Affirm = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Alipay;
+      export type Alma = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Alma;
+      export type AmazonPay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Bancontact;
+      export type Billie = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Billie;
+      export type Bizum = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Bizum;
+      export type Blik = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Blik;
+      export type Boleto = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Boleto;
+      export type Card = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CardPresent;
+      export type Cashapp = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Cashapp;
+      export type Crypto = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CustomerBalance;
+      export type Eps = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Eps;
+      export type Fpx = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Fpx;
+      export type Giropay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Giropay;
+      export type Grabpay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Grabpay;
+      export type Ideal = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Ideal;
+      export type InteracPresent = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.KakaoPay;
+      export type Klarna = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna;
+      export type Konbini = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Konbini;
+      export type KrCard = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.KrCard;
+      export type Link = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Link;
+      export type MbWay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.MbWay;
+      export type Mobilepay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Multibanco;
+      export type NaverPay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Oxxo;
+      export type P24 = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.P24;
+      export type PayByBank = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.PayByBank;
+      export type Payco = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payco;
+      export type Paynow = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Paynow;
+      export type Paypal = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix;
+      export type Promptpay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Promptpay;
+      export type RevolutPay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.SamsungPay;
+      export type Satispay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Satispay;
+      export type Scalapay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.SepaDebit;
+      export type Sofort = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Sofort;
+      export type Swish = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Swish;
+      export type Twint = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Twint;
+      export type Upi = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.WechatPay;
+      export type Zip = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Zip;
+      export namespace AcssDebit {
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AcssDebit.SetupFutureUsage;
+        export type VerificationMethod = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type PaymentSchedule = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace Alipay {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Alipay.SetupFutureUsage;
+      }
+      export namespace AmazonPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AmazonPay.SetupFutureUsage;
+      }
+      export namespace AuBecsDebit {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.AuBecsDebit.SetupFutureUsage;
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.BacsDebit.SetupFutureUsage;
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Bancontact.SetupFutureUsage;
+      }
+      export namespace Boleto {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Boleto.SetupFutureUsage;
+      }
+      export namespace Card {
+        export type Installments = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments;
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.Network;
+        export type RequestExtendedAuthorization = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.RequestExtendedAuthorization;
+        export type RequestIncrementalAuthorization = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.RequestIncrementalAuthorization;
+        export type RequestMulticapture = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.RequestMulticapture;
+        export type RequestOvercapture = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.RequestOvercapture;
+        export type RequestThreeDSecure = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.SetupFutureUsage;
+        export type ThreeDSecure = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure;
+        export namespace Installments {
+          export type Plan = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+        export namespace ThreeDSecure {
+          export type AresTransStatus = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.AresTransStatus;
+          export type ElectronicCommerceIndicator = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type ExemptionIndicator = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.ExemptionIndicator;
+          export type NetworkOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions;
+          export type Version = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.Version;
+          export namespace NetworkOptions {
+            export type CartesBancaires = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires;
+            export namespace CartesBancaires {
+              export type CbAvalgo = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires.CbAvalgo;
+            }
+          }
+        }
+      }
+      export namespace CardPresent {
+        export type CaptureMethod = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CardPresent.CaptureMethod;
+        export type Routing = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CardPresent.Routing;
+        export namespace Routing {
+          export type RequestedPriority = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CardPresent.Routing.RequestedPriority;
+        }
+      }
+      export namespace Cashapp {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Cashapp.SetupFutureUsage;
+      }
+      export namespace CustomerBalance {
+        export type BankTransfer = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer;
+        export namespace BankTransfer {
+          export type EuBankTransfer = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          export type RequestedAddressType = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.RequestedAddressType;
+          export type Type = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.Type;
+        }
+      }
+      export namespace Ideal {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Ideal.SetupFutureUsage;
+      }
+      export namespace KakaoPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.KakaoPay.SetupFutureUsage;
+      }
+      export namespace Klarna {
+        export type OnDemand = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.OnDemand;
+        export type PreferredLocale = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.PreferredLocale;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.SetupFutureUsage;
+        export type Subscription = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.Subscription;
+        export namespace OnDemand {
+          export type PurchaseInterval = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.OnDemand.PurchaseInterval;
+        }
+        export namespace Subscription {
+          export type Interval = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+          export type NextBilling = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+        }
+      }
+      export namespace KrCard {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.KrCard.SetupFutureUsage;
+      }
+      export namespace Link {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Link.SetupFutureUsage;
+      }
+      export namespace NaverPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.NaverPay.SetupFutureUsage;
+      }
+      export namespace NzBankAccount {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.NzBankAccount.SetupFutureUsage;
+      }
+      export namespace Paypal {
+        export type PreferredLocale = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Paypal.PreferredLocale;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Paypal.SetupFutureUsage;
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payto.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type AmountIncludesIof = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix.AmountIncludesIof;
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace RevolutPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.RevolutPay.SetupFutureUsage;
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.SepaDebit.SetupFutureUsage;
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Sofort.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Sofort.SetupFutureUsage;
+      }
+      export namespace Twint {
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Twint.SetupFutureUsage;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Upi.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type Networks = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks;
+        export type SetupFutureUsage = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.SetupFutureUsage;
+        export type TransactionPurpose = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.TransactionPurpose;
+        export type VerificationMethod = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+        export namespace Networks {
+          export type Requested = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks.Requested;
+        }
+      }
+      export namespace WechatPay {
+        export type Client = Stripe.PaymentIntentCreateParams.PaymentMethodOptions.WechatPay.Client;
+      }
+    }
+    export namespace TransferData {
+      export type PaymentData = Stripe.PaymentIntentCreateParams.TransferData.PaymentData;
+    }
   }
   export namespace PaymentIntentUpdateParams {
     export type AmountDetails = Stripe.PaymentIntentUpdateParams.AmountDetails;
@@ -765,6 +3432,361 @@ declare namespace StripeConstructor {
     export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.SetupFutureUsage;
     export type Shipping = Stripe.PaymentIntentUpdateParams.Shipping;
     export type TransferData = Stripe.PaymentIntentUpdateParams.TransferData;
+    export namespace AmountDetails {
+      export type LineItem = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem;
+      export type Shipping = Stripe.PaymentIntentUpdateParams.AmountDetails.Shipping;
+      export type Tax = Stripe.PaymentIntentUpdateParams.AmountDetails.Tax;
+      export namespace LineItem {
+        export type PaymentMethodOptions = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.PaymentMethodOptions;
+        export type Tax = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.Tax;
+        export namespace PaymentMethodOptions {
+          export type Card = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.PaymentMethodOptions.Card;
+          export type CardPresent = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.PaymentMethodOptions.CardPresent;
+          export type Klarna = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.PaymentMethodOptions.Klarna;
+          export type Paypal = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal;
+          export namespace Paypal {
+            export type Category = Stripe.PaymentIntentUpdateParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal.Category;
+          }
+        }
+      }
+    }
+    export namespace Hooks {
+      export type Inputs = Stripe.PaymentIntentUpdateParams.Hooks.Inputs;
+      export namespace Inputs {
+        export type Tax = Stripe.PaymentIntentUpdateParams.Hooks.Inputs.Tax;
+      }
+    }
+    export namespace PaymentMethodData {
+      export type AcssDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodData.AcssDebit;
+      export type Affirm = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Alipay;
+      export type AllowRedisplay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.AllowRedisplay;
+      export type Alma = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Alma;
+      export type AmazonPay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodData.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodData.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Bancontact;
+      export type Billie = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Billie;
+      export type BillingDetails = Stripe.PaymentIntentUpdateParams.PaymentMethodData.BillingDetails;
+      export type Bizum = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Bizum;
+      export type Blik = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Blik;
+      export type Boleto = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Boleto;
+      export type Cashapp = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Cashapp;
+      export type Crypto = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntentUpdateParams.PaymentMethodData.CustomerBalance;
+      export type Eps = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Eps;
+      export type Fpx = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Fpx;
+      export type Giropay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Giropay;
+      export type Grabpay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Grabpay;
+      export type Ideal = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Ideal;
+      export type InteracPresent = Stripe.PaymentIntentUpdateParams.PaymentMethodData.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.KakaoPay;
+      export type Klarna = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Klarna;
+      export type Konbini = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Konbini;
+      export type KrCard = Stripe.PaymentIntentUpdateParams.PaymentMethodData.KrCard;
+      export type Link = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Link;
+      export type MbWay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.MbWay;
+      export type Mobilepay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Multibanco;
+      export type NaverPay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntentUpdateParams.PaymentMethodData.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Oxxo;
+      export type P24 = Stripe.PaymentIntentUpdateParams.PaymentMethodData.P24;
+      export type PayByBank = Stripe.PaymentIntentUpdateParams.PaymentMethodData.PayByBank;
+      export type Payco = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Payco;
+      export type Paynow = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Paynow;
+      export type Paypal = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Paypal;
+      export type Payto = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Payto;
+      export type Pix = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Pix;
+      export type Promptpay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Promptpay;
+      export type RadarOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodData.RadarOptions;
+      export type RevolutPay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.SamsungPay;
+      export type Satispay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Satispay;
+      export type Scalapay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodData.SepaDebit;
+      export type Sofort = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Sofort;
+      export type Sunbit = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Sunbit;
+      export type Swish = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Swish;
+      export type Twint = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Twint;
+      export type Type = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Type;
+      export type Upi = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Upi;
+      export type UsBankAccount = Stripe.PaymentIntentUpdateParams.PaymentMethodData.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntentUpdateParams.PaymentMethodData.WechatPay;
+      export type Zip = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Zip;
+      export namespace Eps {
+        export type Bank = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Fpx.AccountHolderType;
+        export type Bank = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Ideal.Bank;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Klarna.Dob;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.PaymentIntentUpdateParams.PaymentMethodData.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.PaymentIntentUpdateParams.PaymentMethodData.P24.Bank;
+      }
+      export namespace Sofort {
+        export type Country = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Sofort.Country;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentUpdateParams.PaymentMethodData.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.PaymentIntentUpdateParams.PaymentMethodData.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.PaymentIntentUpdateParams.PaymentMethodData.UsBankAccount.AccountType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AcssDebit;
+      export type Affirm = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Alipay;
+      export type Alma = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Alma;
+      export type AmazonPay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Bancontact;
+      export type Billie = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Billie;
+      export type Bizum = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Bizum;
+      export type Blik = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Blik;
+      export type Boleto = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Boleto;
+      export type Card = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent;
+      export type Cashapp = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Cashapp;
+      export type Crypto = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CustomerBalance;
+      export type Eps = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Eps;
+      export type Fpx = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Fpx;
+      export type Giropay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Giropay;
+      export type Grabpay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Grabpay;
+      export type Ideal = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Ideal;
+      export type InteracPresent = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.KakaoPay;
+      export type Klarna = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna;
+      export type Konbini = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Konbini;
+      export type KrCard = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.KrCard;
+      export type Link = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Link;
+      export type MbWay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.MbWay;
+      export type Mobilepay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Multibanco;
+      export type NaverPay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Oxxo;
+      export type P24 = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.P24;
+      export type PayByBank = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.PayByBank;
+      export type Payco = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payco;
+      export type Paynow = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Paynow;
+      export type Paypal = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix;
+      export type Promptpay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Promptpay;
+      export type RevolutPay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.SamsungPay;
+      export type Satispay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Satispay;
+      export type Scalapay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.SepaDebit;
+      export type Sofort = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Sofort;
+      export type Swish = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Swish;
+      export type Twint = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Twint;
+      export type Upi = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.WechatPay;
+      export type Zip = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Zip;
+      export namespace AcssDebit {
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AcssDebit.SetupFutureUsage;
+        export type VerificationMethod = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type PaymentSchedule = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace Alipay {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Alipay.SetupFutureUsage;
+      }
+      export namespace AmazonPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AmazonPay.SetupFutureUsage;
+      }
+      export namespace AuBecsDebit {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.AuBecsDebit.SetupFutureUsage;
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.BacsDebit.SetupFutureUsage;
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Bancontact.SetupFutureUsage;
+      }
+      export namespace Boleto {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Boleto.SetupFutureUsage;
+      }
+      export namespace Card {
+        export type Installments = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments;
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.Network;
+        export type RequestExtendedAuthorization = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.RequestExtendedAuthorization;
+        export type RequestIncrementalAuthorization = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.RequestIncrementalAuthorization;
+        export type RequestMulticapture = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.RequestMulticapture;
+        export type RequestOvercapture = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.RequestOvercapture;
+        export type RequestThreeDSecure = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.SetupFutureUsage;
+        export type ThreeDSecure = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure;
+        export namespace Installments {
+          export type Plan = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+        export namespace ThreeDSecure {
+          export type AresTransStatus = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.AresTransStatus;
+          export type ElectronicCommerceIndicator = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type ExemptionIndicator = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.ExemptionIndicator;
+          export type NetworkOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions;
+          export type Version = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.Version;
+          export namespace NetworkOptions {
+            export type CartesBancaires = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires;
+            export namespace CartesBancaires {
+              export type CbAvalgo = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires.CbAvalgo;
+            }
+          }
+        }
+      }
+      export namespace CardPresent {
+        export type CaptureMethod = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent.CaptureMethod;
+        export type Routing = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent.Routing;
+        export namespace Routing {
+          export type RequestedPriority = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CardPresent.Routing.RequestedPriority;
+        }
+      }
+      export namespace Cashapp {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Cashapp.SetupFutureUsage;
+      }
+      export namespace CustomerBalance {
+        export type BankTransfer = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CustomerBalance.BankTransfer;
+        export namespace BankTransfer {
+          export type EuBankTransfer = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          export type RequestedAddressType = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.RequestedAddressType;
+          export type Type = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.Type;
+        }
+      }
+      export namespace Ideal {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Ideal.SetupFutureUsage;
+      }
+      export namespace KakaoPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.KakaoPay.SetupFutureUsage;
+      }
+      export namespace Klarna {
+        export type OnDemand = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.OnDemand;
+        export type PreferredLocale = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.PreferredLocale;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.SetupFutureUsage;
+        export type Subscription = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.Subscription;
+        export namespace OnDemand {
+          export type PurchaseInterval = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.OnDemand.PurchaseInterval;
+        }
+        export namespace Subscription {
+          export type Interval = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+          export type NextBilling = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+        }
+      }
+      export namespace KrCard {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.KrCard.SetupFutureUsage;
+      }
+      export namespace Link {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Link.SetupFutureUsage;
+      }
+      export namespace NaverPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.NaverPay.SetupFutureUsage;
+      }
+      export namespace NzBankAccount {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.NzBankAccount.SetupFutureUsage;
+      }
+      export namespace Paypal {
+        export type PreferredLocale = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Paypal.PreferredLocale;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Paypal.SetupFutureUsage;
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payto.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type AmountIncludesIof = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix.AmountIncludesIof;
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace RevolutPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.RevolutPay.SetupFutureUsage;
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.SepaDebit.SetupFutureUsage;
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Sofort.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Sofort.SetupFutureUsage;
+      }
+      export namespace Twint {
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Twint.SetupFutureUsage;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Upi.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type Networks = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks;
+        export type SetupFutureUsage = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.SetupFutureUsage;
+        export type TransactionPurpose = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.TransactionPurpose;
+        export type VerificationMethod = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+        export namespace Networks {
+          export type Requested = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks.Requested;
+        }
+      }
+      export namespace WechatPay {
+        export type Client = Stripe.PaymentIntentUpdateParams.PaymentMethodOptions.WechatPay.Client;
+      }
+    }
+    export namespace TransferData {
+      export type PaymentData = Stripe.PaymentIntentUpdateParams.TransferData.PaymentData;
+    }
   }
   export namespace PaymentIntentCancelParams {
     export type CancellationReason = Stripe.PaymentIntentCancelParams.CancellationReason;
@@ -774,6 +3796,30 @@ declare namespace StripeConstructor {
     export type Hooks = Stripe.PaymentIntentCaptureParams.Hooks;
     export type PaymentDetails = Stripe.PaymentIntentCaptureParams.PaymentDetails;
     export type TransferData = Stripe.PaymentIntentCaptureParams.TransferData;
+    export namespace AmountDetails {
+      export type LineItem = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem;
+      export type Shipping = Stripe.PaymentIntentCaptureParams.AmountDetails.Shipping;
+      export type Tax = Stripe.PaymentIntentCaptureParams.AmountDetails.Tax;
+      export namespace LineItem {
+        export type PaymentMethodOptions = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.PaymentMethodOptions;
+        export type Tax = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.Tax;
+        export namespace PaymentMethodOptions {
+          export type Card = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.PaymentMethodOptions.Card;
+          export type CardPresent = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.PaymentMethodOptions.CardPresent;
+          export type Klarna = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.PaymentMethodOptions.Klarna;
+          export type Paypal = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal;
+          export namespace Paypal {
+            export type Category = Stripe.PaymentIntentCaptureParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal.Category;
+          }
+        }
+      }
+    }
+    export namespace Hooks {
+      export type Inputs = Stripe.PaymentIntentCaptureParams.Hooks.Inputs;
+      export namespace Inputs {
+        export type Tax = Stripe.PaymentIntentCaptureParams.Hooks.Inputs.Tax;
+      }
+    }
   }
   export namespace PaymentIntentConfirmParams {
     export type AmountDetails = Stripe.PaymentIntentConfirmParams.AmountDetails;
@@ -788,12 +3834,716 @@ declare namespace StripeConstructor {
     export type RadarOptions = Stripe.PaymentIntentConfirmParams.RadarOptions;
     export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.SetupFutureUsage;
     export type Shipping = Stripe.PaymentIntentConfirmParams.Shipping;
+    export namespace AmountDetails {
+      export type LineItem = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem;
+      export type Shipping = Stripe.PaymentIntentConfirmParams.AmountDetails.Shipping;
+      export type Tax = Stripe.PaymentIntentConfirmParams.AmountDetails.Tax;
+      export namespace LineItem {
+        export type PaymentMethodOptions = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.PaymentMethodOptions;
+        export type Tax = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.Tax;
+        export namespace PaymentMethodOptions {
+          export type Card = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.PaymentMethodOptions.Card;
+          export type CardPresent = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.PaymentMethodOptions.CardPresent;
+          export type Klarna = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.PaymentMethodOptions.Klarna;
+          export type Paypal = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal;
+          export namespace Paypal {
+            export type Category = Stripe.PaymentIntentConfirmParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal.Category;
+          }
+        }
+      }
+    }
+    export namespace Hooks {
+      export type Inputs = Stripe.PaymentIntentConfirmParams.Hooks.Inputs;
+      export namespace Inputs {
+        export type Tax = Stripe.PaymentIntentConfirmParams.Hooks.Inputs.Tax;
+      }
+    }
+    export namespace MandateData {
+      export type CustomerAcceptance = Stripe.PaymentIntentConfirmParams.MandateData.CustomerAcceptance;
+      export namespace CustomerAcceptance {
+        export type Offline = Stripe.PaymentIntentConfirmParams.MandateData.CustomerAcceptance.Offline;
+        export type Online = Stripe.PaymentIntentConfirmParams.MandateData.CustomerAcceptance.Online;
+        export type Type = Stripe.PaymentIntentConfirmParams.MandateData.CustomerAcceptance.Type;
+      }
+    }
+    export namespace PaymentMethodData {
+      export type AcssDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodData.AcssDebit;
+      export type Affirm = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Alipay;
+      export type AllowRedisplay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.AllowRedisplay;
+      export type Alma = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Alma;
+      export type AmazonPay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodData.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodData.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Bancontact;
+      export type Billie = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Billie;
+      export type BillingDetails = Stripe.PaymentIntentConfirmParams.PaymentMethodData.BillingDetails;
+      export type Bizum = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Bizum;
+      export type Blik = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Blik;
+      export type Boleto = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Boleto;
+      export type Cashapp = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Cashapp;
+      export type Crypto = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntentConfirmParams.PaymentMethodData.CustomerBalance;
+      export type Eps = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Eps;
+      export type Fpx = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Fpx;
+      export type Giropay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Giropay;
+      export type Grabpay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Grabpay;
+      export type Ideal = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Ideal;
+      export type InteracPresent = Stripe.PaymentIntentConfirmParams.PaymentMethodData.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.KakaoPay;
+      export type Klarna = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Klarna;
+      export type Konbini = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Konbini;
+      export type KrCard = Stripe.PaymentIntentConfirmParams.PaymentMethodData.KrCard;
+      export type Link = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Link;
+      export type MbWay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.MbWay;
+      export type Mobilepay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Multibanco;
+      export type NaverPay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntentConfirmParams.PaymentMethodData.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Oxxo;
+      export type P24 = Stripe.PaymentIntentConfirmParams.PaymentMethodData.P24;
+      export type PayByBank = Stripe.PaymentIntentConfirmParams.PaymentMethodData.PayByBank;
+      export type Payco = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Payco;
+      export type Paynow = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Paynow;
+      export type Paypal = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Paypal;
+      export type Payto = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Payto;
+      export type Pix = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Pix;
+      export type Promptpay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Promptpay;
+      export type RadarOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodData.RadarOptions;
+      export type RevolutPay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.SamsungPay;
+      export type Satispay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Satispay;
+      export type Scalapay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodData.SepaDebit;
+      export type Sofort = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Sofort;
+      export type Sunbit = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Sunbit;
+      export type Swish = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Swish;
+      export type Twint = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Twint;
+      export type Type = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Type;
+      export type Upi = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Upi;
+      export type UsBankAccount = Stripe.PaymentIntentConfirmParams.PaymentMethodData.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntentConfirmParams.PaymentMethodData.WechatPay;
+      export type Zip = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Zip;
+      export namespace Eps {
+        export type Bank = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Fpx.AccountHolderType;
+        export type Bank = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Ideal.Bank;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Klarna.Dob;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.PaymentIntentConfirmParams.PaymentMethodData.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.PaymentIntentConfirmParams.PaymentMethodData.P24.Bank;
+      }
+      export namespace Sofort {
+        export type Country = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Sofort.Country;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentConfirmParams.PaymentMethodData.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.PaymentIntentConfirmParams.PaymentMethodData.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.PaymentIntentConfirmParams.PaymentMethodData.UsBankAccount.AccountType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AcssDebit;
+      export type Affirm = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Alipay;
+      export type Alma = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Alma;
+      export type AmazonPay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Bancontact;
+      export type Billie = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Billie;
+      export type Bizum = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Bizum;
+      export type Blik = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Blik;
+      export type Boleto = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Boleto;
+      export type Card = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent;
+      export type Cashapp = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Cashapp;
+      export type Crypto = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CustomerBalance;
+      export type Eps = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Eps;
+      export type Fpx = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Fpx;
+      export type Giropay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Giropay;
+      export type Grabpay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Grabpay;
+      export type Ideal = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Ideal;
+      export type InteracPresent = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.KakaoPay;
+      export type Klarna = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna;
+      export type Konbini = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Konbini;
+      export type KrCard = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.KrCard;
+      export type Link = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Link;
+      export type MbWay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.MbWay;
+      export type Mobilepay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Multibanco;
+      export type NaverPay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Oxxo;
+      export type P24 = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.P24;
+      export type PayByBank = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.PayByBank;
+      export type Payco = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payco;
+      export type Paynow = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Paynow;
+      export type Paypal = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix;
+      export type Promptpay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Promptpay;
+      export type RevolutPay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.SamsungPay;
+      export type Satispay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Satispay;
+      export type Scalapay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.SepaDebit;
+      export type Sofort = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Sofort;
+      export type Swish = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Swish;
+      export type Twint = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Twint;
+      export type Upi = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.WechatPay;
+      export type Zip = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Zip;
+      export namespace AcssDebit {
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AcssDebit.SetupFutureUsage;
+        export type VerificationMethod = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type PaymentSchedule = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace Alipay {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Alipay.SetupFutureUsage;
+      }
+      export namespace AmazonPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AmazonPay.SetupFutureUsage;
+      }
+      export namespace AuBecsDebit {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.AuBecsDebit.SetupFutureUsage;
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.BacsDebit.SetupFutureUsage;
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Bancontact.SetupFutureUsage;
+      }
+      export namespace Boleto {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Boleto.SetupFutureUsage;
+      }
+      export namespace Card {
+        export type Installments = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments;
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.Network;
+        export type RequestExtendedAuthorization = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.RequestExtendedAuthorization;
+        export type RequestIncrementalAuthorization = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.RequestIncrementalAuthorization;
+        export type RequestMulticapture = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.RequestMulticapture;
+        export type RequestOvercapture = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.RequestOvercapture;
+        export type RequestThreeDSecure = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.SetupFutureUsage;
+        export type ThreeDSecure = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure;
+        export namespace Installments {
+          export type Plan = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+        export namespace ThreeDSecure {
+          export type AresTransStatus = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.AresTransStatus;
+          export type ElectronicCommerceIndicator = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type ExemptionIndicator = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.ExemptionIndicator;
+          export type NetworkOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions;
+          export type Version = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.Version;
+          export namespace NetworkOptions {
+            export type CartesBancaires = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires;
+            export namespace CartesBancaires {
+              export type CbAvalgo = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires.CbAvalgo;
+            }
+          }
+        }
+      }
+      export namespace CardPresent {
+        export type CaptureMethod = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent.CaptureMethod;
+        export type Routing = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent.Routing;
+        export namespace Routing {
+          export type RequestedPriority = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CardPresent.Routing.RequestedPriority;
+        }
+      }
+      export namespace Cashapp {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Cashapp.SetupFutureUsage;
+      }
+      export namespace CustomerBalance {
+        export type BankTransfer = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CustomerBalance.BankTransfer;
+        export namespace BankTransfer {
+          export type EuBankTransfer = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          export type RequestedAddressType = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CustomerBalance.BankTransfer.RequestedAddressType;
+          export type Type = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.CustomerBalance.BankTransfer.Type;
+        }
+      }
+      export namespace Ideal {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Ideal.SetupFutureUsage;
+      }
+      export namespace KakaoPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.KakaoPay.SetupFutureUsage;
+      }
+      export namespace Klarna {
+        export type OnDemand = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.OnDemand;
+        export type PreferredLocale = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.PreferredLocale;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.SetupFutureUsage;
+        export type Subscription = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.Subscription;
+        export namespace OnDemand {
+          export type PurchaseInterval = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.OnDemand.PurchaseInterval;
+        }
+        export namespace Subscription {
+          export type Interval = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+          export type NextBilling = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+        }
+      }
+      export namespace KrCard {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.KrCard.SetupFutureUsage;
+      }
+      export namespace Link {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Link.SetupFutureUsage;
+      }
+      export namespace NaverPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.NaverPay.SetupFutureUsage;
+      }
+      export namespace NzBankAccount {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.NzBankAccount.SetupFutureUsage;
+      }
+      export namespace Paypal {
+        export type PreferredLocale = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Paypal.PreferredLocale;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Paypal.SetupFutureUsage;
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payto.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type AmountIncludesIof = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix.AmountIncludesIof;
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace RevolutPay {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.RevolutPay.SetupFutureUsage;
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.SepaDebit.SetupFutureUsage;
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Sofort.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Sofort.SetupFutureUsage;
+      }
+      export namespace Twint {
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Twint.SetupFutureUsage;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Upi.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type Networks = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks;
+        export type SetupFutureUsage = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.SetupFutureUsage;
+        export type TransactionPurpose = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.TransactionPurpose;
+        export type VerificationMethod = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+        export namespace Networks {
+          export type Requested = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks.Requested;
+        }
+      }
+      export namespace WechatPay {
+        export type Client = Stripe.PaymentIntentConfirmParams.PaymentMethodOptions.WechatPay.Client;
+      }
+    }
   }
   export namespace PaymentIntentIncrementAuthorizationParams {
     export type AmountDetails = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails;
     export type Hooks = Stripe.PaymentIntentIncrementAuthorizationParams.Hooks;
     export type PaymentDetails = Stripe.PaymentIntentIncrementAuthorizationParams.PaymentDetails;
     export type TransferData = Stripe.PaymentIntentIncrementAuthorizationParams.TransferData;
+    export namespace AmountDetails {
+      export type LineItem = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem;
+      export type Shipping = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.Shipping;
+      export type Tax = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.Tax;
+      export namespace LineItem {
+        export type PaymentMethodOptions = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.PaymentMethodOptions;
+        export type Tax = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.Tax;
+        export namespace PaymentMethodOptions {
+          export type Card = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.PaymentMethodOptions.Card;
+          export type CardPresent = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.PaymentMethodOptions.CardPresent;
+          export type Klarna = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.PaymentMethodOptions.Klarna;
+          export type Paypal = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal;
+          export namespace Paypal {
+            export type Category = Stripe.PaymentIntentIncrementAuthorizationParams.AmountDetails.LineItem.PaymentMethodOptions.Paypal.Category;
+          }
+        }
+      }
+    }
+    export namespace Hooks {
+      export type Inputs = Stripe.PaymentIntentIncrementAuthorizationParams.Hooks.Inputs;
+      export namespace Inputs {
+        export type Tax = Stripe.PaymentIntentIncrementAuthorizationParams.Hooks.Inputs.Tax;
+      }
+    }
+  }
+  export namespace PaymentIntent {
+    export type AmountDetails = Stripe.PaymentIntent.AmountDetails;
+    export type AutomaticPaymentMethods = Stripe.PaymentIntent.AutomaticPaymentMethods;
+    export type CancellationReason = Stripe.PaymentIntent.CancellationReason;
+    export type CaptureMethod = Stripe.PaymentIntent.CaptureMethod;
+    export type ConfirmationMethod = Stripe.PaymentIntent.ConfirmationMethod;
+    export type ExcludedPaymentMethodType = Stripe.PaymentIntent.ExcludedPaymentMethodType;
+    export type Hooks = Stripe.PaymentIntent.Hooks;
+    export type LastPaymentError = Stripe.PaymentIntent.LastPaymentError;
+    export type ManagedPayments = Stripe.PaymentIntent.ManagedPayments;
+    export type NextAction = Stripe.PaymentIntent.NextAction;
+    export type PaymentDetails = Stripe.PaymentIntent.PaymentDetails;
+    export type PaymentMethodConfigurationDetails = Stripe.PaymentIntent.PaymentMethodConfigurationDetails;
+    export type PaymentMethodOptions = Stripe.PaymentIntent.PaymentMethodOptions;
+    export type PresentmentDetails = Stripe.PaymentIntent.PresentmentDetails;
+    export type Processing = Stripe.PaymentIntent.Processing;
+    export type SetupFutureUsage = Stripe.PaymentIntent.SetupFutureUsage;
+    export type Shipping = Stripe.PaymentIntent.Shipping;
+    export type Status = Stripe.PaymentIntent.Status;
+    export type TransferData = Stripe.PaymentIntent.TransferData;
+    export namespace AmountDetails {
+      export type Error = Stripe.PaymentIntent.AmountDetails.Error;
+      export type Shipping = Stripe.PaymentIntent.AmountDetails.Shipping;
+      export type Tax = Stripe.PaymentIntent.AmountDetails.Tax;
+      export type Tip = Stripe.PaymentIntent.AmountDetails.Tip;
+      export namespace Error {
+        export type Code = Stripe.PaymentIntent.AmountDetails.Error.Code;
+      }
+    }
+    export namespace AutomaticPaymentMethods {
+      export type AllowRedirects = Stripe.PaymentIntent.AutomaticPaymentMethods.AllowRedirects;
+    }
+    export namespace Hooks {
+      export type Inputs = Stripe.PaymentIntent.Hooks.Inputs;
+      export namespace Inputs {
+        export type Tax = Stripe.PaymentIntent.Hooks.Inputs.Tax;
+      }
+    }
+    export namespace LastPaymentError {
+      export type Code = Stripe.PaymentIntent.LastPaymentError.Code;
+      export type Type = Stripe.PaymentIntent.LastPaymentError.Type;
+    }
+    export namespace NextAction {
+      export type AlipayHandleRedirect = Stripe.PaymentIntent.NextAction.AlipayHandleRedirect;
+      export type BlikAuthorize = Stripe.PaymentIntent.NextAction.BlikAuthorize;
+      export type BoletoDisplayDetails = Stripe.PaymentIntent.NextAction.BoletoDisplayDetails;
+      export type CardAwaitNotification = Stripe.PaymentIntent.NextAction.CardAwaitNotification;
+      export type CashappHandleRedirectOrDisplayQrCode = Stripe.PaymentIntent.NextAction.CashappHandleRedirectOrDisplayQrCode;
+      export type DisplayBankTransferInstructions = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions;
+      export type KlarnaDisplayQrCode = Stripe.PaymentIntent.NextAction.KlarnaDisplayQrCode;
+      export type KonbiniDisplayDetails = Stripe.PaymentIntent.NextAction.KonbiniDisplayDetails;
+      export type MultibancoDisplayDetails = Stripe.PaymentIntent.NextAction.MultibancoDisplayDetails;
+      export type OxxoDisplayDetails = Stripe.PaymentIntent.NextAction.OxxoDisplayDetails;
+      export type PaynowDisplayQrCode = Stripe.PaymentIntent.NextAction.PaynowDisplayQrCode;
+      export type PixDisplayQrCode = Stripe.PaymentIntent.NextAction.PixDisplayQrCode;
+      export type PromptpayDisplayQrCode = Stripe.PaymentIntent.NextAction.PromptpayDisplayQrCode;
+      export type RedirectToUrl = Stripe.PaymentIntent.NextAction.RedirectToUrl;
+      export type SwishHandleRedirectOrDisplayQrCode = Stripe.PaymentIntent.NextAction.SwishHandleRedirectOrDisplayQrCode;
+      export type UpiHandleRedirectOrDisplayQrCode = Stripe.PaymentIntent.NextAction.UpiHandleRedirectOrDisplayQrCode;
+      export type UseStripeSdk = Stripe.PaymentIntent.NextAction.UseStripeSdk;
+      export type VerifyWithMicrodeposits = Stripe.PaymentIntent.NextAction.VerifyWithMicrodeposits;
+      export type WechatPayDisplayQrCode = Stripe.PaymentIntent.NextAction.WechatPayDisplayQrCode;
+      export type WechatPayRedirectToAndroidApp = Stripe.PaymentIntent.NextAction.WechatPayRedirectToAndroidApp;
+      export type WechatPayRedirectToIosApp = Stripe.PaymentIntent.NextAction.WechatPayRedirectToIosApp;
+      export namespace CashappHandleRedirectOrDisplayQrCode {
+        export type QrCode = Stripe.PaymentIntent.NextAction.CashappHandleRedirectOrDisplayQrCode.QrCode;
+      }
+      export namespace DisplayBankTransferInstructions {
+        export type FinancialAddress = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress;
+        export type Type = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.Type;
+        export namespace FinancialAddress {
+          export type Aba = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.Aba;
+          export type Iban = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.Iban;
+          export type SortCode = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.SortCode;
+          export type Spei = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.Spei;
+          export type SupportedNetwork = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.SupportedNetwork;
+          export type Swift = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.Swift;
+          export type Type = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.Type;
+          export type Zengin = Stripe.PaymentIntent.NextAction.DisplayBankTransferInstructions.FinancialAddress.Zengin;
+        }
+      }
+      export namespace KonbiniDisplayDetails {
+        export type Stores = Stripe.PaymentIntent.NextAction.KonbiniDisplayDetails.Stores;
+        export namespace Stores {
+          export type Familymart = Stripe.PaymentIntent.NextAction.KonbiniDisplayDetails.Stores.Familymart;
+          export type Lawson = Stripe.PaymentIntent.NextAction.KonbiniDisplayDetails.Stores.Lawson;
+          export type Ministop = Stripe.PaymentIntent.NextAction.KonbiniDisplayDetails.Stores.Ministop;
+          export type Seicomart = Stripe.PaymentIntent.NextAction.KonbiniDisplayDetails.Stores.Seicomart;
+        }
+      }
+      export namespace SwishHandleRedirectOrDisplayQrCode {
+        export type QrCode = Stripe.PaymentIntent.NextAction.SwishHandleRedirectOrDisplayQrCode.QrCode;
+      }
+      export namespace UpiHandleRedirectOrDisplayQrCode {
+        export type QrCode = Stripe.PaymentIntent.NextAction.UpiHandleRedirectOrDisplayQrCode.QrCode;
+      }
+      export namespace VerifyWithMicrodeposits {
+        export type MicrodepositType = Stripe.PaymentIntent.NextAction.VerifyWithMicrodeposits.MicrodepositType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.PaymentIntent.PaymentMethodOptions.AcssDebit;
+      export type Affirm = Stripe.PaymentIntent.PaymentMethodOptions.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentIntent.PaymentMethodOptions.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentIntent.PaymentMethodOptions.Alipay;
+      export type Alma = Stripe.PaymentIntent.PaymentMethodOptions.Alma;
+      export type AmazonPay = Stripe.PaymentIntent.PaymentMethodOptions.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentIntent.PaymentMethodOptions.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentIntent.PaymentMethodOptions.BacsDebit;
+      export type Bancontact = Stripe.PaymentIntent.PaymentMethodOptions.Bancontact;
+      export type Billie = Stripe.PaymentIntent.PaymentMethodOptions.Billie;
+      export type Bizum = Stripe.PaymentIntent.PaymentMethodOptions.Bizum;
+      export type Blik = Stripe.PaymentIntent.PaymentMethodOptions.Blik;
+      export type Boleto = Stripe.PaymentIntent.PaymentMethodOptions.Boleto;
+      export type Card = Stripe.PaymentIntent.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.PaymentIntent.PaymentMethodOptions.CardPresent;
+      export type Cashapp = Stripe.PaymentIntent.PaymentMethodOptions.Cashapp;
+      export type Crypto = Stripe.PaymentIntent.PaymentMethodOptions.Crypto;
+      export type CustomerBalance = Stripe.PaymentIntent.PaymentMethodOptions.CustomerBalance;
+      export type Eps = Stripe.PaymentIntent.PaymentMethodOptions.Eps;
+      export type Fpx = Stripe.PaymentIntent.PaymentMethodOptions.Fpx;
+      export type Giropay = Stripe.PaymentIntent.PaymentMethodOptions.Giropay;
+      export type Grabpay = Stripe.PaymentIntent.PaymentMethodOptions.Grabpay;
+      export type Ideal = Stripe.PaymentIntent.PaymentMethodOptions.Ideal;
+      export type InteracPresent = Stripe.PaymentIntent.PaymentMethodOptions.InteracPresent;
+      export type KakaoPay = Stripe.PaymentIntent.PaymentMethodOptions.KakaoPay;
+      export type Klarna = Stripe.PaymentIntent.PaymentMethodOptions.Klarna;
+      export type Konbini = Stripe.PaymentIntent.PaymentMethodOptions.Konbini;
+      export type KrCard = Stripe.PaymentIntent.PaymentMethodOptions.KrCard;
+      export type Link = Stripe.PaymentIntent.PaymentMethodOptions.Link;
+      export type MbWay = Stripe.PaymentIntent.PaymentMethodOptions.MbWay;
+      export type Mobilepay = Stripe.PaymentIntent.PaymentMethodOptions.Mobilepay;
+      export type Multibanco = Stripe.PaymentIntent.PaymentMethodOptions.Multibanco;
+      export type NaverPay = Stripe.PaymentIntent.PaymentMethodOptions.NaverPay;
+      export type NzBankAccount = Stripe.PaymentIntent.PaymentMethodOptions.NzBankAccount;
+      export type Oxxo = Stripe.PaymentIntent.PaymentMethodOptions.Oxxo;
+      export type P24 = Stripe.PaymentIntent.PaymentMethodOptions.P24;
+      export type PayByBank = Stripe.PaymentIntent.PaymentMethodOptions.PayByBank;
+      export type Payco = Stripe.PaymentIntent.PaymentMethodOptions.Payco;
+      export type Paynow = Stripe.PaymentIntent.PaymentMethodOptions.Paynow;
+      export type Paypal = Stripe.PaymentIntent.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.PaymentIntent.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.PaymentIntent.PaymentMethodOptions.Pix;
+      export type Promptpay = Stripe.PaymentIntent.PaymentMethodOptions.Promptpay;
+      export type RevolutPay = Stripe.PaymentIntent.PaymentMethodOptions.RevolutPay;
+      export type SamsungPay = Stripe.PaymentIntent.PaymentMethodOptions.SamsungPay;
+      export type Satispay = Stripe.PaymentIntent.PaymentMethodOptions.Satispay;
+      export type Scalapay = Stripe.PaymentIntent.PaymentMethodOptions.Scalapay;
+      export type SepaDebit = Stripe.PaymentIntent.PaymentMethodOptions.SepaDebit;
+      export type Sofort = Stripe.PaymentIntent.PaymentMethodOptions.Sofort;
+      export type Swish = Stripe.PaymentIntent.PaymentMethodOptions.Swish;
+      export type Twint = Stripe.PaymentIntent.PaymentMethodOptions.Twint;
+      export type Upi = Stripe.PaymentIntent.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount;
+      export type WechatPay = Stripe.PaymentIntent.PaymentMethodOptions.WechatPay;
+      export type Zip = Stripe.PaymentIntent.PaymentMethodOptions.Zip;
+      export namespace AcssDebit {
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.AcssDebit.SetupFutureUsage;
+        export type VerificationMethod = Stripe.PaymentIntent.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type PaymentSchedule = Stripe.PaymentIntent.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.PaymentIntent.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace Alipay {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Alipay.SetupFutureUsage;
+      }
+      export namespace AmazonPay {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.AmazonPay.SetupFutureUsage;
+      }
+      export namespace AuBecsDebit {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.AuBecsDebit.SetupFutureUsage;
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.BacsDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.BacsDebit.SetupFutureUsage;
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.PaymentIntent.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Bancontact.SetupFutureUsage;
+      }
+      export namespace Boleto {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Boleto.SetupFutureUsage;
+      }
+      export namespace Card {
+        export type Installments = Stripe.PaymentIntent.PaymentMethodOptions.Card.Installments;
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.PaymentIntent.PaymentMethodOptions.Card.Network;
+        export type RequestExtendedAuthorization = Stripe.PaymentIntent.PaymentMethodOptions.Card.RequestExtendedAuthorization;
+        export type RequestIncrementalAuthorization = Stripe.PaymentIntent.PaymentMethodOptions.Card.RequestIncrementalAuthorization;
+        export type RequestMulticapture = Stripe.PaymentIntent.PaymentMethodOptions.Card.RequestMulticapture;
+        export type RequestOvercapture = Stripe.PaymentIntent.PaymentMethodOptions.Card.RequestOvercapture;
+        export type RequestThreeDSecure = Stripe.PaymentIntent.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Card.SetupFutureUsage;
+        export namespace Installments {
+          export type AvailablePlan = Stripe.PaymentIntent.PaymentMethodOptions.Card.Installments.AvailablePlan;
+          export type Plan = Stripe.PaymentIntent.PaymentMethodOptions.Card.Installments.Plan;
+          export namespace AvailablePlan {
+            export type Type = Stripe.PaymentIntent.PaymentMethodOptions.Card.Installments.AvailablePlan.Type;
+          }
+          export namespace Plan {
+            export type Type = Stripe.PaymentIntent.PaymentMethodOptions.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntent.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.PaymentIntent.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+      }
+      export namespace CardPresent {
+        export type CaptureMethod = Stripe.PaymentIntent.PaymentMethodOptions.CardPresent.CaptureMethod;
+        export type Routing = Stripe.PaymentIntent.PaymentMethodOptions.CardPresent.Routing;
+        export namespace Routing {
+          export type RequestedPriority = Stripe.PaymentIntent.PaymentMethodOptions.CardPresent.Routing.RequestedPriority;
+        }
+      }
+      export namespace Cashapp {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Cashapp.SetupFutureUsage;
+      }
+      export namespace CustomerBalance {
+        export type BankTransfer = Stripe.PaymentIntent.PaymentMethodOptions.CustomerBalance.BankTransfer;
+        export namespace BankTransfer {
+          export type EuBankTransfer = Stripe.PaymentIntent.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          export type RequestedAddressType = Stripe.PaymentIntent.PaymentMethodOptions.CustomerBalance.BankTransfer.RequestedAddressType;
+          export type Type = Stripe.PaymentIntent.PaymentMethodOptions.CustomerBalance.BankTransfer.Type;
+          export namespace EuBankTransfer {
+            export type Country = Stripe.PaymentIntent.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer.Country;
+          }
+        }
+      }
+      export namespace Ideal {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Ideal.SetupFutureUsage;
+      }
+      export namespace KakaoPay {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.KakaoPay.SetupFutureUsage;
+      }
+      export namespace Klarna {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Klarna.SetupFutureUsage;
+      }
+      export namespace KrCard {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.KrCard.SetupFutureUsage;
+      }
+      export namespace Link {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Link.SetupFutureUsage;
+      }
+      export namespace NaverPay {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.NaverPay.SetupFutureUsage;
+      }
+      export namespace NzBankAccount {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.NzBankAccount.SetupFutureUsage;
+      }
+      export namespace Paypal {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Paypal.SetupFutureUsage;
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.Payto.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Payto.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.PaymentIntent.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntent.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.PaymentIntent.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type AmountIncludesIof = Stripe.PaymentIntent.PaymentMethodOptions.Pix.AmountIncludesIof;
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.Pix.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Pix.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.PaymentIntent.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.PaymentIntent.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.PaymentIntent.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace RevolutPay {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.RevolutPay.SetupFutureUsage;
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.SepaDebit.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.SepaDebit.SetupFutureUsage;
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.PaymentIntent.PaymentMethodOptions.Sofort.PreferredLanguage;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Sofort.SetupFutureUsage;
+      }
+      export namespace Twint {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Twint.SetupFutureUsage;
+      }
+      export namespace Upi {
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.Upi.SetupFutureUsage;
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type SetupFutureUsage = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.SetupFutureUsage;
+        export type TransactionPurpose = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.TransactionPurpose;
+        export type VerificationMethod = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.PaymentIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+      }
+      export namespace WechatPay {
+        export type Client = Stripe.PaymentIntent.PaymentMethodOptions.WechatPay.Client;
+      }
+    }
+    export namespace Processing {
+      export type Card = Stripe.PaymentIntent.Processing.Card;
+      export namespace Card {
+        export type CustomerNotification = Stripe.PaymentIntent.Processing.Card.CustomerNotification;
+      }
+    }
+    export namespace TransferData {
+      export type PaymentData = Stripe.PaymentIntent.TransferData.PaymentData;
+    }
   }
   export namespace PaymentLinkCreateParams {
     export type LineItem = Stripe.PaymentLinkCreateParams.LineItem;
@@ -820,6 +4570,112 @@ declare namespace StripeConstructor {
     export type SubscriptionData = Stripe.PaymentLinkCreateParams.SubscriptionData;
     export type TaxIdCollection = Stripe.PaymentLinkCreateParams.TaxIdCollection;
     export type TransferData = Stripe.PaymentLinkCreateParams.TransferData;
+    export namespace AfterCompletion {
+      export type HostedConfirmation = Stripe.PaymentLinkCreateParams.AfterCompletion.HostedConfirmation;
+      export type Redirect = Stripe.PaymentLinkCreateParams.AfterCompletion.Redirect;
+      export type Type = Stripe.PaymentLinkCreateParams.AfterCompletion.Type;
+    }
+    export namespace AutomaticTax {
+      export type Liability = Stripe.PaymentLinkCreateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.PaymentLinkCreateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace ConsentCollection {
+      export type PaymentMethodReuseAgreement = Stripe.PaymentLinkCreateParams.ConsentCollection.PaymentMethodReuseAgreement;
+      export type Promotions = Stripe.PaymentLinkCreateParams.ConsentCollection.Promotions;
+      export type TermsOfService = Stripe.PaymentLinkCreateParams.ConsentCollection.TermsOfService;
+      export namespace PaymentMethodReuseAgreement {
+        export type Position = Stripe.PaymentLinkCreateParams.ConsentCollection.PaymentMethodReuseAgreement.Position;
+      }
+    }
+    export namespace CustomField {
+      export type Dropdown = Stripe.PaymentLinkCreateParams.CustomField.Dropdown;
+      export type Label = Stripe.PaymentLinkCreateParams.CustomField.Label;
+      export type Numeric = Stripe.PaymentLinkCreateParams.CustomField.Numeric;
+      export type Text = Stripe.PaymentLinkCreateParams.CustomField.Text;
+      export type Type = Stripe.PaymentLinkCreateParams.CustomField.Type;
+      export namespace Dropdown {
+        export type Option = Stripe.PaymentLinkCreateParams.CustomField.Dropdown.Option;
+      }
+    }
+    export namespace CustomText {
+      export type AfterSubmit = Stripe.PaymentLinkCreateParams.CustomText.AfterSubmit;
+      export type ShippingAddress = Stripe.PaymentLinkCreateParams.CustomText.ShippingAddress;
+      export type Submit = Stripe.PaymentLinkCreateParams.CustomText.Submit;
+      export type TermsOfServiceAcceptance = Stripe.PaymentLinkCreateParams.CustomText.TermsOfServiceAcceptance;
+    }
+    export namespace InvoiceCreation {
+      export type InvoiceData = Stripe.PaymentLinkCreateParams.InvoiceCreation.InvoiceData;
+      export namespace InvoiceData {
+        export type CustomField = Stripe.PaymentLinkCreateParams.InvoiceCreation.InvoiceData.CustomField;
+        export type Issuer = Stripe.PaymentLinkCreateParams.InvoiceCreation.InvoiceData.Issuer;
+        export type RenderingOptions = Stripe.PaymentLinkCreateParams.InvoiceCreation.InvoiceData.RenderingOptions;
+        export namespace Issuer {
+          export type Type = Stripe.PaymentLinkCreateParams.InvoiceCreation.InvoiceData.Issuer.Type;
+        }
+        export namespace RenderingOptions {
+          export type AmountTaxDisplay = Stripe.PaymentLinkCreateParams.InvoiceCreation.InvoiceData.RenderingOptions.AmountTaxDisplay;
+        }
+      }
+    }
+    export namespace LineItem {
+      export type AdjustableQuantity = Stripe.PaymentLinkCreateParams.LineItem.AdjustableQuantity;
+      export type PriceData = Stripe.PaymentLinkCreateParams.LineItem.PriceData;
+      export namespace PriceData {
+        export type ProductData = Stripe.PaymentLinkCreateParams.LineItem.PriceData.ProductData;
+        export type Recurring = Stripe.PaymentLinkCreateParams.LineItem.PriceData.Recurring;
+        export type TaxBehavior = Stripe.PaymentLinkCreateParams.LineItem.PriceData.TaxBehavior;
+        export namespace Recurring {
+          export type Interval = Stripe.PaymentLinkCreateParams.LineItem.PriceData.Recurring.Interval;
+        }
+      }
+    }
+    export namespace NameCollection {
+      export type Business = Stripe.PaymentLinkCreateParams.NameCollection.Business;
+      export type Individual = Stripe.PaymentLinkCreateParams.NameCollection.Individual;
+    }
+    export namespace OptionalItem {
+      export type AdjustableQuantity = Stripe.PaymentLinkCreateParams.OptionalItem.AdjustableQuantity;
+    }
+    export namespace PaymentIntentData {
+      export type CaptureMethod = Stripe.PaymentLinkCreateParams.PaymentIntentData.CaptureMethod;
+      export type SetupFutureUsage = Stripe.PaymentLinkCreateParams.PaymentIntentData.SetupFutureUsage;
+    }
+    export namespace PaymentMethodOptions {
+      export type Card = Stripe.PaymentLinkCreateParams.PaymentMethodOptions.Card;
+      export namespace Card {
+        export type Restrictions = Stripe.PaymentLinkCreateParams.PaymentMethodOptions.Card.Restrictions;
+        export namespace Restrictions {
+          export type BrandsBlocked = Stripe.PaymentLinkCreateParams.PaymentMethodOptions.Card.Restrictions.BrandsBlocked;
+        }
+      }
+    }
+    export namespace Restrictions {
+      export type CompletedSessions = Stripe.PaymentLinkCreateParams.Restrictions.CompletedSessions;
+    }
+    export namespace ShippingAddressCollection {
+      export type AllowedCountry = Stripe.PaymentLinkCreateParams.ShippingAddressCollection.AllowedCountry;
+    }
+    export namespace SubscriptionData {
+      export type InvoiceSettings = Stripe.PaymentLinkCreateParams.SubscriptionData.InvoiceSettings;
+      export type TrialSettings = Stripe.PaymentLinkCreateParams.SubscriptionData.TrialSettings;
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.PaymentLinkCreateParams.SubscriptionData.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.PaymentLinkCreateParams.SubscriptionData.InvoiceSettings.Issuer.Type;
+        }
+      }
+      export namespace TrialSettings {
+        export type EndBehavior = Stripe.PaymentLinkCreateParams.SubscriptionData.TrialSettings.EndBehavior;
+        export namespace EndBehavior {
+          export type MissingPaymentMethod = Stripe.PaymentLinkCreateParams.SubscriptionData.TrialSettings.EndBehavior.MissingPaymentMethod;
+        }
+      }
+    }
+    export namespace TaxIdCollection {
+      export type Required = Stripe.PaymentLinkCreateParams.TaxIdCollection.Required;
+    }
   }
   export namespace PaymentLinkUpdateParams {
     export type AfterCompletion = Stripe.PaymentLinkUpdateParams.AfterCompletion;
@@ -842,6 +4698,207 @@ declare namespace StripeConstructor {
     export type SubmitType = Stripe.PaymentLinkUpdateParams.SubmitType;
     export type SubscriptionData = Stripe.PaymentLinkUpdateParams.SubscriptionData;
     export type TaxIdCollection = Stripe.PaymentLinkUpdateParams.TaxIdCollection;
+    export namespace AfterCompletion {
+      export type HostedConfirmation = Stripe.PaymentLinkUpdateParams.AfterCompletion.HostedConfirmation;
+      export type Redirect = Stripe.PaymentLinkUpdateParams.AfterCompletion.Redirect;
+      export type Type = Stripe.PaymentLinkUpdateParams.AfterCompletion.Type;
+    }
+    export namespace AutomaticTax {
+      export type Liability = Stripe.PaymentLinkUpdateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.PaymentLinkUpdateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace CustomField {
+      export type Dropdown = Stripe.PaymentLinkUpdateParams.CustomField.Dropdown;
+      export type Label = Stripe.PaymentLinkUpdateParams.CustomField.Label;
+      export type Numeric = Stripe.PaymentLinkUpdateParams.CustomField.Numeric;
+      export type Text = Stripe.PaymentLinkUpdateParams.CustomField.Text;
+      export type Type = Stripe.PaymentLinkUpdateParams.CustomField.Type;
+      export namespace Dropdown {
+        export type Option = Stripe.PaymentLinkUpdateParams.CustomField.Dropdown.Option;
+      }
+    }
+    export namespace CustomText {
+      export type AfterSubmit = Stripe.PaymentLinkUpdateParams.CustomText.AfterSubmit;
+      export type ShippingAddress = Stripe.PaymentLinkUpdateParams.CustomText.ShippingAddress;
+      export type Submit = Stripe.PaymentLinkUpdateParams.CustomText.Submit;
+      export type TermsOfServiceAcceptance = Stripe.PaymentLinkUpdateParams.CustomText.TermsOfServiceAcceptance;
+    }
+    export namespace InvoiceCreation {
+      export type InvoiceData = Stripe.PaymentLinkUpdateParams.InvoiceCreation.InvoiceData;
+      export namespace InvoiceData {
+        export type CustomField = Stripe.PaymentLinkUpdateParams.InvoiceCreation.InvoiceData.CustomField;
+        export type Issuer = Stripe.PaymentLinkUpdateParams.InvoiceCreation.InvoiceData.Issuer;
+        export type RenderingOptions = Stripe.PaymentLinkUpdateParams.InvoiceCreation.InvoiceData.RenderingOptions;
+        export namespace Issuer {
+          export type Type = Stripe.PaymentLinkUpdateParams.InvoiceCreation.InvoiceData.Issuer.Type;
+        }
+        export namespace RenderingOptions {
+          export type AmountTaxDisplay = Stripe.PaymentLinkUpdateParams.InvoiceCreation.InvoiceData.RenderingOptions.AmountTaxDisplay;
+        }
+      }
+    }
+    export namespace LineItem {
+      export type AdjustableQuantity = Stripe.PaymentLinkUpdateParams.LineItem.AdjustableQuantity;
+    }
+    export namespace NameCollection {
+      export type Business = Stripe.PaymentLinkUpdateParams.NameCollection.Business;
+      export type Individual = Stripe.PaymentLinkUpdateParams.NameCollection.Individual;
+    }
+    export namespace OptionalItem {
+      export type AdjustableQuantity = Stripe.PaymentLinkUpdateParams.OptionalItem.AdjustableQuantity;
+    }
+    export namespace PaymentMethodOptions {
+      export type Card = Stripe.PaymentLinkUpdateParams.PaymentMethodOptions.Card;
+      export namespace Card {
+        export type Restrictions = Stripe.PaymentLinkUpdateParams.PaymentMethodOptions.Card.Restrictions;
+        export namespace Restrictions {
+          export type BrandsBlocked = Stripe.PaymentLinkUpdateParams.PaymentMethodOptions.Card.Restrictions.BrandsBlocked;
+        }
+      }
+    }
+    export namespace Restrictions {
+      export type CompletedSessions = Stripe.PaymentLinkUpdateParams.Restrictions.CompletedSessions;
+    }
+    export namespace ShippingAddressCollection {
+      export type AllowedCountry = Stripe.PaymentLinkUpdateParams.ShippingAddressCollection.AllowedCountry;
+    }
+    export namespace SubscriptionData {
+      export type InvoiceSettings = Stripe.PaymentLinkUpdateParams.SubscriptionData.InvoiceSettings;
+      export type TrialSettings = Stripe.PaymentLinkUpdateParams.SubscriptionData.TrialSettings;
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.PaymentLinkUpdateParams.SubscriptionData.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.PaymentLinkUpdateParams.SubscriptionData.InvoiceSettings.Issuer.Type;
+        }
+      }
+      export namespace TrialSettings {
+        export type EndBehavior = Stripe.PaymentLinkUpdateParams.SubscriptionData.TrialSettings.EndBehavior;
+        export namespace EndBehavior {
+          export type MissingPaymentMethod = Stripe.PaymentLinkUpdateParams.SubscriptionData.TrialSettings.EndBehavior.MissingPaymentMethod;
+        }
+      }
+    }
+    export namespace TaxIdCollection {
+      export type Required = Stripe.PaymentLinkUpdateParams.TaxIdCollection.Required;
+    }
+  }
+  export namespace PaymentLink {
+    export type AfterCompletion = Stripe.PaymentLink.AfterCompletion;
+    export type AutomaticTax = Stripe.PaymentLink.AutomaticTax;
+    export type BillingAddressCollection = Stripe.PaymentLink.BillingAddressCollection;
+    export type ConsentCollection = Stripe.PaymentLink.ConsentCollection;
+    export type CustomField = Stripe.PaymentLink.CustomField;
+    export type CustomText = Stripe.PaymentLink.CustomText;
+    export type CustomerCreation = Stripe.PaymentLink.CustomerCreation;
+    export type InvoiceCreation = Stripe.PaymentLink.InvoiceCreation;
+    export type ManagedPayments = Stripe.PaymentLink.ManagedPayments;
+    export type NameCollection = Stripe.PaymentLink.NameCollection;
+    export type OptionalItem = Stripe.PaymentLink.OptionalItem;
+    export type PaymentIntentData = Stripe.PaymentLink.PaymentIntentData;
+    export type PaymentMethodCollection = Stripe.PaymentLink.PaymentMethodCollection;
+    export type PaymentMethodOptions = Stripe.PaymentLink.PaymentMethodOptions;
+    export type PaymentMethodType = Stripe.PaymentLink.PaymentMethodType;
+    export type PhoneNumberCollection = Stripe.PaymentLink.PhoneNumberCollection;
+    export type Restrictions = Stripe.PaymentLink.Restrictions;
+    export type ShippingAddressCollection = Stripe.PaymentLink.ShippingAddressCollection;
+    export type ShippingOption = Stripe.PaymentLink.ShippingOption;
+    export type SubmitType = Stripe.PaymentLink.SubmitType;
+    export type SubscriptionData = Stripe.PaymentLink.SubscriptionData;
+    export type TaxIdCollection = Stripe.PaymentLink.TaxIdCollection;
+    export type TransferData = Stripe.PaymentLink.TransferData;
+    export namespace AfterCompletion {
+      export type HostedConfirmation = Stripe.PaymentLink.AfterCompletion.HostedConfirmation;
+      export type Redirect = Stripe.PaymentLink.AfterCompletion.Redirect;
+      export type Type = Stripe.PaymentLink.AfterCompletion.Type;
+    }
+    export namespace AutomaticTax {
+      export type Liability = Stripe.PaymentLink.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.PaymentLink.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace ConsentCollection {
+      export type PaymentMethodReuseAgreement = Stripe.PaymentLink.ConsentCollection.PaymentMethodReuseAgreement;
+      export type Promotions = Stripe.PaymentLink.ConsentCollection.Promotions;
+      export type TermsOfService = Stripe.PaymentLink.ConsentCollection.TermsOfService;
+      export namespace PaymentMethodReuseAgreement {
+        export type Position = Stripe.PaymentLink.ConsentCollection.PaymentMethodReuseAgreement.Position;
+      }
+    }
+    export namespace CustomField {
+      export type Dropdown = Stripe.PaymentLink.CustomField.Dropdown;
+      export type Label = Stripe.PaymentLink.CustomField.Label;
+      export type Numeric = Stripe.PaymentLink.CustomField.Numeric;
+      export type Text = Stripe.PaymentLink.CustomField.Text;
+      export type Type = Stripe.PaymentLink.CustomField.Type;
+      export namespace Dropdown {
+        export type Option = Stripe.PaymentLink.CustomField.Dropdown.Option;
+      }
+    }
+    export namespace CustomText {
+      export type AfterSubmit = Stripe.PaymentLink.CustomText.AfterSubmit;
+      export type ShippingAddress = Stripe.PaymentLink.CustomText.ShippingAddress;
+      export type Submit = Stripe.PaymentLink.CustomText.Submit;
+      export type TermsOfServiceAcceptance = Stripe.PaymentLink.CustomText.TermsOfServiceAcceptance;
+    }
+    export namespace InvoiceCreation {
+      export type InvoiceData = Stripe.PaymentLink.InvoiceCreation.InvoiceData;
+      export namespace InvoiceData {
+        export type CustomField = Stripe.PaymentLink.InvoiceCreation.InvoiceData.CustomField;
+        export type Issuer = Stripe.PaymentLink.InvoiceCreation.InvoiceData.Issuer;
+        export type RenderingOptions = Stripe.PaymentLink.InvoiceCreation.InvoiceData.RenderingOptions;
+        export namespace Issuer {
+          export type Type = Stripe.PaymentLink.InvoiceCreation.InvoiceData.Issuer.Type;
+        }
+      }
+    }
+    export namespace NameCollection {
+      export type Business = Stripe.PaymentLink.NameCollection.Business;
+      export type Individual = Stripe.PaymentLink.NameCollection.Individual;
+    }
+    export namespace OptionalItem {
+      export type AdjustableQuantity = Stripe.PaymentLink.OptionalItem.AdjustableQuantity;
+    }
+    export namespace PaymentIntentData {
+      export type CaptureMethod = Stripe.PaymentLink.PaymentIntentData.CaptureMethod;
+      export type SetupFutureUsage = Stripe.PaymentLink.PaymentIntentData.SetupFutureUsage;
+    }
+    export namespace PaymentMethodOptions {
+      export type Card = Stripe.PaymentLink.PaymentMethodOptions.Card;
+      export namespace Card {
+        export type Restrictions = Stripe.PaymentLink.PaymentMethodOptions.Card.Restrictions;
+        export namespace Restrictions {
+          export type BrandsBlocked = Stripe.PaymentLink.PaymentMethodOptions.Card.Restrictions.BrandsBlocked;
+        }
+      }
+    }
+    export namespace Restrictions {
+      export type CompletedSessions = Stripe.PaymentLink.Restrictions.CompletedSessions;
+    }
+    export namespace ShippingAddressCollection {
+      export type AllowedCountry = Stripe.PaymentLink.ShippingAddressCollection.AllowedCountry;
+    }
+    export namespace SubscriptionData {
+      export type InvoiceSettings = Stripe.PaymentLink.SubscriptionData.InvoiceSettings;
+      export type TrialSettings = Stripe.PaymentLink.SubscriptionData.TrialSettings;
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.PaymentLink.SubscriptionData.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.PaymentLink.SubscriptionData.InvoiceSettings.Issuer.Type;
+        }
+      }
+      export namespace TrialSettings {
+        export type EndBehavior = Stripe.PaymentLink.SubscriptionData.TrialSettings.EndBehavior;
+        export namespace EndBehavior {
+          export type MissingPaymentMethod = Stripe.PaymentLink.SubscriptionData.TrialSettings.EndBehavior.MissingPaymentMethod;
+        }
+      }
+    }
+    export namespace TaxIdCollection {
+      export type Required = Stripe.PaymentLink.TaxIdCollection.Required;
+    }
   }
   export namespace PaymentMethodCreateParams {
     export type AcssDebit = Stripe.PaymentMethodCreateParams.AcssDebit;
@@ -904,6 +4961,44 @@ declare namespace StripeConstructor {
     export type UsBankAccount = Stripe.PaymentMethodCreateParams.UsBankAccount;
     export type WechatPay = Stripe.PaymentMethodCreateParams.WechatPay;
     export type Zip = Stripe.PaymentMethodCreateParams.Zip;
+    export namespace Card {
+      export type Networks = Stripe.PaymentMethodCreateParams.Card.Networks;
+      export namespace Networks {
+        export type Preferred = Stripe.PaymentMethodCreateParams.Card.Networks.Preferred;
+      }
+    }
+    export namespace Eps {
+      export type Bank = Stripe.PaymentMethodCreateParams.Eps.Bank;
+    }
+    export namespace Fpx {
+      export type AccountHolderType = Stripe.PaymentMethodCreateParams.Fpx.AccountHolderType;
+      export type Bank = Stripe.PaymentMethodCreateParams.Fpx.Bank;
+    }
+    export namespace Ideal {
+      export type Bank = Stripe.PaymentMethodCreateParams.Ideal.Bank;
+    }
+    export namespace Klarna {
+      export type Dob = Stripe.PaymentMethodCreateParams.Klarna.Dob;
+    }
+    export namespace NaverPay {
+      export type Funding = Stripe.PaymentMethodCreateParams.NaverPay.Funding;
+    }
+    export namespace P24 {
+      export type Bank = Stripe.PaymentMethodCreateParams.P24.Bank;
+    }
+    export namespace Sofort {
+      export type Country = Stripe.PaymentMethodCreateParams.Sofort.Country;
+    }
+    export namespace Upi {
+      export type MandateOptions = Stripe.PaymentMethodCreateParams.Upi.MandateOptions;
+      export namespace MandateOptions {
+        export type AmountType = Stripe.PaymentMethodCreateParams.Upi.MandateOptions.AmountType;
+      }
+    }
+    export namespace UsBankAccount {
+      export type AccountHolderType = Stripe.PaymentMethodCreateParams.UsBankAccount.AccountHolderType;
+      export type AccountType = Stripe.PaymentMethodCreateParams.UsBankAccount.AccountType;
+    }
   }
   export namespace PaymentMethodUpdateParams {
     export type AllowRedisplay = Stripe.PaymentMethodUpdateParams.AllowRedisplay;
@@ -911,10 +5006,177 @@ declare namespace StripeConstructor {
     export type Card = Stripe.PaymentMethodUpdateParams.Card;
     export type Payto = Stripe.PaymentMethodUpdateParams.Payto;
     export type UsBankAccount = Stripe.PaymentMethodUpdateParams.UsBankAccount;
+    export namespace Card {
+      export type Networks = Stripe.PaymentMethodUpdateParams.Card.Networks;
+      export namespace Networks {
+        export type Preferred = Stripe.PaymentMethodUpdateParams.Card.Networks.Preferred;
+      }
+    }
+    export namespace UsBankAccount {
+      export type AccountHolderType = Stripe.PaymentMethodUpdateParams.UsBankAccount.AccountHolderType;
+      export type AccountType = Stripe.PaymentMethodUpdateParams.UsBankAccount.AccountType;
+    }
   }
   export namespace PaymentMethodListParams {
     export type AllowRedisplay = Stripe.PaymentMethodListParams.AllowRedisplay;
     export type Type = Stripe.PaymentMethodListParams.Type;
+  }
+  export namespace PaymentMethod {
+    export type AcssDebit = Stripe.PaymentMethod.AcssDebit;
+    export type Affirm = Stripe.PaymentMethod.Affirm;
+    export type AfterpayClearpay = Stripe.PaymentMethod.AfterpayClearpay;
+    export type Alipay = Stripe.PaymentMethod.Alipay;
+    export type AllowRedisplay = Stripe.PaymentMethod.AllowRedisplay;
+    export type Alma = Stripe.PaymentMethod.Alma;
+    export type AmazonPay = Stripe.PaymentMethod.AmazonPay;
+    export type AuBecsDebit = Stripe.PaymentMethod.AuBecsDebit;
+    export type BacsDebit = Stripe.PaymentMethod.BacsDebit;
+    export type Bancontact = Stripe.PaymentMethod.Bancontact;
+    export type Billie = Stripe.PaymentMethod.Billie;
+    export type BillingDetails = Stripe.PaymentMethod.BillingDetails;
+    export type Bizum = Stripe.PaymentMethod.Bizum;
+    export type Blik = Stripe.PaymentMethod.Blik;
+    export type Boleto = Stripe.PaymentMethod.Boleto;
+    export type Card = Stripe.PaymentMethod.Card;
+    export type CardPresent = Stripe.PaymentMethod.CardPresent;
+    export type Cashapp = Stripe.PaymentMethod.Cashapp;
+    export type Crypto = Stripe.PaymentMethod.Crypto;
+    export type Custom = Stripe.PaymentMethod.Custom;
+    export type CustomerBalance = Stripe.PaymentMethod.CustomerBalance;
+    export type Eps = Stripe.PaymentMethod.Eps;
+    export type Fpx = Stripe.PaymentMethod.Fpx;
+    export type Giropay = Stripe.PaymentMethod.Giropay;
+    export type Grabpay = Stripe.PaymentMethod.Grabpay;
+    export type Ideal = Stripe.PaymentMethod.Ideal;
+    export type InteracPresent = Stripe.PaymentMethod.InteracPresent;
+    export type KakaoPay = Stripe.PaymentMethod.KakaoPay;
+    export type Klarna = Stripe.PaymentMethod.Klarna;
+    export type Konbini = Stripe.PaymentMethod.Konbini;
+    export type KrCard = Stripe.PaymentMethod.KrCard;
+    export type Link = Stripe.PaymentMethod.Link;
+    export type MbWay = Stripe.PaymentMethod.MbWay;
+    export type Mobilepay = Stripe.PaymentMethod.Mobilepay;
+    export type Multibanco = Stripe.PaymentMethod.Multibanco;
+    export type NaverPay = Stripe.PaymentMethod.NaverPay;
+    export type NzBankAccount = Stripe.PaymentMethod.NzBankAccount;
+    export type Oxxo = Stripe.PaymentMethod.Oxxo;
+    export type P24 = Stripe.PaymentMethod.P24;
+    export type PayByBank = Stripe.PaymentMethod.PayByBank;
+    export type Payco = Stripe.PaymentMethod.Payco;
+    export type Paynow = Stripe.PaymentMethod.Paynow;
+    export type Paypal = Stripe.PaymentMethod.Paypal;
+    export type Payto = Stripe.PaymentMethod.Payto;
+    export type Pix = Stripe.PaymentMethod.Pix;
+    export type Promptpay = Stripe.PaymentMethod.Promptpay;
+    export type RadarOptions = Stripe.PaymentMethod.RadarOptions;
+    export type RevolutPay = Stripe.PaymentMethod.RevolutPay;
+    export type SamsungPay = Stripe.PaymentMethod.SamsungPay;
+    export type Satispay = Stripe.PaymentMethod.Satispay;
+    export type Scalapay = Stripe.PaymentMethod.Scalapay;
+    export type SepaDebit = Stripe.PaymentMethod.SepaDebit;
+    export type Sofort = Stripe.PaymentMethod.Sofort;
+    export type Sunbit = Stripe.PaymentMethod.Sunbit;
+    export type Swish = Stripe.PaymentMethod.Swish;
+    export type Twint = Stripe.PaymentMethod.Twint;
+    export type Type = Stripe.PaymentMethod.Type;
+    export type Upi = Stripe.PaymentMethod.Upi;
+    export type UsBankAccount = Stripe.PaymentMethod.UsBankAccount;
+    export type WechatPay = Stripe.PaymentMethod.WechatPay;
+    export type Zip = Stripe.PaymentMethod.Zip;
+    export namespace Card {
+      export type Checks = Stripe.PaymentMethod.Card.Checks;
+      export type GeneratedFrom = Stripe.PaymentMethod.Card.GeneratedFrom;
+      export type Networks = Stripe.PaymentMethod.Card.Networks;
+      export type RegulatedStatus = Stripe.PaymentMethod.Card.RegulatedStatus;
+      export type ThreeDSecureUsage = Stripe.PaymentMethod.Card.ThreeDSecureUsage;
+      export type Wallet = Stripe.PaymentMethod.Card.Wallet;
+      export namespace GeneratedFrom {
+        export type PaymentMethodDetails = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails;
+        export namespace PaymentMethodDetails {
+          export type CardPresent = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent;
+          export namespace CardPresent {
+            export type Offline = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Offline;
+            export type ReadMethod = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.ReadMethod;
+            export type Receipt = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Receipt;
+            export type Wallet = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Wallet;
+            export namespace Receipt {
+              export type AccountType = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Receipt.AccountType;
+            }
+            export namespace Wallet {
+              export type Type = Stripe.PaymentMethod.Card.GeneratedFrom.PaymentMethodDetails.CardPresent.Wallet.Type;
+            }
+          }
+        }
+      }
+      export namespace Wallet {
+        export type AmexExpressCheckout = Stripe.PaymentMethod.Card.Wallet.AmexExpressCheckout;
+        export type ApplePay = Stripe.PaymentMethod.Card.Wallet.ApplePay;
+        export type GooglePay = Stripe.PaymentMethod.Card.Wallet.GooglePay;
+        export type Link = Stripe.PaymentMethod.Card.Wallet.Link;
+        export type Masterpass = Stripe.PaymentMethod.Card.Wallet.Masterpass;
+        export type SamsungPay = Stripe.PaymentMethod.Card.Wallet.SamsungPay;
+        export type Type = Stripe.PaymentMethod.Card.Wallet.Type;
+        export type VisaCheckout = Stripe.PaymentMethod.Card.Wallet.VisaCheckout;
+      }
+    }
+    export namespace CardPresent {
+      export type Networks = Stripe.PaymentMethod.CardPresent.Networks;
+      export type Offline = Stripe.PaymentMethod.CardPresent.Offline;
+      export type ReadMethod = Stripe.PaymentMethod.CardPresent.ReadMethod;
+      export type Wallet = Stripe.PaymentMethod.CardPresent.Wallet;
+      export namespace Wallet {
+        export type Type = Stripe.PaymentMethod.CardPresent.Wallet.Type;
+      }
+    }
+    export namespace Custom {
+      export type Logo = Stripe.PaymentMethod.Custom.Logo;
+    }
+    export namespace Eps {
+      export type Bank = Stripe.PaymentMethod.Eps.Bank;
+    }
+    export namespace Fpx {
+      export type AccountHolderType = Stripe.PaymentMethod.Fpx.AccountHolderType;
+      export type Bank = Stripe.PaymentMethod.Fpx.Bank;
+    }
+    export namespace Ideal {
+      export type Bank = Stripe.PaymentMethod.Ideal.Bank;
+      export type Bic = Stripe.PaymentMethod.Ideal.Bic;
+    }
+    export namespace InteracPresent {
+      export type Networks = Stripe.PaymentMethod.InteracPresent.Networks;
+      export type ReadMethod = Stripe.PaymentMethod.InteracPresent.ReadMethod;
+    }
+    export namespace Klarna {
+      export type Dob = Stripe.PaymentMethod.Klarna.Dob;
+    }
+    export namespace KrCard {
+      export type Brand = Stripe.PaymentMethod.KrCard.Brand;
+    }
+    export namespace NaverPay {
+      export type Funding = Stripe.PaymentMethod.NaverPay.Funding;
+    }
+    export namespace P24 {
+      export type Bank = Stripe.PaymentMethod.P24.Bank;
+    }
+    export namespace SepaDebit {
+      export type GeneratedFrom = Stripe.PaymentMethod.SepaDebit.GeneratedFrom;
+    }
+    export namespace UsBankAccount {
+      export type AccountHolderType = Stripe.PaymentMethod.UsBankAccount.AccountHolderType;
+      export type AccountType = Stripe.PaymentMethod.UsBankAccount.AccountType;
+      export type Networks = Stripe.PaymentMethod.UsBankAccount.Networks;
+      export type StatusDetails = Stripe.PaymentMethod.UsBankAccount.StatusDetails;
+      export namespace Networks {
+        export type Supported = Stripe.PaymentMethod.UsBankAccount.Networks.Supported;
+      }
+      export namespace StatusDetails {
+        export type Blocked = Stripe.PaymentMethod.UsBankAccount.StatusDetails.Blocked;
+        export namespace Blocked {
+          export type NetworkCode = Stripe.PaymentMethod.UsBankAccount.StatusDetails.Blocked.NetworkCode;
+          export type Reason = Stripe.PaymentMethod.UsBankAccount.StatusDetails.Blocked.Reason;
+        }
+      }
+    }
   }
   export namespace PaymentMethodConfigurationCreateParams {
     export type AcssDebit = Stripe.PaymentMethodConfigurationCreateParams.AcssDebit;
@@ -977,6 +5239,366 @@ declare namespace StripeConstructor {
     export type UsBankAccount = Stripe.PaymentMethodConfigurationCreateParams.UsBankAccount;
     export type WechatPay = Stripe.PaymentMethodConfigurationCreateParams.WechatPay;
     export type Zip = Stripe.PaymentMethodConfigurationCreateParams.Zip;
+    export namespace AcssDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.AcssDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.AcssDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Affirm {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Affirm.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Affirm.DisplayPreference.Preference;
+      }
+    }
+    export namespace AfterpayClearpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.AfterpayClearpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.AfterpayClearpay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Alipay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Alipay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Alipay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Alma {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Alma.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Alma.DisplayPreference.Preference;
+      }
+    }
+    export namespace AmazonPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.AmazonPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.AmazonPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace ApplePay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.ApplePay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.ApplePay.DisplayPreference.Preference;
+      }
+    }
+    export namespace ApplePayLater {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.ApplePayLater.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.ApplePayLater.DisplayPreference.Preference;
+      }
+    }
+    export namespace AuBecsDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.AuBecsDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.AuBecsDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace BacsDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.BacsDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.BacsDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Bancontact {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Bancontact.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Bancontact.DisplayPreference.Preference;
+      }
+    }
+    export namespace Billie {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Billie.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Billie.DisplayPreference.Preference;
+      }
+    }
+    export namespace Bizum {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Bizum.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Bizum.DisplayPreference.Preference;
+      }
+    }
+    export namespace Blik {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Blik.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Blik.DisplayPreference.Preference;
+      }
+    }
+    export namespace Boleto {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Boleto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Boleto.DisplayPreference.Preference;
+      }
+    }
+    export namespace Card {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Card.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Card.DisplayPreference.Preference;
+      }
+    }
+    export namespace CartesBancaires {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.CartesBancaires.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.CartesBancaires.DisplayPreference.Preference;
+      }
+    }
+    export namespace Cashapp {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Cashapp.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Cashapp.DisplayPreference.Preference;
+      }
+    }
+    export namespace Crypto {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Crypto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Crypto.DisplayPreference.Preference;
+      }
+    }
+    export namespace CustomerBalance {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.CustomerBalance.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.CustomerBalance.DisplayPreference.Preference;
+      }
+    }
+    export namespace Eps {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Eps.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Eps.DisplayPreference.Preference;
+      }
+    }
+    export namespace Fpx {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Fpx.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Fpx.DisplayPreference.Preference;
+      }
+    }
+    export namespace FrMealVoucherConecs {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.FrMealVoucherConecs.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.FrMealVoucherConecs.DisplayPreference.Preference;
+      }
+    }
+    export namespace Giropay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Giropay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Giropay.DisplayPreference.Preference;
+      }
+    }
+    export namespace GooglePay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.GooglePay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.GooglePay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Grabpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Grabpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Grabpay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Ideal {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Ideal.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Ideal.DisplayPreference.Preference;
+      }
+    }
+    export namespace Jcb {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Jcb.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Jcb.DisplayPreference.Preference;
+      }
+    }
+    export namespace KakaoPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.KakaoPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.KakaoPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Klarna {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Klarna.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Klarna.DisplayPreference.Preference;
+      }
+    }
+    export namespace Konbini {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Konbini.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Konbini.DisplayPreference.Preference;
+      }
+    }
+    export namespace KrCard {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.KrCard.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.KrCard.DisplayPreference.Preference;
+      }
+    }
+    export namespace Link {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Link.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Link.DisplayPreference.Preference;
+      }
+    }
+    export namespace MbWay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.MbWay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.MbWay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Mobilepay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Mobilepay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Mobilepay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Multibanco {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Multibanco.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Multibanco.DisplayPreference.Preference;
+      }
+    }
+    export namespace NaverPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.NaverPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.NaverPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace NzBankAccount {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.NzBankAccount.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.NzBankAccount.DisplayPreference.Preference;
+      }
+    }
+    export namespace Oxxo {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Oxxo.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Oxxo.DisplayPreference.Preference;
+      }
+    }
+    export namespace P24 {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.P24.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.P24.DisplayPreference.Preference;
+      }
+    }
+    export namespace PayByBank {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.PayByBank.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.PayByBank.DisplayPreference.Preference;
+      }
+    }
+    export namespace Payco {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Payco.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Payco.DisplayPreference.Preference;
+      }
+    }
+    export namespace Paynow {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Paynow.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Paynow.DisplayPreference.Preference;
+      }
+    }
+    export namespace Paypal {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Paypal.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Paypal.DisplayPreference.Preference;
+      }
+    }
+    export namespace Payto {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Payto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Payto.DisplayPreference.Preference;
+      }
+    }
+    export namespace Pix {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Pix.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Pix.DisplayPreference.Preference;
+      }
+    }
+    export namespace Promptpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Promptpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Promptpay.DisplayPreference.Preference;
+      }
+    }
+    export namespace RevolutPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.RevolutPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.RevolutPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace SamsungPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.SamsungPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.SamsungPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Satispay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Satispay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Satispay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Scalapay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Scalapay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Scalapay.DisplayPreference.Preference;
+      }
+    }
+    export namespace SepaDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.SepaDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.SepaDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Sofort {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Sofort.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Sofort.DisplayPreference.Preference;
+      }
+    }
+    export namespace Sunbit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Sunbit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Sunbit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Swish {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Swish.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Swish.DisplayPreference.Preference;
+      }
+    }
+    export namespace Twint {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Twint.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Twint.DisplayPreference.Preference;
+      }
+    }
+    export namespace Upi {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Upi.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Upi.DisplayPreference.Preference;
+      }
+    }
+    export namespace UsBankAccount {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.UsBankAccount.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.UsBankAccount.DisplayPreference.Preference;
+      }
+    }
+    export namespace WechatPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.WechatPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.WechatPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Zip {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationCreateParams.Zip.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationCreateParams.Zip.DisplayPreference.Preference;
+      }
+    }
   }
   export namespace PaymentMethodConfigurationUpdateParams {
     export type AcssDebit = Stripe.PaymentMethodConfigurationUpdateParams.AcssDebit;
@@ -1039,6 +5661,864 @@ declare namespace StripeConstructor {
     export type UsBankAccount = Stripe.PaymentMethodConfigurationUpdateParams.UsBankAccount;
     export type WechatPay = Stripe.PaymentMethodConfigurationUpdateParams.WechatPay;
     export type Zip = Stripe.PaymentMethodConfigurationUpdateParams.Zip;
+    export namespace AcssDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.AcssDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.AcssDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Affirm {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Affirm.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Affirm.DisplayPreference.Preference;
+      }
+    }
+    export namespace AfterpayClearpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.AfterpayClearpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.AfterpayClearpay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Alipay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Alipay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Alipay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Alma {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Alma.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Alma.DisplayPreference.Preference;
+      }
+    }
+    export namespace AmazonPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.AmazonPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.AmazonPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace ApplePay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.ApplePay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.ApplePay.DisplayPreference.Preference;
+      }
+    }
+    export namespace ApplePayLater {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.ApplePayLater.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.ApplePayLater.DisplayPreference.Preference;
+      }
+    }
+    export namespace AuBecsDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.AuBecsDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.AuBecsDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace BacsDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.BacsDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.BacsDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Bancontact {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Bancontact.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Bancontact.DisplayPreference.Preference;
+      }
+    }
+    export namespace Billie {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Billie.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Billie.DisplayPreference.Preference;
+      }
+    }
+    export namespace Bizum {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Bizum.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Bizum.DisplayPreference.Preference;
+      }
+    }
+    export namespace Blik {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Blik.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Blik.DisplayPreference.Preference;
+      }
+    }
+    export namespace Boleto {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Boleto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Boleto.DisplayPreference.Preference;
+      }
+    }
+    export namespace Card {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Card.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Card.DisplayPreference.Preference;
+      }
+    }
+    export namespace CartesBancaires {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.CartesBancaires.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.CartesBancaires.DisplayPreference.Preference;
+      }
+    }
+    export namespace Cashapp {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Cashapp.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Cashapp.DisplayPreference.Preference;
+      }
+    }
+    export namespace Crypto {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Crypto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Crypto.DisplayPreference.Preference;
+      }
+    }
+    export namespace CustomerBalance {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.CustomerBalance.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.CustomerBalance.DisplayPreference.Preference;
+      }
+    }
+    export namespace Eps {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Eps.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Eps.DisplayPreference.Preference;
+      }
+    }
+    export namespace Fpx {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Fpx.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Fpx.DisplayPreference.Preference;
+      }
+    }
+    export namespace FrMealVoucherConecs {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.FrMealVoucherConecs.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.FrMealVoucherConecs.DisplayPreference.Preference;
+      }
+    }
+    export namespace Giropay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Giropay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Giropay.DisplayPreference.Preference;
+      }
+    }
+    export namespace GooglePay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.GooglePay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.GooglePay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Grabpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Grabpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Grabpay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Ideal {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Ideal.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Ideal.DisplayPreference.Preference;
+      }
+    }
+    export namespace Jcb {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Jcb.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Jcb.DisplayPreference.Preference;
+      }
+    }
+    export namespace KakaoPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.KakaoPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.KakaoPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Klarna {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Klarna.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Klarna.DisplayPreference.Preference;
+      }
+    }
+    export namespace Konbini {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Konbini.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Konbini.DisplayPreference.Preference;
+      }
+    }
+    export namespace KrCard {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.KrCard.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.KrCard.DisplayPreference.Preference;
+      }
+    }
+    export namespace Link {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Link.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Link.DisplayPreference.Preference;
+      }
+    }
+    export namespace MbWay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.MbWay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.MbWay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Mobilepay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Mobilepay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Mobilepay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Multibanco {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Multibanco.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Multibanco.DisplayPreference.Preference;
+      }
+    }
+    export namespace NaverPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.NaverPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.NaverPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace NzBankAccount {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.NzBankAccount.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.NzBankAccount.DisplayPreference.Preference;
+      }
+    }
+    export namespace Oxxo {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Oxxo.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Oxxo.DisplayPreference.Preference;
+      }
+    }
+    export namespace P24 {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.P24.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.P24.DisplayPreference.Preference;
+      }
+    }
+    export namespace PayByBank {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.PayByBank.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.PayByBank.DisplayPreference.Preference;
+      }
+    }
+    export namespace Payco {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Payco.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Payco.DisplayPreference.Preference;
+      }
+    }
+    export namespace Paynow {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Paynow.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Paynow.DisplayPreference.Preference;
+      }
+    }
+    export namespace Paypal {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Paypal.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Paypal.DisplayPreference.Preference;
+      }
+    }
+    export namespace Payto {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Payto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Payto.DisplayPreference.Preference;
+      }
+    }
+    export namespace Pix {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Pix.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Pix.DisplayPreference.Preference;
+      }
+    }
+    export namespace Promptpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Promptpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Promptpay.DisplayPreference.Preference;
+      }
+    }
+    export namespace RevolutPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.RevolutPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.RevolutPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace SamsungPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.SamsungPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.SamsungPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Satispay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Satispay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Satispay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Scalapay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Scalapay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Scalapay.DisplayPreference.Preference;
+      }
+    }
+    export namespace SepaDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.SepaDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.SepaDebit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Sofort {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Sofort.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Sofort.DisplayPreference.Preference;
+      }
+    }
+    export namespace Sunbit {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Sunbit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Sunbit.DisplayPreference.Preference;
+      }
+    }
+    export namespace Swish {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Swish.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Swish.DisplayPreference.Preference;
+      }
+    }
+    export namespace Twint {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Twint.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Twint.DisplayPreference.Preference;
+      }
+    }
+    export namespace Upi {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Upi.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Upi.DisplayPreference.Preference;
+      }
+    }
+    export namespace UsBankAccount {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.UsBankAccount.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.UsBankAccount.DisplayPreference.Preference;
+      }
+    }
+    export namespace WechatPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.WechatPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.WechatPay.DisplayPreference.Preference;
+      }
+    }
+    export namespace Zip {
+      export type DisplayPreference = Stripe.PaymentMethodConfigurationUpdateParams.Zip.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfigurationUpdateParams.Zip.DisplayPreference.Preference;
+      }
+    }
+  }
+  export namespace PaymentMethodConfiguration {
+    export type AcssDebit = Stripe.PaymentMethodConfiguration.AcssDebit;
+    export type Affirm = Stripe.PaymentMethodConfiguration.Affirm;
+    export type AfterpayClearpay = Stripe.PaymentMethodConfiguration.AfterpayClearpay;
+    export type Alipay = Stripe.PaymentMethodConfiguration.Alipay;
+    export type Alma = Stripe.PaymentMethodConfiguration.Alma;
+    export type AmazonPay = Stripe.PaymentMethodConfiguration.AmazonPay;
+    export type ApplePay = Stripe.PaymentMethodConfiguration.ApplePay;
+    export type AuBecsDebit = Stripe.PaymentMethodConfiguration.AuBecsDebit;
+    export type BacsDebit = Stripe.PaymentMethodConfiguration.BacsDebit;
+    export type Bancontact = Stripe.PaymentMethodConfiguration.Bancontact;
+    export type Billie = Stripe.PaymentMethodConfiguration.Billie;
+    export type Bizum = Stripe.PaymentMethodConfiguration.Bizum;
+    export type Blik = Stripe.PaymentMethodConfiguration.Blik;
+    export type Boleto = Stripe.PaymentMethodConfiguration.Boleto;
+    export type Card = Stripe.PaymentMethodConfiguration.Card;
+    export type CartesBancaires = Stripe.PaymentMethodConfiguration.CartesBancaires;
+    export type Cashapp = Stripe.PaymentMethodConfiguration.Cashapp;
+    export type Crypto = Stripe.PaymentMethodConfiguration.Crypto;
+    export type CustomerBalance = Stripe.PaymentMethodConfiguration.CustomerBalance;
+    export type Eps = Stripe.PaymentMethodConfiguration.Eps;
+    export type Fpx = Stripe.PaymentMethodConfiguration.Fpx;
+    export type Giropay = Stripe.PaymentMethodConfiguration.Giropay;
+    export type GooglePay = Stripe.PaymentMethodConfiguration.GooglePay;
+    export type Grabpay = Stripe.PaymentMethodConfiguration.Grabpay;
+    export type Ideal = Stripe.PaymentMethodConfiguration.Ideal;
+    export type Jcb = Stripe.PaymentMethodConfiguration.Jcb;
+    export type KakaoPay = Stripe.PaymentMethodConfiguration.KakaoPay;
+    export type Klarna = Stripe.PaymentMethodConfiguration.Klarna;
+    export type Konbini = Stripe.PaymentMethodConfiguration.Konbini;
+    export type KrCard = Stripe.PaymentMethodConfiguration.KrCard;
+    export type Link = Stripe.PaymentMethodConfiguration.Link;
+    export type MbWay = Stripe.PaymentMethodConfiguration.MbWay;
+    export type Mobilepay = Stripe.PaymentMethodConfiguration.Mobilepay;
+    export type Multibanco = Stripe.PaymentMethodConfiguration.Multibanco;
+    export type NaverPay = Stripe.PaymentMethodConfiguration.NaverPay;
+    export type NzBankAccount = Stripe.PaymentMethodConfiguration.NzBankAccount;
+    export type Oxxo = Stripe.PaymentMethodConfiguration.Oxxo;
+    export type P24 = Stripe.PaymentMethodConfiguration.P24;
+    export type PayByBank = Stripe.PaymentMethodConfiguration.PayByBank;
+    export type Payco = Stripe.PaymentMethodConfiguration.Payco;
+    export type Paynow = Stripe.PaymentMethodConfiguration.Paynow;
+    export type Paypal = Stripe.PaymentMethodConfiguration.Paypal;
+    export type Payto = Stripe.PaymentMethodConfiguration.Payto;
+    export type Pix = Stripe.PaymentMethodConfiguration.Pix;
+    export type Promptpay = Stripe.PaymentMethodConfiguration.Promptpay;
+    export type RevolutPay = Stripe.PaymentMethodConfiguration.RevolutPay;
+    export type SamsungPay = Stripe.PaymentMethodConfiguration.SamsungPay;
+    export type Satispay = Stripe.PaymentMethodConfiguration.Satispay;
+    export type Scalapay = Stripe.PaymentMethodConfiguration.Scalapay;
+    export type SepaDebit = Stripe.PaymentMethodConfiguration.SepaDebit;
+    export type Sofort = Stripe.PaymentMethodConfiguration.Sofort;
+    export type Sunbit = Stripe.PaymentMethodConfiguration.Sunbit;
+    export type Swish = Stripe.PaymentMethodConfiguration.Swish;
+    export type Twint = Stripe.PaymentMethodConfiguration.Twint;
+    export type Upi = Stripe.PaymentMethodConfiguration.Upi;
+    export type UsBankAccount = Stripe.PaymentMethodConfiguration.UsBankAccount;
+    export type WechatPay = Stripe.PaymentMethodConfiguration.WechatPay;
+    export type Zip = Stripe.PaymentMethodConfiguration.Zip;
+    export namespace AcssDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.AcssDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.AcssDebit.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.AcssDebit.DisplayPreference.Value;
+      }
+    }
+    export namespace Affirm {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Affirm.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Affirm.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Affirm.DisplayPreference.Value;
+      }
+    }
+    export namespace AfterpayClearpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.AfterpayClearpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.AfterpayClearpay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.AfterpayClearpay.DisplayPreference.Value;
+      }
+    }
+    export namespace Alipay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Alipay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Alipay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Alipay.DisplayPreference.Value;
+      }
+    }
+    export namespace Alma {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Alma.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Alma.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Alma.DisplayPreference.Value;
+      }
+    }
+    export namespace AmazonPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.AmazonPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.AmazonPay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.AmazonPay.DisplayPreference.Value;
+      }
+    }
+    export namespace ApplePay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.ApplePay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.ApplePay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.ApplePay.DisplayPreference.Value;
+      }
+    }
+    export namespace AuBecsDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.AuBecsDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.AuBecsDebit.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.AuBecsDebit.DisplayPreference.Value;
+      }
+    }
+    export namespace BacsDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.BacsDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.BacsDebit.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.BacsDebit.DisplayPreference.Value;
+      }
+    }
+    export namespace Bancontact {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Bancontact.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Bancontact.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Bancontact.DisplayPreference.Value;
+      }
+    }
+    export namespace Billie {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Billie.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Billie.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Billie.DisplayPreference.Value;
+      }
+    }
+    export namespace Bizum {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Bizum.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Bizum.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Bizum.DisplayPreference.Value;
+      }
+    }
+    export namespace Blik {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Blik.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Blik.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Blik.DisplayPreference.Value;
+      }
+    }
+    export namespace Boleto {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Boleto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Boleto.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Boleto.DisplayPreference.Value;
+      }
+    }
+    export namespace Card {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Card.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Card.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Card.DisplayPreference.Value;
+      }
+    }
+    export namespace CartesBancaires {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.CartesBancaires.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.CartesBancaires.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.CartesBancaires.DisplayPreference.Value;
+      }
+    }
+    export namespace Cashapp {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Cashapp.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Cashapp.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Cashapp.DisplayPreference.Value;
+      }
+    }
+    export namespace Crypto {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Crypto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Crypto.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Crypto.DisplayPreference.Value;
+      }
+    }
+    export namespace CustomerBalance {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.CustomerBalance.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.CustomerBalance.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.CustomerBalance.DisplayPreference.Value;
+      }
+    }
+    export namespace Eps {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Eps.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Eps.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Eps.DisplayPreference.Value;
+      }
+    }
+    export namespace Fpx {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Fpx.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Fpx.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Fpx.DisplayPreference.Value;
+      }
+    }
+    export namespace Giropay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Giropay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Giropay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Giropay.DisplayPreference.Value;
+      }
+    }
+    export namespace GooglePay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.GooglePay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.GooglePay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.GooglePay.DisplayPreference.Value;
+      }
+    }
+    export namespace Grabpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Grabpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Grabpay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Grabpay.DisplayPreference.Value;
+      }
+    }
+    export namespace Ideal {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Ideal.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Ideal.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Ideal.DisplayPreference.Value;
+      }
+    }
+    export namespace Jcb {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Jcb.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Jcb.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Jcb.DisplayPreference.Value;
+      }
+    }
+    export namespace KakaoPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.KakaoPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.KakaoPay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.KakaoPay.DisplayPreference.Value;
+      }
+    }
+    export namespace Klarna {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Klarna.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Klarna.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Klarna.DisplayPreference.Value;
+      }
+    }
+    export namespace Konbini {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Konbini.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Konbini.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Konbini.DisplayPreference.Value;
+      }
+    }
+    export namespace KrCard {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.KrCard.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.KrCard.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.KrCard.DisplayPreference.Value;
+      }
+    }
+    export namespace Link {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Link.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Link.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Link.DisplayPreference.Value;
+      }
+    }
+    export namespace MbWay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.MbWay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.MbWay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.MbWay.DisplayPreference.Value;
+      }
+    }
+    export namespace Mobilepay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Mobilepay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Mobilepay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Mobilepay.DisplayPreference.Value;
+      }
+    }
+    export namespace Multibanco {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Multibanco.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Multibanco.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Multibanco.DisplayPreference.Value;
+      }
+    }
+    export namespace NaverPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.NaverPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.NaverPay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.NaverPay.DisplayPreference.Value;
+      }
+    }
+    export namespace NzBankAccount {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.NzBankAccount.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.NzBankAccount.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.NzBankAccount.DisplayPreference.Value;
+      }
+    }
+    export namespace Oxxo {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Oxxo.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Oxxo.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Oxxo.DisplayPreference.Value;
+      }
+    }
+    export namespace P24 {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.P24.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.P24.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.P24.DisplayPreference.Value;
+      }
+    }
+    export namespace PayByBank {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.PayByBank.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.PayByBank.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.PayByBank.DisplayPreference.Value;
+      }
+    }
+    export namespace Payco {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Payco.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Payco.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Payco.DisplayPreference.Value;
+      }
+    }
+    export namespace Paynow {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Paynow.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Paynow.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Paynow.DisplayPreference.Value;
+      }
+    }
+    export namespace Paypal {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Paypal.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Paypal.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Paypal.DisplayPreference.Value;
+      }
+    }
+    export namespace Payto {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Payto.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Payto.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Payto.DisplayPreference.Value;
+      }
+    }
+    export namespace Pix {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Pix.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Pix.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Pix.DisplayPreference.Value;
+      }
+    }
+    export namespace Promptpay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Promptpay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Promptpay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Promptpay.DisplayPreference.Value;
+      }
+    }
+    export namespace RevolutPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.RevolutPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.RevolutPay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.RevolutPay.DisplayPreference.Value;
+      }
+    }
+    export namespace SamsungPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.SamsungPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.SamsungPay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.SamsungPay.DisplayPreference.Value;
+      }
+    }
+    export namespace Satispay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Satispay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Satispay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Satispay.DisplayPreference.Value;
+      }
+    }
+    export namespace Scalapay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Scalapay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Scalapay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Scalapay.DisplayPreference.Value;
+      }
+    }
+    export namespace SepaDebit {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.SepaDebit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.SepaDebit.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.SepaDebit.DisplayPreference.Value;
+      }
+    }
+    export namespace Sofort {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Sofort.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Sofort.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Sofort.DisplayPreference.Value;
+      }
+    }
+    export namespace Sunbit {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Sunbit.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Sunbit.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Sunbit.DisplayPreference.Value;
+      }
+    }
+    export namespace Swish {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Swish.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Swish.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Swish.DisplayPreference.Value;
+      }
+    }
+    export namespace Twint {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Twint.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Twint.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Twint.DisplayPreference.Value;
+      }
+    }
+    export namespace Upi {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Upi.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Upi.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Upi.DisplayPreference.Value;
+      }
+    }
+    export namespace UsBankAccount {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.UsBankAccount.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.UsBankAccount.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.UsBankAccount.DisplayPreference.Value;
+      }
+    }
+    export namespace WechatPay {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.WechatPay.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.WechatPay.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.WechatPay.DisplayPreference.Value;
+      }
+    }
+    export namespace Zip {
+      export type DisplayPreference = Stripe.PaymentMethodConfiguration.Zip.DisplayPreference;
+      export namespace DisplayPreference {
+        export type Preference = Stripe.PaymentMethodConfiguration.Zip.DisplayPreference.Preference;
+        export type Value = Stripe.PaymentMethodConfiguration.Zip.DisplayPreference.Value;
+      }
+    }
+  }
+  export namespace PaymentMethodDomain {
+    export type AmazonPay = Stripe.PaymentMethodDomain.AmazonPay;
+    export type ApplePay = Stripe.PaymentMethodDomain.ApplePay;
+    export type GooglePay = Stripe.PaymentMethodDomain.GooglePay;
+    export type Klarna = Stripe.PaymentMethodDomain.Klarna;
+    export type Link = Stripe.PaymentMethodDomain.Link;
+    export type Paypal = Stripe.PaymentMethodDomain.Paypal;
+    export namespace AmazonPay {
+      export type Status = Stripe.PaymentMethodDomain.AmazonPay.Status;
+      export type StatusDetails = Stripe.PaymentMethodDomain.AmazonPay.StatusDetails;
+    }
+    export namespace ApplePay {
+      export type Status = Stripe.PaymentMethodDomain.ApplePay.Status;
+      export type StatusDetails = Stripe.PaymentMethodDomain.ApplePay.StatusDetails;
+    }
+    export namespace GooglePay {
+      export type Status = Stripe.PaymentMethodDomain.GooglePay.Status;
+      export type StatusDetails = Stripe.PaymentMethodDomain.GooglePay.StatusDetails;
+    }
+    export namespace Klarna {
+      export type Status = Stripe.PaymentMethodDomain.Klarna.Status;
+      export type StatusDetails = Stripe.PaymentMethodDomain.Klarna.StatusDetails;
+    }
+    export namespace Link {
+      export type Status = Stripe.PaymentMethodDomain.Link.Status;
+      export type StatusDetails = Stripe.PaymentMethodDomain.Link.StatusDetails;
+    }
+    export namespace Paypal {
+      export type Status = Stripe.PaymentMethodDomain.Paypal.Status;
+      export type StatusDetails = Stripe.PaymentMethodDomain.Paypal.StatusDetails;
+    }
   }
   export namespace PaymentRecordReportPaymentParams {
     export type AmountRequested = Stripe.PaymentRecordReportPaymentParams.AmountRequested;
@@ -1050,6 +6530,13 @@ declare namespace StripeConstructor {
     export type Outcome = Stripe.PaymentRecordReportPaymentParams.Outcome;
     export type ProcessorDetails = Stripe.PaymentRecordReportPaymentParams.ProcessorDetails;
     export type ShippingDetails = Stripe.PaymentRecordReportPaymentParams.ShippingDetails;
+    export namespace PaymentMethodDetails {
+      export type BillingDetails = Stripe.PaymentRecordReportPaymentParams.PaymentMethodDetails.BillingDetails;
+      export type Custom = Stripe.PaymentRecordReportPaymentParams.PaymentMethodDetails.Custom;
+    }
+    export namespace ProcessorDetails {
+      export type Custom = Stripe.PaymentRecordReportPaymentParams.ProcessorDetails.Custom;
+    }
   }
   export namespace PaymentRecordReportPaymentAttemptParams {
     export type Failed = Stripe.PaymentRecordReportPaymentAttemptParams.Failed;
@@ -1057,6 +6544,10 @@ declare namespace StripeConstructor {
     export type Outcome = Stripe.PaymentRecordReportPaymentAttemptParams.Outcome;
     export type PaymentMethodDetails = Stripe.PaymentRecordReportPaymentAttemptParams.PaymentMethodDetails;
     export type ShippingDetails = Stripe.PaymentRecordReportPaymentAttemptParams.ShippingDetails;
+    export namespace PaymentMethodDetails {
+      export type BillingDetails = Stripe.PaymentRecordReportPaymentAttemptParams.PaymentMethodDetails.BillingDetails;
+      export type Custom = Stripe.PaymentRecordReportPaymentAttemptParams.PaymentMethodDetails.Custom;
+    }
   }
   export namespace PaymentRecordReportPaymentAttemptInformationalParams {
     export type CustomerDetails = Stripe.PaymentRecordReportPaymentAttemptInformationalParams.CustomerDetails;
@@ -1066,10 +6557,225 @@ declare namespace StripeConstructor {
     export type ProcessorDetails = Stripe.PaymentRecordReportRefundParams.ProcessorDetails;
     export type Refunded = Stripe.PaymentRecordReportRefundParams.Refunded;
     export type Amount = Stripe.PaymentRecordReportRefundParams.Amount;
+    export namespace ProcessorDetails {
+      export type Custom = Stripe.PaymentRecordReportRefundParams.ProcessorDetails.Custom;
+    }
+  }
+  export namespace PaymentRecord {
+    export type Amount = Stripe.PaymentRecord.Amount;
+    export type AmountAuthorized = Stripe.PaymentRecord.AmountAuthorized;
+    export type AmountCanceled = Stripe.PaymentRecord.AmountCanceled;
+    export type AmountFailed = Stripe.PaymentRecord.AmountFailed;
+    export type AmountGuaranteed = Stripe.PaymentRecord.AmountGuaranteed;
+    export type AmountRefunded = Stripe.PaymentRecord.AmountRefunded;
+    export type AmountRequested = Stripe.PaymentRecord.AmountRequested;
+    export type CustomerDetails = Stripe.PaymentRecord.CustomerDetails;
+    export type CustomerPresence = Stripe.PaymentRecord.CustomerPresence;
+    export type PaymentMethodDetails = Stripe.PaymentRecord.PaymentMethodDetails;
+    export type ProcessorDetails = Stripe.PaymentRecord.ProcessorDetails;
+    export type ReportedBy = Stripe.PaymentRecord.ReportedBy;
+    export type ShippingDetails = Stripe.PaymentRecord.ShippingDetails;
+    export namespace PaymentMethodDetails {
+      export type AchCreditTransfer = Stripe.PaymentRecord.PaymentMethodDetails.AchCreditTransfer;
+      export type AchDebit = Stripe.PaymentRecord.PaymentMethodDetails.AchDebit;
+      export type AcssDebit = Stripe.PaymentRecord.PaymentMethodDetails.AcssDebit;
+      export type Affirm = Stripe.PaymentRecord.PaymentMethodDetails.Affirm;
+      export type AfterpayClearpay = Stripe.PaymentRecord.PaymentMethodDetails.AfterpayClearpay;
+      export type Alipay = Stripe.PaymentRecord.PaymentMethodDetails.Alipay;
+      export type Alma = Stripe.PaymentRecord.PaymentMethodDetails.Alma;
+      export type AmazonPay = Stripe.PaymentRecord.PaymentMethodDetails.AmazonPay;
+      export type AuBecsDebit = Stripe.PaymentRecord.PaymentMethodDetails.AuBecsDebit;
+      export type BacsDebit = Stripe.PaymentRecord.PaymentMethodDetails.BacsDebit;
+      export type Bancontact = Stripe.PaymentRecord.PaymentMethodDetails.Bancontact;
+      export type Billie = Stripe.PaymentRecord.PaymentMethodDetails.Billie;
+      export type BillingDetails = Stripe.PaymentRecord.PaymentMethodDetails.BillingDetails;
+      export type Bizum = Stripe.PaymentRecord.PaymentMethodDetails.Bizum;
+      export type Blik = Stripe.PaymentRecord.PaymentMethodDetails.Blik;
+      export type Boleto = Stripe.PaymentRecord.PaymentMethodDetails.Boleto;
+      export type Card = Stripe.PaymentRecord.PaymentMethodDetails.Card;
+      export type CardPresent = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent;
+      export type Cashapp = Stripe.PaymentRecord.PaymentMethodDetails.Cashapp;
+      export type Crypto = Stripe.PaymentRecord.PaymentMethodDetails.Crypto;
+      export type Custom = Stripe.PaymentRecord.PaymentMethodDetails.Custom;
+      export type CustomerBalance = Stripe.PaymentRecord.PaymentMethodDetails.CustomerBalance;
+      export type Eps = Stripe.PaymentRecord.PaymentMethodDetails.Eps;
+      export type Fpx = Stripe.PaymentRecord.PaymentMethodDetails.Fpx;
+      export type Giropay = Stripe.PaymentRecord.PaymentMethodDetails.Giropay;
+      export type Grabpay = Stripe.PaymentRecord.PaymentMethodDetails.Grabpay;
+      export type Ideal = Stripe.PaymentRecord.PaymentMethodDetails.Ideal;
+      export type InteracPresent = Stripe.PaymentRecord.PaymentMethodDetails.InteracPresent;
+      export type KakaoPay = Stripe.PaymentRecord.PaymentMethodDetails.KakaoPay;
+      export type Klarna = Stripe.PaymentRecord.PaymentMethodDetails.Klarna;
+      export type Konbini = Stripe.PaymentRecord.PaymentMethodDetails.Konbini;
+      export type KrCard = Stripe.PaymentRecord.PaymentMethodDetails.KrCard;
+      export type Link = Stripe.PaymentRecord.PaymentMethodDetails.Link;
+      export type MbWay = Stripe.PaymentRecord.PaymentMethodDetails.MbWay;
+      export type Mobilepay = Stripe.PaymentRecord.PaymentMethodDetails.Mobilepay;
+      export type Multibanco = Stripe.PaymentRecord.PaymentMethodDetails.Multibanco;
+      export type NaverPay = Stripe.PaymentRecord.PaymentMethodDetails.NaverPay;
+      export type NzBankAccount = Stripe.PaymentRecord.PaymentMethodDetails.NzBankAccount;
+      export type Oxxo = Stripe.PaymentRecord.PaymentMethodDetails.Oxxo;
+      export type P24 = Stripe.PaymentRecord.PaymentMethodDetails.P24;
+      export type PayByBank = Stripe.PaymentRecord.PaymentMethodDetails.PayByBank;
+      export type Payco = Stripe.PaymentRecord.PaymentMethodDetails.Payco;
+      export type Paynow = Stripe.PaymentRecord.PaymentMethodDetails.Paynow;
+      export type Paypal = Stripe.PaymentRecord.PaymentMethodDetails.Paypal;
+      export type Payto = Stripe.PaymentRecord.PaymentMethodDetails.Payto;
+      export type Pix = Stripe.PaymentRecord.PaymentMethodDetails.Pix;
+      export type Promptpay = Stripe.PaymentRecord.PaymentMethodDetails.Promptpay;
+      export type RevolutPay = Stripe.PaymentRecord.PaymentMethodDetails.RevolutPay;
+      export type SamsungPay = Stripe.PaymentRecord.PaymentMethodDetails.SamsungPay;
+      export type Satispay = Stripe.PaymentRecord.PaymentMethodDetails.Satispay;
+      export type Scalapay = Stripe.PaymentRecord.PaymentMethodDetails.Scalapay;
+      export type SepaCreditTransfer = Stripe.PaymentRecord.PaymentMethodDetails.SepaCreditTransfer;
+      export type SepaDebit = Stripe.PaymentRecord.PaymentMethodDetails.SepaDebit;
+      export type Sofort = Stripe.PaymentRecord.PaymentMethodDetails.Sofort;
+      export type StripeAccount = Stripe.PaymentRecord.PaymentMethodDetails.StripeAccount;
+      export type Sunbit = Stripe.PaymentRecord.PaymentMethodDetails.Sunbit;
+      export type Swish = Stripe.PaymentRecord.PaymentMethodDetails.Swish;
+      export type Twint = Stripe.PaymentRecord.PaymentMethodDetails.Twint;
+      export type Upi = Stripe.PaymentRecord.PaymentMethodDetails.Upi;
+      export type UsBankAccount = Stripe.PaymentRecord.PaymentMethodDetails.UsBankAccount;
+      export type Wechat = Stripe.PaymentRecord.PaymentMethodDetails.Wechat;
+      export type WechatPay = Stripe.PaymentRecord.PaymentMethodDetails.WechatPay;
+      export type Zip = Stripe.PaymentRecord.PaymentMethodDetails.Zip;
+      export namespace AchDebit {
+        export type AccountHolderType = Stripe.PaymentRecord.PaymentMethodDetails.AchDebit.AccountHolderType;
+      }
+      export namespace Alma {
+        export type Installments = Stripe.PaymentRecord.PaymentMethodDetails.Alma.Installments;
+      }
+      export namespace AmazonPay {
+        export type Funding = Stripe.PaymentRecord.PaymentMethodDetails.AmazonPay.Funding;
+        export namespace Funding {
+          export type Card = Stripe.PaymentRecord.PaymentMethodDetails.AmazonPay.Funding.Card;
+        }
+      }
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.PaymentRecord.PaymentMethodDetails.Bancontact.PreferredLanguage;
+      }
+      export namespace Card {
+        export type Brand = Stripe.PaymentRecord.PaymentMethodDetails.Card.Brand;
+        export type Checks = Stripe.PaymentRecord.PaymentMethodDetails.Card.Checks;
+        export type Funding = Stripe.PaymentRecord.PaymentMethodDetails.Card.Funding;
+        export type Installments = Stripe.PaymentRecord.PaymentMethodDetails.Card.Installments;
+        export type Network = Stripe.PaymentRecord.PaymentMethodDetails.Card.Network;
+        export type NetworkToken = Stripe.PaymentRecord.PaymentMethodDetails.Card.NetworkToken;
+        export type StoredCredentialUsage = Stripe.PaymentRecord.PaymentMethodDetails.Card.StoredCredentialUsage;
+        export type ThreeDSecure = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure;
+        export type Wallet = Stripe.PaymentRecord.PaymentMethodDetails.Card.Wallet;
+        export namespace Checks {
+          export type AddressLine1Check = Stripe.PaymentRecord.PaymentMethodDetails.Card.Checks.AddressLine1Check;
+          export type AddressPostalCodeCheck = Stripe.PaymentRecord.PaymentMethodDetails.Card.Checks.AddressPostalCodeCheck;
+          export type CvcCheck = Stripe.PaymentRecord.PaymentMethodDetails.Card.Checks.CvcCheck;
+        }
+        export namespace Installments {
+          export type Plan = Stripe.PaymentRecord.PaymentMethodDetails.Card.Installments.Plan;
+          export namespace Plan {
+            export type Type = Stripe.PaymentRecord.PaymentMethodDetails.Card.Installments.Plan.Type;
+          }
+        }
+        export namespace ThreeDSecure {
+          export type AuthenticationFlow = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure.AuthenticationFlow;
+          export type ElectronicCommerceIndicator = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type ExemptionIndicator = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure.ExemptionIndicator;
+          export type Result = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure.Result;
+          export type ResultReason = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure.ResultReason;
+          export type Version = Stripe.PaymentRecord.PaymentMethodDetails.Card.ThreeDSecure.Version;
+        }
+        export namespace Wallet {
+          export type ApplePay = Stripe.PaymentRecord.PaymentMethodDetails.Card.Wallet.ApplePay;
+          export type GooglePay = Stripe.PaymentRecord.PaymentMethodDetails.Card.Wallet.GooglePay;
+        }
+      }
+      export namespace CardPresent {
+        export type Offline = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent.Offline;
+        export type ReadMethod = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent.ReadMethod;
+        export type Receipt = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent.Receipt;
+        export type Wallet = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent.Wallet;
+        export namespace Receipt {
+          export type AccountType = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent.Receipt.AccountType;
+        }
+        export namespace Wallet {
+          export type Type = Stripe.PaymentRecord.PaymentMethodDetails.CardPresent.Wallet.Type;
+        }
+      }
+      export namespace Crypto {
+        export type Network = Stripe.PaymentRecord.PaymentMethodDetails.Crypto.Network;
+        export type TokenCurrency = Stripe.PaymentRecord.PaymentMethodDetails.Crypto.TokenCurrency;
+      }
+      export namespace Eps {
+        export type Bank = Stripe.PaymentRecord.PaymentMethodDetails.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.PaymentRecord.PaymentMethodDetails.Fpx.AccountHolderType;
+        export type Bank = Stripe.PaymentRecord.PaymentMethodDetails.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.PaymentRecord.PaymentMethodDetails.Ideal.Bank;
+        export type Bic = Stripe.PaymentRecord.PaymentMethodDetails.Ideal.Bic;
+      }
+      export namespace InteracPresent {
+        export type ReadMethod = Stripe.PaymentRecord.PaymentMethodDetails.InteracPresent.ReadMethod;
+        export type Receipt = Stripe.PaymentRecord.PaymentMethodDetails.InteracPresent.Receipt;
+        export namespace Receipt {
+          export type AccountType = Stripe.PaymentRecord.PaymentMethodDetails.InteracPresent.Receipt.AccountType;
+        }
+      }
+      export namespace Klarna {
+        export type PayerDetails = Stripe.PaymentRecord.PaymentMethodDetails.Klarna.PayerDetails;
+        export namespace PayerDetails {
+          export type Address = Stripe.PaymentRecord.PaymentMethodDetails.Klarna.PayerDetails.Address;
+        }
+      }
+      export namespace Konbini {
+        export type Store = Stripe.PaymentRecord.PaymentMethodDetails.Konbini.Store;
+        export namespace Store {
+          export type Chain = Stripe.PaymentRecord.PaymentMethodDetails.Konbini.Store.Chain;
+        }
+      }
+      export namespace KrCard {
+        export type Brand = Stripe.PaymentRecord.PaymentMethodDetails.KrCard.Brand;
+      }
+      export namespace Mobilepay {
+        export type Card = Stripe.PaymentRecord.PaymentMethodDetails.Mobilepay.Card;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.PaymentRecord.PaymentMethodDetails.P24.Bank;
+      }
+      export namespace Paypal {
+        export type SellerProtection = Stripe.PaymentRecord.PaymentMethodDetails.Paypal.SellerProtection;
+        export namespace SellerProtection {
+          export type DisputeCategory = Stripe.PaymentRecord.PaymentMethodDetails.Paypal.SellerProtection.DisputeCategory;
+          export type Status = Stripe.PaymentRecord.PaymentMethodDetails.Paypal.SellerProtection.Status;
+        }
+      }
+      export namespace RevolutPay {
+        export type Funding = Stripe.PaymentRecord.PaymentMethodDetails.RevolutPay.Funding;
+        export namespace Funding {
+          export type Card = Stripe.PaymentRecord.PaymentMethodDetails.RevolutPay.Funding.Card;
+        }
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.PaymentRecord.PaymentMethodDetails.Sofort.PreferredLanguage;
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.PaymentRecord.PaymentMethodDetails.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.PaymentRecord.PaymentMethodDetails.UsBankAccount.AccountType;
+      }
+    }
+    export namespace ProcessorDetails {
+      export type Custom = Stripe.PaymentRecord.ProcessorDetails.Custom;
+    }
   }
   export namespace PayoutCreateParams {
     export type Method = Stripe.PayoutCreateParams.Method;
     export type SourceType = Stripe.PayoutCreateParams.SourceType;
+  }
+  export namespace Payout {
+    export type ReconciliationStatus = Stripe.Payout.ReconciliationStatus;
+    export type TraceId = Stripe.Payout.TraceId;
+    export type Type = Stripe.Payout.Type;
   }
   export namespace PlanCreateParams {
     export type Interval = Stripe.PlanCreateParams.Interval;
@@ -1079,6 +6785,20 @@ declare namespace StripeConstructor {
     export type TiersMode = Stripe.PlanCreateParams.TiersMode;
     export type TransformUsage = Stripe.PlanCreateParams.TransformUsage;
     export type UsageType = Stripe.PlanCreateParams.UsageType;
+    export namespace TransformUsage {
+      export type Round = Stripe.PlanCreateParams.TransformUsage.Round;
+    }
+  }
+  export namespace Plan {
+    export type BillingScheme = Stripe.Plan.BillingScheme;
+    export type Interval = Stripe.Plan.Interval;
+    export type Tier = Stripe.Plan.Tier;
+    export type TiersMode = Stripe.Plan.TiersMode;
+    export type TransformUsage = Stripe.Plan.TransformUsage;
+    export type UsageType = Stripe.Plan.UsageType;
+    export namespace TransformUsage {
+      export type Round = Stripe.Plan.TransformUsage.Round;
+    }
   }
   export namespace PriceCreateParams {
     export type BillingScheme = Stripe.PriceCreateParams.BillingScheme;
@@ -1090,20 +6810,78 @@ declare namespace StripeConstructor {
     export type Tier = Stripe.PriceCreateParams.Tier;
     export type TiersMode = Stripe.PriceCreateParams.TiersMode;
     export type TransformQuantity = Stripe.PriceCreateParams.TransformQuantity;
+    export namespace CurrencyOptions {
+      export type CustomUnitAmount = Stripe.PriceCreateParams.CurrencyOptions.CustomUnitAmount;
+      export type TaxBehavior = Stripe.PriceCreateParams.CurrencyOptions.TaxBehavior;
+      export type Tier = Stripe.PriceCreateParams.CurrencyOptions.Tier;
+    }
+    export namespace Recurring {
+      export type Interval = Stripe.PriceCreateParams.Recurring.Interval;
+      export type UsageType = Stripe.PriceCreateParams.Recurring.UsageType;
+    }
+    export namespace TransformQuantity {
+      export type Round = Stripe.PriceCreateParams.TransformQuantity.Round;
+    }
   }
   export namespace PriceUpdateParams {
     export type CurrencyOptions = Stripe.PriceUpdateParams.CurrencyOptions;
     export type TaxBehavior = Stripe.PriceUpdateParams.TaxBehavior;
+    export namespace CurrencyOptions {
+      export type CustomUnitAmount = Stripe.PriceUpdateParams.CurrencyOptions.CustomUnitAmount;
+      export type TaxBehavior = Stripe.PriceUpdateParams.CurrencyOptions.TaxBehavior;
+      export type Tier = Stripe.PriceUpdateParams.CurrencyOptions.Tier;
+    }
   }
   export namespace PriceListParams {
     export type Recurring = Stripe.PriceListParams.Recurring;
     export type Type = Stripe.PriceListParams.Type;
+    export namespace Recurring {
+      export type Interval = Stripe.PriceListParams.Recurring.Interval;
+      export type UsageType = Stripe.PriceListParams.Recurring.UsageType;
+    }
+  }
+  export namespace Price {
+    export type BillingScheme = Stripe.Price.BillingScheme;
+    export type CurrencyOptions = Stripe.Price.CurrencyOptions;
+    export type CustomUnitAmount = Stripe.Price.CustomUnitAmount;
+    export type Recurring = Stripe.Price.Recurring;
+    export type TaxBehavior = Stripe.Price.TaxBehavior;
+    export type Tier = Stripe.Price.Tier;
+    export type TiersMode = Stripe.Price.TiersMode;
+    export type TransformQuantity = Stripe.Price.TransformQuantity;
+    export type Type = Stripe.Price.Type;
+    export namespace CurrencyOptions {
+      export type CustomUnitAmount = Stripe.Price.CurrencyOptions.CustomUnitAmount;
+      export type TaxBehavior = Stripe.Price.CurrencyOptions.TaxBehavior;
+      export type Tier = Stripe.Price.CurrencyOptions.Tier;
+    }
+    export namespace Recurring {
+      export type Interval = Stripe.Price.Recurring.Interval;
+      export type UsageType = Stripe.Price.Recurring.UsageType;
+    }
+    export namespace TransformQuantity {
+      export type Round = Stripe.Price.TransformQuantity.Round;
+    }
   }
   export namespace ProductCreateParams {
     export type DefaultPriceData = Stripe.ProductCreateParams.DefaultPriceData;
     export type MarketingFeature = Stripe.ProductCreateParams.MarketingFeature;
     export type PackageDimensions = Stripe.ProductCreateParams.PackageDimensions;
     export type Type = Stripe.ProductCreateParams.Type;
+    export namespace DefaultPriceData {
+      export type CurrencyOptions = Stripe.ProductCreateParams.DefaultPriceData.CurrencyOptions;
+      export type CustomUnitAmount = Stripe.ProductCreateParams.DefaultPriceData.CustomUnitAmount;
+      export type Recurring = Stripe.ProductCreateParams.DefaultPriceData.Recurring;
+      export type TaxBehavior = Stripe.ProductCreateParams.DefaultPriceData.TaxBehavior;
+      export namespace CurrencyOptions {
+        export type CustomUnitAmount = Stripe.ProductCreateParams.DefaultPriceData.CurrencyOptions.CustomUnitAmount;
+        export type TaxBehavior = Stripe.ProductCreateParams.DefaultPriceData.CurrencyOptions.TaxBehavior;
+        export type Tier = Stripe.ProductCreateParams.DefaultPriceData.CurrencyOptions.Tier;
+      }
+      export namespace Recurring {
+        export type Interval = Stripe.ProductCreateParams.DefaultPriceData.Recurring.Interval;
+      }
+    }
   }
   export namespace ProductUpdateParams {
     export type MarketingFeature = Stripe.ProductUpdateParams.MarketingFeature;
@@ -1112,12 +6890,30 @@ declare namespace StripeConstructor {
   export namespace ProductListParams {
     export type Type = Stripe.ProductListParams.Type;
   }
+  export namespace Product {
+    export type MarketingFeature = Stripe.Product.MarketingFeature;
+    export type PackageDimensions = Stripe.Product.PackageDimensions;
+    export type Type = Stripe.Product.Type;
+  }
   export namespace PromotionCodeCreateParams {
     export type Promotion = Stripe.PromotionCodeCreateParams.Promotion;
     export type Restrictions = Stripe.PromotionCodeCreateParams.Restrictions;
+    export namespace Restrictions {
+      export type CurrencyOptions = Stripe.PromotionCodeCreateParams.Restrictions.CurrencyOptions;
+    }
   }
   export namespace PromotionCodeUpdateParams {
     export type Restrictions = Stripe.PromotionCodeUpdateParams.Restrictions;
+    export namespace Restrictions {
+      export type CurrencyOptions = Stripe.PromotionCodeUpdateParams.Restrictions.CurrencyOptions;
+    }
+  }
+  export namespace PromotionCode {
+    export type Promotion = Stripe.PromotionCode.Promotion;
+    export type Restrictions = Stripe.PromotionCode.Restrictions;
+    export namespace Restrictions {
+      export type CurrencyOptions = Stripe.PromotionCode.Restrictions.CurrencyOptions;
+    }
   }
   export namespace QuoteCreateParams {
     export type AutomaticTax = Stripe.QuoteCreateParams.AutomaticTax;
@@ -1128,6 +6924,39 @@ declare namespace StripeConstructor {
     export type LineItem = Stripe.QuoteCreateParams.LineItem;
     export type SubscriptionData = Stripe.QuoteCreateParams.SubscriptionData;
     export type TransferData = Stripe.QuoteCreateParams.TransferData;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.QuoteCreateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.QuoteCreateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace InvoiceSettings {
+      export type Issuer = Stripe.QuoteCreateParams.InvoiceSettings.Issuer;
+      export namespace Issuer {
+        export type Type = Stripe.QuoteCreateParams.InvoiceSettings.Issuer.Type;
+      }
+    }
+    export namespace LineItem {
+      export type Discount = Stripe.QuoteCreateParams.LineItem.Discount;
+      export type PriceData = Stripe.QuoteCreateParams.LineItem.PriceData;
+      export namespace PriceData {
+        export type Recurring = Stripe.QuoteCreateParams.LineItem.PriceData.Recurring;
+        export type TaxBehavior = Stripe.QuoteCreateParams.LineItem.PriceData.TaxBehavior;
+        export namespace Recurring {
+          export type Interval = Stripe.QuoteCreateParams.LineItem.PriceData.Recurring.Interval;
+        }
+      }
+    }
+    export namespace SubscriptionData {
+      export type BillingMode = Stripe.QuoteCreateParams.SubscriptionData.BillingMode;
+      export namespace BillingMode {
+        export type Flexible = Stripe.QuoteCreateParams.SubscriptionData.BillingMode.Flexible;
+        export type Type = Stripe.QuoteCreateParams.SubscriptionData.BillingMode.Type;
+        export namespace Flexible {
+          export type ProrationDiscounts = Stripe.QuoteCreateParams.SubscriptionData.BillingMode.Flexible.ProrationDiscounts;
+        }
+      }
+    }
   }
   export namespace QuoteUpdateParams {
     export type AutomaticTax = Stripe.QuoteUpdateParams.AutomaticTax;
@@ -1137,12 +6966,237 @@ declare namespace StripeConstructor {
     export type LineItem = Stripe.QuoteUpdateParams.LineItem;
     export type SubscriptionData = Stripe.QuoteUpdateParams.SubscriptionData;
     export type TransferData = Stripe.QuoteUpdateParams.TransferData;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.QuoteUpdateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.QuoteUpdateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace InvoiceSettings {
+      export type Issuer = Stripe.QuoteUpdateParams.InvoiceSettings.Issuer;
+      export namespace Issuer {
+        export type Type = Stripe.QuoteUpdateParams.InvoiceSettings.Issuer.Type;
+      }
+    }
+    export namespace LineItem {
+      export type Discount = Stripe.QuoteUpdateParams.LineItem.Discount;
+      export type PriceData = Stripe.QuoteUpdateParams.LineItem.PriceData;
+      export namespace PriceData {
+        export type Recurring = Stripe.QuoteUpdateParams.LineItem.PriceData.Recurring;
+        export type TaxBehavior = Stripe.QuoteUpdateParams.LineItem.PriceData.TaxBehavior;
+        export namespace Recurring {
+          export type Interval = Stripe.QuoteUpdateParams.LineItem.PriceData.Recurring.Interval;
+        }
+      }
+    }
   }
   export namespace QuoteListParams {
     export type Status = Stripe.QuoteListParams.Status;
   }
+  export namespace Quote {
+    export type AutomaticTax = Stripe.Quote.AutomaticTax;
+    export type CollectionMethod = Stripe.Quote.CollectionMethod;
+    export type Computed = Stripe.Quote.Computed;
+    export type FromQuote = Stripe.Quote.FromQuote;
+    export type InvoiceSettings = Stripe.Quote.InvoiceSettings;
+    export type Status = Stripe.Quote.Status;
+    export type StatusTransitions = Stripe.Quote.StatusTransitions;
+    export type SubscriptionData = Stripe.Quote.SubscriptionData;
+    export type TotalDetails = Stripe.Quote.TotalDetails;
+    export type TransferData = Stripe.Quote.TransferData;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.Quote.AutomaticTax.Liability;
+      export type Status = Stripe.Quote.AutomaticTax.Status;
+      export namespace Liability {
+        export type Type = Stripe.Quote.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace Computed {
+      export type Recurring = Stripe.Quote.Computed.Recurring;
+      export type Upfront = Stripe.Quote.Computed.Upfront;
+      export namespace Recurring {
+        export type Interval = Stripe.Quote.Computed.Recurring.Interval;
+        export type TotalDetails = Stripe.Quote.Computed.Recurring.TotalDetails;
+        export namespace TotalDetails {
+          export type Breakdown = Stripe.Quote.Computed.Recurring.TotalDetails.Breakdown;
+          export namespace Breakdown {
+            export type Discount = Stripe.Quote.Computed.Recurring.TotalDetails.Breakdown.Discount;
+            export type Tax = Stripe.Quote.Computed.Recurring.TotalDetails.Breakdown.Tax;
+            export namespace Tax {
+              export type TaxabilityReason = Stripe.Quote.Computed.Recurring.TotalDetails.Breakdown.Tax.TaxabilityReason;
+            }
+          }
+        }
+      }
+      export namespace Upfront {
+        export type TotalDetails = Stripe.Quote.Computed.Upfront.TotalDetails;
+        export namespace TotalDetails {
+          export type Breakdown = Stripe.Quote.Computed.Upfront.TotalDetails.Breakdown;
+          export namespace Breakdown {
+            export type Discount = Stripe.Quote.Computed.Upfront.TotalDetails.Breakdown.Discount;
+            export type Tax = Stripe.Quote.Computed.Upfront.TotalDetails.Breakdown.Tax;
+            export namespace Tax {
+              export type TaxabilityReason = Stripe.Quote.Computed.Upfront.TotalDetails.Breakdown.Tax.TaxabilityReason;
+            }
+          }
+        }
+      }
+    }
+    export namespace InvoiceSettings {
+      export type Issuer = Stripe.Quote.InvoiceSettings.Issuer;
+      export namespace Issuer {
+        export type Type = Stripe.Quote.InvoiceSettings.Issuer.Type;
+      }
+    }
+    export namespace SubscriptionData {
+      export type BillingMode = Stripe.Quote.SubscriptionData.BillingMode;
+      export namespace BillingMode {
+        export type Flexible = Stripe.Quote.SubscriptionData.BillingMode.Flexible;
+        export type Type = Stripe.Quote.SubscriptionData.BillingMode.Type;
+        export namespace Flexible {
+          export type ProrationDiscounts = Stripe.Quote.SubscriptionData.BillingMode.Flexible.ProrationDiscounts;
+        }
+      }
+    }
+    export namespace TotalDetails {
+      export type Breakdown = Stripe.Quote.TotalDetails.Breakdown;
+      export namespace Breakdown {
+        export type Discount = Stripe.Quote.TotalDetails.Breakdown.Discount;
+        export type Tax = Stripe.Quote.TotalDetails.Breakdown.Tax;
+        export namespace Tax {
+          export type TaxabilityReason = Stripe.Quote.TotalDetails.Breakdown.Tax.TaxabilityReason;
+        }
+      }
+    }
+  }
   export namespace RefundCreateParams {
     export type Reason = Stripe.RefundCreateParams.Reason;
+  }
+  export namespace Refund {
+    export type DestinationDetails = Stripe.Refund.DestinationDetails;
+    export type NextAction = Stripe.Refund.NextAction;
+    export type PendingReason = Stripe.Refund.PendingReason;
+    export type PresentmentDetails = Stripe.Refund.PresentmentDetails;
+    export type Reason = Stripe.Refund.Reason;
+    export namespace DestinationDetails {
+      export type Affirm = Stripe.Refund.DestinationDetails.Affirm;
+      export type AfterpayClearpay = Stripe.Refund.DestinationDetails.AfterpayClearpay;
+      export type Alipay = Stripe.Refund.DestinationDetails.Alipay;
+      export type Alma = Stripe.Refund.DestinationDetails.Alma;
+      export type AmazonPay = Stripe.Refund.DestinationDetails.AmazonPay;
+      export type AuBankTransfer = Stripe.Refund.DestinationDetails.AuBankTransfer;
+      export type Blik = Stripe.Refund.DestinationDetails.Blik;
+      export type BrBankTransfer = Stripe.Refund.DestinationDetails.BrBankTransfer;
+      export type Card = Stripe.Refund.DestinationDetails.Card;
+      export type Cashapp = Stripe.Refund.DestinationDetails.Cashapp;
+      export type Crypto = Stripe.Refund.DestinationDetails.Crypto;
+      export type CustomerCashBalance = Stripe.Refund.DestinationDetails.CustomerCashBalance;
+      export type Eps = Stripe.Refund.DestinationDetails.Eps;
+      export type EuBankTransfer = Stripe.Refund.DestinationDetails.EuBankTransfer;
+      export type GbBankTransfer = Stripe.Refund.DestinationDetails.GbBankTransfer;
+      export type Giropay = Stripe.Refund.DestinationDetails.Giropay;
+      export type Grabpay = Stripe.Refund.DestinationDetails.Grabpay;
+      export type JpBankTransfer = Stripe.Refund.DestinationDetails.JpBankTransfer;
+      export type Klarna = Stripe.Refund.DestinationDetails.Klarna;
+      export type MbWay = Stripe.Refund.DestinationDetails.MbWay;
+      export type Multibanco = Stripe.Refund.DestinationDetails.Multibanco;
+      export type MxBankTransfer = Stripe.Refund.DestinationDetails.MxBankTransfer;
+      export type NzBankTransfer = Stripe.Refund.DestinationDetails.NzBankTransfer;
+      export type P24 = Stripe.Refund.DestinationDetails.P24;
+      export type Paynow = Stripe.Refund.DestinationDetails.Paynow;
+      export type Paypal = Stripe.Refund.DestinationDetails.Paypal;
+      export type Pix = Stripe.Refund.DestinationDetails.Pix;
+      export type Revolut = Stripe.Refund.DestinationDetails.Revolut;
+      export type Scalapay = Stripe.Refund.DestinationDetails.Scalapay;
+      export type Sofort = Stripe.Refund.DestinationDetails.Sofort;
+      export type Swish = Stripe.Refund.DestinationDetails.Swish;
+      export type ThBankTransfer = Stripe.Refund.DestinationDetails.ThBankTransfer;
+      export type Twint = Stripe.Refund.DestinationDetails.Twint;
+      export type UsBankTransfer = Stripe.Refund.DestinationDetails.UsBankTransfer;
+      export type WechatPay = Stripe.Refund.DestinationDetails.WechatPay;
+      export type Zip = Stripe.Refund.DestinationDetails.Zip;
+      export namespace Card {
+        export type Type = Stripe.Refund.DestinationDetails.Card.Type;
+      }
+    }
+    export namespace NextAction {
+      export type DisplayDetails = Stripe.Refund.NextAction.DisplayDetails;
+      export namespace DisplayDetails {
+        export type EmailSent = Stripe.Refund.NextAction.DisplayDetails.EmailSent;
+      }
+    }
+  }
+  export namespace Review {
+    export type ClosedReason = Stripe.Review.ClosedReason;
+    export type IpAddressLocation = Stripe.Review.IpAddressLocation;
+    export type OpenedReason = Stripe.Review.OpenedReason;
+    export type Session = Stripe.Review.Session;
+  }
+  export namespace SetupAttempt {
+    export type FlowDirection = Stripe.SetupAttempt.FlowDirection;
+    export type PaymentMethodDetails = Stripe.SetupAttempt.PaymentMethodDetails;
+    export type SetupError = Stripe.SetupAttempt.SetupError;
+    export namespace PaymentMethodDetails {
+      export type AcssDebit = Stripe.SetupAttempt.PaymentMethodDetails.AcssDebit;
+      export type AmazonPay = Stripe.SetupAttempt.PaymentMethodDetails.AmazonPay;
+      export type AuBecsDebit = Stripe.SetupAttempt.PaymentMethodDetails.AuBecsDebit;
+      export type BacsDebit = Stripe.SetupAttempt.PaymentMethodDetails.BacsDebit;
+      export type Bancontact = Stripe.SetupAttempt.PaymentMethodDetails.Bancontact;
+      export type Boleto = Stripe.SetupAttempt.PaymentMethodDetails.Boleto;
+      export type Card = Stripe.SetupAttempt.PaymentMethodDetails.Card;
+      export type CardPresent = Stripe.SetupAttempt.PaymentMethodDetails.CardPresent;
+      export type Cashapp = Stripe.SetupAttempt.PaymentMethodDetails.Cashapp;
+      export type Ideal = Stripe.SetupAttempt.PaymentMethodDetails.Ideal;
+      export type KakaoPay = Stripe.SetupAttempt.PaymentMethodDetails.KakaoPay;
+      export type Klarna = Stripe.SetupAttempt.PaymentMethodDetails.Klarna;
+      export type KrCard = Stripe.SetupAttempt.PaymentMethodDetails.KrCard;
+      export type Link = Stripe.SetupAttempt.PaymentMethodDetails.Link;
+      export type NaverPay = Stripe.SetupAttempt.PaymentMethodDetails.NaverPay;
+      export type NzBankAccount = Stripe.SetupAttempt.PaymentMethodDetails.NzBankAccount;
+      export type Paypal = Stripe.SetupAttempt.PaymentMethodDetails.Paypal;
+      export type Payto = Stripe.SetupAttempt.PaymentMethodDetails.Payto;
+      export type Pix = Stripe.SetupAttempt.PaymentMethodDetails.Pix;
+      export type RevolutPay = Stripe.SetupAttempt.PaymentMethodDetails.RevolutPay;
+      export type SepaDebit = Stripe.SetupAttempt.PaymentMethodDetails.SepaDebit;
+      export type Sofort = Stripe.SetupAttempt.PaymentMethodDetails.Sofort;
+      export type Twint = Stripe.SetupAttempt.PaymentMethodDetails.Twint;
+      export type Upi = Stripe.SetupAttempt.PaymentMethodDetails.Upi;
+      export type UsBankAccount = Stripe.SetupAttempt.PaymentMethodDetails.UsBankAccount;
+      export namespace Bancontact {
+        export type PreferredLanguage = Stripe.SetupAttempt.PaymentMethodDetails.Bancontact.PreferredLanguage;
+      }
+      export namespace Card {
+        export type Checks = Stripe.SetupAttempt.PaymentMethodDetails.Card.Checks;
+        export type ThreeDSecure = Stripe.SetupAttempt.PaymentMethodDetails.Card.ThreeDSecure;
+        export type Wallet = Stripe.SetupAttempt.PaymentMethodDetails.Card.Wallet;
+        export namespace ThreeDSecure {
+          export type AuthenticationFlow = Stripe.SetupAttempt.PaymentMethodDetails.Card.ThreeDSecure.AuthenticationFlow;
+          export type ElectronicCommerceIndicator = Stripe.SetupAttempt.PaymentMethodDetails.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type Result = Stripe.SetupAttempt.PaymentMethodDetails.Card.ThreeDSecure.Result;
+          export type ResultReason = Stripe.SetupAttempt.PaymentMethodDetails.Card.ThreeDSecure.ResultReason;
+          export type Version = Stripe.SetupAttempt.PaymentMethodDetails.Card.ThreeDSecure.Version;
+        }
+        export namespace Wallet {
+          export type ApplePay = Stripe.SetupAttempt.PaymentMethodDetails.Card.Wallet.ApplePay;
+          export type GooglePay = Stripe.SetupAttempt.PaymentMethodDetails.Card.Wallet.GooglePay;
+          export type Type = Stripe.SetupAttempt.PaymentMethodDetails.Card.Wallet.Type;
+        }
+      }
+      export namespace CardPresent {
+        export type Offline = Stripe.SetupAttempt.PaymentMethodDetails.CardPresent.Offline;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.SetupAttempt.PaymentMethodDetails.Ideal.Bank;
+        export type Bic = Stripe.SetupAttempt.PaymentMethodDetails.Ideal.Bic;
+      }
+      export namespace Sofort {
+        export type PreferredLanguage = Stripe.SetupAttempt.PaymentMethodDetails.Sofort.PreferredLanguage;
+      }
+    }
+    export namespace SetupError {
+      export type Code = Stripe.SetupAttempt.SetupError.Code;
+      export type Type = Stripe.SetupAttempt.SetupError.Type;
+    }
   }
   export namespace SetupIntentCreateParams {
     export type AutomaticPaymentMethods = Stripe.SetupIntentCreateParams.AutomaticPaymentMethods;
@@ -1153,12 +7207,419 @@ declare namespace StripeConstructor {
     export type PaymentMethodOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions;
     export type SingleUse = Stripe.SetupIntentCreateParams.SingleUse;
     export type Usage = Stripe.SetupIntentCreateParams.Usage;
+    export namespace AutomaticPaymentMethods {
+      export type AllowRedirects = Stripe.SetupIntentCreateParams.AutomaticPaymentMethods.AllowRedirects;
+    }
+    export namespace MandateData {
+      export type CustomerAcceptance = Stripe.SetupIntentCreateParams.MandateData.CustomerAcceptance;
+      export namespace CustomerAcceptance {
+        export type Offline = Stripe.SetupIntentCreateParams.MandateData.CustomerAcceptance.Offline;
+        export type Online = Stripe.SetupIntentCreateParams.MandateData.CustomerAcceptance.Online;
+        export type Type = Stripe.SetupIntentCreateParams.MandateData.CustomerAcceptance.Type;
+      }
+    }
+    export namespace PaymentMethodData {
+      export type AcssDebit = Stripe.SetupIntentCreateParams.PaymentMethodData.AcssDebit;
+      export type Affirm = Stripe.SetupIntentCreateParams.PaymentMethodData.Affirm;
+      export type AfterpayClearpay = Stripe.SetupIntentCreateParams.PaymentMethodData.AfterpayClearpay;
+      export type Alipay = Stripe.SetupIntentCreateParams.PaymentMethodData.Alipay;
+      export type AllowRedisplay = Stripe.SetupIntentCreateParams.PaymentMethodData.AllowRedisplay;
+      export type Alma = Stripe.SetupIntentCreateParams.PaymentMethodData.Alma;
+      export type AmazonPay = Stripe.SetupIntentCreateParams.PaymentMethodData.AmazonPay;
+      export type AuBecsDebit = Stripe.SetupIntentCreateParams.PaymentMethodData.AuBecsDebit;
+      export type BacsDebit = Stripe.SetupIntentCreateParams.PaymentMethodData.BacsDebit;
+      export type Bancontact = Stripe.SetupIntentCreateParams.PaymentMethodData.Bancontact;
+      export type Billie = Stripe.SetupIntentCreateParams.PaymentMethodData.Billie;
+      export type BillingDetails = Stripe.SetupIntentCreateParams.PaymentMethodData.BillingDetails;
+      export type Bizum = Stripe.SetupIntentCreateParams.PaymentMethodData.Bizum;
+      export type Blik = Stripe.SetupIntentCreateParams.PaymentMethodData.Blik;
+      export type Boleto = Stripe.SetupIntentCreateParams.PaymentMethodData.Boleto;
+      export type Cashapp = Stripe.SetupIntentCreateParams.PaymentMethodData.Cashapp;
+      export type Crypto = Stripe.SetupIntentCreateParams.PaymentMethodData.Crypto;
+      export type CustomerBalance = Stripe.SetupIntentCreateParams.PaymentMethodData.CustomerBalance;
+      export type Eps = Stripe.SetupIntentCreateParams.PaymentMethodData.Eps;
+      export type Fpx = Stripe.SetupIntentCreateParams.PaymentMethodData.Fpx;
+      export type Giropay = Stripe.SetupIntentCreateParams.PaymentMethodData.Giropay;
+      export type Grabpay = Stripe.SetupIntentCreateParams.PaymentMethodData.Grabpay;
+      export type Ideal = Stripe.SetupIntentCreateParams.PaymentMethodData.Ideal;
+      export type InteracPresent = Stripe.SetupIntentCreateParams.PaymentMethodData.InteracPresent;
+      export type KakaoPay = Stripe.SetupIntentCreateParams.PaymentMethodData.KakaoPay;
+      export type Klarna = Stripe.SetupIntentCreateParams.PaymentMethodData.Klarna;
+      export type Konbini = Stripe.SetupIntentCreateParams.PaymentMethodData.Konbini;
+      export type KrCard = Stripe.SetupIntentCreateParams.PaymentMethodData.KrCard;
+      export type Link = Stripe.SetupIntentCreateParams.PaymentMethodData.Link;
+      export type MbWay = Stripe.SetupIntentCreateParams.PaymentMethodData.MbWay;
+      export type Mobilepay = Stripe.SetupIntentCreateParams.PaymentMethodData.Mobilepay;
+      export type Multibanco = Stripe.SetupIntentCreateParams.PaymentMethodData.Multibanco;
+      export type NaverPay = Stripe.SetupIntentCreateParams.PaymentMethodData.NaverPay;
+      export type NzBankAccount = Stripe.SetupIntentCreateParams.PaymentMethodData.NzBankAccount;
+      export type Oxxo = Stripe.SetupIntentCreateParams.PaymentMethodData.Oxxo;
+      export type P24 = Stripe.SetupIntentCreateParams.PaymentMethodData.P24;
+      export type PayByBank = Stripe.SetupIntentCreateParams.PaymentMethodData.PayByBank;
+      export type Payco = Stripe.SetupIntentCreateParams.PaymentMethodData.Payco;
+      export type Paynow = Stripe.SetupIntentCreateParams.PaymentMethodData.Paynow;
+      export type Paypal = Stripe.SetupIntentCreateParams.PaymentMethodData.Paypal;
+      export type Payto = Stripe.SetupIntentCreateParams.PaymentMethodData.Payto;
+      export type Pix = Stripe.SetupIntentCreateParams.PaymentMethodData.Pix;
+      export type Promptpay = Stripe.SetupIntentCreateParams.PaymentMethodData.Promptpay;
+      export type RadarOptions = Stripe.SetupIntentCreateParams.PaymentMethodData.RadarOptions;
+      export type RevolutPay = Stripe.SetupIntentCreateParams.PaymentMethodData.RevolutPay;
+      export type SamsungPay = Stripe.SetupIntentCreateParams.PaymentMethodData.SamsungPay;
+      export type Satispay = Stripe.SetupIntentCreateParams.PaymentMethodData.Satispay;
+      export type Scalapay = Stripe.SetupIntentCreateParams.PaymentMethodData.Scalapay;
+      export type SepaDebit = Stripe.SetupIntentCreateParams.PaymentMethodData.SepaDebit;
+      export type Sofort = Stripe.SetupIntentCreateParams.PaymentMethodData.Sofort;
+      export type Sunbit = Stripe.SetupIntentCreateParams.PaymentMethodData.Sunbit;
+      export type Swish = Stripe.SetupIntentCreateParams.PaymentMethodData.Swish;
+      export type Twint = Stripe.SetupIntentCreateParams.PaymentMethodData.Twint;
+      export type Type = Stripe.SetupIntentCreateParams.PaymentMethodData.Type;
+      export type Upi = Stripe.SetupIntentCreateParams.PaymentMethodData.Upi;
+      export type UsBankAccount = Stripe.SetupIntentCreateParams.PaymentMethodData.UsBankAccount;
+      export type WechatPay = Stripe.SetupIntentCreateParams.PaymentMethodData.WechatPay;
+      export type Zip = Stripe.SetupIntentCreateParams.PaymentMethodData.Zip;
+      export namespace Eps {
+        export type Bank = Stripe.SetupIntentCreateParams.PaymentMethodData.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.SetupIntentCreateParams.PaymentMethodData.Fpx.AccountHolderType;
+        export type Bank = Stripe.SetupIntentCreateParams.PaymentMethodData.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.SetupIntentCreateParams.PaymentMethodData.Ideal.Bank;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.SetupIntentCreateParams.PaymentMethodData.Klarna.Dob;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.SetupIntentCreateParams.PaymentMethodData.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.SetupIntentCreateParams.PaymentMethodData.P24.Bank;
+      }
+      export namespace Sofort {
+        export type Country = Stripe.SetupIntentCreateParams.PaymentMethodData.Sofort.Country;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodData.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentCreateParams.PaymentMethodData.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.SetupIntentCreateParams.PaymentMethodData.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.SetupIntentCreateParams.PaymentMethodData.UsBankAccount.AccountType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit;
+      export type AmazonPay = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AmazonPay;
+      export type BacsDebit = Stripe.SetupIntentCreateParams.PaymentMethodOptions.BacsDebit;
+      export type Bizum = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Bizum;
+      export type Card = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.SetupIntentCreateParams.PaymentMethodOptions.CardPresent;
+      export type Klarna = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna;
+      export type Link = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Link;
+      export type Paypal = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Pix;
+      export type SepaDebit = Stripe.SetupIntentCreateParams.PaymentMethodOptions.SepaDebit;
+      export type Upi = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount;
+      export namespace AcssDebit {
+        export type Currency = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.Currency;
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type VerificationMethod = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type DefaultFor = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.DefaultFor;
+          export type PaymentSchedule = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.SetupIntentCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+      }
+      export namespace Card {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.Network;
+        export type RequestThreeDSecure = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type ThreeDSecure = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+        export namespace ThreeDSecure {
+          export type AresTransStatus = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.AresTransStatus;
+          export type ElectronicCommerceIndicator = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type NetworkOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions;
+          export type Version = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.Version;
+          export namespace NetworkOptions {
+            export type CartesBancaires = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires;
+            export namespace CartesBancaires {
+              export type CbAvalgo = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires.CbAvalgo;
+            }
+          }
+        }
+      }
+      export namespace Klarna {
+        export type OnDemand = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna.OnDemand;
+        export type PreferredLocale = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna.PreferredLocale;
+        export type Subscription = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna.Subscription;
+        export namespace OnDemand {
+          export type PurchaseInterval = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna.OnDemand.PurchaseInterval;
+        }
+        export namespace Subscription {
+          export type Interval = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+          export type NextBilling = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+        }
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Upi.MandateOptions;
+        export type SetupFutureUsage = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentCreateParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type Networks = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks;
+        export type VerificationMethod = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+        export namespace Networks {
+          export type Requested = Stripe.SetupIntentCreateParams.PaymentMethodOptions.UsBankAccount.Networks.Requested;
+        }
+      }
+    }
   }
   export namespace SetupIntentUpdateParams {
     export type ExcludedPaymentMethodType = Stripe.SetupIntentUpdateParams.ExcludedPaymentMethodType;
     export type FlowDirection = Stripe.SetupIntentUpdateParams.FlowDirection;
     export type PaymentMethodData = Stripe.SetupIntentUpdateParams.PaymentMethodData;
     export type PaymentMethodOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions;
+    export namespace PaymentMethodData {
+      export type AcssDebit = Stripe.SetupIntentUpdateParams.PaymentMethodData.AcssDebit;
+      export type Affirm = Stripe.SetupIntentUpdateParams.PaymentMethodData.Affirm;
+      export type AfterpayClearpay = Stripe.SetupIntentUpdateParams.PaymentMethodData.AfterpayClearpay;
+      export type Alipay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Alipay;
+      export type AllowRedisplay = Stripe.SetupIntentUpdateParams.PaymentMethodData.AllowRedisplay;
+      export type Alma = Stripe.SetupIntentUpdateParams.PaymentMethodData.Alma;
+      export type AmazonPay = Stripe.SetupIntentUpdateParams.PaymentMethodData.AmazonPay;
+      export type AuBecsDebit = Stripe.SetupIntentUpdateParams.PaymentMethodData.AuBecsDebit;
+      export type BacsDebit = Stripe.SetupIntentUpdateParams.PaymentMethodData.BacsDebit;
+      export type Bancontact = Stripe.SetupIntentUpdateParams.PaymentMethodData.Bancontact;
+      export type Billie = Stripe.SetupIntentUpdateParams.PaymentMethodData.Billie;
+      export type BillingDetails = Stripe.SetupIntentUpdateParams.PaymentMethodData.BillingDetails;
+      export type Bizum = Stripe.SetupIntentUpdateParams.PaymentMethodData.Bizum;
+      export type Blik = Stripe.SetupIntentUpdateParams.PaymentMethodData.Blik;
+      export type Boleto = Stripe.SetupIntentUpdateParams.PaymentMethodData.Boleto;
+      export type Cashapp = Stripe.SetupIntentUpdateParams.PaymentMethodData.Cashapp;
+      export type Crypto = Stripe.SetupIntentUpdateParams.PaymentMethodData.Crypto;
+      export type CustomerBalance = Stripe.SetupIntentUpdateParams.PaymentMethodData.CustomerBalance;
+      export type Eps = Stripe.SetupIntentUpdateParams.PaymentMethodData.Eps;
+      export type Fpx = Stripe.SetupIntentUpdateParams.PaymentMethodData.Fpx;
+      export type Giropay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Giropay;
+      export type Grabpay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Grabpay;
+      export type Ideal = Stripe.SetupIntentUpdateParams.PaymentMethodData.Ideal;
+      export type InteracPresent = Stripe.SetupIntentUpdateParams.PaymentMethodData.InteracPresent;
+      export type KakaoPay = Stripe.SetupIntentUpdateParams.PaymentMethodData.KakaoPay;
+      export type Klarna = Stripe.SetupIntentUpdateParams.PaymentMethodData.Klarna;
+      export type Konbini = Stripe.SetupIntentUpdateParams.PaymentMethodData.Konbini;
+      export type KrCard = Stripe.SetupIntentUpdateParams.PaymentMethodData.KrCard;
+      export type Link = Stripe.SetupIntentUpdateParams.PaymentMethodData.Link;
+      export type MbWay = Stripe.SetupIntentUpdateParams.PaymentMethodData.MbWay;
+      export type Mobilepay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Mobilepay;
+      export type Multibanco = Stripe.SetupIntentUpdateParams.PaymentMethodData.Multibanco;
+      export type NaverPay = Stripe.SetupIntentUpdateParams.PaymentMethodData.NaverPay;
+      export type NzBankAccount = Stripe.SetupIntentUpdateParams.PaymentMethodData.NzBankAccount;
+      export type Oxxo = Stripe.SetupIntentUpdateParams.PaymentMethodData.Oxxo;
+      export type P24 = Stripe.SetupIntentUpdateParams.PaymentMethodData.P24;
+      export type PayByBank = Stripe.SetupIntentUpdateParams.PaymentMethodData.PayByBank;
+      export type Payco = Stripe.SetupIntentUpdateParams.PaymentMethodData.Payco;
+      export type Paynow = Stripe.SetupIntentUpdateParams.PaymentMethodData.Paynow;
+      export type Paypal = Stripe.SetupIntentUpdateParams.PaymentMethodData.Paypal;
+      export type Payto = Stripe.SetupIntentUpdateParams.PaymentMethodData.Payto;
+      export type Pix = Stripe.SetupIntentUpdateParams.PaymentMethodData.Pix;
+      export type Promptpay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Promptpay;
+      export type RadarOptions = Stripe.SetupIntentUpdateParams.PaymentMethodData.RadarOptions;
+      export type RevolutPay = Stripe.SetupIntentUpdateParams.PaymentMethodData.RevolutPay;
+      export type SamsungPay = Stripe.SetupIntentUpdateParams.PaymentMethodData.SamsungPay;
+      export type Satispay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Satispay;
+      export type Scalapay = Stripe.SetupIntentUpdateParams.PaymentMethodData.Scalapay;
+      export type SepaDebit = Stripe.SetupIntentUpdateParams.PaymentMethodData.SepaDebit;
+      export type Sofort = Stripe.SetupIntentUpdateParams.PaymentMethodData.Sofort;
+      export type Sunbit = Stripe.SetupIntentUpdateParams.PaymentMethodData.Sunbit;
+      export type Swish = Stripe.SetupIntentUpdateParams.PaymentMethodData.Swish;
+      export type Twint = Stripe.SetupIntentUpdateParams.PaymentMethodData.Twint;
+      export type Type = Stripe.SetupIntentUpdateParams.PaymentMethodData.Type;
+      export type Upi = Stripe.SetupIntentUpdateParams.PaymentMethodData.Upi;
+      export type UsBankAccount = Stripe.SetupIntentUpdateParams.PaymentMethodData.UsBankAccount;
+      export type WechatPay = Stripe.SetupIntentUpdateParams.PaymentMethodData.WechatPay;
+      export type Zip = Stripe.SetupIntentUpdateParams.PaymentMethodData.Zip;
+      export namespace Eps {
+        export type Bank = Stripe.SetupIntentUpdateParams.PaymentMethodData.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.SetupIntentUpdateParams.PaymentMethodData.Fpx.AccountHolderType;
+        export type Bank = Stripe.SetupIntentUpdateParams.PaymentMethodData.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.SetupIntentUpdateParams.PaymentMethodData.Ideal.Bank;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.SetupIntentUpdateParams.PaymentMethodData.Klarna.Dob;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.SetupIntentUpdateParams.PaymentMethodData.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.SetupIntentUpdateParams.PaymentMethodData.P24.Bank;
+      }
+      export namespace Sofort {
+        export type Country = Stripe.SetupIntentUpdateParams.PaymentMethodData.Sofort.Country;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodData.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentUpdateParams.PaymentMethodData.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.SetupIntentUpdateParams.PaymentMethodData.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.SetupIntentUpdateParams.PaymentMethodData.UsBankAccount.AccountType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit;
+      export type AmazonPay = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AmazonPay;
+      export type BacsDebit = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.BacsDebit;
+      export type Bizum = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Bizum;
+      export type Card = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.CardPresent;
+      export type Klarna = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna;
+      export type Link = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Link;
+      export type Paypal = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Pix;
+      export type SepaDebit = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.SepaDebit;
+      export type Upi = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount;
+      export namespace AcssDebit {
+        export type Currency = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.Currency;
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type VerificationMethod = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type DefaultFor = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions.DefaultFor;
+          export type PaymentSchedule = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+      }
+      export namespace Card {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.Network;
+        export type RequestThreeDSecure = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type ThreeDSecure = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+        export namespace ThreeDSecure {
+          export type AresTransStatus = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.AresTransStatus;
+          export type ElectronicCommerceIndicator = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type NetworkOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions;
+          export type Version = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.Version;
+          export namespace NetworkOptions {
+            export type CartesBancaires = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires;
+            export namespace CartesBancaires {
+              export type CbAvalgo = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires.CbAvalgo;
+            }
+          }
+        }
+      }
+      export namespace Klarna {
+        export type OnDemand = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna.OnDemand;
+        export type PreferredLocale = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna.PreferredLocale;
+        export type Subscription = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna.Subscription;
+        export namespace OnDemand {
+          export type PurchaseInterval = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna.OnDemand.PurchaseInterval;
+        }
+        export namespace Subscription {
+          export type Interval = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+          export type NextBilling = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+        }
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Upi.MandateOptions;
+        export type SetupFutureUsage = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type Networks = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks;
+        export type VerificationMethod = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+        export namespace Networks {
+          export type Requested = Stripe.SetupIntentUpdateParams.PaymentMethodOptions.UsBankAccount.Networks.Requested;
+        }
+      }
+    }
   }
   export namespace SetupIntentCancelParams {
     export type CancellationReason = Stripe.SetupIntentCancelParams.CancellationReason;
@@ -1167,15 +7628,377 @@ declare namespace StripeConstructor {
     export type MandateData = Stripe.SetupIntentConfirmParams.MandateData;
     export type PaymentMethodData = Stripe.SetupIntentConfirmParams.PaymentMethodData;
     export type PaymentMethodOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions;
+    export namespace MandateData {
+      export type CustomerAcceptance = Stripe.SetupIntentConfirmParams.MandateData.CustomerAcceptance;
+      export namespace CustomerAcceptance {
+        export type Offline = Stripe.SetupIntentConfirmParams.MandateData.CustomerAcceptance.Offline;
+        export type Online = Stripe.SetupIntentConfirmParams.MandateData.CustomerAcceptance.Online;
+        export type Type = Stripe.SetupIntentConfirmParams.MandateData.CustomerAcceptance.Type;
+      }
+    }
+    export namespace PaymentMethodData {
+      export type AcssDebit = Stripe.SetupIntentConfirmParams.PaymentMethodData.AcssDebit;
+      export type Affirm = Stripe.SetupIntentConfirmParams.PaymentMethodData.Affirm;
+      export type AfterpayClearpay = Stripe.SetupIntentConfirmParams.PaymentMethodData.AfterpayClearpay;
+      export type Alipay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Alipay;
+      export type AllowRedisplay = Stripe.SetupIntentConfirmParams.PaymentMethodData.AllowRedisplay;
+      export type Alma = Stripe.SetupIntentConfirmParams.PaymentMethodData.Alma;
+      export type AmazonPay = Stripe.SetupIntentConfirmParams.PaymentMethodData.AmazonPay;
+      export type AuBecsDebit = Stripe.SetupIntentConfirmParams.PaymentMethodData.AuBecsDebit;
+      export type BacsDebit = Stripe.SetupIntentConfirmParams.PaymentMethodData.BacsDebit;
+      export type Bancontact = Stripe.SetupIntentConfirmParams.PaymentMethodData.Bancontact;
+      export type Billie = Stripe.SetupIntentConfirmParams.PaymentMethodData.Billie;
+      export type BillingDetails = Stripe.SetupIntentConfirmParams.PaymentMethodData.BillingDetails;
+      export type Bizum = Stripe.SetupIntentConfirmParams.PaymentMethodData.Bizum;
+      export type Blik = Stripe.SetupIntentConfirmParams.PaymentMethodData.Blik;
+      export type Boleto = Stripe.SetupIntentConfirmParams.PaymentMethodData.Boleto;
+      export type Cashapp = Stripe.SetupIntentConfirmParams.PaymentMethodData.Cashapp;
+      export type Crypto = Stripe.SetupIntentConfirmParams.PaymentMethodData.Crypto;
+      export type CustomerBalance = Stripe.SetupIntentConfirmParams.PaymentMethodData.CustomerBalance;
+      export type Eps = Stripe.SetupIntentConfirmParams.PaymentMethodData.Eps;
+      export type Fpx = Stripe.SetupIntentConfirmParams.PaymentMethodData.Fpx;
+      export type Giropay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Giropay;
+      export type Grabpay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Grabpay;
+      export type Ideal = Stripe.SetupIntentConfirmParams.PaymentMethodData.Ideal;
+      export type InteracPresent = Stripe.SetupIntentConfirmParams.PaymentMethodData.InteracPresent;
+      export type KakaoPay = Stripe.SetupIntentConfirmParams.PaymentMethodData.KakaoPay;
+      export type Klarna = Stripe.SetupIntentConfirmParams.PaymentMethodData.Klarna;
+      export type Konbini = Stripe.SetupIntentConfirmParams.PaymentMethodData.Konbini;
+      export type KrCard = Stripe.SetupIntentConfirmParams.PaymentMethodData.KrCard;
+      export type Link = Stripe.SetupIntentConfirmParams.PaymentMethodData.Link;
+      export type MbWay = Stripe.SetupIntentConfirmParams.PaymentMethodData.MbWay;
+      export type Mobilepay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Mobilepay;
+      export type Multibanco = Stripe.SetupIntentConfirmParams.PaymentMethodData.Multibanco;
+      export type NaverPay = Stripe.SetupIntentConfirmParams.PaymentMethodData.NaverPay;
+      export type NzBankAccount = Stripe.SetupIntentConfirmParams.PaymentMethodData.NzBankAccount;
+      export type Oxxo = Stripe.SetupIntentConfirmParams.PaymentMethodData.Oxxo;
+      export type P24 = Stripe.SetupIntentConfirmParams.PaymentMethodData.P24;
+      export type PayByBank = Stripe.SetupIntentConfirmParams.PaymentMethodData.PayByBank;
+      export type Payco = Stripe.SetupIntentConfirmParams.PaymentMethodData.Payco;
+      export type Paynow = Stripe.SetupIntentConfirmParams.PaymentMethodData.Paynow;
+      export type Paypal = Stripe.SetupIntentConfirmParams.PaymentMethodData.Paypal;
+      export type Payto = Stripe.SetupIntentConfirmParams.PaymentMethodData.Payto;
+      export type Pix = Stripe.SetupIntentConfirmParams.PaymentMethodData.Pix;
+      export type Promptpay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Promptpay;
+      export type RadarOptions = Stripe.SetupIntentConfirmParams.PaymentMethodData.RadarOptions;
+      export type RevolutPay = Stripe.SetupIntentConfirmParams.PaymentMethodData.RevolutPay;
+      export type SamsungPay = Stripe.SetupIntentConfirmParams.PaymentMethodData.SamsungPay;
+      export type Satispay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Satispay;
+      export type Scalapay = Stripe.SetupIntentConfirmParams.PaymentMethodData.Scalapay;
+      export type SepaDebit = Stripe.SetupIntentConfirmParams.PaymentMethodData.SepaDebit;
+      export type Sofort = Stripe.SetupIntentConfirmParams.PaymentMethodData.Sofort;
+      export type Sunbit = Stripe.SetupIntentConfirmParams.PaymentMethodData.Sunbit;
+      export type Swish = Stripe.SetupIntentConfirmParams.PaymentMethodData.Swish;
+      export type Twint = Stripe.SetupIntentConfirmParams.PaymentMethodData.Twint;
+      export type Type = Stripe.SetupIntentConfirmParams.PaymentMethodData.Type;
+      export type Upi = Stripe.SetupIntentConfirmParams.PaymentMethodData.Upi;
+      export type UsBankAccount = Stripe.SetupIntentConfirmParams.PaymentMethodData.UsBankAccount;
+      export type WechatPay = Stripe.SetupIntentConfirmParams.PaymentMethodData.WechatPay;
+      export type Zip = Stripe.SetupIntentConfirmParams.PaymentMethodData.Zip;
+      export namespace Eps {
+        export type Bank = Stripe.SetupIntentConfirmParams.PaymentMethodData.Eps.Bank;
+      }
+      export namespace Fpx {
+        export type AccountHolderType = Stripe.SetupIntentConfirmParams.PaymentMethodData.Fpx.AccountHolderType;
+        export type Bank = Stripe.SetupIntentConfirmParams.PaymentMethodData.Fpx.Bank;
+      }
+      export namespace Ideal {
+        export type Bank = Stripe.SetupIntentConfirmParams.PaymentMethodData.Ideal.Bank;
+      }
+      export namespace Klarna {
+        export type Dob = Stripe.SetupIntentConfirmParams.PaymentMethodData.Klarna.Dob;
+      }
+      export namespace NaverPay {
+        export type Funding = Stripe.SetupIntentConfirmParams.PaymentMethodData.NaverPay.Funding;
+      }
+      export namespace P24 {
+        export type Bank = Stripe.SetupIntentConfirmParams.PaymentMethodData.P24.Bank;
+      }
+      export namespace Sofort {
+        export type Country = Stripe.SetupIntentConfirmParams.PaymentMethodData.Sofort.Country;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodData.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentConfirmParams.PaymentMethodData.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type AccountHolderType = Stripe.SetupIntentConfirmParams.PaymentMethodData.UsBankAccount.AccountHolderType;
+        export type AccountType = Stripe.SetupIntentConfirmParams.PaymentMethodData.UsBankAccount.AccountType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit;
+      export type AmazonPay = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AmazonPay;
+      export type BacsDebit = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.BacsDebit;
+      export type Bizum = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Bizum;
+      export type Card = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.CardPresent;
+      export type Klarna = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna;
+      export type Link = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Link;
+      export type Paypal = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Pix;
+      export type SepaDebit = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.SepaDebit;
+      export type Upi = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount;
+      export namespace AcssDebit {
+        export type Currency = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.Currency;
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type VerificationMethod = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type DefaultFor = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions.DefaultFor;
+          export type PaymentSchedule = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+      }
+      export namespace Card {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.Network;
+        export type RequestThreeDSecure = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export type ThreeDSecure = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+        export namespace ThreeDSecure {
+          export type AresTransStatus = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.AresTransStatus;
+          export type ElectronicCommerceIndicator = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.ElectronicCommerceIndicator;
+          export type NetworkOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions;
+          export type Version = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.Version;
+          export namespace NetworkOptions {
+            export type CartesBancaires = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires;
+            export namespace CartesBancaires {
+              export type CbAvalgo = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Card.ThreeDSecure.NetworkOptions.CartesBancaires.CbAvalgo;
+            }
+          }
+        }
+      }
+      export namespace Klarna {
+        export type OnDemand = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna.OnDemand;
+        export type PreferredLocale = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna.PreferredLocale;
+        export type Subscription = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna.Subscription;
+        export namespace OnDemand {
+          export type PurchaseInterval = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna.OnDemand.PurchaseInterval;
+        }
+        export namespace Subscription {
+          export type Interval = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+          export type NextBilling = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+        }
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Upi.MandateOptions;
+        export type SetupFutureUsage = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type Networks = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks;
+        export type VerificationMethod = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+        export namespace Networks {
+          export type Requested = Stripe.SetupIntentConfirmParams.PaymentMethodOptions.UsBankAccount.Networks.Requested;
+        }
+      }
+    }
+  }
+  export namespace SetupIntent {
+    export type AutomaticPaymentMethods = Stripe.SetupIntent.AutomaticPaymentMethods;
+    export type CancellationReason = Stripe.SetupIntent.CancellationReason;
+    export type ExcludedPaymentMethodType = Stripe.SetupIntent.ExcludedPaymentMethodType;
+    export type FlowDirection = Stripe.SetupIntent.FlowDirection;
+    export type LastSetupError = Stripe.SetupIntent.LastSetupError;
+    export type ManagedPayments = Stripe.SetupIntent.ManagedPayments;
+    export type NextAction = Stripe.SetupIntent.NextAction;
+    export type PaymentMethodConfigurationDetails = Stripe.SetupIntent.PaymentMethodConfigurationDetails;
+    export type PaymentMethodOptions = Stripe.SetupIntent.PaymentMethodOptions;
+    export type Status = Stripe.SetupIntent.Status;
+    export namespace AutomaticPaymentMethods {
+      export type AllowRedirects = Stripe.SetupIntent.AutomaticPaymentMethods.AllowRedirects;
+    }
+    export namespace LastSetupError {
+      export type Code = Stripe.SetupIntent.LastSetupError.Code;
+      export type Type = Stripe.SetupIntent.LastSetupError.Type;
+    }
+    export namespace NextAction {
+      export type BlikAuthorize = Stripe.SetupIntent.NextAction.BlikAuthorize;
+      export type CashappHandleRedirectOrDisplayQrCode = Stripe.SetupIntent.NextAction.CashappHandleRedirectOrDisplayQrCode;
+      export type PixDisplayQrCode = Stripe.SetupIntent.NextAction.PixDisplayQrCode;
+      export type RedirectToUrl = Stripe.SetupIntent.NextAction.RedirectToUrl;
+      export type UpiHandleRedirectOrDisplayQrCode = Stripe.SetupIntent.NextAction.UpiHandleRedirectOrDisplayQrCode;
+      export type UseStripeSdk = Stripe.SetupIntent.NextAction.UseStripeSdk;
+      export type VerifyWithMicrodeposits = Stripe.SetupIntent.NextAction.VerifyWithMicrodeposits;
+      export namespace CashappHandleRedirectOrDisplayQrCode {
+        export type QrCode = Stripe.SetupIntent.NextAction.CashappHandleRedirectOrDisplayQrCode.QrCode;
+      }
+      export namespace UpiHandleRedirectOrDisplayQrCode {
+        export type QrCode = Stripe.SetupIntent.NextAction.UpiHandleRedirectOrDisplayQrCode.QrCode;
+      }
+      export namespace VerifyWithMicrodeposits {
+        export type MicrodepositType = Stripe.SetupIntent.NextAction.VerifyWithMicrodeposits.MicrodepositType;
+      }
+    }
+    export namespace PaymentMethodOptions {
+      export type AcssDebit = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit;
+      export type AmazonPay = Stripe.SetupIntent.PaymentMethodOptions.AmazonPay;
+      export type BacsDebit = Stripe.SetupIntent.PaymentMethodOptions.BacsDebit;
+      export type Bizum = Stripe.SetupIntent.PaymentMethodOptions.Bizum;
+      export type Card = Stripe.SetupIntent.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.SetupIntent.PaymentMethodOptions.CardPresent;
+      export type Klarna = Stripe.SetupIntent.PaymentMethodOptions.Klarna;
+      export type Link = Stripe.SetupIntent.PaymentMethodOptions.Link;
+      export type Paypal = Stripe.SetupIntent.PaymentMethodOptions.Paypal;
+      export type Payto = Stripe.SetupIntent.PaymentMethodOptions.Payto;
+      export type Pix = Stripe.SetupIntent.PaymentMethodOptions.Pix;
+      export type SepaDebit = Stripe.SetupIntent.PaymentMethodOptions.SepaDebit;
+      export type Upi = Stripe.SetupIntent.PaymentMethodOptions.Upi;
+      export type UsBankAccount = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount;
+      export namespace AcssDebit {
+        export type Currency = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit.Currency;
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit.MandateOptions;
+        export type VerificationMethod = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit.VerificationMethod;
+        export namespace MandateOptions {
+          export type DefaultFor = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit.MandateOptions.DefaultFor;
+          export type PaymentSchedule = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+          export type TransactionType = Stripe.SetupIntent.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+        }
+      }
+      export namespace BacsDebit {
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.BacsDebit.MandateOptions;
+      }
+      export namespace Card {
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.Card.MandateOptions;
+        export type Network = Stripe.SetupIntent.PaymentMethodOptions.Card.Network;
+        export type RequestThreeDSecure = Stripe.SetupIntent.PaymentMethodOptions.Card.RequestThreeDSecure;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntent.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          export type Interval = Stripe.SetupIntent.PaymentMethodOptions.Card.MandateOptions.Interval;
+        }
+      }
+      export namespace Payto {
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.Payto.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntent.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntent.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+          export type Purpose = Stripe.SetupIntent.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+        }
+      }
+      export namespace Pix {
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.Pix.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountIncludesIof = Stripe.SetupIntent.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+          export type AmountType = Stripe.SetupIntent.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+          export type PaymentSchedule = Stripe.SetupIntent.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+        }
+      }
+      export namespace SepaDebit {
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.SepaDebit.MandateOptions;
+      }
+      export namespace Upi {
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.Upi.MandateOptions;
+        export namespace MandateOptions {
+          export type AmountType = Stripe.SetupIntent.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+        }
+      }
+      export namespace UsBankAccount {
+        export type FinancialConnections = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+        export type MandateOptions = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.MandateOptions;
+        export type VerificationMethod = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+        export namespace FinancialConnections {
+          export type Filters = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+          export type Permission = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+          export type Prefetch = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          export namespace Filters {
+            export type AccountSubcategory = Stripe.SetupIntent.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+          }
+        }
+      }
+    }
   }
   export namespace ShippingRateCreateParams {
     export type DeliveryEstimate = Stripe.ShippingRateCreateParams.DeliveryEstimate;
     export type FixedAmount = Stripe.ShippingRateCreateParams.FixedAmount;
     export type TaxBehavior = Stripe.ShippingRateCreateParams.TaxBehavior;
+    export namespace DeliveryEstimate {
+      export type Maximum = Stripe.ShippingRateCreateParams.DeliveryEstimate.Maximum;
+      export type Minimum = Stripe.ShippingRateCreateParams.DeliveryEstimate.Minimum;
+      export namespace Maximum {
+        export type Unit = Stripe.ShippingRateCreateParams.DeliveryEstimate.Maximum.Unit;
+      }
+      export namespace Minimum {
+        export type Unit = Stripe.ShippingRateCreateParams.DeliveryEstimate.Minimum.Unit;
+      }
+    }
+    export namespace FixedAmount {
+      export type CurrencyOptions = Stripe.ShippingRateCreateParams.FixedAmount.CurrencyOptions;
+      export namespace CurrencyOptions {
+        export type TaxBehavior = Stripe.ShippingRateCreateParams.FixedAmount.CurrencyOptions.TaxBehavior;
+      }
+    }
   }
   export namespace ShippingRateUpdateParams {
     export type FixedAmount = Stripe.ShippingRateUpdateParams.FixedAmount;
     export type TaxBehavior = Stripe.ShippingRateUpdateParams.TaxBehavior;
+    export namespace FixedAmount {
+      export type CurrencyOptions = Stripe.ShippingRateUpdateParams.FixedAmount.CurrencyOptions;
+      export namespace CurrencyOptions {
+        export type TaxBehavior = Stripe.ShippingRateUpdateParams.FixedAmount.CurrencyOptions.TaxBehavior;
+      }
+    }
+  }
+  export namespace ShippingRate {
+    export type DeliveryEstimate = Stripe.ShippingRate.DeliveryEstimate;
+    export type FixedAmount = Stripe.ShippingRate.FixedAmount;
+    export type TaxBehavior = Stripe.ShippingRate.TaxBehavior;
+    export namespace DeliveryEstimate {
+      export type Maximum = Stripe.ShippingRate.DeliveryEstimate.Maximum;
+      export type Minimum = Stripe.ShippingRate.DeliveryEstimate.Minimum;
+      export namespace Maximum {
+        export type Unit = Stripe.ShippingRate.DeliveryEstimate.Maximum.Unit;
+      }
+      export namespace Minimum {
+        export type Unit = Stripe.ShippingRate.DeliveryEstimate.Minimum.Unit;
+      }
+    }
+    export namespace FixedAmount {
+      export type CurrencyOptions = Stripe.ShippingRate.FixedAmount.CurrencyOptions;
+      export namespace CurrencyOptions {
+        export type TaxBehavior = Stripe.ShippingRate.FixedAmount.CurrencyOptions.TaxBehavior;
+      }
+    }
   }
   export namespace SourceCreateParams {
     export type Flow = Stripe.SourceCreateParams.Flow;
@@ -1185,11 +8008,82 @@ declare namespace StripeConstructor {
     export type Redirect = Stripe.SourceCreateParams.Redirect;
     export type SourceOrder = Stripe.SourceCreateParams.SourceOrder;
     export type Usage = Stripe.SourceCreateParams.Usage;
+    export namespace Mandate {
+      export type Acceptance = Stripe.SourceCreateParams.Mandate.Acceptance;
+      export type Interval = Stripe.SourceCreateParams.Mandate.Interval;
+      export type NotificationMethod = Stripe.SourceCreateParams.Mandate.NotificationMethod;
+      export namespace Acceptance {
+        export type Offline = Stripe.SourceCreateParams.Mandate.Acceptance.Offline;
+        export type Online = Stripe.SourceCreateParams.Mandate.Acceptance.Online;
+        export type Status = Stripe.SourceCreateParams.Mandate.Acceptance.Status;
+        export type Type = Stripe.SourceCreateParams.Mandate.Acceptance.Type;
+      }
+    }
+    export namespace Receiver {
+      export type RefundAttributesMethod = Stripe.SourceCreateParams.Receiver.RefundAttributesMethod;
+    }
+    export namespace SourceOrder {
+      export type Item = Stripe.SourceCreateParams.SourceOrder.Item;
+      export type Shipping = Stripe.SourceCreateParams.SourceOrder.Shipping;
+      export namespace Item {
+        export type Type = Stripe.SourceCreateParams.SourceOrder.Item.Type;
+      }
+    }
   }
   export namespace SourceUpdateParams {
     export type Mandate = Stripe.SourceUpdateParams.Mandate;
     export type Owner = Stripe.SourceUpdateParams.Owner;
     export type SourceOrder = Stripe.SourceUpdateParams.SourceOrder;
+    export namespace Mandate {
+      export type Acceptance = Stripe.SourceUpdateParams.Mandate.Acceptance;
+      export type Interval = Stripe.SourceUpdateParams.Mandate.Interval;
+      export type NotificationMethod = Stripe.SourceUpdateParams.Mandate.NotificationMethod;
+      export namespace Acceptance {
+        export type Offline = Stripe.SourceUpdateParams.Mandate.Acceptance.Offline;
+        export type Online = Stripe.SourceUpdateParams.Mandate.Acceptance.Online;
+        export type Status = Stripe.SourceUpdateParams.Mandate.Acceptance.Status;
+        export type Type = Stripe.SourceUpdateParams.Mandate.Acceptance.Type;
+      }
+    }
+    export namespace SourceOrder {
+      export type Item = Stripe.SourceUpdateParams.SourceOrder.Item;
+      export type Shipping = Stripe.SourceUpdateParams.SourceOrder.Shipping;
+      export namespace Item {
+        export type Type = Stripe.SourceUpdateParams.SourceOrder.Item.Type;
+      }
+    }
+  }
+  export namespace Source {
+    export type AchCreditTransfer = Stripe.Source.AchCreditTransfer;
+    export type AchDebit = Stripe.Source.AchDebit;
+    export type AcssDebit = Stripe.Source.AcssDebit;
+    export type Alipay = Stripe.Source.Alipay;
+    export type AllowRedisplay = Stripe.Source.AllowRedisplay;
+    export type AuBecsDebit = Stripe.Source.AuBecsDebit;
+    export type Bancontact = Stripe.Source.Bancontact;
+    export type Card = Stripe.Source.Card;
+    export type CardPresent = Stripe.Source.CardPresent;
+    export type CodeVerification = Stripe.Source.CodeVerification;
+    export type Eps = Stripe.Source.Eps;
+    export type Giropay = Stripe.Source.Giropay;
+    export type Ideal = Stripe.Source.Ideal;
+    export type Klarna = Stripe.Source.Klarna;
+    export type Multibanco = Stripe.Source.Multibanco;
+    export type Owner = Stripe.Source.Owner;
+    export type P24 = Stripe.Source.P24;
+    export type Receiver = Stripe.Source.Receiver;
+    export type Redirect = Stripe.Source.Redirect;
+    export type SepaCreditTransfer = Stripe.Source.SepaCreditTransfer;
+    export type SepaDebit = Stripe.Source.SepaDebit;
+    export type Sofort = Stripe.Source.Sofort;
+    export type SourceOrder = Stripe.Source.SourceOrder;
+    export type ThreeDSecure = Stripe.Source.ThreeDSecure;
+    export type Type = Stripe.Source.Type;
+    export type Wechat = Stripe.Source.Wechat;
+    export namespace SourceOrder {
+      export type Item = Stripe.Source.SourceOrder.Item;
+      export type Shipping = Stripe.Source.SourceOrder.Shipping;
+    }
   }
   export namespace SubscriptionCreateParams {
     export type AddInvoiceItem = Stripe.SubscriptionCreateParams.AddInvoiceItem;
@@ -1209,6 +8103,147 @@ declare namespace StripeConstructor {
     export type ProrationBehavior = Stripe.SubscriptionCreateParams.ProrationBehavior;
     export type TransferData = Stripe.SubscriptionCreateParams.TransferData;
     export type TrialSettings = Stripe.SubscriptionCreateParams.TrialSettings;
+    export namespace AddInvoiceItem {
+      export type Discount = Stripe.SubscriptionCreateParams.AddInvoiceItem.Discount;
+      export type Period = Stripe.SubscriptionCreateParams.AddInvoiceItem.Period;
+      export type PriceData = Stripe.SubscriptionCreateParams.AddInvoiceItem.PriceData;
+      export namespace Period {
+        export type End = Stripe.SubscriptionCreateParams.AddInvoiceItem.Period.End;
+        export type Start = Stripe.SubscriptionCreateParams.AddInvoiceItem.Period.Start;
+        export namespace End {
+          export type Type = Stripe.SubscriptionCreateParams.AddInvoiceItem.Period.End.Type;
+        }
+        export namespace Start {
+          export type Type = Stripe.SubscriptionCreateParams.AddInvoiceItem.Period.Start.Type;
+        }
+      }
+      export namespace PriceData {
+        export type TaxBehavior = Stripe.SubscriptionCreateParams.AddInvoiceItem.PriceData.TaxBehavior;
+      }
+    }
+    export namespace AutomaticTax {
+      export type Liability = Stripe.SubscriptionCreateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.SubscriptionCreateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace BillingMode {
+      export type Flexible = Stripe.SubscriptionCreateParams.BillingMode.Flexible;
+      export type Type = Stripe.SubscriptionCreateParams.BillingMode.Type;
+      export namespace Flexible {
+        export type ProrationDiscounts = Stripe.SubscriptionCreateParams.BillingMode.Flexible.ProrationDiscounts;
+      }
+    }
+    export namespace BillingSchedule {
+      export type AppliesTo = Stripe.SubscriptionCreateParams.BillingSchedule.AppliesTo;
+      export type BillUntil = Stripe.SubscriptionCreateParams.BillingSchedule.BillUntil;
+      export namespace BillUntil {
+        export type Duration = Stripe.SubscriptionCreateParams.BillingSchedule.BillUntil.Duration;
+        export type Type = Stripe.SubscriptionCreateParams.BillingSchedule.BillUntil.Type;
+        export namespace Duration {
+          export type Interval = Stripe.SubscriptionCreateParams.BillingSchedule.BillUntil.Duration.Interval;
+        }
+      }
+    }
+    export namespace InvoiceSettings {
+      export type Issuer = Stripe.SubscriptionCreateParams.InvoiceSettings.Issuer;
+      export namespace Issuer {
+        export type Type = Stripe.SubscriptionCreateParams.InvoiceSettings.Issuer.Type;
+      }
+    }
+    export namespace Item {
+      export type BillingThresholds = Stripe.SubscriptionCreateParams.Item.BillingThresholds;
+      export type Discount = Stripe.SubscriptionCreateParams.Item.Discount;
+      export type PriceData = Stripe.SubscriptionCreateParams.Item.PriceData;
+      export namespace PriceData {
+        export type Recurring = Stripe.SubscriptionCreateParams.Item.PriceData.Recurring;
+        export type TaxBehavior = Stripe.SubscriptionCreateParams.Item.PriceData.TaxBehavior;
+        export namespace Recurring {
+          export type Interval = Stripe.SubscriptionCreateParams.Item.PriceData.Recurring.Interval;
+        }
+      }
+    }
+    export namespace PaymentSettings {
+      export type PaymentMethodOptions = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions;
+      export type PaymentMethodType = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodType;
+      export type SaveDefaultPaymentMethod = Stripe.SubscriptionCreateParams.PaymentSettings.SaveDefaultPaymentMethod;
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit;
+        export type Bancontact = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Bancontact;
+        export type Card = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card;
+        export type CustomerBalance = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance;
+        export type Konbini = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Konbini;
+        export type Payto = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Pix;
+        export type SepaDebit = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.SepaDebit;
+        export type Upi = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type MandateOptions = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type VerificationMethod = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type TransactionType = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace Bancontact {
+          export type PreferredLanguage = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        }
+        export namespace Card {
+          export type MandateOptions = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions;
+          export type Network = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card.Network;
+          export type RequestThreeDSecure = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          }
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          }
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions;
+          export namespace MandateOptions {
+            export type Purpose = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type MandateOptions = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountIncludesIof = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+            export type PaymentSchedule = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+          }
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type VerificationMethod = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.SubscriptionCreateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+    }
+    export namespace PendingInvoiceItemInterval {
+      export type Interval = Stripe.SubscriptionCreateParams.PendingInvoiceItemInterval.Interval;
+    }
+    export namespace TrialSettings {
+      export type EndBehavior = Stripe.SubscriptionCreateParams.TrialSettings.EndBehavior;
+      export namespace EndBehavior {
+        export type MissingPaymentMethod = Stripe.SubscriptionCreateParams.TrialSettings.EndBehavior.MissingPaymentMethod;
+      }
+    }
   }
   export namespace SubscriptionUpdateParams {
     export type AddInvoiceItem = Stripe.SubscriptionUpdateParams.AddInvoiceItem;
@@ -1229,6 +8264,146 @@ declare namespace StripeConstructor {
     export type ProrationBehavior = Stripe.SubscriptionUpdateParams.ProrationBehavior;
     export type TransferData = Stripe.SubscriptionUpdateParams.TransferData;
     export type TrialSettings = Stripe.SubscriptionUpdateParams.TrialSettings;
+    export namespace AddInvoiceItem {
+      export type Discount = Stripe.SubscriptionUpdateParams.AddInvoiceItem.Discount;
+      export type Period = Stripe.SubscriptionUpdateParams.AddInvoiceItem.Period;
+      export type PriceData = Stripe.SubscriptionUpdateParams.AddInvoiceItem.PriceData;
+      export namespace Period {
+        export type End = Stripe.SubscriptionUpdateParams.AddInvoiceItem.Period.End;
+        export type Start = Stripe.SubscriptionUpdateParams.AddInvoiceItem.Period.Start;
+        export namespace End {
+          export type Type = Stripe.SubscriptionUpdateParams.AddInvoiceItem.Period.End.Type;
+        }
+        export namespace Start {
+          export type Type = Stripe.SubscriptionUpdateParams.AddInvoiceItem.Period.Start.Type;
+        }
+      }
+      export namespace PriceData {
+        export type TaxBehavior = Stripe.SubscriptionUpdateParams.AddInvoiceItem.PriceData.TaxBehavior;
+      }
+    }
+    export namespace AutomaticTax {
+      export type Liability = Stripe.SubscriptionUpdateParams.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.SubscriptionUpdateParams.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace BillingSchedule {
+      export type AppliesTo = Stripe.SubscriptionUpdateParams.BillingSchedule.AppliesTo;
+      export type BillUntil = Stripe.SubscriptionUpdateParams.BillingSchedule.BillUntil;
+      export namespace BillUntil {
+        export type Duration = Stripe.SubscriptionUpdateParams.BillingSchedule.BillUntil.Duration;
+        export type Type = Stripe.SubscriptionUpdateParams.BillingSchedule.BillUntil.Type;
+        export namespace Duration {
+          export type Interval = Stripe.SubscriptionUpdateParams.BillingSchedule.BillUntil.Duration.Interval;
+        }
+      }
+    }
+    export namespace CancellationDetails {
+      export type Feedback = Stripe.SubscriptionUpdateParams.CancellationDetails.Feedback;
+    }
+    export namespace InvoiceSettings {
+      export type Issuer = Stripe.SubscriptionUpdateParams.InvoiceSettings.Issuer;
+      export namespace Issuer {
+        export type Type = Stripe.SubscriptionUpdateParams.InvoiceSettings.Issuer.Type;
+      }
+    }
+    export namespace Item {
+      export type BillingThresholds = Stripe.SubscriptionUpdateParams.Item.BillingThresholds;
+      export type Discount = Stripe.SubscriptionUpdateParams.Item.Discount;
+      export type PriceData = Stripe.SubscriptionUpdateParams.Item.PriceData;
+      export namespace PriceData {
+        export type Recurring = Stripe.SubscriptionUpdateParams.Item.PriceData.Recurring;
+        export type TaxBehavior = Stripe.SubscriptionUpdateParams.Item.PriceData.TaxBehavior;
+        export namespace Recurring {
+          export type Interval = Stripe.SubscriptionUpdateParams.Item.PriceData.Recurring.Interval;
+        }
+      }
+    }
+    export namespace PauseCollection {
+      export type Behavior = Stripe.SubscriptionUpdateParams.PauseCollection.Behavior;
+    }
+    export namespace PaymentSettings {
+      export type PaymentMethodOptions = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions;
+      export type PaymentMethodType = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodType;
+      export type SaveDefaultPaymentMethod = Stripe.SubscriptionUpdateParams.PaymentSettings.SaveDefaultPaymentMethod;
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit;
+        export type Bancontact = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Bancontact;
+        export type Card = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card;
+        export type CustomerBalance = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance;
+        export type Konbini = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Konbini;
+        export type Payto = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Pix;
+        export type SepaDebit = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.SepaDebit;
+        export type Upi = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type MandateOptions = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type VerificationMethod = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type TransactionType = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace Bancontact {
+          export type PreferredLanguage = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        }
+        export namespace Card {
+          export type MandateOptions = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions;
+          export type Network = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card.Network;
+          export type RequestThreeDSecure = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          }
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+          }
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions;
+          export namespace MandateOptions {
+            export type Purpose = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type MandateOptions = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountIncludesIof = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+            export type PaymentSchedule = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+          }
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type VerificationMethod = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.SubscriptionUpdateParams.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+    }
+    export namespace PendingInvoiceItemInterval {
+      export type Interval = Stripe.SubscriptionUpdateParams.PendingInvoiceItemInterval.Interval;
+    }
+    export namespace TrialSettings {
+      export type EndBehavior = Stripe.SubscriptionUpdateParams.TrialSettings.EndBehavior;
+      export namespace EndBehavior {
+        export type MissingPaymentMethod = Stripe.SubscriptionUpdateParams.TrialSettings.EndBehavior.MissingPaymentMethod;
+      }
+    }
   }
   export namespace SubscriptionListParams {
     export type AutomaticTax = Stripe.SubscriptionListParams.AutomaticTax;
@@ -1237,13 +8412,163 @@ declare namespace StripeConstructor {
   }
   export namespace SubscriptionCancelParams {
     export type CancellationDetails = Stripe.SubscriptionCancelParams.CancellationDetails;
+    export namespace CancellationDetails {
+      export type Feedback = Stripe.SubscriptionCancelParams.CancellationDetails.Feedback;
+    }
   }
   export namespace SubscriptionMigrateParams {
     export type BillingMode = Stripe.SubscriptionMigrateParams.BillingMode;
+    export namespace BillingMode {
+      export type Flexible = Stripe.SubscriptionMigrateParams.BillingMode.Flexible;
+      export namespace Flexible {
+        export type ProrationDiscounts = Stripe.SubscriptionMigrateParams.BillingMode.Flexible.ProrationDiscounts;
+      }
+    }
   }
   export namespace SubscriptionResumeParams {
     export type BillingCycleAnchor = Stripe.SubscriptionResumeParams.BillingCycleAnchor;
     export type ProrationBehavior = Stripe.SubscriptionResumeParams.ProrationBehavior;
+  }
+  export namespace Subscription {
+    export type AutomaticTax = Stripe.Subscription.AutomaticTax;
+    export type BillingCycleAnchorConfig = Stripe.Subscription.BillingCycleAnchorConfig;
+    export type BillingMode = Stripe.Subscription.BillingMode;
+    export type BillingSchedule = Stripe.Subscription.BillingSchedule;
+    export type BillingThresholds = Stripe.Subscription.BillingThresholds;
+    export type CancellationDetails = Stripe.Subscription.CancellationDetails;
+    export type CollectionMethod = Stripe.Subscription.CollectionMethod;
+    export type InvoiceSettings = Stripe.Subscription.InvoiceSettings;
+    export type ManagedPayments = Stripe.Subscription.ManagedPayments;
+    export type PauseCollection = Stripe.Subscription.PauseCollection;
+    export type PaymentSettings = Stripe.Subscription.PaymentSettings;
+    export type PendingInvoiceItemInterval = Stripe.Subscription.PendingInvoiceItemInterval;
+    export type PendingUpdate = Stripe.Subscription.PendingUpdate;
+    export type PresentmentDetails = Stripe.Subscription.PresentmentDetails;
+    export type Status = Stripe.Subscription.Status;
+    export type TransferData = Stripe.Subscription.TransferData;
+    export type TrialSettings = Stripe.Subscription.TrialSettings;
+    export namespace AutomaticTax {
+      export type Liability = Stripe.Subscription.AutomaticTax.Liability;
+      export namespace Liability {
+        export type Type = Stripe.Subscription.AutomaticTax.Liability.Type;
+      }
+    }
+    export namespace BillingMode {
+      export type Flexible = Stripe.Subscription.BillingMode.Flexible;
+      export type Type = Stripe.Subscription.BillingMode.Type;
+      export namespace Flexible {
+        export type ProrationDiscounts = Stripe.Subscription.BillingMode.Flexible.ProrationDiscounts;
+      }
+    }
+    export namespace BillingSchedule {
+      export type AppliesTo = Stripe.Subscription.BillingSchedule.AppliesTo;
+      export type BillUntil = Stripe.Subscription.BillingSchedule.BillUntil;
+      export namespace BillUntil {
+        export type Duration = Stripe.Subscription.BillingSchedule.BillUntil.Duration;
+        export type Type = Stripe.Subscription.BillingSchedule.BillUntil.Type;
+        export namespace Duration {
+          export type Interval = Stripe.Subscription.BillingSchedule.BillUntil.Duration.Interval;
+        }
+      }
+    }
+    export namespace CancellationDetails {
+      export type Feedback = Stripe.Subscription.CancellationDetails.Feedback;
+      export type Reason = Stripe.Subscription.CancellationDetails.Reason;
+    }
+    export namespace InvoiceSettings {
+      export type Issuer = Stripe.Subscription.InvoiceSettings.Issuer;
+      export namespace Issuer {
+        export type Type = Stripe.Subscription.InvoiceSettings.Issuer.Type;
+      }
+    }
+    export namespace PauseCollection {
+      export type Behavior = Stripe.Subscription.PauseCollection.Behavior;
+    }
+    export namespace PaymentSettings {
+      export type PaymentMethodOptions = Stripe.Subscription.PaymentSettings.PaymentMethodOptions;
+      export type PaymentMethodType = Stripe.Subscription.PaymentSettings.PaymentMethodType;
+      export type SaveDefaultPaymentMethod = Stripe.Subscription.PaymentSettings.SaveDefaultPaymentMethod;
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.AcssDebit;
+        export type Bancontact = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Bancontact;
+        export type Card = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Card;
+        export type CustomerBalance = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.CustomerBalance;
+        export type Konbini = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Konbini;
+        export type Payto = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Pix;
+        export type SepaDebit = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.SepaDebit;
+        export type Upi = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type MandateOptions = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type VerificationMethod = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type TransactionType = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace Bancontact {
+          export type PreferredLanguage = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Bancontact.PreferredLanguage;
+        }
+        export namespace Card {
+          export type MandateOptions = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Card.MandateOptions;
+          export type Network = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Card.Network;
+          export type RequestThreeDSecure = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Card.MandateOptions.AmountType;
+          }
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+            export namespace EuBankTransfer {
+              export type Country = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer.Country;
+            }
+          }
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+            export type Purpose = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type MandateOptions = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountIncludesIof = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+            export type PaymentSchedule = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+          }
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type VerificationMethod = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.Subscription.PaymentSettings.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+    }
+    export namespace PendingInvoiceItemInterval {
+      export type Interval = Stripe.Subscription.PendingInvoiceItemInterval.Interval;
+    }
+    export namespace TrialSettings {
+      export type EndBehavior = Stripe.Subscription.TrialSettings.EndBehavior;
+      export namespace EndBehavior {
+        export type MissingPaymentMethod = Stripe.Subscription.TrialSettings.EndBehavior.MissingPaymentMethod;
+      }
+    }
   }
   export namespace SubscriptionItemCreateParams {
     export type BillingThresholds = Stripe.SubscriptionItemCreateParams.BillingThresholds;
@@ -1251,6 +8576,13 @@ declare namespace StripeConstructor {
     export type PaymentBehavior = Stripe.SubscriptionItemCreateParams.PaymentBehavior;
     export type PriceData = Stripe.SubscriptionItemCreateParams.PriceData;
     export type ProrationBehavior = Stripe.SubscriptionItemCreateParams.ProrationBehavior;
+    export namespace PriceData {
+      export type Recurring = Stripe.SubscriptionItemCreateParams.PriceData.Recurring;
+      export type TaxBehavior = Stripe.SubscriptionItemCreateParams.PriceData.TaxBehavior;
+      export namespace Recurring {
+        export type Interval = Stripe.SubscriptionItemCreateParams.PriceData.Recurring.Interval;
+      }
+    }
   }
   export namespace SubscriptionItemUpdateParams {
     export type BillingThresholds = Stripe.SubscriptionItemUpdateParams.BillingThresholds;
@@ -1258,35 +8590,308 @@ declare namespace StripeConstructor {
     export type PaymentBehavior = Stripe.SubscriptionItemUpdateParams.PaymentBehavior;
     export type PriceData = Stripe.SubscriptionItemUpdateParams.PriceData;
     export type ProrationBehavior = Stripe.SubscriptionItemUpdateParams.ProrationBehavior;
+    export namespace PriceData {
+      export type Recurring = Stripe.SubscriptionItemUpdateParams.PriceData.Recurring;
+      export type TaxBehavior = Stripe.SubscriptionItemUpdateParams.PriceData.TaxBehavior;
+      export namespace Recurring {
+        export type Interval = Stripe.SubscriptionItemUpdateParams.PriceData.Recurring.Interval;
+      }
+    }
   }
   export namespace SubscriptionItemDeleteParams {
     export type PaymentBehavior = Stripe.SubscriptionItemDeleteParams.PaymentBehavior;
     export type ProrationBehavior = Stripe.SubscriptionItemDeleteParams.ProrationBehavior;
+  }
+  export namespace SubscriptionItem {
+    export type BillingThresholds = Stripe.SubscriptionItem.BillingThresholds;
   }
   export namespace SubscriptionScheduleCreateParams {
     export type BillingMode = Stripe.SubscriptionScheduleCreateParams.BillingMode;
     export type DefaultSettings = Stripe.SubscriptionScheduleCreateParams.DefaultSettings;
     export type EndBehavior = Stripe.SubscriptionScheduleCreateParams.EndBehavior;
     export type Phase = Stripe.SubscriptionScheduleCreateParams.Phase;
+    export namespace BillingMode {
+      export type Flexible = Stripe.SubscriptionScheduleCreateParams.BillingMode.Flexible;
+      export type Type = Stripe.SubscriptionScheduleCreateParams.BillingMode.Type;
+      export namespace Flexible {
+        export type ProrationDiscounts = Stripe.SubscriptionScheduleCreateParams.BillingMode.Flexible.ProrationDiscounts;
+      }
+    }
+    export namespace DefaultSettings {
+      export type AutomaticTax = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.AutomaticTax;
+      export type BillingCycleAnchor = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.BillingCycleAnchor;
+      export type BillingThresholds = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.BillingThresholds;
+      export type CollectionMethod = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.CollectionMethod;
+      export type InvoiceSettings = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings;
+      export type TransferData = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.TransferData;
+      export namespace AutomaticTax {
+        export type Liability = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.SubscriptionScheduleCreateParams.DefaultSettings.InvoiceSettings.Issuer.Type;
+        }
+      }
+    }
+    export namespace Phase {
+      export type AddInvoiceItem = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem;
+      export type AutomaticTax = Stripe.SubscriptionScheduleCreateParams.Phase.AutomaticTax;
+      export type BillingCycleAnchor = Stripe.SubscriptionScheduleCreateParams.Phase.BillingCycleAnchor;
+      export type BillingThresholds = Stripe.SubscriptionScheduleCreateParams.Phase.BillingThresholds;
+      export type CollectionMethod = Stripe.SubscriptionScheduleCreateParams.Phase.CollectionMethod;
+      export type Discount = Stripe.SubscriptionScheduleCreateParams.Phase.Discount;
+      export type Duration = Stripe.SubscriptionScheduleCreateParams.Phase.Duration;
+      export type InvoiceSettings = Stripe.SubscriptionScheduleCreateParams.Phase.InvoiceSettings;
+      export type Item = Stripe.SubscriptionScheduleCreateParams.Phase.Item;
+      export type ProrationBehavior = Stripe.SubscriptionScheduleCreateParams.Phase.ProrationBehavior;
+      export type TransferData = Stripe.SubscriptionScheduleCreateParams.Phase.TransferData;
+      export namespace AddInvoiceItem {
+        export type Discount = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.Discount;
+        export type Period = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.Period;
+        export type PriceData = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.PriceData;
+        export namespace Period {
+          export type End = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.Period.End;
+          export type Start = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.Period.Start;
+          export namespace End {
+            export type Type = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.Period.End.Type;
+          }
+          export namespace Start {
+            export type Type = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.Period.Start.Type;
+          }
+        }
+        export namespace PriceData {
+          export type TaxBehavior = Stripe.SubscriptionScheduleCreateParams.Phase.AddInvoiceItem.PriceData.TaxBehavior;
+        }
+      }
+      export namespace AutomaticTax {
+        export type Liability = Stripe.SubscriptionScheduleCreateParams.Phase.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.SubscriptionScheduleCreateParams.Phase.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace Duration {
+        export type Interval = Stripe.SubscriptionScheduleCreateParams.Phase.Duration.Interval;
+      }
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.SubscriptionScheduleCreateParams.Phase.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.SubscriptionScheduleCreateParams.Phase.InvoiceSettings.Issuer.Type;
+        }
+      }
+      export namespace Item {
+        export type BillingThresholds = Stripe.SubscriptionScheduleCreateParams.Phase.Item.BillingThresholds;
+        export type Discount = Stripe.SubscriptionScheduleCreateParams.Phase.Item.Discount;
+        export type PriceData = Stripe.SubscriptionScheduleCreateParams.Phase.Item.PriceData;
+        export namespace PriceData {
+          export type Recurring = Stripe.SubscriptionScheduleCreateParams.Phase.Item.PriceData.Recurring;
+          export type TaxBehavior = Stripe.SubscriptionScheduleCreateParams.Phase.Item.PriceData.TaxBehavior;
+          export namespace Recurring {
+            export type Interval = Stripe.SubscriptionScheduleCreateParams.Phase.Item.PriceData.Recurring.Interval;
+          }
+        }
+      }
+    }
   }
   export namespace SubscriptionScheduleUpdateParams {
     export type DefaultSettings = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings;
     export type EndBehavior = Stripe.SubscriptionScheduleUpdateParams.EndBehavior;
     export type Phase = Stripe.SubscriptionScheduleUpdateParams.Phase;
     export type ProrationBehavior = Stripe.SubscriptionScheduleUpdateParams.ProrationBehavior;
+    export namespace DefaultSettings {
+      export type AutomaticTax = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.AutomaticTax;
+      export type BillingCycleAnchor = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.BillingCycleAnchor;
+      export type BillingThresholds = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.BillingThresholds;
+      export type CollectionMethod = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.CollectionMethod;
+      export type InvoiceSettings = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings;
+      export type TransferData = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.TransferData;
+      export namespace AutomaticTax {
+        export type Liability = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.SubscriptionScheduleUpdateParams.DefaultSettings.InvoiceSettings.Issuer.Type;
+        }
+      }
+    }
+    export namespace Phase {
+      export type AddInvoiceItem = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem;
+      export type AutomaticTax = Stripe.SubscriptionScheduleUpdateParams.Phase.AutomaticTax;
+      export type BillingCycleAnchor = Stripe.SubscriptionScheduleUpdateParams.Phase.BillingCycleAnchor;
+      export type BillingThresholds = Stripe.SubscriptionScheduleUpdateParams.Phase.BillingThresholds;
+      export type CollectionMethod = Stripe.SubscriptionScheduleUpdateParams.Phase.CollectionMethod;
+      export type Discount = Stripe.SubscriptionScheduleUpdateParams.Phase.Discount;
+      export type Duration = Stripe.SubscriptionScheduleUpdateParams.Phase.Duration;
+      export type InvoiceSettings = Stripe.SubscriptionScheduleUpdateParams.Phase.InvoiceSettings;
+      export type Item = Stripe.SubscriptionScheduleUpdateParams.Phase.Item;
+      export type ProrationBehavior = Stripe.SubscriptionScheduleUpdateParams.Phase.ProrationBehavior;
+      export type TransferData = Stripe.SubscriptionScheduleUpdateParams.Phase.TransferData;
+      export namespace AddInvoiceItem {
+        export type Discount = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.Discount;
+        export type Period = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.Period;
+        export type PriceData = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.PriceData;
+        export namespace Period {
+          export type End = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.Period.End;
+          export type Start = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.Period.Start;
+          export namespace End {
+            export type Type = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.Period.End.Type;
+          }
+          export namespace Start {
+            export type Type = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.Period.Start.Type;
+          }
+        }
+        export namespace PriceData {
+          export type TaxBehavior = Stripe.SubscriptionScheduleUpdateParams.Phase.AddInvoiceItem.PriceData.TaxBehavior;
+        }
+      }
+      export namespace AutomaticTax {
+        export type Liability = Stripe.SubscriptionScheduleUpdateParams.Phase.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.SubscriptionScheduleUpdateParams.Phase.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace Duration {
+        export type Interval = Stripe.SubscriptionScheduleUpdateParams.Phase.Duration.Interval;
+      }
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.SubscriptionScheduleUpdateParams.Phase.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.SubscriptionScheduleUpdateParams.Phase.InvoiceSettings.Issuer.Type;
+        }
+      }
+      export namespace Item {
+        export type BillingThresholds = Stripe.SubscriptionScheduleUpdateParams.Phase.Item.BillingThresholds;
+        export type Discount = Stripe.SubscriptionScheduleUpdateParams.Phase.Item.Discount;
+        export type PriceData = Stripe.SubscriptionScheduleUpdateParams.Phase.Item.PriceData;
+        export namespace PriceData {
+          export type Recurring = Stripe.SubscriptionScheduleUpdateParams.Phase.Item.PriceData.Recurring;
+          export type TaxBehavior = Stripe.SubscriptionScheduleUpdateParams.Phase.Item.PriceData.TaxBehavior;
+          export namespace Recurring {
+            export type Interval = Stripe.SubscriptionScheduleUpdateParams.Phase.Item.PriceData.Recurring.Interval;
+          }
+        }
+      }
+    }
+  }
+  export namespace SubscriptionSchedule {
+    export type BillingMode = Stripe.SubscriptionSchedule.BillingMode;
+    export type CurrentPhase = Stripe.SubscriptionSchedule.CurrentPhase;
+    export type DefaultSettings = Stripe.SubscriptionSchedule.DefaultSettings;
+    export type EndBehavior = Stripe.SubscriptionSchedule.EndBehavior;
+    export type Phase = Stripe.SubscriptionSchedule.Phase;
+    export type Status = Stripe.SubscriptionSchedule.Status;
+    export namespace BillingMode {
+      export type Flexible = Stripe.SubscriptionSchedule.BillingMode.Flexible;
+      export type Type = Stripe.SubscriptionSchedule.BillingMode.Type;
+      export namespace Flexible {
+        export type ProrationDiscounts = Stripe.SubscriptionSchedule.BillingMode.Flexible.ProrationDiscounts;
+      }
+    }
+    export namespace DefaultSettings {
+      export type AutomaticTax = Stripe.SubscriptionSchedule.DefaultSettings.AutomaticTax;
+      export type BillingCycleAnchor = Stripe.SubscriptionSchedule.DefaultSettings.BillingCycleAnchor;
+      export type BillingThresholds = Stripe.SubscriptionSchedule.DefaultSettings.BillingThresholds;
+      export type CollectionMethod = Stripe.SubscriptionSchedule.DefaultSettings.CollectionMethod;
+      export type InvoiceSettings = Stripe.SubscriptionSchedule.DefaultSettings.InvoiceSettings;
+      export type TransferData = Stripe.SubscriptionSchedule.DefaultSettings.TransferData;
+      export namespace AutomaticTax {
+        export type Liability = Stripe.SubscriptionSchedule.DefaultSettings.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.SubscriptionSchedule.DefaultSettings.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.SubscriptionSchedule.DefaultSettings.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.SubscriptionSchedule.DefaultSettings.InvoiceSettings.Issuer.Type;
+        }
+      }
+    }
+    export namespace Phase {
+      export type AddInvoiceItem = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem;
+      export type AutomaticTax = Stripe.SubscriptionSchedule.Phase.AutomaticTax;
+      export type BillingCycleAnchor = Stripe.SubscriptionSchedule.Phase.BillingCycleAnchor;
+      export type BillingThresholds = Stripe.SubscriptionSchedule.Phase.BillingThresholds;
+      export type CollectionMethod = Stripe.SubscriptionSchedule.Phase.CollectionMethod;
+      export type Discount = Stripe.SubscriptionSchedule.Phase.Discount;
+      export type InvoiceSettings = Stripe.SubscriptionSchedule.Phase.InvoiceSettings;
+      export type Item = Stripe.SubscriptionSchedule.Phase.Item;
+      export type ProrationBehavior = Stripe.SubscriptionSchedule.Phase.ProrationBehavior;
+      export type TransferData = Stripe.SubscriptionSchedule.Phase.TransferData;
+      export namespace AddInvoiceItem {
+        export type Discount = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem.Discount;
+        export type Period = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem.Period;
+        export namespace Period {
+          export type End = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem.Period.End;
+          export type Start = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem.Period.Start;
+          export namespace End {
+            export type Type = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem.Period.End.Type;
+          }
+          export namespace Start {
+            export type Type = Stripe.SubscriptionSchedule.Phase.AddInvoiceItem.Period.Start.Type;
+          }
+        }
+      }
+      export namespace AutomaticTax {
+        export type Liability = Stripe.SubscriptionSchedule.Phase.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.SubscriptionSchedule.Phase.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace InvoiceSettings {
+        export type Issuer = Stripe.SubscriptionSchedule.Phase.InvoiceSettings.Issuer;
+        export namespace Issuer {
+          export type Type = Stripe.SubscriptionSchedule.Phase.InvoiceSettings.Issuer.Type;
+        }
+      }
+      export namespace Item {
+        export type BillingThresholds = Stripe.SubscriptionSchedule.Phase.Item.BillingThresholds;
+        export type Discount = Stripe.SubscriptionSchedule.Phase.Item.Discount;
+      }
+    }
   }
   export namespace TaxIdCreateParams {
     export type Type = Stripe.TaxIdCreateParams.Type;
     export type Owner = Stripe.TaxIdCreateParams.Owner;
+    export namespace Owner {
+      export type Type = Stripe.TaxIdCreateParams.Owner.Type;
+    }
   }
   export namespace TaxIdListParams {
     export type Owner = Stripe.TaxIdListParams.Owner;
+    export namespace Owner {
+      export type Type = Stripe.TaxIdListParams.Owner.Type;
+    }
+  }
+  export namespace TaxId {
+    export type Owner = Stripe.TaxId.Owner;
+    export type Type = Stripe.TaxId.Type;
+    export type Verification = Stripe.TaxId.Verification;
+    export namespace Owner {
+      export type Type = Stripe.TaxId.Owner.Type;
+    }
+    export namespace Verification {
+      export type Status = Stripe.TaxId.Verification.Status;
+    }
   }
   export namespace TaxRateCreateParams {
     export type TaxType = Stripe.TaxRateCreateParams.TaxType;
   }
   export namespace TaxRateUpdateParams {
     export type TaxType = Stripe.TaxRateUpdateParams.TaxType;
+  }
+  export namespace TaxRate {
+    export type FlatAmount = Stripe.TaxRate.FlatAmount;
+    export type JurisdictionLevel = Stripe.TaxRate.JurisdictionLevel;
+    export type RateType = Stripe.TaxRate.RateType;
+    export type TaxType = Stripe.TaxRate.TaxType;
   }
   export namespace TokenCreateParams {
     export type Account = Stripe.TokenCreateParams.Account;
@@ -1295,9 +8900,80 @@ declare namespace StripeConstructor {
     export type CvcUpdate = Stripe.TokenCreateParams.CvcUpdate;
     export type Person = Stripe.TokenCreateParams.Person;
     export type Pii = Stripe.TokenCreateParams.Pii;
+    export namespace Account {
+      export type BusinessType = Stripe.TokenCreateParams.Account.BusinessType;
+      export type Company = Stripe.TokenCreateParams.Account.Company;
+      export type Individual = Stripe.TokenCreateParams.Account.Individual;
+      export namespace Company {
+        export type DirectorshipDeclaration = Stripe.TokenCreateParams.Account.Company.DirectorshipDeclaration;
+        export type OwnershipDeclaration = Stripe.TokenCreateParams.Account.Company.OwnershipDeclaration;
+        export type OwnershipExemptionReason = Stripe.TokenCreateParams.Account.Company.OwnershipExemptionReason;
+        export type RegistrationDate = Stripe.TokenCreateParams.Account.Company.RegistrationDate;
+        export type RepresentativeDeclaration = Stripe.TokenCreateParams.Account.Company.RepresentativeDeclaration;
+        export type Structure = Stripe.TokenCreateParams.Account.Company.Structure;
+        export type Verification = Stripe.TokenCreateParams.Account.Company.Verification;
+        export namespace Verification {
+          export type Document = Stripe.TokenCreateParams.Account.Company.Verification.Document;
+        }
+      }
+      export namespace Individual {
+        export type Dob = Stripe.TokenCreateParams.Account.Individual.Dob;
+        export type PoliticalExposure = Stripe.TokenCreateParams.Account.Individual.PoliticalExposure;
+        export type Relationship = Stripe.TokenCreateParams.Account.Individual.Relationship;
+        export type Verification = Stripe.TokenCreateParams.Account.Individual.Verification;
+        export namespace Verification {
+          export type AdditionalDocument = Stripe.TokenCreateParams.Account.Individual.Verification.AdditionalDocument;
+          export type Document = Stripe.TokenCreateParams.Account.Individual.Verification.Document;
+        }
+      }
+    }
+    export namespace BankAccount {
+      export type AccountHolderType = Stripe.TokenCreateParams.BankAccount.AccountHolderType;
+      export type AccountType = Stripe.TokenCreateParams.BankAccount.AccountType;
+    }
+    export namespace Card {
+      export type Networks = Stripe.TokenCreateParams.Card.Networks;
+      export namespace Networks {
+        export type Preferred = Stripe.TokenCreateParams.Card.Networks.Preferred;
+      }
+    }
+    export namespace Person {
+      export type AdditionalTosAcceptances = Stripe.TokenCreateParams.Person.AdditionalTosAcceptances;
+      export type Dob = Stripe.TokenCreateParams.Person.Dob;
+      export type Documents = Stripe.TokenCreateParams.Person.Documents;
+      export type PoliticalExposure = Stripe.TokenCreateParams.Person.PoliticalExposure;
+      export type Relationship = Stripe.TokenCreateParams.Person.Relationship;
+      export type UsCfpbData = Stripe.TokenCreateParams.Person.UsCfpbData;
+      export type Verification = Stripe.TokenCreateParams.Person.Verification;
+      export namespace AdditionalTosAcceptances {
+        export type Account = Stripe.TokenCreateParams.Person.AdditionalTosAcceptances.Account;
+      }
+      export namespace Documents {
+        export type CompanyAuthorization = Stripe.TokenCreateParams.Person.Documents.CompanyAuthorization;
+        export type Passport = Stripe.TokenCreateParams.Person.Documents.Passport;
+        export type Visa = Stripe.TokenCreateParams.Person.Documents.Visa;
+      }
+      export namespace UsCfpbData {
+        export type EthnicityDetails = Stripe.TokenCreateParams.Person.UsCfpbData.EthnicityDetails;
+        export type RaceDetails = Stripe.TokenCreateParams.Person.UsCfpbData.RaceDetails;
+        export namespace EthnicityDetails {
+          export type Ethnicity = Stripe.TokenCreateParams.Person.UsCfpbData.EthnicityDetails.Ethnicity;
+        }
+        export namespace RaceDetails {
+          export type Race = Stripe.TokenCreateParams.Person.UsCfpbData.RaceDetails.Race;
+        }
+      }
+      export namespace Verification {
+        export type AdditionalDocument = Stripe.TokenCreateParams.Person.Verification.AdditionalDocument;
+        export type Document = Stripe.TokenCreateParams.Person.Verification.Document;
+      }
+    }
   }
   export namespace TopupListParams {
     export type Status = Stripe.TopupListParams.Status;
+  }
+  export namespace Topup {
+    export type Status = Stripe.Topup.Status;
   }
   export namespace TransferCreateParams {
     export type SourceType = Stripe.TransferCreateParams.SourceType;
@@ -1308,6 +8984,231 @@ declare namespace StripeConstructor {
   }
   export namespace WebhookEndpointUpdateParams {
     export type EnabledEvent = Stripe.WebhookEndpointUpdateParams.EnabledEvent;
+  }
+  export namespace BankAccount {
+    export type AvailablePayoutMethod = Stripe.BankAccount.AvailablePayoutMethod;
+    export type FutureRequirements = Stripe.BankAccount.FutureRequirements;
+    export type Requirements = Stripe.BankAccount.Requirements;
+    export namespace FutureRequirements {
+      export type Error = Stripe.BankAccount.FutureRequirements.Error;
+      export namespace Error {
+        export type Code = Stripe.BankAccount.FutureRequirements.Error.Code;
+      }
+    }
+    export namespace Requirements {
+      export type Error = Stripe.BankAccount.Requirements.Error;
+      export namespace Error {
+        export type Code = Stripe.BankAccount.Requirements.Error.Code;
+      }
+    }
+  }
+  export namespace Card {
+    export type AllowRedisplay = Stripe.Card.AllowRedisplay;
+    export type AvailablePayoutMethod = Stripe.Card.AvailablePayoutMethod;
+    export type Networks = Stripe.Card.Networks;
+    export type RegulatedStatus = Stripe.Card.RegulatedStatus;
+  }
+  export namespace DeletedDiscount {
+    export type Source = Stripe.DeletedDiscount.Source;
+  }
+  export namespace Discount {
+    export type Source = Stripe.Discount.Source;
+  }
+  export namespace FundingInstructions {
+    export type BankTransfer = Stripe.FundingInstructions.BankTransfer;
+    export namespace BankTransfer {
+      export type FinancialAddress = Stripe.FundingInstructions.BankTransfer.FinancialAddress;
+      export type Type = Stripe.FundingInstructions.BankTransfer.Type;
+      export namespace FinancialAddress {
+        export type Aba = Stripe.FundingInstructions.BankTransfer.FinancialAddress.Aba;
+        export type Iban = Stripe.FundingInstructions.BankTransfer.FinancialAddress.Iban;
+        export type SortCode = Stripe.FundingInstructions.BankTransfer.FinancialAddress.SortCode;
+        export type Spei = Stripe.FundingInstructions.BankTransfer.FinancialAddress.Spei;
+        export type SupportedNetwork = Stripe.FundingInstructions.BankTransfer.FinancialAddress.SupportedNetwork;
+        export type Swift = Stripe.FundingInstructions.BankTransfer.FinancialAddress.Swift;
+        export type Type = Stripe.FundingInstructions.BankTransfer.FinancialAddress.Type;
+        export type Zengin = Stripe.FundingInstructions.BankTransfer.FinancialAddress.Zengin;
+      }
+    }
+  }
+  export namespace LineItem {
+    export type AdjustableQuantity = Stripe.LineItem.AdjustableQuantity;
+    export type Discount = Stripe.LineItem.Discount;
+    export type Tax = Stripe.LineItem.Tax;
+    export namespace Tax {
+      export type TaxabilityReason = Stripe.LineItem.Tax.TaxabilityReason;
+    }
+  }
+  export namespace SourceMandateNotification {
+    export type AcssDebit = Stripe.SourceMandateNotification.AcssDebit;
+    export type BacsDebit = Stripe.SourceMandateNotification.BacsDebit;
+    export type SepaDebit = Stripe.SourceMandateNotification.SepaDebit;
+  }
+  export namespace SourceTransaction {
+    export type AchCreditTransfer = Stripe.SourceTransaction.AchCreditTransfer;
+    export type ChfCreditTransfer = Stripe.SourceTransaction.ChfCreditTransfer;
+    export type GbpCreditTransfer = Stripe.SourceTransaction.GbpCreditTransfer;
+    export type PaperCheck = Stripe.SourceTransaction.PaperCheck;
+    export type SepaCreditTransfer = Stripe.SourceTransaction.SepaCreditTransfer;
+    export type Type = Stripe.SourceTransaction.Type;
+  }
+  export namespace Capability {
+    export type FutureRequirements = Stripe.Capability.FutureRequirements;
+    export type Requirements = Stripe.Capability.Requirements;
+    export type Status = Stripe.Capability.Status;
+    export namespace FutureRequirements {
+      export type Alternative = Stripe.Capability.FutureRequirements.Alternative;
+      export type DisabledReason = Stripe.Capability.FutureRequirements.DisabledReason;
+      export type Error = Stripe.Capability.FutureRequirements.Error;
+      export namespace Error {
+        export type Code = Stripe.Capability.FutureRequirements.Error.Code;
+      }
+    }
+    export namespace Requirements {
+      export type Alternative = Stripe.Capability.Requirements.Alternative;
+      export type DisabledReason = Stripe.Capability.Requirements.DisabledReason;
+      export type Error = Stripe.Capability.Requirements.Error;
+      export namespace Error {
+        export type Code = Stripe.Capability.Requirements.Error.Code;
+      }
+    }
+  }
+  export namespace Person {
+    export type AdditionalTosAcceptances = Stripe.Person.AdditionalTosAcceptances;
+    export type AddressKana = Stripe.Person.AddressKana;
+    export type AddressKanji = Stripe.Person.AddressKanji;
+    export type Dob = Stripe.Person.Dob;
+    export type FutureRequirements = Stripe.Person.FutureRequirements;
+    export type PoliticalExposure = Stripe.Person.PoliticalExposure;
+    export type Relationship = Stripe.Person.Relationship;
+    export type Requirements = Stripe.Person.Requirements;
+    export type UsCfpbData = Stripe.Person.UsCfpbData;
+    export type Verification = Stripe.Person.Verification;
+    export namespace AdditionalTosAcceptances {
+      export type Account = Stripe.Person.AdditionalTosAcceptances.Account;
+    }
+    export namespace FutureRequirements {
+      export type Alternative = Stripe.Person.FutureRequirements.Alternative;
+      export type Error = Stripe.Person.FutureRequirements.Error;
+      export namespace Error {
+        export type Code = Stripe.Person.FutureRequirements.Error.Code;
+      }
+    }
+    export namespace Requirements {
+      export type Alternative = Stripe.Person.Requirements.Alternative;
+      export type Error = Stripe.Person.Requirements.Error;
+      export namespace Error {
+        export type Code = Stripe.Person.Requirements.Error.Code;
+      }
+    }
+    export namespace UsCfpbData {
+      export type EthnicityDetails = Stripe.Person.UsCfpbData.EthnicityDetails;
+      export type RaceDetails = Stripe.Person.UsCfpbData.RaceDetails;
+      export namespace EthnicityDetails {
+        export type Ethnicity = Stripe.Person.UsCfpbData.EthnicityDetails.Ethnicity;
+      }
+      export namespace RaceDetails {
+        export type Race = Stripe.Person.UsCfpbData.RaceDetails.Race;
+      }
+    }
+    export namespace Verification {
+      export type AdditionalDocument = Stripe.Person.Verification.AdditionalDocument;
+      export type Document = Stripe.Person.Verification.Document;
+    }
+  }
+  export namespace CreditNoteLineItem {
+    export type DiscountAmount = Stripe.CreditNoteLineItem.DiscountAmount;
+    export type PretaxCreditAmount = Stripe.CreditNoteLineItem.PretaxCreditAmount;
+    export type Tax = Stripe.CreditNoteLineItem.Tax;
+    export type Type = Stripe.CreditNoteLineItem.Type;
+    export namespace PretaxCreditAmount {
+      export type Type = Stripe.CreditNoteLineItem.PretaxCreditAmount.Type;
+    }
+    export namespace Tax {
+      export type TaxBehavior = Stripe.CreditNoteLineItem.Tax.TaxBehavior;
+      export type TaxRateDetails = Stripe.CreditNoteLineItem.Tax.TaxRateDetails;
+      export type TaxabilityReason = Stripe.CreditNoteLineItem.Tax.TaxabilityReason;
+    }
+  }
+  export namespace CustomerBalanceTransaction {
+    export type Type = Stripe.CustomerBalanceTransaction.Type;
+  }
+  export namespace CashBalance {
+    export type Settings = Stripe.CashBalance.Settings;
+    export namespace Settings {
+      export type ReconciliationMode = Stripe.CashBalance.Settings.ReconciliationMode;
+    }
+  }
+  export namespace CustomerCashBalanceTransaction {
+    export type AdjustedForOverdraft = Stripe.CustomerCashBalanceTransaction.AdjustedForOverdraft;
+    export type AppliedToPayment = Stripe.CustomerCashBalanceTransaction.AppliedToPayment;
+    export type Funded = Stripe.CustomerCashBalanceTransaction.Funded;
+    export type RefundedFromPayment = Stripe.CustomerCashBalanceTransaction.RefundedFromPayment;
+    export type TransferredToBalance = Stripe.CustomerCashBalanceTransaction.TransferredToBalance;
+    export type Type = Stripe.CustomerCashBalanceTransaction.Type;
+    export type UnappliedFromPayment = Stripe.CustomerCashBalanceTransaction.UnappliedFromPayment;
+    export namespace Funded {
+      export type BankTransfer = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer;
+      export namespace BankTransfer {
+        export type EuBankTransfer = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer.EuBankTransfer;
+        export type GbBankTransfer = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer.GbBankTransfer;
+        export type JpBankTransfer = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer.JpBankTransfer;
+        export type Type = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer.Type;
+        export type UsBankTransfer = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer.UsBankTransfer;
+        export namespace UsBankTransfer {
+          export type Network = Stripe.CustomerCashBalanceTransaction.Funded.BankTransfer.UsBankTransfer.Network;
+        }
+      }
+    }
+  }
+  export namespace InvoiceLineItem {
+    export type DiscountAmount = Stripe.InvoiceLineItem.DiscountAmount;
+    export type Parent = Stripe.InvoiceLineItem.Parent;
+    export type Period = Stripe.InvoiceLineItem.Period;
+    export type PretaxCreditAmount = Stripe.InvoiceLineItem.PretaxCreditAmount;
+    export type Pricing = Stripe.InvoiceLineItem.Pricing;
+    export type Tax = Stripe.InvoiceLineItem.Tax;
+    export namespace Parent {
+      export type InvoiceItemDetails = Stripe.InvoiceLineItem.Parent.InvoiceItemDetails;
+      export type SubscriptionItemDetails = Stripe.InvoiceLineItem.Parent.SubscriptionItemDetails;
+      export type Type = Stripe.InvoiceLineItem.Parent.Type;
+      export namespace InvoiceItemDetails {
+        export type ProrationDetails = Stripe.InvoiceLineItem.Parent.InvoiceItemDetails.ProrationDetails;
+        export namespace ProrationDetails {
+          export type CreditedItems = Stripe.InvoiceLineItem.Parent.InvoiceItemDetails.ProrationDetails.CreditedItems;
+        }
+      }
+      export namespace SubscriptionItemDetails {
+        export type ProrationDetails = Stripe.InvoiceLineItem.Parent.SubscriptionItemDetails.ProrationDetails;
+        export namespace ProrationDetails {
+          export type CreditedItems = Stripe.InvoiceLineItem.Parent.SubscriptionItemDetails.ProrationDetails.CreditedItems;
+        }
+      }
+    }
+    export namespace PretaxCreditAmount {
+      export type Type = Stripe.InvoiceLineItem.PretaxCreditAmount.Type;
+    }
+    export namespace Pricing {
+      export type PriceDetails = Stripe.InvoiceLineItem.Pricing.PriceDetails;
+    }
+    export namespace Tax {
+      export type TaxBehavior = Stripe.InvoiceLineItem.Tax.TaxBehavior;
+      export type TaxRateDetails = Stripe.InvoiceLineItem.Tax.TaxRateDetails;
+      export type TaxabilityReason = Stripe.InvoiceLineItem.Tax.TaxabilityReason;
+    }
+  }
+  export namespace PaymentIntentAmountDetailsLineItem {
+    export type PaymentMethodOptions = Stripe.PaymentIntentAmountDetailsLineItem.PaymentMethodOptions;
+    export type Tax = Stripe.PaymentIntentAmountDetailsLineItem.Tax;
+    export namespace PaymentMethodOptions {
+      export type Card = Stripe.PaymentIntentAmountDetailsLineItem.PaymentMethodOptions.Card;
+      export type CardPresent = Stripe.PaymentIntentAmountDetailsLineItem.PaymentMethodOptions.CardPresent;
+      export type Klarna = Stripe.PaymentIntentAmountDetailsLineItem.PaymentMethodOptions.Klarna;
+      export type Paypal = Stripe.PaymentIntentAmountDetailsLineItem.PaymentMethodOptions.Paypal;
+      export namespace Paypal {
+        export type Category = Stripe.PaymentIntentAmountDetailsLineItem.PaymentMethodOptions.Paypal.Category;
+      }
+    }
   }
   export type Apps = Stripe.Apps;
   export type Billing = Stripe.Billing;
@@ -1337,15 +9238,15 @@ declare namespace StripeConstructor {
     export type SecretResource = Stripe.Apps.SecretResource;
     export namespace SecretCreateParams {
       export type Scope = Stripe.Apps.SecretCreateParams.Scope;
+      export namespace Scope {
+        export type Type = Stripe.Apps.SecretCreateParams.Scope.Type;
+      }
     }
-    export namespace SecretListParams {
-      export type Scope = Stripe.Apps.SecretListParams.Scope;
-    }
-    export namespace SecretDeleteWhereParams {
-      export type Scope = Stripe.Apps.SecretDeleteWhereParams.Scope;
-    }
-    export namespace SecretFindParams {
-      export type Scope = Stripe.Apps.SecretFindParams.Scope;
+    export namespace Secret {
+      export type Scope = Stripe.Apps.Secret.Scope;
+      export namespace Scope {
+        export type Type = Stripe.Apps.Secret.Scope.Type;
+      }
     }
   }
   export namespace Billing {
@@ -1391,29 +9292,115 @@ declare namespace StripeConstructor {
     export type MeterEventSummary = Stripe.Billing.MeterEventSummary;
     export namespace AlertCreateParams {
       export type UsageThreshold = Stripe.Billing.AlertCreateParams.UsageThreshold;
+      export namespace UsageThreshold {
+        export type Filter = Stripe.Billing.AlertCreateParams.UsageThreshold.Filter;
+      }
+    }
+    export namespace Alert {
+      export type Status = Stripe.Billing.Alert.Status;
+      export type UsageThreshold = Stripe.Billing.Alert.UsageThreshold;
+      export namespace UsageThreshold {
+        export type Filter = Stripe.Billing.Alert.UsageThreshold.Filter;
+      }
     }
     export namespace CreditBalanceSummaryRetrieveParams {
       export type Filter = Stripe.Billing.CreditBalanceSummaryRetrieveParams.Filter;
+      export namespace Filter {
+        export type ApplicabilityScope = Stripe.Billing.CreditBalanceSummaryRetrieveParams.Filter.ApplicabilityScope;
+        export type Type = Stripe.Billing.CreditBalanceSummaryRetrieveParams.Filter.Type;
+        export namespace ApplicabilityScope {
+          export type Price = Stripe.Billing.CreditBalanceSummaryRetrieveParams.Filter.ApplicabilityScope.Price;
+        }
+      }
+    }
+    export namespace CreditBalanceSummary {
+      export type Balance = Stripe.Billing.CreditBalanceSummary.Balance;
+      export namespace Balance {
+        export type AvailableBalance = Stripe.Billing.CreditBalanceSummary.Balance.AvailableBalance;
+        export type LedgerBalance = Stripe.Billing.CreditBalanceSummary.Balance.LedgerBalance;
+        export namespace AvailableBalance {
+          export type Monetary = Stripe.Billing.CreditBalanceSummary.Balance.AvailableBalance.Monetary;
+        }
+        export namespace LedgerBalance {
+          export type Monetary = Stripe.Billing.CreditBalanceSummary.Balance.LedgerBalance.Monetary;
+        }
+      }
+    }
+    export namespace CreditBalanceTransaction {
+      export type Credit = Stripe.Billing.CreditBalanceTransaction.Credit;
+      export type Debit = Stripe.Billing.CreditBalanceTransaction.Debit;
+      export type Type = Stripe.Billing.CreditBalanceTransaction.Type;
+      export namespace Credit {
+        export type Amount = Stripe.Billing.CreditBalanceTransaction.Credit.Amount;
+        export type CreditsApplicationInvoiceVoided = Stripe.Billing.CreditBalanceTransaction.Credit.CreditsApplicationInvoiceVoided;
+        export type Type = Stripe.Billing.CreditBalanceTransaction.Credit.Type;
+        export namespace Amount {
+          export type Monetary = Stripe.Billing.CreditBalanceTransaction.Credit.Amount.Monetary;
+        }
+      }
+      export namespace Debit {
+        export type Amount = Stripe.Billing.CreditBalanceTransaction.Debit.Amount;
+        export type CreditsApplied = Stripe.Billing.CreditBalanceTransaction.Debit.CreditsApplied;
+        export type Type = Stripe.Billing.CreditBalanceTransaction.Debit.Type;
+        export namespace Amount {
+          export type Monetary = Stripe.Billing.CreditBalanceTransaction.Debit.Amount.Monetary;
+        }
+      }
     }
     export namespace CreditGrantCreateParams {
       export type Amount = Stripe.Billing.CreditGrantCreateParams.Amount;
       export type ApplicabilityConfig = Stripe.Billing.CreditGrantCreateParams.ApplicabilityConfig;
       export type Category = Stripe.Billing.CreditGrantCreateParams.Category;
+      export namespace Amount {
+        export type Monetary = Stripe.Billing.CreditGrantCreateParams.Amount.Monetary;
+      }
+      export namespace ApplicabilityConfig {
+        export type Scope = Stripe.Billing.CreditGrantCreateParams.ApplicabilityConfig.Scope;
+        export namespace Scope {
+          export type Price = Stripe.Billing.CreditGrantCreateParams.ApplicabilityConfig.Scope.Price;
+        }
+      }
+    }
+    export namespace CreditGrant {
+      export type Amount = Stripe.Billing.CreditGrant.Amount;
+      export type ApplicabilityConfig = Stripe.Billing.CreditGrant.ApplicabilityConfig;
+      export type Category = Stripe.Billing.CreditGrant.Category;
+      export namespace Amount {
+        export type Monetary = Stripe.Billing.CreditGrant.Amount.Monetary;
+      }
+      export namespace ApplicabilityConfig {
+        export type Scope = Stripe.Billing.CreditGrant.ApplicabilityConfig.Scope;
+        export namespace Scope {
+          export type Price = Stripe.Billing.CreditGrant.ApplicabilityConfig.Scope.Price;
+        }
+      }
     }
     export namespace MeterCreateParams {
       export type DefaultAggregation = Stripe.Billing.MeterCreateParams.DefaultAggregation;
       export type CustomerMapping = Stripe.Billing.MeterCreateParams.CustomerMapping;
       export type EventTimeWindow = Stripe.Billing.MeterCreateParams.EventTimeWindow;
       export type ValueSettings = Stripe.Billing.MeterCreateParams.ValueSettings;
+      export namespace DefaultAggregation {
+        export type Formula = Stripe.Billing.MeterCreateParams.DefaultAggregation.Formula;
+      }
     }
-    export namespace MeterListParams {
-      export type Status = Stripe.Billing.MeterListParams.Status;
-    }
-    export namespace MeterListEventSummariesParams {
-      export type ValueGroupingWindow = Stripe.Billing.MeterListEventSummariesParams.ValueGroupingWindow;
+    export namespace Meter {
+      export type CustomerMapping = Stripe.Billing.Meter.CustomerMapping;
+      export type DefaultAggregation = Stripe.Billing.Meter.DefaultAggregation;
+      export type EventTimeWindow = Stripe.Billing.Meter.EventTimeWindow;
+      export type Status = Stripe.Billing.Meter.Status;
+      export type StatusTransitions = Stripe.Billing.Meter.StatusTransitions;
+      export type ValueSettings = Stripe.Billing.Meter.ValueSettings;
+      export namespace DefaultAggregation {
+        export type Formula = Stripe.Billing.Meter.DefaultAggregation.Formula;
+      }
     }
     export namespace MeterEventAdjustmentCreateParams {
       export type Cancel = Stripe.Billing.MeterEventAdjustmentCreateParams.Cancel;
+    }
+    export namespace MeterEventAdjustment {
+      export type Cancel = Stripe.Billing.MeterEventAdjustment.Cancel;
+      export type Status = Stripe.Billing.MeterEventAdjustment.Status;
     }
   }
   export namespace BillingPortal {
@@ -1430,15 +9417,133 @@ declare namespace StripeConstructor {
       export type Features = Stripe.BillingPortal.ConfigurationCreateParams.Features;
       export type BusinessProfile = Stripe.BillingPortal.ConfigurationCreateParams.BusinessProfile;
       export type LoginPage = Stripe.BillingPortal.ConfigurationCreateParams.LoginPage;
+      export namespace Features {
+        export type CustomerUpdate = Stripe.BillingPortal.ConfigurationCreateParams.Features.CustomerUpdate;
+        export type InvoiceHistory = Stripe.BillingPortal.ConfigurationCreateParams.Features.InvoiceHistory;
+        export type PaymentMethodUpdate = Stripe.BillingPortal.ConfigurationCreateParams.Features.PaymentMethodUpdate;
+        export type SubscriptionCancel = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionCancel;
+        export type SubscriptionUpdate = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate;
+        export namespace CustomerUpdate {
+          export type AllowedUpdate = Stripe.BillingPortal.ConfigurationCreateParams.Features.CustomerUpdate.AllowedUpdate;
+        }
+        export namespace SubscriptionCancel {
+          export type CancellationReason = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionCancel.CancellationReason;
+          export type Mode = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionCancel.Mode;
+          export type ProrationBehavior = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionCancel.ProrationBehavior;
+          export namespace CancellationReason {
+            export type Option = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionCancel.CancellationReason.Option;
+          }
+        }
+        export namespace SubscriptionUpdate {
+          export type BillingCycleAnchor = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.BillingCycleAnchor;
+          export type DefaultAllowedUpdate = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.DefaultAllowedUpdate;
+          export type Product = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.Product;
+          export type ProrationBehavior = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.ProrationBehavior;
+          export type ScheduleAtPeriodEnd = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.ScheduleAtPeriodEnd;
+          export type TrialUpdateBehavior = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.TrialUpdateBehavior;
+          export namespace Product {
+            export type AdjustableQuantity = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.Product.AdjustableQuantity;
+          }
+          export namespace ScheduleAtPeriodEnd {
+            export type Condition = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.ScheduleAtPeriodEnd.Condition;
+            export namespace Condition {
+              export type Type = Stripe.BillingPortal.ConfigurationCreateParams.Features.SubscriptionUpdate.ScheduleAtPeriodEnd.Condition.Type;
+            }
+          }
+        }
+      }
     }
-    export namespace ConfigurationUpdateParams {
-      export type BusinessProfile = Stripe.BillingPortal.ConfigurationUpdateParams.BusinessProfile;
-      export type Features = Stripe.BillingPortal.ConfigurationUpdateParams.Features;
-      export type LoginPage = Stripe.BillingPortal.ConfigurationUpdateParams.LoginPage;
+    export namespace Configuration {
+      export type BusinessProfile = Stripe.BillingPortal.Configuration.BusinessProfile;
+      export type Features = Stripe.BillingPortal.Configuration.Features;
+      export type LoginPage = Stripe.BillingPortal.Configuration.LoginPage;
+      export namespace Features {
+        export type CustomerUpdate = Stripe.BillingPortal.Configuration.Features.CustomerUpdate;
+        export type InvoiceHistory = Stripe.BillingPortal.Configuration.Features.InvoiceHistory;
+        export type PaymentMethodUpdate = Stripe.BillingPortal.Configuration.Features.PaymentMethodUpdate;
+        export type SubscriptionCancel = Stripe.BillingPortal.Configuration.Features.SubscriptionCancel;
+        export type SubscriptionUpdate = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate;
+        export namespace CustomerUpdate {
+          export type AllowedUpdate = Stripe.BillingPortal.Configuration.Features.CustomerUpdate.AllowedUpdate;
+        }
+        export namespace SubscriptionCancel {
+          export type CancellationReason = Stripe.BillingPortal.Configuration.Features.SubscriptionCancel.CancellationReason;
+          export type Mode = Stripe.BillingPortal.Configuration.Features.SubscriptionCancel.Mode;
+          export type ProrationBehavior = Stripe.BillingPortal.Configuration.Features.SubscriptionCancel.ProrationBehavior;
+          export namespace CancellationReason {
+            export type Option = Stripe.BillingPortal.Configuration.Features.SubscriptionCancel.CancellationReason.Option;
+          }
+        }
+        export namespace SubscriptionUpdate {
+          export type BillingCycleAnchor = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.BillingCycleAnchor;
+          export type DefaultAllowedUpdate = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.DefaultAllowedUpdate;
+          export type Product = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.Product;
+          export type ProrationBehavior = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.ProrationBehavior;
+          export type ScheduleAtPeriodEnd = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.ScheduleAtPeriodEnd;
+          export type TrialUpdateBehavior = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.TrialUpdateBehavior;
+          export namespace Product {
+            export type AdjustableQuantity = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.Product.AdjustableQuantity;
+          }
+          export namespace ScheduleAtPeriodEnd {
+            export type Condition = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.ScheduleAtPeriodEnd.Condition;
+            export namespace Condition {
+              export type Type = Stripe.BillingPortal.Configuration.Features.SubscriptionUpdate.ScheduleAtPeriodEnd.Condition.Type;
+            }
+          }
+        }
+      }
     }
     export namespace SessionCreateParams {
       export type FlowData = Stripe.BillingPortal.SessionCreateParams.FlowData;
       export type Locale = Stripe.BillingPortal.SessionCreateParams.Locale;
+      export namespace FlowData {
+        export type AfterCompletion = Stripe.BillingPortal.SessionCreateParams.FlowData.AfterCompletion;
+        export type SubscriptionCancel = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionCancel;
+        export type SubscriptionUpdate = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionUpdate;
+        export type SubscriptionUpdateConfirm = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionUpdateConfirm;
+        export type Type = Stripe.BillingPortal.SessionCreateParams.FlowData.Type;
+        export namespace AfterCompletion {
+          export type HostedConfirmation = Stripe.BillingPortal.SessionCreateParams.FlowData.AfterCompletion.HostedConfirmation;
+          export type Redirect = Stripe.BillingPortal.SessionCreateParams.FlowData.AfterCompletion.Redirect;
+          export type Type = Stripe.BillingPortal.SessionCreateParams.FlowData.AfterCompletion.Type;
+        }
+        export namespace SubscriptionCancel {
+          export type Retention = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionCancel.Retention;
+          export namespace Retention {
+            export type CouponOffer = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionCancel.Retention.CouponOffer;
+          }
+        }
+        export namespace SubscriptionUpdateConfirm {
+          export type Discount = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionUpdateConfirm.Discount;
+          export type Item = Stripe.BillingPortal.SessionCreateParams.FlowData.SubscriptionUpdateConfirm.Item;
+        }
+      }
+    }
+    export namespace Session {
+      export type Flow = Stripe.BillingPortal.Session.Flow;
+      export type Locale = Stripe.BillingPortal.Session.Locale;
+      export namespace Flow {
+        export type AfterCompletion = Stripe.BillingPortal.Session.Flow.AfterCompletion;
+        export type SubscriptionCancel = Stripe.BillingPortal.Session.Flow.SubscriptionCancel;
+        export type SubscriptionUpdate = Stripe.BillingPortal.Session.Flow.SubscriptionUpdate;
+        export type SubscriptionUpdateConfirm = Stripe.BillingPortal.Session.Flow.SubscriptionUpdateConfirm;
+        export type Type = Stripe.BillingPortal.Session.Flow.Type;
+        export namespace AfterCompletion {
+          export type HostedConfirmation = Stripe.BillingPortal.Session.Flow.AfterCompletion.HostedConfirmation;
+          export type Redirect = Stripe.BillingPortal.Session.Flow.AfterCompletion.Redirect;
+          export type Type = Stripe.BillingPortal.Session.Flow.AfterCompletion.Type;
+        }
+        export namespace SubscriptionCancel {
+          export type Retention = Stripe.BillingPortal.Session.Flow.SubscriptionCancel.Retention;
+          export namespace Retention {
+            export type CouponOffer = Stripe.BillingPortal.Session.Flow.SubscriptionCancel.Retention.CouponOffer;
+          }
+        }
+        export namespace SubscriptionUpdateConfirm {
+          export type Discount = Stripe.BillingPortal.Session.Flow.SubscriptionUpdateConfirm.Discount;
+          export type Item = Stripe.BillingPortal.Session.Flow.SubscriptionUpdateConfirm.Item;
+        }
+      }
     }
   }
   export namespace Checkout {
@@ -1488,15 +9593,652 @@ declare namespace StripeConstructor {
       export type TaxIdCollection = Stripe.Checkout.SessionCreateParams.TaxIdCollection;
       export type UiMode = Stripe.Checkout.SessionCreateParams.UiMode;
       export type WalletOptions = Stripe.Checkout.SessionCreateParams.WalletOptions;
+      export namespace AfterExpiration {
+        export type Recovery = Stripe.Checkout.SessionCreateParams.AfterExpiration.Recovery;
+      }
+      export namespace AutomaticTax {
+        export type Liability = Stripe.Checkout.SessionCreateParams.AutomaticTax.Liability;
+        export namespace Liability {
+          export type Type = Stripe.Checkout.SessionCreateParams.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace BrandingSettings {
+        export type BorderStyle = Stripe.Checkout.SessionCreateParams.BrandingSettings.BorderStyle;
+        export type FontFamily = Stripe.Checkout.SessionCreateParams.BrandingSettings.FontFamily;
+        export type Icon = Stripe.Checkout.SessionCreateParams.BrandingSettings.Icon;
+        export type Logo = Stripe.Checkout.SessionCreateParams.BrandingSettings.Logo;
+        export namespace Icon {
+          export type Type = Stripe.Checkout.SessionCreateParams.BrandingSettings.Icon.Type;
+        }
+        export namespace Logo {
+          export type Type = Stripe.Checkout.SessionCreateParams.BrandingSettings.Logo.Type;
+        }
+      }
+      export namespace ConsentCollection {
+        export type PaymentMethodReuseAgreement = Stripe.Checkout.SessionCreateParams.ConsentCollection.PaymentMethodReuseAgreement;
+        export type Promotions = Stripe.Checkout.SessionCreateParams.ConsentCollection.Promotions;
+        export type TermsOfService = Stripe.Checkout.SessionCreateParams.ConsentCollection.TermsOfService;
+        export namespace PaymentMethodReuseAgreement {
+          export type Position = Stripe.Checkout.SessionCreateParams.ConsentCollection.PaymentMethodReuseAgreement.Position;
+        }
+      }
+      export namespace CustomerUpdate {
+        export type Address = Stripe.Checkout.SessionCreateParams.CustomerUpdate.Address;
+        export type Name = Stripe.Checkout.SessionCreateParams.CustomerUpdate.Name;
+        export type Shipping = Stripe.Checkout.SessionCreateParams.CustomerUpdate.Shipping;
+      }
+      export namespace CustomField {
+        export type Dropdown = Stripe.Checkout.SessionCreateParams.CustomField.Dropdown;
+        export type Label = Stripe.Checkout.SessionCreateParams.CustomField.Label;
+        export type Numeric = Stripe.Checkout.SessionCreateParams.CustomField.Numeric;
+        export type Text = Stripe.Checkout.SessionCreateParams.CustomField.Text;
+        export type Type = Stripe.Checkout.SessionCreateParams.CustomField.Type;
+        export namespace Dropdown {
+          export type Option = Stripe.Checkout.SessionCreateParams.CustomField.Dropdown.Option;
+        }
+      }
+      export namespace CustomText {
+        export type AfterSubmit = Stripe.Checkout.SessionCreateParams.CustomText.AfterSubmit;
+        export type ShippingAddress = Stripe.Checkout.SessionCreateParams.CustomText.ShippingAddress;
+        export type Submit = Stripe.Checkout.SessionCreateParams.CustomText.Submit;
+        export type TermsOfServiceAcceptance = Stripe.Checkout.SessionCreateParams.CustomText.TermsOfServiceAcceptance;
+      }
+      export namespace InvoiceCreation {
+        export type InvoiceData = Stripe.Checkout.SessionCreateParams.InvoiceCreation.InvoiceData;
+        export namespace InvoiceData {
+          export type CustomField = Stripe.Checkout.SessionCreateParams.InvoiceCreation.InvoiceData.CustomField;
+          export type Issuer = Stripe.Checkout.SessionCreateParams.InvoiceCreation.InvoiceData.Issuer;
+          export type RenderingOptions = Stripe.Checkout.SessionCreateParams.InvoiceCreation.InvoiceData.RenderingOptions;
+          export namespace Issuer {
+            export type Type = Stripe.Checkout.SessionCreateParams.InvoiceCreation.InvoiceData.Issuer.Type;
+          }
+          export namespace RenderingOptions {
+            export type AmountTaxDisplay = Stripe.Checkout.SessionCreateParams.InvoiceCreation.InvoiceData.RenderingOptions.AmountTaxDisplay;
+          }
+        }
+      }
+      export namespace LineItem {
+        export type AdjustableQuantity = Stripe.Checkout.SessionCreateParams.LineItem.AdjustableQuantity;
+        export type PriceData = Stripe.Checkout.SessionCreateParams.LineItem.PriceData;
+        export namespace PriceData {
+          export type ProductData = Stripe.Checkout.SessionCreateParams.LineItem.PriceData.ProductData;
+          export type Recurring = Stripe.Checkout.SessionCreateParams.LineItem.PriceData.Recurring;
+          export type TaxBehavior = Stripe.Checkout.SessionCreateParams.LineItem.PriceData.TaxBehavior;
+          export namespace Recurring {
+            export type Interval = Stripe.Checkout.SessionCreateParams.LineItem.PriceData.Recurring.Interval;
+          }
+        }
+      }
+      export namespace NameCollection {
+        export type Business = Stripe.Checkout.SessionCreateParams.NameCollection.Business;
+        export type Individual = Stripe.Checkout.SessionCreateParams.NameCollection.Individual;
+      }
+      export namespace OptionalItem {
+        export type AdjustableQuantity = Stripe.Checkout.SessionCreateParams.OptionalItem.AdjustableQuantity;
+      }
+      export namespace PaymentIntentData {
+        export type CaptureMethod = Stripe.Checkout.SessionCreateParams.PaymentIntentData.CaptureMethod;
+        export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentIntentData.SetupFutureUsage;
+        export type Shipping = Stripe.Checkout.SessionCreateParams.PaymentIntentData.Shipping;
+        export type TransferData = Stripe.Checkout.SessionCreateParams.PaymentIntentData.TransferData;
+      }
+      export namespace PaymentMethodData {
+        export type AllowRedisplay = Stripe.Checkout.SessionCreateParams.PaymentMethodData.AllowRedisplay;
+      }
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit;
+        export type Affirm = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Affirm;
+        export type AfterpayClearpay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AfterpayClearpay;
+        export type Alipay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Alipay;
+        export type Alma = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Alma;
+        export type AmazonPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AmazonPay;
+        export type AuBecsDebit = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AuBecsDebit;
+        export type BacsDebit = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.BacsDebit;
+        export type Bancontact = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Bancontact;
+        export type Billie = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Billie;
+        export type Boleto = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Boleto;
+        export type Card = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card;
+        export type Cashapp = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Cashapp;
+        export type Crypto = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Crypto;
+        export type CustomerBalance = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.CustomerBalance;
+        export type DemoPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.DemoPay;
+        export type Eps = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Eps;
+        export type Fpx = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Fpx;
+        export type Giropay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Giropay;
+        export type Grabpay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Grabpay;
+        export type Ideal = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Ideal;
+        export type KakaoPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.KakaoPay;
+        export type Klarna = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Klarna;
+        export type Konbini = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Konbini;
+        export type KrCard = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.KrCard;
+        export type Link = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Link;
+        export type Mobilepay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Mobilepay;
+        export type Multibanco = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Multibanco;
+        export type NaverPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.NaverPay;
+        export type Oxxo = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Oxxo;
+        export type P24 = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.P24;
+        export type PayByBank = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.PayByBank;
+        export type Payco = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payco;
+        export type Paynow = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Paynow;
+        export type Paypal = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Paypal;
+        export type Payto = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix;
+        export type RevolutPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.RevolutPay;
+        export type SamsungPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.SamsungPay;
+        export type Satispay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Satispay;
+        export type Scalapay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Scalapay;
+        export type SepaDebit = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.SepaDebit;
+        export type Sofort = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Sofort;
+        export type Swish = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Swish;
+        export type Twint = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Twint;
+        export type Upi = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.UsBankAccount;
+        export type WechatPay = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.WechatPay;
+        export namespace AcssDebit {
+          export type Currency = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.Currency;
+          export type MandateOptions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.SetupFutureUsage;
+          export type VerificationMethod = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type DefaultFor = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.DefaultFor;
+            export type PaymentSchedule = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+            export type TransactionType = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace AmazonPay {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.AmazonPay.SetupFutureUsage;
+        }
+        export namespace BacsDebit {
+          export type MandateOptions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.BacsDebit.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.BacsDebit.SetupFutureUsage;
+        }
+        export namespace Boleto {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Boleto.SetupFutureUsage;
+        }
+        export namespace Card {
+          export type Installments = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.Installments;
+          export type RequestExtendedAuthorization = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.RequestExtendedAuthorization;
+          export type RequestIncrementalAuthorization = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.RequestIncrementalAuthorization;
+          export type RequestMulticapture = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.RequestMulticapture;
+          export type RequestOvercapture = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.RequestOvercapture;
+          export type RequestThreeDSecure = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export type Restrictions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.Restrictions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.SetupFutureUsage;
+          export namespace Restrictions {
+            export type BrandsBlocked = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Card.Restrictions.BrandsBlocked;
+          }
+        }
+        export namespace Cashapp {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Cashapp.SetupFutureUsage;
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+            export type RequestedAddressType = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.RequestedAddressType;
+            export type Type = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.CustomerBalance.BankTransfer.Type;
+          }
+        }
+        export namespace DemoPay {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.DemoPay.SetupFutureUsage;
+        }
+        export namespace KakaoPay {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.KakaoPay.SetupFutureUsage;
+        }
+        export namespace Klarna {
+          export type Subscription = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Klarna.Subscription;
+          export namespace Subscription {
+            export type Interval = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Klarna.Subscription.Interval;
+            export type NextBilling = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Klarna.Subscription.NextBilling;
+          }
+        }
+        export namespace KrCard {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.KrCard.SetupFutureUsage;
+        }
+        export namespace Link {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Link.SetupFutureUsage;
+        }
+        export namespace NaverPay {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.NaverPay.SetupFutureUsage;
+        }
+        export namespace Paypal {
+          export type PreferredLocale = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Paypal.PreferredLocale;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Paypal.SetupFutureUsage;
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payto.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payto.SetupFutureUsage;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+            export type PaymentSchedule = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+            export type Purpose = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type AmountIncludesIof = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix.AmountIncludesIof;
+          export type MandateOptions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix.SetupFutureUsage;
+          export namespace MandateOptions {
+            export type AmountIncludesIof = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+            export type AmountType = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+            export type PaymentSchedule = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+          }
+        }
+        export namespace RevolutPay {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.RevolutPay.SetupFutureUsage;
+        }
+        export namespace SepaDebit {
+          export type MandateOptions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.SepaDebit.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.SepaDebit.SetupFutureUsage;
+        }
+        export namespace Twint {
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Twint.SetupFutureUsage;
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Upi.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Upi.SetupFutureUsage;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type SetupFutureUsage = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.UsBankAccount.SetupFutureUsage;
+          export type VerificationMethod = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Permission = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+          }
+        }
+        export namespace WechatPay {
+          export type Client = Stripe.Checkout.SessionCreateParams.PaymentMethodOptions.WechatPay.Client;
+        }
+      }
+      export namespace Permissions {
+        export type UpdateShippingDetails = Stripe.Checkout.SessionCreateParams.Permissions.UpdateShippingDetails;
+      }
+      export namespace SavedPaymentMethodOptions {
+        export type AllowRedisplayFilter = Stripe.Checkout.SessionCreateParams.SavedPaymentMethodOptions.AllowRedisplayFilter;
+        export type PaymentMethodRemove = Stripe.Checkout.SessionCreateParams.SavedPaymentMethodOptions.PaymentMethodRemove;
+        export type PaymentMethodSave = Stripe.Checkout.SessionCreateParams.SavedPaymentMethodOptions.PaymentMethodSave;
+      }
+      export namespace ShippingAddressCollection {
+        export type AllowedCountry = Stripe.Checkout.SessionCreateParams.ShippingAddressCollection.AllowedCountry;
+      }
+      export namespace ShippingOption {
+        export type ShippingRateData = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData;
+        export namespace ShippingRateData {
+          export type DeliveryEstimate = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.DeliveryEstimate;
+          export type FixedAmount = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.FixedAmount;
+          export type TaxBehavior = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.TaxBehavior;
+          export namespace DeliveryEstimate {
+            export type Maximum = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.DeliveryEstimate.Maximum;
+            export type Minimum = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.DeliveryEstimate.Minimum;
+            export namespace Maximum {
+              export type Unit = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.DeliveryEstimate.Maximum.Unit;
+            }
+            export namespace Minimum {
+              export type Unit = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.DeliveryEstimate.Minimum.Unit;
+            }
+          }
+          export namespace FixedAmount {
+            export type CurrencyOptions = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.FixedAmount.CurrencyOptions;
+            export namespace CurrencyOptions {
+              export type TaxBehavior = Stripe.Checkout.SessionCreateParams.ShippingOption.ShippingRateData.FixedAmount.CurrencyOptions.TaxBehavior;
+            }
+          }
+        }
+      }
+      export namespace SubscriptionData {
+        export type BillingMode = Stripe.Checkout.SessionCreateParams.SubscriptionData.BillingMode;
+        export type InvoiceSettings = Stripe.Checkout.SessionCreateParams.SubscriptionData.InvoiceSettings;
+        export type PendingInvoiceItemInterval = Stripe.Checkout.SessionCreateParams.SubscriptionData.PendingInvoiceItemInterval;
+        export type ProrationBehavior = Stripe.Checkout.SessionCreateParams.SubscriptionData.ProrationBehavior;
+        export type TransferData = Stripe.Checkout.SessionCreateParams.SubscriptionData.TransferData;
+        export type TrialSettings = Stripe.Checkout.SessionCreateParams.SubscriptionData.TrialSettings;
+        export namespace BillingMode {
+          export type Flexible = Stripe.Checkout.SessionCreateParams.SubscriptionData.BillingMode.Flexible;
+          export type Type = Stripe.Checkout.SessionCreateParams.SubscriptionData.BillingMode.Type;
+          export namespace Flexible {
+            export type ProrationDiscounts = Stripe.Checkout.SessionCreateParams.SubscriptionData.BillingMode.Flexible.ProrationDiscounts;
+          }
+        }
+        export namespace InvoiceSettings {
+          export type Issuer = Stripe.Checkout.SessionCreateParams.SubscriptionData.InvoiceSettings.Issuer;
+          export namespace Issuer {
+            export type Type = Stripe.Checkout.SessionCreateParams.SubscriptionData.InvoiceSettings.Issuer.Type;
+          }
+        }
+        export namespace PendingInvoiceItemInterval {
+          export type Interval = Stripe.Checkout.SessionCreateParams.SubscriptionData.PendingInvoiceItemInterval.Interval;
+        }
+        export namespace TrialSettings {
+          export type EndBehavior = Stripe.Checkout.SessionCreateParams.SubscriptionData.TrialSettings.EndBehavior;
+          export namespace EndBehavior {
+            export type MissingPaymentMethod = Stripe.Checkout.SessionCreateParams.SubscriptionData.TrialSettings.EndBehavior.MissingPaymentMethod;
+          }
+        }
+      }
+      export namespace TaxIdCollection {
+        export type Required = Stripe.Checkout.SessionCreateParams.TaxIdCollection.Required;
+      }
+      export namespace WalletOptions {
+        export type Link = Stripe.Checkout.SessionCreateParams.WalletOptions.Link;
+        export namespace Link {
+          export type Display = Stripe.Checkout.SessionCreateParams.WalletOptions.Link.Display;
+        }
+      }
     }
-    export namespace SessionUpdateParams {
-      export type CollectedInformation = Stripe.Checkout.SessionUpdateParams.CollectedInformation;
-      export type LineItem = Stripe.Checkout.SessionUpdateParams.LineItem;
-      export type ShippingOption = Stripe.Checkout.SessionUpdateParams.ShippingOption;
-    }
-    export namespace SessionListParams {
-      export type CustomerDetails = Stripe.Checkout.SessionListParams.CustomerDetails;
-      export type Status = Stripe.Checkout.SessionListParams.Status;
+    export namespace Session {
+      export type AdaptivePricing = Stripe.Checkout.Session.AdaptivePricing;
+      export type AfterExpiration = Stripe.Checkout.Session.AfterExpiration;
+      export type AutomaticTax = Stripe.Checkout.Session.AutomaticTax;
+      export type BillingAddressCollection = Stripe.Checkout.Session.BillingAddressCollection;
+      export type BrandingSettings = Stripe.Checkout.Session.BrandingSettings;
+      export type CollectedInformation = Stripe.Checkout.Session.CollectedInformation;
+      export type Consent = Stripe.Checkout.Session.Consent;
+      export type ConsentCollection = Stripe.Checkout.Session.ConsentCollection;
+      export type CurrencyConversion = Stripe.Checkout.Session.CurrencyConversion;
+      export type CustomField = Stripe.Checkout.Session.CustomField;
+      export type CustomText = Stripe.Checkout.Session.CustomText;
+      export type CustomerCreation = Stripe.Checkout.Session.CustomerCreation;
+      export type CustomerDetails = Stripe.Checkout.Session.CustomerDetails;
+      export type Discount = Stripe.Checkout.Session.Discount;
+      export type InvoiceCreation = Stripe.Checkout.Session.InvoiceCreation;
+      export type Locale = Stripe.Checkout.Session.Locale;
+      export type ManagedPayments = Stripe.Checkout.Session.ManagedPayments;
+      export type Mode = Stripe.Checkout.Session.Mode;
+      export type NameCollection = Stripe.Checkout.Session.NameCollection;
+      export type OptionalItem = Stripe.Checkout.Session.OptionalItem;
+      export type OriginContext = Stripe.Checkout.Session.OriginContext;
+      export type PaymentMethodCollection = Stripe.Checkout.Session.PaymentMethodCollection;
+      export type PaymentMethodConfigurationDetails = Stripe.Checkout.Session.PaymentMethodConfigurationDetails;
+      export type PaymentMethodOptions = Stripe.Checkout.Session.PaymentMethodOptions;
+      export type PaymentStatus = Stripe.Checkout.Session.PaymentStatus;
+      export type Permissions = Stripe.Checkout.Session.Permissions;
+      export type PhoneNumberCollection = Stripe.Checkout.Session.PhoneNumberCollection;
+      export type PresentmentDetails = Stripe.Checkout.Session.PresentmentDetails;
+      export type RedirectOnCompletion = Stripe.Checkout.Session.RedirectOnCompletion;
+      export type SavedPaymentMethodOptions = Stripe.Checkout.Session.SavedPaymentMethodOptions;
+      export type ShippingAddressCollection = Stripe.Checkout.Session.ShippingAddressCollection;
+      export type ShippingCost = Stripe.Checkout.Session.ShippingCost;
+      export type ShippingOption = Stripe.Checkout.Session.ShippingOption;
+      export type Status = Stripe.Checkout.Session.Status;
+      export type SubmitType = Stripe.Checkout.Session.SubmitType;
+      export type TaxIdCollection = Stripe.Checkout.Session.TaxIdCollection;
+      export type TotalDetails = Stripe.Checkout.Session.TotalDetails;
+      export type UiMode = Stripe.Checkout.Session.UiMode;
+      export type WalletOptions = Stripe.Checkout.Session.WalletOptions;
+      export namespace AfterExpiration {
+        export type Recovery = Stripe.Checkout.Session.AfterExpiration.Recovery;
+      }
+      export namespace AutomaticTax {
+        export type Liability = Stripe.Checkout.Session.AutomaticTax.Liability;
+        export type Status = Stripe.Checkout.Session.AutomaticTax.Status;
+        export namespace Liability {
+          export type Type = Stripe.Checkout.Session.AutomaticTax.Liability.Type;
+        }
+      }
+      export namespace BrandingSettings {
+        export type BorderStyle = Stripe.Checkout.Session.BrandingSettings.BorderStyle;
+        export type Icon = Stripe.Checkout.Session.BrandingSettings.Icon;
+        export type Logo = Stripe.Checkout.Session.BrandingSettings.Logo;
+        export namespace Icon {
+          export type Type = Stripe.Checkout.Session.BrandingSettings.Icon.Type;
+        }
+        export namespace Logo {
+          export type Type = Stripe.Checkout.Session.BrandingSettings.Logo.Type;
+        }
+      }
+      export namespace CollectedInformation {
+        export type ShippingDetails = Stripe.Checkout.Session.CollectedInformation.ShippingDetails;
+      }
+      export namespace Consent {
+        export type Promotions = Stripe.Checkout.Session.Consent.Promotions;
+      }
+      export namespace ConsentCollection {
+        export type PaymentMethodReuseAgreement = Stripe.Checkout.Session.ConsentCollection.PaymentMethodReuseAgreement;
+        export type Promotions = Stripe.Checkout.Session.ConsentCollection.Promotions;
+        export type TermsOfService = Stripe.Checkout.Session.ConsentCollection.TermsOfService;
+        export namespace PaymentMethodReuseAgreement {
+          export type Position = Stripe.Checkout.Session.ConsentCollection.PaymentMethodReuseAgreement.Position;
+        }
+      }
+      export namespace CustomerDetails {
+        export type TaxExempt = Stripe.Checkout.Session.CustomerDetails.TaxExempt;
+        export type TaxId = Stripe.Checkout.Session.CustomerDetails.TaxId;
+        export namespace TaxId {
+          export type Type = Stripe.Checkout.Session.CustomerDetails.TaxId.Type;
+        }
+      }
+      export namespace CustomField {
+        export type Dropdown = Stripe.Checkout.Session.CustomField.Dropdown;
+        export type Label = Stripe.Checkout.Session.CustomField.Label;
+        export type Numeric = Stripe.Checkout.Session.CustomField.Numeric;
+        export type Text = Stripe.Checkout.Session.CustomField.Text;
+        export type Type = Stripe.Checkout.Session.CustomField.Type;
+        export namespace Dropdown {
+          export type Option = Stripe.Checkout.Session.CustomField.Dropdown.Option;
+        }
+      }
+      export namespace CustomText {
+        export type AfterSubmit = Stripe.Checkout.Session.CustomText.AfterSubmit;
+        export type ShippingAddress = Stripe.Checkout.Session.CustomText.ShippingAddress;
+        export type Submit = Stripe.Checkout.Session.CustomText.Submit;
+        export type TermsOfServiceAcceptance = Stripe.Checkout.Session.CustomText.TermsOfServiceAcceptance;
+      }
+      export namespace InvoiceCreation {
+        export type InvoiceData = Stripe.Checkout.Session.InvoiceCreation.InvoiceData;
+        export namespace InvoiceData {
+          export type CustomField = Stripe.Checkout.Session.InvoiceCreation.InvoiceData.CustomField;
+          export type Issuer = Stripe.Checkout.Session.InvoiceCreation.InvoiceData.Issuer;
+          export type RenderingOptions = Stripe.Checkout.Session.InvoiceCreation.InvoiceData.RenderingOptions;
+          export namespace Issuer {
+            export type Type = Stripe.Checkout.Session.InvoiceCreation.InvoiceData.Issuer.Type;
+          }
+        }
+      }
+      export namespace NameCollection {
+        export type Business = Stripe.Checkout.Session.NameCollection.Business;
+        export type Individual = Stripe.Checkout.Session.NameCollection.Individual;
+      }
+      export namespace OptionalItem {
+        export type AdjustableQuantity = Stripe.Checkout.Session.OptionalItem.AdjustableQuantity;
+      }
+      export namespace PaymentMethodOptions {
+        export type AcssDebit = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit;
+        export type Affirm = Stripe.Checkout.Session.PaymentMethodOptions.Affirm;
+        export type AfterpayClearpay = Stripe.Checkout.Session.PaymentMethodOptions.AfterpayClearpay;
+        export type Alipay = Stripe.Checkout.Session.PaymentMethodOptions.Alipay;
+        export type Alma = Stripe.Checkout.Session.PaymentMethodOptions.Alma;
+        export type AmazonPay = Stripe.Checkout.Session.PaymentMethodOptions.AmazonPay;
+        export type AuBecsDebit = Stripe.Checkout.Session.PaymentMethodOptions.AuBecsDebit;
+        export type BacsDebit = Stripe.Checkout.Session.PaymentMethodOptions.BacsDebit;
+        export type Bancontact = Stripe.Checkout.Session.PaymentMethodOptions.Bancontact;
+        export type Billie = Stripe.Checkout.Session.PaymentMethodOptions.Billie;
+        export type Boleto = Stripe.Checkout.Session.PaymentMethodOptions.Boleto;
+        export type Card = Stripe.Checkout.Session.PaymentMethodOptions.Card;
+        export type Cashapp = Stripe.Checkout.Session.PaymentMethodOptions.Cashapp;
+        export type CustomerBalance = Stripe.Checkout.Session.PaymentMethodOptions.CustomerBalance;
+        export type Eps = Stripe.Checkout.Session.PaymentMethodOptions.Eps;
+        export type Fpx = Stripe.Checkout.Session.PaymentMethodOptions.Fpx;
+        export type Giropay = Stripe.Checkout.Session.PaymentMethodOptions.Giropay;
+        export type Grabpay = Stripe.Checkout.Session.PaymentMethodOptions.Grabpay;
+        export type Ideal = Stripe.Checkout.Session.PaymentMethodOptions.Ideal;
+        export type KakaoPay = Stripe.Checkout.Session.PaymentMethodOptions.KakaoPay;
+        export type Klarna = Stripe.Checkout.Session.PaymentMethodOptions.Klarna;
+        export type Konbini = Stripe.Checkout.Session.PaymentMethodOptions.Konbini;
+        export type KrCard = Stripe.Checkout.Session.PaymentMethodOptions.KrCard;
+        export type Link = Stripe.Checkout.Session.PaymentMethodOptions.Link;
+        export type Mobilepay = Stripe.Checkout.Session.PaymentMethodOptions.Mobilepay;
+        export type Multibanco = Stripe.Checkout.Session.PaymentMethodOptions.Multibanco;
+        export type NaverPay = Stripe.Checkout.Session.PaymentMethodOptions.NaverPay;
+        export type Oxxo = Stripe.Checkout.Session.PaymentMethodOptions.Oxxo;
+        export type P24 = Stripe.Checkout.Session.PaymentMethodOptions.P24;
+        export type Payco = Stripe.Checkout.Session.PaymentMethodOptions.Payco;
+        export type Paynow = Stripe.Checkout.Session.PaymentMethodOptions.Paynow;
+        export type Paypal = Stripe.Checkout.Session.PaymentMethodOptions.Paypal;
+        export type Payto = Stripe.Checkout.Session.PaymentMethodOptions.Payto;
+        export type Pix = Stripe.Checkout.Session.PaymentMethodOptions.Pix;
+        export type RevolutPay = Stripe.Checkout.Session.PaymentMethodOptions.RevolutPay;
+        export type SamsungPay = Stripe.Checkout.Session.PaymentMethodOptions.SamsungPay;
+        export type Satispay = Stripe.Checkout.Session.PaymentMethodOptions.Satispay;
+        export type Scalapay = Stripe.Checkout.Session.PaymentMethodOptions.Scalapay;
+        export type SepaDebit = Stripe.Checkout.Session.PaymentMethodOptions.SepaDebit;
+        export type Sofort = Stripe.Checkout.Session.PaymentMethodOptions.Sofort;
+        export type Swish = Stripe.Checkout.Session.PaymentMethodOptions.Swish;
+        export type Twint = Stripe.Checkout.Session.PaymentMethodOptions.Twint;
+        export type Upi = Stripe.Checkout.Session.PaymentMethodOptions.Upi;
+        export type UsBankAccount = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount;
+        export namespace AcssDebit {
+          export type Currency = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.Currency;
+          export type MandateOptions = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.SetupFutureUsage;
+          export type VerificationMethod = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.VerificationMethod;
+          export namespace MandateOptions {
+            export type DefaultFor = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.MandateOptions.DefaultFor;
+            export type PaymentSchedule = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.MandateOptions.PaymentSchedule;
+            export type TransactionType = Stripe.Checkout.Session.PaymentMethodOptions.AcssDebit.MandateOptions.TransactionType;
+          }
+        }
+        export namespace AmazonPay {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.AmazonPay.SetupFutureUsage;
+        }
+        export namespace BacsDebit {
+          export type MandateOptions = Stripe.Checkout.Session.PaymentMethodOptions.BacsDebit.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.BacsDebit.SetupFutureUsage;
+        }
+        export namespace Boleto {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Boleto.SetupFutureUsage;
+        }
+        export namespace Card {
+          export type Installments = Stripe.Checkout.Session.PaymentMethodOptions.Card.Installments;
+          export type RequestExtendedAuthorization = Stripe.Checkout.Session.PaymentMethodOptions.Card.RequestExtendedAuthorization;
+          export type RequestIncrementalAuthorization = Stripe.Checkout.Session.PaymentMethodOptions.Card.RequestIncrementalAuthorization;
+          export type RequestMulticapture = Stripe.Checkout.Session.PaymentMethodOptions.Card.RequestMulticapture;
+          export type RequestOvercapture = Stripe.Checkout.Session.PaymentMethodOptions.Card.RequestOvercapture;
+          export type RequestThreeDSecure = Stripe.Checkout.Session.PaymentMethodOptions.Card.RequestThreeDSecure;
+          export type Restrictions = Stripe.Checkout.Session.PaymentMethodOptions.Card.Restrictions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Card.SetupFutureUsage;
+          export namespace Restrictions {
+            export type BrandsBlocked = Stripe.Checkout.Session.PaymentMethodOptions.Card.Restrictions.BrandsBlocked;
+          }
+        }
+        export namespace CustomerBalance {
+          export type BankTransfer = Stripe.Checkout.Session.PaymentMethodOptions.CustomerBalance.BankTransfer;
+          export namespace BankTransfer {
+            export type EuBankTransfer = Stripe.Checkout.Session.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer;
+            export type RequestedAddressType = Stripe.Checkout.Session.PaymentMethodOptions.CustomerBalance.BankTransfer.RequestedAddressType;
+            export type Type = Stripe.Checkout.Session.PaymentMethodOptions.CustomerBalance.BankTransfer.Type;
+            export namespace EuBankTransfer {
+              export type Country = Stripe.Checkout.Session.PaymentMethodOptions.CustomerBalance.BankTransfer.EuBankTransfer.Country;
+            }
+          }
+        }
+        export namespace KakaoPay {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.KakaoPay.SetupFutureUsage;
+        }
+        export namespace Klarna {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Klarna.SetupFutureUsage;
+        }
+        export namespace KrCard {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.KrCard.SetupFutureUsage;
+        }
+        export namespace Link {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Link.SetupFutureUsage;
+        }
+        export namespace NaverPay {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.NaverPay.SetupFutureUsage;
+        }
+        export namespace Paypal {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Paypal.SetupFutureUsage;
+        }
+        export namespace Payto {
+          export type MandateOptions = Stripe.Checkout.Session.PaymentMethodOptions.Payto.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Payto.SetupFutureUsage;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Checkout.Session.PaymentMethodOptions.Payto.MandateOptions.AmountType;
+            export type PaymentSchedule = Stripe.Checkout.Session.PaymentMethodOptions.Payto.MandateOptions.PaymentSchedule;
+            export type Purpose = Stripe.Checkout.Session.PaymentMethodOptions.Payto.MandateOptions.Purpose;
+          }
+        }
+        export namespace Pix {
+          export type AmountIncludesIof = Stripe.Checkout.Session.PaymentMethodOptions.Pix.AmountIncludesIof;
+          export type MandateOptions = Stripe.Checkout.Session.PaymentMethodOptions.Pix.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Pix.SetupFutureUsage;
+          export namespace MandateOptions {
+            export type AmountIncludesIof = Stripe.Checkout.Session.PaymentMethodOptions.Pix.MandateOptions.AmountIncludesIof;
+            export type AmountType = Stripe.Checkout.Session.PaymentMethodOptions.Pix.MandateOptions.AmountType;
+            export type PaymentSchedule = Stripe.Checkout.Session.PaymentMethodOptions.Pix.MandateOptions.PaymentSchedule;
+          }
+        }
+        export namespace RevolutPay {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.RevolutPay.SetupFutureUsage;
+        }
+        export namespace SepaDebit {
+          export type MandateOptions = Stripe.Checkout.Session.PaymentMethodOptions.SepaDebit.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.SepaDebit.SetupFutureUsage;
+        }
+        export namespace Twint {
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Twint.SetupFutureUsage;
+        }
+        export namespace Upi {
+          export type MandateOptions = Stripe.Checkout.Session.PaymentMethodOptions.Upi.MandateOptions;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.Upi.SetupFutureUsage;
+          export namespace MandateOptions {
+            export type AmountType = Stripe.Checkout.Session.PaymentMethodOptions.Upi.MandateOptions.AmountType;
+          }
+        }
+        export namespace UsBankAccount {
+          export type FinancialConnections = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.FinancialConnections;
+          export type SetupFutureUsage = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.SetupFutureUsage;
+          export type VerificationMethod = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.VerificationMethod;
+          export namespace FinancialConnections {
+            export type Filters = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters;
+            export type Permission = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.FinancialConnections.Permission;
+            export type Prefetch = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.FinancialConnections.Prefetch;
+            export namespace Filters {
+              export type AccountSubcategory = Stripe.Checkout.Session.PaymentMethodOptions.UsBankAccount.FinancialConnections.Filters.AccountSubcategory;
+            }
+          }
+        }
+      }
+      export namespace Permissions {
+        export type UpdateShippingDetails = Stripe.Checkout.Session.Permissions.UpdateShippingDetails;
+      }
+      export namespace SavedPaymentMethodOptions {
+        export type AllowRedisplayFilter = Stripe.Checkout.Session.SavedPaymentMethodOptions.AllowRedisplayFilter;
+        export type PaymentMethodRemove = Stripe.Checkout.Session.SavedPaymentMethodOptions.PaymentMethodRemove;
+        export type PaymentMethodSave = Stripe.Checkout.Session.SavedPaymentMethodOptions.PaymentMethodSave;
+      }
+      export namespace ShippingAddressCollection {
+        export type AllowedCountry = Stripe.Checkout.Session.ShippingAddressCollection.AllowedCountry;
+      }
+      export namespace ShippingCost {
+        export type Tax = Stripe.Checkout.Session.ShippingCost.Tax;
+        export namespace Tax {
+          export type TaxabilityReason = Stripe.Checkout.Session.ShippingCost.Tax.TaxabilityReason;
+        }
+      }
+      export namespace TaxIdCollection {
+        export type Required = Stripe.Checkout.Session.TaxIdCollection.Required;
+      }
+      export namespace TotalDetails {
+        export type Breakdown = Stripe.Checkout.Session.TotalDetails.Breakdown;
+        export namespace Breakdown {
+          export type Discount = Stripe.Checkout.Session.TotalDetails.Breakdown.Discount;
+          export type Tax = Stripe.Checkout.Session.TotalDetails.Breakdown.Tax;
+          export namespace Tax {
+            export type TaxabilityReason = Stripe.Checkout.Session.TotalDetails.Breakdown.Tax.TaxabilityReason;
+          }
+        }
+      }
+      export namespace WalletOptions {
+        export type Link = Stripe.Checkout.Session.WalletOptions.Link;
+        export namespace Link {
+          export type Display = Stripe.Checkout.Session.WalletOptions.Link.Display;
+        }
+      }
     }
   }
   export namespace Climate {
@@ -1518,8 +10260,21 @@ declare namespace StripeConstructor {
     export namespace OrderCreateParams {
       export type Beneficiary = Stripe.Climate.OrderCreateParams.Beneficiary;
     }
-    export namespace OrderUpdateParams {
-      export type Beneficiary = Stripe.Climate.OrderUpdateParams.Beneficiary;
+    export namespace Order {
+      export type Beneficiary = Stripe.Climate.Order.Beneficiary;
+      export type CancellationReason = Stripe.Climate.Order.CancellationReason;
+      export type DeliveryDetail = Stripe.Climate.Order.DeliveryDetail;
+      export type Status = Stripe.Climate.Order.Status;
+      export namespace DeliveryDetail {
+        export type Location = Stripe.Climate.Order.DeliveryDetail.Location;
+      }
+    }
+    export namespace Product {
+      export type CurrentPricesPerMetricTon = Stripe.Climate.Product.CurrentPricesPerMetricTon;
+    }
+    export namespace Supplier {
+      export type Location = Stripe.Climate.Supplier.Location;
+      export type RemovalPathway = Stripe.Climate.Supplier.RemovalPathway;
     }
   }
   export namespace Entitlements {
@@ -1555,20 +10310,67 @@ declare namespace StripeConstructor {
     export type TransactionResource = Stripe.FinancialConnections.TransactionResource;
     export type AccountOwner = Stripe.FinancialConnections.AccountOwner;
     export type AccountOwnership = Stripe.FinancialConnections.AccountOwnership;
-    export namespace AccountListParams {
-      export type AccountHolder = Stripe.FinancialConnections.AccountListParams.AccountHolder;
-    }
-    export namespace AccountRefreshParams {
-      export type Feature = Stripe.FinancialConnections.AccountRefreshParams.Feature;
+    export namespace Account {
+      export type AccountHolder = Stripe.FinancialConnections.Account.AccountHolder;
+      export type AccountNumber = Stripe.FinancialConnections.Account.AccountNumber;
+      export type Balance = Stripe.FinancialConnections.Account.Balance;
+      export type BalanceRefresh = Stripe.FinancialConnections.Account.BalanceRefresh;
+      export type Category = Stripe.FinancialConnections.Account.Category;
+      export type OwnershipRefresh = Stripe.FinancialConnections.Account.OwnershipRefresh;
+      export type Permission = Stripe.FinancialConnections.Account.Permission;
+      export type Status = Stripe.FinancialConnections.Account.Status;
+      export type Subcategory = Stripe.FinancialConnections.Account.Subcategory;
+      export type SupportedPaymentMethodType = Stripe.FinancialConnections.Account.SupportedPaymentMethodType;
+      export type TransactionRefresh = Stripe.FinancialConnections.Account.TransactionRefresh;
+      export namespace AccountHolder {
+        export type Type = Stripe.FinancialConnections.Account.AccountHolder.Type;
+      }
+      export namespace AccountNumber {
+        export type IdentifierType = Stripe.FinancialConnections.Account.AccountNumber.IdentifierType;
+        export type Status = Stripe.FinancialConnections.Account.AccountNumber.Status;
+      }
+      export namespace Balance {
+        export type Cash = Stripe.FinancialConnections.Account.Balance.Cash;
+        export type Credit = Stripe.FinancialConnections.Account.Balance.Credit;
+        export type Type = Stripe.FinancialConnections.Account.Balance.Type;
+      }
+      export namespace BalanceRefresh {
+        export type Status = Stripe.FinancialConnections.Account.BalanceRefresh.Status;
+      }
+      export namespace OwnershipRefresh {
+        export type Status = Stripe.FinancialConnections.Account.OwnershipRefresh.Status;
+      }
+      export namespace TransactionRefresh {
+        export type Status = Stripe.FinancialConnections.Account.TransactionRefresh.Status;
+      }
     }
     export namespace SessionCreateParams {
       export type AccountHolder = Stripe.FinancialConnections.SessionCreateParams.AccountHolder;
       export type Permission = Stripe.FinancialConnections.SessionCreateParams.Permission;
       export type Filters = Stripe.FinancialConnections.SessionCreateParams.Filters;
       export type Prefetch = Stripe.FinancialConnections.SessionCreateParams.Prefetch;
+      export namespace AccountHolder {
+        export type Type = Stripe.FinancialConnections.SessionCreateParams.AccountHolder.Type;
+      }
+      export namespace Filters {
+        export type AccountSubcategory = Stripe.FinancialConnections.SessionCreateParams.Filters.AccountSubcategory;
+      }
     }
-    export namespace TransactionListParams {
-      export type TransactionRefresh = Stripe.FinancialConnections.TransactionListParams.TransactionRefresh;
+    export namespace Session {
+      export type AccountHolder = Stripe.FinancialConnections.Session.AccountHolder;
+      export type Filters = Stripe.FinancialConnections.Session.Filters;
+      export type Permission = Stripe.FinancialConnections.Session.Permission;
+      export type Prefetch = Stripe.FinancialConnections.Session.Prefetch;
+      export namespace AccountHolder {
+        export type Type = Stripe.FinancialConnections.Session.AccountHolder.Type;
+      }
+      export namespace Filters {
+        export type AccountSubcategory = Stripe.FinancialConnections.Session.Filters.AccountSubcategory;
+      }
+    }
+    export namespace Transaction {
+      export type Status = Stripe.FinancialConnections.Transaction.Status;
+      export type StatusTransitions = Stripe.FinancialConnections.Transaction.StatusTransitions;
     }
   }
   export namespace Forwarding {
@@ -1580,6 +10382,21 @@ declare namespace StripeConstructor {
     export namespace RequestCreateParams {
       export type Replacement = Stripe.Forwarding.RequestCreateParams.Replacement;
       export type Request = Stripe.Forwarding.RequestCreateParams.Request;
+      export namespace Request {
+        export type Header = Stripe.Forwarding.RequestCreateParams.Request.Header;
+      }
+    }
+    export namespace Request {
+      export type Replacement = Stripe.Forwarding.Request.Replacement;
+      export type RequestContext = Stripe.Forwarding.Request.RequestContext;
+      export type RequestDetails = Stripe.Forwarding.Request.RequestDetails;
+      export type ResponseDetails = Stripe.Forwarding.Request.ResponseDetails;
+      export namespace RequestDetails {
+        export type Header = Stripe.Forwarding.Request.RequestDetails.Header;
+      }
+      export namespace ResponseDetails {
+        export type Header = Stripe.Forwarding.Request.ResponseDetails.Header;
+      }
     }
   }
   export namespace Identity {
@@ -1595,22 +10412,110 @@ declare namespace StripeConstructor {
     export type VerificationSessionCancelParams = Stripe.Identity.VerificationSessionCancelParams;
     export type VerificationSessionRedactParams = Stripe.Identity.VerificationSessionRedactParams;
     export type VerificationSessionResource = Stripe.Identity.VerificationSessionResource;
-    export namespace VerificationReportListParams {
-      export type Type = Stripe.Identity.VerificationReportListParams.Type;
+    export namespace VerificationReport {
+      export type Document = Stripe.Identity.VerificationReport.Document;
+      export type Email = Stripe.Identity.VerificationReport.Email;
+      export type IdNumber = Stripe.Identity.VerificationReport.IdNumber;
+      export type Options = Stripe.Identity.VerificationReport.Options;
+      export type Phone = Stripe.Identity.VerificationReport.Phone;
+      export type Selfie = Stripe.Identity.VerificationReport.Selfie;
+      export type Type = Stripe.Identity.VerificationReport.Type;
+      export namespace Document {
+        export type Dob = Stripe.Identity.VerificationReport.Document.Dob;
+        export type Error = Stripe.Identity.VerificationReport.Document.Error;
+        export type ExpirationDate = Stripe.Identity.VerificationReport.Document.ExpirationDate;
+        export type IssuedDate = Stripe.Identity.VerificationReport.Document.IssuedDate;
+        export type Sex = Stripe.Identity.VerificationReport.Document.Sex;
+        export type Status = Stripe.Identity.VerificationReport.Document.Status;
+        export type Type = Stripe.Identity.VerificationReport.Document.Type;
+        export namespace Error {
+          export type Code = Stripe.Identity.VerificationReport.Document.Error.Code;
+        }
+      }
+      export namespace Email {
+        export type Error = Stripe.Identity.VerificationReport.Email.Error;
+        export type Status = Stripe.Identity.VerificationReport.Email.Status;
+        export namespace Error {
+          export type Code = Stripe.Identity.VerificationReport.Email.Error.Code;
+        }
+      }
+      export namespace IdNumber {
+        export type Dob = Stripe.Identity.VerificationReport.IdNumber.Dob;
+        export type Error = Stripe.Identity.VerificationReport.IdNumber.Error;
+        export type IdNumberType = Stripe.Identity.VerificationReport.IdNumber.IdNumberType;
+        export type Status = Stripe.Identity.VerificationReport.IdNumber.Status;
+        export namespace Error {
+          export type Code = Stripe.Identity.VerificationReport.IdNumber.Error.Code;
+        }
+      }
+      export namespace Options {
+        export type Document = Stripe.Identity.VerificationReport.Options.Document;
+        export type IdNumber = Stripe.Identity.VerificationReport.Options.IdNumber;
+        export namespace Document {
+          export type AllowedType = Stripe.Identity.VerificationReport.Options.Document.AllowedType;
+        }
+      }
+      export namespace Phone {
+        export type Error = Stripe.Identity.VerificationReport.Phone.Error;
+        export type Status = Stripe.Identity.VerificationReport.Phone.Status;
+        export namespace Error {
+          export type Code = Stripe.Identity.VerificationReport.Phone.Error.Code;
+        }
+      }
+      export namespace Selfie {
+        export type Error = Stripe.Identity.VerificationReport.Selfie.Error;
+        export type Status = Stripe.Identity.VerificationReport.Selfie.Status;
+        export namespace Error {
+          export type Code = Stripe.Identity.VerificationReport.Selfie.Error.Code;
+        }
+      }
     }
     export namespace VerificationSessionCreateParams {
       export type Options = Stripe.Identity.VerificationSessionCreateParams.Options;
       export type ProvidedDetails = Stripe.Identity.VerificationSessionCreateParams.ProvidedDetails;
       export type RelatedPerson = Stripe.Identity.VerificationSessionCreateParams.RelatedPerson;
       export type Type = Stripe.Identity.VerificationSessionCreateParams.Type;
+      export namespace Options {
+        export type Document = Stripe.Identity.VerificationSessionCreateParams.Options.Document;
+        export namespace Document {
+          export type AllowedType = Stripe.Identity.VerificationSessionCreateParams.Options.Document.AllowedType;
+        }
+      }
     }
-    export namespace VerificationSessionUpdateParams {
-      export type Options = Stripe.Identity.VerificationSessionUpdateParams.Options;
-      export type ProvidedDetails = Stripe.Identity.VerificationSessionUpdateParams.ProvidedDetails;
-      export type Type = Stripe.Identity.VerificationSessionUpdateParams.Type;
-    }
-    export namespace VerificationSessionListParams {
-      export type Status = Stripe.Identity.VerificationSessionListParams.Status;
+    export namespace VerificationSession {
+      export type LastError = Stripe.Identity.VerificationSession.LastError;
+      export type Options = Stripe.Identity.VerificationSession.Options;
+      export type ProvidedDetails = Stripe.Identity.VerificationSession.ProvidedDetails;
+      export type Redaction = Stripe.Identity.VerificationSession.Redaction;
+      export type RelatedPerson = Stripe.Identity.VerificationSession.RelatedPerson;
+      export type Status = Stripe.Identity.VerificationSession.Status;
+      export type Type = Stripe.Identity.VerificationSession.Type;
+      export type VerifiedOutputs = Stripe.Identity.VerificationSession.VerifiedOutputs;
+      export namespace LastError {
+        export type Code = Stripe.Identity.VerificationSession.LastError.Code;
+      }
+      export namespace Options {
+        export type Document = Stripe.Identity.VerificationSession.Options.Document;
+        export type Email = Stripe.Identity.VerificationSession.Options.Email;
+        export type IdNumber = Stripe.Identity.VerificationSession.Options.IdNumber;
+        export type Matching = Stripe.Identity.VerificationSession.Options.Matching;
+        export type Phone = Stripe.Identity.VerificationSession.Options.Phone;
+        export namespace Document {
+          export type AllowedType = Stripe.Identity.VerificationSession.Options.Document.AllowedType;
+        }
+        export namespace Matching {
+          export type Dob = Stripe.Identity.VerificationSession.Options.Matching.Dob;
+          export type Name = Stripe.Identity.VerificationSession.Options.Matching.Name;
+        }
+      }
+      export namespace Redaction {
+        export type Status = Stripe.Identity.VerificationSession.Redaction.Status;
+      }
+      export namespace VerifiedOutputs {
+        export type Dob = Stripe.Identity.VerificationSession.VerifiedOutputs.Dob;
+        export type IdNumberType = Stripe.Identity.VerificationSession.VerifiedOutputs.IdNumberType;
+        export type Sex = Stripe.Identity.VerificationSession.VerifiedOutputs.Sex;
+      }
     }
   }
   export namespace Issuing {
@@ -1660,8 +10565,61 @@ declare namespace StripeConstructor {
     export type TransactionUpdateParams = Stripe.Issuing.TransactionUpdateParams;
     export type TransactionListParams = Stripe.Issuing.TransactionListParams;
     export type TransactionResource = Stripe.Issuing.TransactionResource;
-    export namespace AuthorizationListParams {
-      export type Status = Stripe.Issuing.AuthorizationListParams.Status;
+    export namespace Authorization {
+      export type AmountDetails = Stripe.Issuing.Authorization.AmountDetails;
+      export type AuthorizationMethod = Stripe.Issuing.Authorization.AuthorizationMethod;
+      export type CardPresence = Stripe.Issuing.Authorization.CardPresence;
+      export type Fleet = Stripe.Issuing.Authorization.Fleet;
+      export type FraudChallenge = Stripe.Issuing.Authorization.FraudChallenge;
+      export type Fuel = Stripe.Issuing.Authorization.Fuel;
+      export type MerchantData = Stripe.Issuing.Authorization.MerchantData;
+      export type NetworkData = Stripe.Issuing.Authorization.NetworkData;
+      export type PendingRequest = Stripe.Issuing.Authorization.PendingRequest;
+      export type RequestHistory = Stripe.Issuing.Authorization.RequestHistory;
+      export type Status = Stripe.Issuing.Authorization.Status;
+      export type Treasury = Stripe.Issuing.Authorization.Treasury;
+      export type VerificationData = Stripe.Issuing.Authorization.VerificationData;
+      export namespace Fleet {
+        export type CardholderPromptData = Stripe.Issuing.Authorization.Fleet.CardholderPromptData;
+        export type PurchaseType = Stripe.Issuing.Authorization.Fleet.PurchaseType;
+        export type ReportedBreakdown = Stripe.Issuing.Authorization.Fleet.ReportedBreakdown;
+        export type ServiceType = Stripe.Issuing.Authorization.Fleet.ServiceType;
+        export namespace ReportedBreakdown {
+          export type Fuel = Stripe.Issuing.Authorization.Fleet.ReportedBreakdown.Fuel;
+          export type NonFuel = Stripe.Issuing.Authorization.Fleet.ReportedBreakdown.NonFuel;
+          export type Tax = Stripe.Issuing.Authorization.Fleet.ReportedBreakdown.Tax;
+        }
+      }
+      export namespace FraudChallenge {
+        export type Status = Stripe.Issuing.Authorization.FraudChallenge.Status;
+        export type UndeliverableReason = Stripe.Issuing.Authorization.FraudChallenge.UndeliverableReason;
+      }
+      export namespace Fuel {
+        export type Type = Stripe.Issuing.Authorization.Fuel.Type;
+        export type Unit = Stripe.Issuing.Authorization.Fuel.Unit;
+      }
+      export namespace PendingRequest {
+        export type AmountDetails = Stripe.Issuing.Authorization.PendingRequest.AmountDetails;
+      }
+      export namespace RequestHistory {
+        export type AmountDetails = Stripe.Issuing.Authorization.RequestHistory.AmountDetails;
+        export type Reason = Stripe.Issuing.Authorization.RequestHistory.Reason;
+      }
+      export namespace VerificationData {
+        export type AddressLine1Check = Stripe.Issuing.Authorization.VerificationData.AddressLine1Check;
+        export type AddressPostalCodeCheck = Stripe.Issuing.Authorization.VerificationData.AddressPostalCodeCheck;
+        export type AuthenticationExemption = Stripe.Issuing.Authorization.VerificationData.AuthenticationExemption;
+        export type CvcCheck = Stripe.Issuing.Authorization.VerificationData.CvcCheck;
+        export type ExpiryCheck = Stripe.Issuing.Authorization.VerificationData.ExpiryCheck;
+        export type ThreeDSecure = Stripe.Issuing.Authorization.VerificationData.ThreeDSecure;
+        export namespace AuthenticationExemption {
+          export type ClaimedBy = Stripe.Issuing.Authorization.VerificationData.AuthenticationExemption.ClaimedBy;
+          export type Type = Stripe.Issuing.Authorization.VerificationData.AuthenticationExemption.Type;
+        }
+        export namespace ThreeDSecure {
+          export type Result = Stripe.Issuing.Authorization.VerificationData.ThreeDSecure.Result;
+        }
+      }
     }
     export namespace CardCreateParams {
       export type Type = Stripe.Issuing.CardCreateParams.Type;
@@ -1671,17 +10629,80 @@ declare namespace StripeConstructor {
       export type Shipping = Stripe.Issuing.CardCreateParams.Shipping;
       export type SpendingControls = Stripe.Issuing.CardCreateParams.SpendingControls;
       export type Status = Stripe.Issuing.CardCreateParams.Status;
+      export namespace LifecycleControls {
+        export type CancelAfter = Stripe.Issuing.CardCreateParams.LifecycleControls.CancelAfter;
+      }
+      export namespace Shipping {
+        export type Address = Stripe.Issuing.CardCreateParams.Shipping.Address;
+        export type AddressValidation = Stripe.Issuing.CardCreateParams.Shipping.AddressValidation;
+        export type Customs = Stripe.Issuing.CardCreateParams.Shipping.Customs;
+        export type Service = Stripe.Issuing.CardCreateParams.Shipping.Service;
+        export type Type = Stripe.Issuing.CardCreateParams.Shipping.Type;
+        export namespace AddressValidation {
+          export type Mode = Stripe.Issuing.CardCreateParams.Shipping.AddressValidation.Mode;
+        }
+      }
+      export namespace SpendingControls {
+        export type AllowedCardPresence = Stripe.Issuing.CardCreateParams.SpendingControls.AllowedCardPresence;
+        export type AllowedCategory = Stripe.Issuing.CardCreateParams.SpendingControls.AllowedCategory;
+        export type BlockedCardPresence = Stripe.Issuing.CardCreateParams.SpendingControls.BlockedCardPresence;
+        export type BlockedCategory = Stripe.Issuing.CardCreateParams.SpendingControls.BlockedCategory;
+        export type SpendingLimit = Stripe.Issuing.CardCreateParams.SpendingControls.SpendingLimit;
+        export namespace SpendingLimit {
+          export type Category = Stripe.Issuing.CardCreateParams.SpendingControls.SpendingLimit.Category;
+          export type Interval = Stripe.Issuing.CardCreateParams.SpendingControls.SpendingLimit.Interval;
+        }
+      }
     }
-    export namespace CardUpdateParams {
-      export type CancellationReason = Stripe.Issuing.CardUpdateParams.CancellationReason;
-      export type Pin = Stripe.Issuing.CardUpdateParams.Pin;
-      export type Shipping = Stripe.Issuing.CardUpdateParams.Shipping;
-      export type SpendingControls = Stripe.Issuing.CardUpdateParams.SpendingControls;
-      export type Status = Stripe.Issuing.CardUpdateParams.Status;
-    }
-    export namespace CardListParams {
-      export type Status = Stripe.Issuing.CardListParams.Status;
-      export type Type = Stripe.Issuing.CardListParams.Type;
+    export namespace Card {
+      export type CancellationReason = Stripe.Issuing.Card.CancellationReason;
+      export type LatestFraudWarning = Stripe.Issuing.Card.LatestFraudWarning;
+      export type LifecycleControls = Stripe.Issuing.Card.LifecycleControls;
+      export type ReplacementReason = Stripe.Issuing.Card.ReplacementReason;
+      export type Shipping = Stripe.Issuing.Card.Shipping;
+      export type SpendingControls = Stripe.Issuing.Card.SpendingControls;
+      export type Status = Stripe.Issuing.Card.Status;
+      export type Type = Stripe.Issuing.Card.Type;
+      export type Wallets = Stripe.Issuing.Card.Wallets;
+      export namespace LatestFraudWarning {
+        export type Type = Stripe.Issuing.Card.LatestFraudWarning.Type;
+      }
+      export namespace LifecycleControls {
+        export type CancelAfter = Stripe.Issuing.Card.LifecycleControls.CancelAfter;
+      }
+      export namespace Shipping {
+        export type AddressValidation = Stripe.Issuing.Card.Shipping.AddressValidation;
+        export type Carrier = Stripe.Issuing.Card.Shipping.Carrier;
+        export type Customs = Stripe.Issuing.Card.Shipping.Customs;
+        export type Service = Stripe.Issuing.Card.Shipping.Service;
+        export type Status = Stripe.Issuing.Card.Shipping.Status;
+        export type Type = Stripe.Issuing.Card.Shipping.Type;
+        export namespace AddressValidation {
+          export type Mode = Stripe.Issuing.Card.Shipping.AddressValidation.Mode;
+          export type Result = Stripe.Issuing.Card.Shipping.AddressValidation.Result;
+        }
+      }
+      export namespace SpendingControls {
+        export type AllowedCardPresence = Stripe.Issuing.Card.SpendingControls.AllowedCardPresence;
+        export type AllowedCategory = Stripe.Issuing.Card.SpendingControls.AllowedCategory;
+        export type BlockedCardPresence = Stripe.Issuing.Card.SpendingControls.BlockedCardPresence;
+        export type BlockedCategory = Stripe.Issuing.Card.SpendingControls.BlockedCategory;
+        export type SpendingLimit = Stripe.Issuing.Card.SpendingControls.SpendingLimit;
+        export namespace SpendingLimit {
+          export type Category = Stripe.Issuing.Card.SpendingControls.SpendingLimit.Category;
+          export type Interval = Stripe.Issuing.Card.SpendingControls.SpendingLimit.Interval;
+        }
+      }
+      export namespace Wallets {
+        export type ApplePay = Stripe.Issuing.Card.Wallets.ApplePay;
+        export type GooglePay = Stripe.Issuing.Card.Wallets.GooglePay;
+        export namespace ApplePay {
+          export type IneligibleReason = Stripe.Issuing.Card.Wallets.ApplePay.IneligibleReason;
+        }
+        export namespace GooglePay {
+          export type IneligibleReason = Stripe.Issuing.Card.Wallets.GooglePay.IneligibleReason;
+        }
+      }
     }
     export namespace CardholderCreateParams {
       export type Billing = Stripe.Issuing.CardholderCreateParams.Billing;
@@ -1691,53 +10712,199 @@ declare namespace StripeConstructor {
       export type SpendingControls = Stripe.Issuing.CardholderCreateParams.SpendingControls;
       export type Status = Stripe.Issuing.CardholderCreateParams.Status;
       export type Type = Stripe.Issuing.CardholderCreateParams.Type;
+      export namespace Billing {
+        export type Address = Stripe.Issuing.CardholderCreateParams.Billing.Address;
+      }
+      export namespace Individual {
+        export type CardIssuing = Stripe.Issuing.CardholderCreateParams.Individual.CardIssuing;
+        export type Dob = Stripe.Issuing.CardholderCreateParams.Individual.Dob;
+        export type Verification = Stripe.Issuing.CardholderCreateParams.Individual.Verification;
+        export namespace CardIssuing {
+          export type UserTermsAcceptance = Stripe.Issuing.CardholderCreateParams.Individual.CardIssuing.UserTermsAcceptance;
+        }
+        export namespace Verification {
+          export type Document = Stripe.Issuing.CardholderCreateParams.Individual.Verification.Document;
+        }
+      }
+      export namespace SpendingControls {
+        export type AllowedCardPresence = Stripe.Issuing.CardholderCreateParams.SpendingControls.AllowedCardPresence;
+        export type AllowedCategory = Stripe.Issuing.CardholderCreateParams.SpendingControls.AllowedCategory;
+        export type BlockedCardPresence = Stripe.Issuing.CardholderCreateParams.SpendingControls.BlockedCardPresence;
+        export type BlockedCategory = Stripe.Issuing.CardholderCreateParams.SpendingControls.BlockedCategory;
+        export type SpendingLimit = Stripe.Issuing.CardholderCreateParams.SpendingControls.SpendingLimit;
+        export namespace SpendingLimit {
+          export type Category = Stripe.Issuing.CardholderCreateParams.SpendingControls.SpendingLimit.Category;
+          export type Interval = Stripe.Issuing.CardholderCreateParams.SpendingControls.SpendingLimit.Interval;
+        }
+      }
     }
-    export namespace CardholderUpdateParams {
-      export type Billing = Stripe.Issuing.CardholderUpdateParams.Billing;
-      export type Company = Stripe.Issuing.CardholderUpdateParams.Company;
-      export type Individual = Stripe.Issuing.CardholderUpdateParams.Individual;
-      export type PreferredLocale = Stripe.Issuing.CardholderUpdateParams.PreferredLocale;
-      export type SpendingControls = Stripe.Issuing.CardholderUpdateParams.SpendingControls;
-      export type Status = Stripe.Issuing.CardholderUpdateParams.Status;
-    }
-    export namespace CardholderListParams {
-      export type Status = Stripe.Issuing.CardholderListParams.Status;
-      export type Type = Stripe.Issuing.CardholderListParams.Type;
+    export namespace Cardholder {
+      export type Billing = Stripe.Issuing.Cardholder.Billing;
+      export type Company = Stripe.Issuing.Cardholder.Company;
+      export type Individual = Stripe.Issuing.Cardholder.Individual;
+      export type PreferredLocale = Stripe.Issuing.Cardholder.PreferredLocale;
+      export type Requirements = Stripe.Issuing.Cardholder.Requirements;
+      export type SpendingControls = Stripe.Issuing.Cardholder.SpendingControls;
+      export type Status = Stripe.Issuing.Cardholder.Status;
+      export type Type = Stripe.Issuing.Cardholder.Type;
+      export namespace Individual {
+        export type CardIssuing = Stripe.Issuing.Cardholder.Individual.CardIssuing;
+        export type Dob = Stripe.Issuing.Cardholder.Individual.Dob;
+        export type Verification = Stripe.Issuing.Cardholder.Individual.Verification;
+        export namespace CardIssuing {
+          export type UserTermsAcceptance = Stripe.Issuing.Cardholder.Individual.CardIssuing.UserTermsAcceptance;
+        }
+        export namespace Verification {
+          export type Document = Stripe.Issuing.Cardholder.Individual.Verification.Document;
+        }
+      }
+      export namespace Requirements {
+        export type DisabledReason = Stripe.Issuing.Cardholder.Requirements.DisabledReason;
+        export type PastDue = Stripe.Issuing.Cardholder.Requirements.PastDue;
+      }
+      export namespace SpendingControls {
+        export type AllowedCardPresence = Stripe.Issuing.Cardholder.SpendingControls.AllowedCardPresence;
+        export type AllowedCategory = Stripe.Issuing.Cardholder.SpendingControls.AllowedCategory;
+        export type BlockedCardPresence = Stripe.Issuing.Cardholder.SpendingControls.BlockedCardPresence;
+        export type BlockedCategory = Stripe.Issuing.Cardholder.SpendingControls.BlockedCategory;
+        export type SpendingLimit = Stripe.Issuing.Cardholder.SpendingControls.SpendingLimit;
+        export namespace SpendingLimit {
+          export type Category = Stripe.Issuing.Cardholder.SpendingControls.SpendingLimit.Category;
+          export type Interval = Stripe.Issuing.Cardholder.SpendingControls.SpendingLimit.Interval;
+        }
+      }
     }
     export namespace DisputeCreateParams {
       export type Evidence = Stripe.Issuing.DisputeCreateParams.Evidence;
       export type Treasury = Stripe.Issuing.DisputeCreateParams.Treasury;
+      export namespace Evidence {
+        export type Canceled = Stripe.Issuing.DisputeCreateParams.Evidence.Canceled;
+        export type Duplicate = Stripe.Issuing.DisputeCreateParams.Evidence.Duplicate;
+        export type Fraudulent = Stripe.Issuing.DisputeCreateParams.Evidence.Fraudulent;
+        export type MerchandiseNotAsDescribed = Stripe.Issuing.DisputeCreateParams.Evidence.MerchandiseNotAsDescribed;
+        export type NoValidAuthorization = Stripe.Issuing.DisputeCreateParams.Evidence.NoValidAuthorization;
+        export type NotReceived = Stripe.Issuing.DisputeCreateParams.Evidence.NotReceived;
+        export type Other = Stripe.Issuing.DisputeCreateParams.Evidence.Other;
+        export type Reason = Stripe.Issuing.DisputeCreateParams.Evidence.Reason;
+        export type ServiceNotAsDescribed = Stripe.Issuing.DisputeCreateParams.Evidence.ServiceNotAsDescribed;
+        export namespace Canceled {
+          export type ProductType = Stripe.Issuing.DisputeCreateParams.Evidence.Canceled.ProductType;
+          export type ReturnStatus = Stripe.Issuing.DisputeCreateParams.Evidence.Canceled.ReturnStatus;
+        }
+        export namespace MerchandiseNotAsDescribed {
+          export type ReturnStatus = Stripe.Issuing.DisputeCreateParams.Evidence.MerchandiseNotAsDescribed.ReturnStatus;
+        }
+        export namespace NotReceived {
+          export type ProductType = Stripe.Issuing.DisputeCreateParams.Evidence.NotReceived.ProductType;
+        }
+        export namespace Other {
+          export type ProductType = Stripe.Issuing.DisputeCreateParams.Evidence.Other.ProductType;
+        }
+      }
     }
-    export namespace DisputeUpdateParams {
-      export type Evidence = Stripe.Issuing.DisputeUpdateParams.Evidence;
-    }
-    export namespace DisputeListParams {
-      export type Status = Stripe.Issuing.DisputeListParams.Status;
+    export namespace Dispute {
+      export type Evidence = Stripe.Issuing.Dispute.Evidence;
+      export type LossReason = Stripe.Issuing.Dispute.LossReason;
+      export type Status = Stripe.Issuing.Dispute.Status;
+      export type Treasury = Stripe.Issuing.Dispute.Treasury;
+      export namespace Evidence {
+        export type Canceled = Stripe.Issuing.Dispute.Evidence.Canceled;
+        export type Duplicate = Stripe.Issuing.Dispute.Evidence.Duplicate;
+        export type Fraudulent = Stripe.Issuing.Dispute.Evidence.Fraudulent;
+        export type MerchandiseNotAsDescribed = Stripe.Issuing.Dispute.Evidence.MerchandiseNotAsDescribed;
+        export type NoValidAuthorization = Stripe.Issuing.Dispute.Evidence.NoValidAuthorization;
+        export type NotReceived = Stripe.Issuing.Dispute.Evidence.NotReceived;
+        export type Other = Stripe.Issuing.Dispute.Evidence.Other;
+        export type Reason = Stripe.Issuing.Dispute.Evidence.Reason;
+        export type ServiceNotAsDescribed = Stripe.Issuing.Dispute.Evidence.ServiceNotAsDescribed;
+        export namespace Canceled {
+          export type ProductType = Stripe.Issuing.Dispute.Evidence.Canceled.ProductType;
+          export type ReturnStatus = Stripe.Issuing.Dispute.Evidence.Canceled.ReturnStatus;
+        }
+        export namespace MerchandiseNotAsDescribed {
+          export type ReturnStatus = Stripe.Issuing.Dispute.Evidence.MerchandiseNotAsDescribed.ReturnStatus;
+        }
+        export namespace NotReceived {
+          export type ProductType = Stripe.Issuing.Dispute.Evidence.NotReceived.ProductType;
+        }
+        export namespace Other {
+          export type ProductType = Stripe.Issuing.Dispute.Evidence.Other.ProductType;
+        }
+      }
     }
     export namespace PersonalizationDesignCreateParams {
       export type CarrierText = Stripe.Issuing.PersonalizationDesignCreateParams.CarrierText;
       export type Preferences = Stripe.Issuing.PersonalizationDesignCreateParams.Preferences;
     }
-    export namespace PersonalizationDesignUpdateParams {
-      export type CarrierText = Stripe.Issuing.PersonalizationDesignUpdateParams.CarrierText;
-      export type Preferences = Stripe.Issuing.PersonalizationDesignUpdateParams.Preferences;
+    export namespace PersonalizationDesign {
+      export type CarrierText = Stripe.Issuing.PersonalizationDesign.CarrierText;
+      export type Preferences = Stripe.Issuing.PersonalizationDesign.Preferences;
+      export type RejectionReasons = Stripe.Issuing.PersonalizationDesign.RejectionReasons;
+      export type Status = Stripe.Issuing.PersonalizationDesign.Status;
+      export namespace RejectionReasons {
+        export type CardLogo = Stripe.Issuing.PersonalizationDesign.RejectionReasons.CardLogo;
+        export type CarrierText = Stripe.Issuing.PersonalizationDesign.RejectionReasons.CarrierText;
+      }
     }
-    export namespace PersonalizationDesignListParams {
-      export type Preferences = Stripe.Issuing.PersonalizationDesignListParams.Preferences;
-      export type Status = Stripe.Issuing.PersonalizationDesignListParams.Status;
+    export namespace PhysicalBundle {
+      export type Features = Stripe.Issuing.PhysicalBundle.Features;
+      export type Status = Stripe.Issuing.PhysicalBundle.Status;
+      export type Type = Stripe.Issuing.PhysicalBundle.Type;
+      export namespace Features {
+        export type CardLogo = Stripe.Issuing.PhysicalBundle.Features.CardLogo;
+        export type CarrierText = Stripe.Issuing.PhysicalBundle.Features.CarrierText;
+        export type SecondLine = Stripe.Issuing.PhysicalBundle.Features.SecondLine;
+      }
     }
-    export namespace PhysicalBundleListParams {
-      export type Status = Stripe.Issuing.PhysicalBundleListParams.Status;
-      export type Type = Stripe.Issuing.PhysicalBundleListParams.Type;
+    export namespace Token {
+      export type Network = Stripe.Issuing.Token.Network;
+      export type NetworkData = Stripe.Issuing.Token.NetworkData;
+      export type Status = Stripe.Issuing.Token.Status;
+      export type WalletProvider = Stripe.Issuing.Token.WalletProvider;
+      export namespace NetworkData {
+        export type Device = Stripe.Issuing.Token.NetworkData.Device;
+        export type Mastercard = Stripe.Issuing.Token.NetworkData.Mastercard;
+        export type Type = Stripe.Issuing.Token.NetworkData.Type;
+        export type Visa = Stripe.Issuing.Token.NetworkData.Visa;
+        export type WalletProvider = Stripe.Issuing.Token.NetworkData.WalletProvider;
+        export namespace Device {
+          export type Type = Stripe.Issuing.Token.NetworkData.Device.Type;
+        }
+        export namespace WalletProvider {
+          export type CardNumberSource = Stripe.Issuing.Token.NetworkData.WalletProvider.CardNumberSource;
+          export type CardholderAddress = Stripe.Issuing.Token.NetworkData.WalletProvider.CardholderAddress;
+          export type ReasonCode = Stripe.Issuing.Token.NetworkData.WalletProvider.ReasonCode;
+          export type SuggestedDecision = Stripe.Issuing.Token.NetworkData.WalletProvider.SuggestedDecision;
+        }
+      }
     }
-    export namespace TokenUpdateParams {
-      export type Status = Stripe.Issuing.TokenUpdateParams.Status;
-    }
-    export namespace TokenListParams {
-      export type Status = Stripe.Issuing.TokenListParams.Status;
-    }
-    export namespace TransactionListParams {
-      export type Type = Stripe.Issuing.TransactionListParams.Type;
+    export namespace Transaction {
+      export type AmountDetails = Stripe.Issuing.Transaction.AmountDetails;
+      export type MerchantData = Stripe.Issuing.Transaction.MerchantData;
+      export type NetworkData = Stripe.Issuing.Transaction.NetworkData;
+      export type PurchaseDetails = Stripe.Issuing.Transaction.PurchaseDetails;
+      export type Treasury = Stripe.Issuing.Transaction.Treasury;
+      export type Type = Stripe.Issuing.Transaction.Type;
+      export type Wallet = Stripe.Issuing.Transaction.Wallet;
+      export namespace PurchaseDetails {
+        export type Fleet = Stripe.Issuing.Transaction.PurchaseDetails.Fleet;
+        export type Flight = Stripe.Issuing.Transaction.PurchaseDetails.Flight;
+        export type Fuel = Stripe.Issuing.Transaction.PurchaseDetails.Fuel;
+        export type Lodging = Stripe.Issuing.Transaction.PurchaseDetails.Lodging;
+        export type Receipt = Stripe.Issuing.Transaction.PurchaseDetails.Receipt;
+        export namespace Fleet {
+          export type CardholderPromptData = Stripe.Issuing.Transaction.PurchaseDetails.Fleet.CardholderPromptData;
+          export type ReportedBreakdown = Stripe.Issuing.Transaction.PurchaseDetails.Fleet.ReportedBreakdown;
+          export namespace ReportedBreakdown {
+            export type Fuel = Stripe.Issuing.Transaction.PurchaseDetails.Fleet.ReportedBreakdown.Fuel;
+            export type NonFuel = Stripe.Issuing.Transaction.PurchaseDetails.Fleet.ReportedBreakdown.NonFuel;
+            export type Tax = Stripe.Issuing.Transaction.PurchaseDetails.Fleet.ReportedBreakdown.Tax;
+          }
+        }
+        export namespace Flight {
+          export type Segment = Stripe.Issuing.Transaction.PurchaseDetails.Flight.Segment;
+        }
+      }
     }
   }
   export namespace Radar {
@@ -1767,9 +10934,107 @@ declare namespace StripeConstructor {
       export type CustomerDetails = Stripe.Radar.PaymentEvaluationCreateParams.CustomerDetails;
       export type PaymentDetails = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails;
       export type ClientDeviceMetadataDetails = Stripe.Radar.PaymentEvaluationCreateParams.ClientDeviceMetadataDetails;
+      export namespace PaymentDetails {
+        export type MoneyMovementDetails = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.MoneyMovementDetails;
+        export type PaymentMethodDetails = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.PaymentMethodDetails;
+        export type ShippingDetails = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.ShippingDetails;
+        export namespace MoneyMovementDetails {
+          export type Card = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.MoneyMovementDetails.Card;
+          export namespace Card {
+            export type CustomerPresence = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.MoneyMovementDetails.Card.CustomerPresence;
+            export type PaymentType = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.MoneyMovementDetails.Card.PaymentType;
+          }
+        }
+        export namespace PaymentMethodDetails {
+          export type BillingDetails = Stripe.Radar.PaymentEvaluationCreateParams.PaymentDetails.PaymentMethodDetails.BillingDetails;
+        }
+      }
+    }
+    export namespace PaymentEvaluation {
+      export type ClientDeviceMetadataDetails = Stripe.Radar.PaymentEvaluation.ClientDeviceMetadataDetails;
+      export type CustomerDetails = Stripe.Radar.PaymentEvaluation.CustomerDetails;
+      export type Event = Stripe.Radar.PaymentEvaluation.Event;
+      export type Outcome = Stripe.Radar.PaymentEvaluation.Outcome;
+      export type PaymentDetails = Stripe.Radar.PaymentEvaluation.PaymentDetails;
+      export type RecommendedAction = Stripe.Radar.PaymentEvaluation.RecommendedAction;
+      export type Signals = Stripe.Radar.PaymentEvaluation.Signals;
+      export namespace Event {
+        export type DisputeOpened = Stripe.Radar.PaymentEvaluation.Event.DisputeOpened;
+        export type EarlyFraudWarningReceived = Stripe.Radar.PaymentEvaluation.Event.EarlyFraudWarningReceived;
+        export type Refunded = Stripe.Radar.PaymentEvaluation.Event.Refunded;
+        export type Type = Stripe.Radar.PaymentEvaluation.Event.Type;
+        export type UserInterventionRaised = Stripe.Radar.PaymentEvaluation.Event.UserInterventionRaised;
+        export type UserInterventionResolved = Stripe.Radar.PaymentEvaluation.Event.UserInterventionResolved;
+        export namespace DisputeOpened {
+          export type Reason = Stripe.Radar.PaymentEvaluation.Event.DisputeOpened.Reason;
+        }
+        export namespace EarlyFraudWarningReceived {
+          export type FraudType = Stripe.Radar.PaymentEvaluation.Event.EarlyFraudWarningReceived.FraudType;
+        }
+        export namespace Refunded {
+          export type Reason = Stripe.Radar.PaymentEvaluation.Event.Refunded.Reason;
+        }
+        export namespace UserInterventionRaised {
+          export type Custom = Stripe.Radar.PaymentEvaluation.Event.UserInterventionRaised.Custom;
+          export type Type = Stripe.Radar.PaymentEvaluation.Event.UserInterventionRaised.Type;
+        }
+        export namespace UserInterventionResolved {
+          export type Outcome = Stripe.Radar.PaymentEvaluation.Event.UserInterventionResolved.Outcome;
+        }
+      }
+      export namespace Outcome {
+        export type MerchantBlocked = Stripe.Radar.PaymentEvaluation.Outcome.MerchantBlocked;
+        export type Rejected = Stripe.Radar.PaymentEvaluation.Outcome.Rejected;
+        export type Succeeded = Stripe.Radar.PaymentEvaluation.Outcome.Succeeded;
+        export type Type = Stripe.Radar.PaymentEvaluation.Outcome.Type;
+        export namespace MerchantBlocked {
+          export type Reason = Stripe.Radar.PaymentEvaluation.Outcome.MerchantBlocked.Reason;
+        }
+        export namespace Rejected {
+          export type Card = Stripe.Radar.PaymentEvaluation.Outcome.Rejected.Card;
+          export namespace Card {
+            export type AddressLine1Check = Stripe.Radar.PaymentEvaluation.Outcome.Rejected.Card.AddressLine1Check;
+            export type AddressPostalCodeCheck = Stripe.Radar.PaymentEvaluation.Outcome.Rejected.Card.AddressPostalCodeCheck;
+            export type CvcCheck = Stripe.Radar.PaymentEvaluation.Outcome.Rejected.Card.CvcCheck;
+            export type Reason = Stripe.Radar.PaymentEvaluation.Outcome.Rejected.Card.Reason;
+          }
+        }
+        export namespace Succeeded {
+          export type Card = Stripe.Radar.PaymentEvaluation.Outcome.Succeeded.Card;
+          export namespace Card {
+            export type AddressLine1Check = Stripe.Radar.PaymentEvaluation.Outcome.Succeeded.Card.AddressLine1Check;
+            export type AddressPostalCodeCheck = Stripe.Radar.PaymentEvaluation.Outcome.Succeeded.Card.AddressPostalCodeCheck;
+            export type CvcCheck = Stripe.Radar.PaymentEvaluation.Outcome.Succeeded.Card.CvcCheck;
+          }
+        }
+      }
+      export namespace PaymentDetails {
+        export type MoneyMovementDetails = Stripe.Radar.PaymentEvaluation.PaymentDetails.MoneyMovementDetails;
+        export type PaymentMethodDetails = Stripe.Radar.PaymentEvaluation.PaymentDetails.PaymentMethodDetails;
+        export type ShippingDetails = Stripe.Radar.PaymentEvaluation.PaymentDetails.ShippingDetails;
+        export namespace MoneyMovementDetails {
+          export type Card = Stripe.Radar.PaymentEvaluation.PaymentDetails.MoneyMovementDetails.Card;
+          export namespace Card {
+            export type CustomerPresence = Stripe.Radar.PaymentEvaluation.PaymentDetails.MoneyMovementDetails.Card.CustomerPresence;
+            export type PaymentType = Stripe.Radar.PaymentEvaluation.PaymentDetails.MoneyMovementDetails.Card.PaymentType;
+          }
+        }
+        export namespace PaymentMethodDetails {
+          export type BillingDetails = Stripe.Radar.PaymentEvaluation.PaymentDetails.PaymentMethodDetails.BillingDetails;
+        }
+      }
+      export namespace Signals {
+        export type FraudulentPayment = Stripe.Radar.PaymentEvaluation.Signals.FraudulentPayment;
+        export namespace FraudulentPayment {
+          export type RiskLevel = Stripe.Radar.PaymentEvaluation.Signals.FraudulentPayment.RiskLevel;
+        }
+      }
     }
     export namespace ValueListCreateParams {
       export type ItemType = Stripe.Radar.ValueListCreateParams.ItemType;
+    }
+    export namespace ValueList {
+      export type ItemType = Stripe.Radar.ValueList.ItemType;
     }
   }
   export namespace Reporting {
@@ -1784,6 +11049,13 @@ declare namespace StripeConstructor {
     export type ReportTypeResource = Stripe.Reporting.ReportTypeResource;
     export namespace ReportRunCreateParams {
       export type Parameters = Stripe.Reporting.ReportRunCreateParams.Parameters;
+      export namespace Parameters {
+        export type ReportingCategory = Stripe.Reporting.ReportRunCreateParams.Parameters.ReportingCategory;
+        export type Timezone = Stripe.Reporting.ReportRunCreateParams.Parameters.Timezone;
+      }
+    }
+    export namespace ReportRun {
+      export type Parameters = Stripe.Reporting.ReportRun.Parameters;
     }
   }
   export namespace Sigma {
@@ -1791,6 +11063,9 @@ declare namespace StripeConstructor {
     export type ScheduledQueryRunRetrieveParams = Stripe.Sigma.ScheduledQueryRunRetrieveParams;
     export type ScheduledQueryRunListParams = Stripe.Sigma.ScheduledQueryRunListParams;
     export type ScheduledQueryRunResource = Stripe.Sigma.ScheduledQueryRunResource;
+    export namespace ScheduledQueryRun {
+      export type Error = Stripe.Sigma.ScheduledQueryRun.Error;
+    }
   }
   export namespace Tax {
     export type Association = Stripe.Tax.Association;
@@ -1819,26 +11094,995 @@ declare namespace StripeConstructor {
     export type TransactionResource = Stripe.Tax.TransactionResource;
     export type CalculationLineItem = Stripe.Tax.CalculationLineItem;
     export type TransactionLineItem = Stripe.Tax.TransactionLineItem;
+    export namespace Association {
+      export type TaxTransactionAttempt = Stripe.Tax.Association.TaxTransactionAttempt;
+      export namespace TaxTransactionAttempt {
+        export type Committed = Stripe.Tax.Association.TaxTransactionAttempt.Committed;
+        export type Errored = Stripe.Tax.Association.TaxTransactionAttempt.Errored;
+        export namespace Errored {
+          export type Reason = Stripe.Tax.Association.TaxTransactionAttempt.Errored.Reason;
+        }
+      }
+    }
     export namespace CalculationCreateParams {
       export type LineItem = Stripe.Tax.CalculationCreateParams.LineItem;
       export type CustomerDetails = Stripe.Tax.CalculationCreateParams.CustomerDetails;
       export type ShipFromDetails = Stripe.Tax.CalculationCreateParams.ShipFromDetails;
       export type ShippingCost = Stripe.Tax.CalculationCreateParams.ShippingCost;
+      export namespace CustomerDetails {
+        export type Address = Stripe.Tax.CalculationCreateParams.CustomerDetails.Address;
+        export type AddressSource = Stripe.Tax.CalculationCreateParams.CustomerDetails.AddressSource;
+        export type TaxId = Stripe.Tax.CalculationCreateParams.CustomerDetails.TaxId;
+        export type TaxabilityOverride = Stripe.Tax.CalculationCreateParams.CustomerDetails.TaxabilityOverride;
+        export namespace TaxId {
+          export type Type = Stripe.Tax.CalculationCreateParams.CustomerDetails.TaxId.Type;
+        }
+      }
+      export namespace LineItem {
+        export type TaxBehavior = Stripe.Tax.CalculationCreateParams.LineItem.TaxBehavior;
+      }
+      export namespace ShipFromDetails {
+        export type Address = Stripe.Tax.CalculationCreateParams.ShipFromDetails.Address;
+      }
+      export namespace ShippingCost {
+        export type TaxBehavior = Stripe.Tax.CalculationCreateParams.ShippingCost.TaxBehavior;
+      }
+    }
+    export namespace Calculation {
+      export type CustomerDetails = Stripe.Tax.Calculation.CustomerDetails;
+      export type ShipFromDetails = Stripe.Tax.Calculation.ShipFromDetails;
+      export type ShippingCost = Stripe.Tax.Calculation.ShippingCost;
+      export type TaxBreakdown = Stripe.Tax.Calculation.TaxBreakdown;
+      export namespace CustomerDetails {
+        export type AddressSource = Stripe.Tax.Calculation.CustomerDetails.AddressSource;
+        export type TaxId = Stripe.Tax.Calculation.CustomerDetails.TaxId;
+        export type TaxabilityOverride = Stripe.Tax.Calculation.CustomerDetails.TaxabilityOverride;
+        export namespace TaxId {
+          export type Type = Stripe.Tax.Calculation.CustomerDetails.TaxId.Type;
+        }
+      }
+      export namespace ShippingCost {
+        export type TaxBehavior = Stripe.Tax.Calculation.ShippingCost.TaxBehavior;
+        export type TaxBreakdown = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown;
+        export namespace TaxBreakdown {
+          export type Jurisdiction = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown.Jurisdiction;
+          export type Sourcing = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown.Sourcing;
+          export type TaxRateDetails = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown.TaxRateDetails;
+          export type TaxabilityReason = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown.TaxabilityReason;
+          export namespace Jurisdiction {
+            export type Level = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown.Jurisdiction.Level;
+          }
+          export namespace TaxRateDetails {
+            export type TaxType = Stripe.Tax.Calculation.ShippingCost.TaxBreakdown.TaxRateDetails.TaxType;
+          }
+        }
+      }
+      export namespace TaxBreakdown {
+        export type TaxRateDetails = Stripe.Tax.Calculation.TaxBreakdown.TaxRateDetails;
+        export type TaxabilityReason = Stripe.Tax.Calculation.TaxBreakdown.TaxabilityReason;
+        export namespace TaxRateDetails {
+          export type FlatAmount = Stripe.Tax.Calculation.TaxBreakdown.TaxRateDetails.FlatAmount;
+          export type RateType = Stripe.Tax.Calculation.TaxBreakdown.TaxRateDetails.RateType;
+          export type TaxType = Stripe.Tax.Calculation.TaxBreakdown.TaxRateDetails.TaxType;
+        }
+      }
     }
     export namespace RegistrationCreateParams {
       export type CountryOptions = Stripe.Tax.RegistrationCreateParams.CountryOptions;
+      export namespace CountryOptions {
+        export type Ae = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ae;
+        export type Al = Stripe.Tax.RegistrationCreateParams.CountryOptions.Al;
+        export type Am = Stripe.Tax.RegistrationCreateParams.CountryOptions.Am;
+        export type Ao = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ao;
+        export type At = Stripe.Tax.RegistrationCreateParams.CountryOptions.At;
+        export type Au = Stripe.Tax.RegistrationCreateParams.CountryOptions.Au;
+        export type Aw = Stripe.Tax.RegistrationCreateParams.CountryOptions.Aw;
+        export type Az = Stripe.Tax.RegistrationCreateParams.CountryOptions.Az;
+        export type Ba = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ba;
+        export type Bb = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bb;
+        export type Bd = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bd;
+        export type Be = Stripe.Tax.RegistrationCreateParams.CountryOptions.Be;
+        export type Bf = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bf;
+        export type Bg = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bg;
+        export type Bh = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bh;
+        export type Bj = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bj;
+        export type Bs = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bs;
+        export type By = Stripe.Tax.RegistrationCreateParams.CountryOptions.By;
+        export type Ca = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ca;
+        export type Cd = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cd;
+        export type Ch = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ch;
+        export type Cl = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cl;
+        export type Cm = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cm;
+        export type Co = Stripe.Tax.RegistrationCreateParams.CountryOptions.Co;
+        export type Cr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cr;
+        export type Cv = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cv;
+        export type Cy = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cy;
+        export type Cz = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cz;
+        export type De = Stripe.Tax.RegistrationCreateParams.CountryOptions.De;
+        export type Dk = Stripe.Tax.RegistrationCreateParams.CountryOptions.Dk;
+        export type Ec = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ec;
+        export type Ee = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ee;
+        export type Eg = Stripe.Tax.RegistrationCreateParams.CountryOptions.Eg;
+        export type Es = Stripe.Tax.RegistrationCreateParams.CountryOptions.Es;
+        export type Et = Stripe.Tax.RegistrationCreateParams.CountryOptions.Et;
+        export type Fi = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fi;
+        export type Fr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fr;
+        export type Gb = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gb;
+        export type Ge = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ge;
+        export type Gn = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gn;
+        export type Gr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gr;
+        export type Hr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hr;
+        export type Hu = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hu;
+        export type Id = Stripe.Tax.RegistrationCreateParams.CountryOptions.Id;
+        export type Ie = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ie;
+        export type In = Stripe.Tax.RegistrationCreateParams.CountryOptions.In;
+        export type Is = Stripe.Tax.RegistrationCreateParams.CountryOptions.Is;
+        export type It = Stripe.Tax.RegistrationCreateParams.CountryOptions.It;
+        export type Jp = Stripe.Tax.RegistrationCreateParams.CountryOptions.Jp;
+        export type Ke = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ke;
+        export type Kg = Stripe.Tax.RegistrationCreateParams.CountryOptions.Kg;
+        export type Kh = Stripe.Tax.RegistrationCreateParams.CountryOptions.Kh;
+        export type Kr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Kr;
+        export type Kz = Stripe.Tax.RegistrationCreateParams.CountryOptions.Kz;
+        export type La = Stripe.Tax.RegistrationCreateParams.CountryOptions.La;
+        export type Lk = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lk;
+        export type Lt = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lt;
+        export type Lu = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lu;
+        export type Lv = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lv;
+        export type Ma = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ma;
+        export type Md = Stripe.Tax.RegistrationCreateParams.CountryOptions.Md;
+        export type Me = Stripe.Tax.RegistrationCreateParams.CountryOptions.Me;
+        export type Mk = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mk;
+        export type Mr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mr;
+        export type Mt = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mt;
+        export type Mx = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mx;
+        export type My = Stripe.Tax.RegistrationCreateParams.CountryOptions.My;
+        export type Ng = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ng;
+        export type Nl = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nl;
+        export type No = Stripe.Tax.RegistrationCreateParams.CountryOptions.No;
+        export type Np = Stripe.Tax.RegistrationCreateParams.CountryOptions.Np;
+        export type Nz = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nz;
+        export type Om = Stripe.Tax.RegistrationCreateParams.CountryOptions.Om;
+        export type Pe = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pe;
+        export type Ph = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ph;
+        export type Pl = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pl;
+        export type Pt = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pt;
+        export type Ro = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ro;
+        export type Rs = Stripe.Tax.RegistrationCreateParams.CountryOptions.Rs;
+        export type Ru = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ru;
+        export type Sa = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sa;
+        export type Se = Stripe.Tax.RegistrationCreateParams.CountryOptions.Se;
+        export type Sg = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sg;
+        export type Si = Stripe.Tax.RegistrationCreateParams.CountryOptions.Si;
+        export type Sk = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sk;
+        export type Sn = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sn;
+        export type Sr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sr;
+        export type Th = Stripe.Tax.RegistrationCreateParams.CountryOptions.Th;
+        export type Tj = Stripe.Tax.RegistrationCreateParams.CountryOptions.Tj;
+        export type Tr = Stripe.Tax.RegistrationCreateParams.CountryOptions.Tr;
+        export type Tw = Stripe.Tax.RegistrationCreateParams.CountryOptions.Tw;
+        export type Tz = Stripe.Tax.RegistrationCreateParams.CountryOptions.Tz;
+        export type Ua = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ua;
+        export type Ug = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ug;
+        export type Us = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us;
+        export type Uy = Stripe.Tax.RegistrationCreateParams.CountryOptions.Uy;
+        export type Uz = Stripe.Tax.RegistrationCreateParams.CountryOptions.Uz;
+        export type Vn = Stripe.Tax.RegistrationCreateParams.CountryOptions.Vn;
+        export type Za = Stripe.Tax.RegistrationCreateParams.CountryOptions.Za;
+        export type Zm = Stripe.Tax.RegistrationCreateParams.CountryOptions.Zm;
+        export type Zw = Stripe.Tax.RegistrationCreateParams.CountryOptions.Zw;
+        export namespace Ae {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ae.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ae.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Al {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Al.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Al.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ao {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ao.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ao.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace At {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.At.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.At.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.At.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Au {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Au.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Au.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Aw {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Aw.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Aw.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ba {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ba.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ba.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bb {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bb.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bb.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bd {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bd.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bd.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Be {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Be.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Be.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Be.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bf {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bf.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bf.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bg {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bg.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bg.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bg.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bh {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bh.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bh.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bs {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bs.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Bs.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ca {
+          export type ProvinceStandard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ca.ProvinceStandard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ca.Type;
+        }
+        export namespace Cd {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cd.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cd.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ch {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ch.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ch.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Cy {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cy.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cy.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cy.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Cz {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cz.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cz.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Cz.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace De {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.De.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.De.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.De.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Dk {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Dk.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Dk.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Dk.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ee {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ee.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ee.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ee.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Es {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Es.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Es.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Es.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Et {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Et.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Et.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Fi {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fi.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fi.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fi.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Fr {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fr.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fr.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Fr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Gb {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gb.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gb.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Gn {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gn.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gn.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Gr {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gr.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gr.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Gr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Hr {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hr.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hr.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Hu {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hu.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hu.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Hu.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ie {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ie.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ie.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ie.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Is {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Is.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Is.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace It {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.It.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.It.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.It.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Jp {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Jp.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Jp.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Lt {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lt.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lt.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lt.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Lu {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lu.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lu.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lu.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Lv {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lv.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lv.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Lv.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Me {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Me.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Me.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Mk {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mk.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mk.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Mr {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mr.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Mt {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mt.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mt.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Mt.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Nl {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nl.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nl.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nl.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace No {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.No.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.No.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Nz {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nz.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Nz.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Om {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Om.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Om.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Pl {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pl.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pl.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pl.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Pt {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pt.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pt.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Pt.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ro {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ro.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ro.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Ro.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Rs {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Rs.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Rs.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Se {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Se.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Se.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Se.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Sg {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sg.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sg.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Si {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Si.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Si.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Si.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Sk {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sk.Standard;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sk.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sk.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Sr {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sr.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Sr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Us {
+          export type LocalAmusementTax = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us.LocalAmusementTax;
+          export type LocalLeaseTax = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us.LocalLeaseTax;
+          export type StateSalesTax = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us.StateSalesTax;
+          export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us.Type;
+          export namespace StateSalesTax {
+            export type Election = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us.StateSalesTax.Election;
+            export namespace Election {
+              export type Type = Stripe.Tax.RegistrationCreateParams.CountryOptions.Us.StateSalesTax.Election.Type;
+            }
+          }
+        }
+        export namespace Uy {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Uy.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Uy.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Za {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Za.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Za.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Zw {
+          export type Standard = Stripe.Tax.RegistrationCreateParams.CountryOptions.Zw.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.RegistrationCreateParams.CountryOptions.Zw.Standard.PlaceOfSupplyScheme;
+          }
+        }
+      }
     }
-    export namespace RegistrationListParams {
-      export type Status = Stripe.Tax.RegistrationListParams.Status;
+    export namespace Registration {
+      export type CountryOptions = Stripe.Tax.Registration.CountryOptions;
+      export type Status = Stripe.Tax.Registration.Status;
+      export namespace CountryOptions {
+        export type Ae = Stripe.Tax.Registration.CountryOptions.Ae;
+        export type Al = Stripe.Tax.Registration.CountryOptions.Al;
+        export type Am = Stripe.Tax.Registration.CountryOptions.Am;
+        export type Ao = Stripe.Tax.Registration.CountryOptions.Ao;
+        export type At = Stripe.Tax.Registration.CountryOptions.At;
+        export type Au = Stripe.Tax.Registration.CountryOptions.Au;
+        export type Aw = Stripe.Tax.Registration.CountryOptions.Aw;
+        export type Az = Stripe.Tax.Registration.CountryOptions.Az;
+        export type Ba = Stripe.Tax.Registration.CountryOptions.Ba;
+        export type Bb = Stripe.Tax.Registration.CountryOptions.Bb;
+        export type Bd = Stripe.Tax.Registration.CountryOptions.Bd;
+        export type Be = Stripe.Tax.Registration.CountryOptions.Be;
+        export type Bf = Stripe.Tax.Registration.CountryOptions.Bf;
+        export type Bg = Stripe.Tax.Registration.CountryOptions.Bg;
+        export type Bh = Stripe.Tax.Registration.CountryOptions.Bh;
+        export type Bj = Stripe.Tax.Registration.CountryOptions.Bj;
+        export type Bs = Stripe.Tax.Registration.CountryOptions.Bs;
+        export type By = Stripe.Tax.Registration.CountryOptions.By;
+        export type Ca = Stripe.Tax.Registration.CountryOptions.Ca;
+        export type Cd = Stripe.Tax.Registration.CountryOptions.Cd;
+        export type Ch = Stripe.Tax.Registration.CountryOptions.Ch;
+        export type Cl = Stripe.Tax.Registration.CountryOptions.Cl;
+        export type Cm = Stripe.Tax.Registration.CountryOptions.Cm;
+        export type Co = Stripe.Tax.Registration.CountryOptions.Co;
+        export type Cr = Stripe.Tax.Registration.CountryOptions.Cr;
+        export type Cv = Stripe.Tax.Registration.CountryOptions.Cv;
+        export type Cy = Stripe.Tax.Registration.CountryOptions.Cy;
+        export type Cz = Stripe.Tax.Registration.CountryOptions.Cz;
+        export type De = Stripe.Tax.Registration.CountryOptions.De;
+        export type Dk = Stripe.Tax.Registration.CountryOptions.Dk;
+        export type Ec = Stripe.Tax.Registration.CountryOptions.Ec;
+        export type Ee = Stripe.Tax.Registration.CountryOptions.Ee;
+        export type Eg = Stripe.Tax.Registration.CountryOptions.Eg;
+        export type Es = Stripe.Tax.Registration.CountryOptions.Es;
+        export type Et = Stripe.Tax.Registration.CountryOptions.Et;
+        export type Fi = Stripe.Tax.Registration.CountryOptions.Fi;
+        export type Fr = Stripe.Tax.Registration.CountryOptions.Fr;
+        export type Gb = Stripe.Tax.Registration.CountryOptions.Gb;
+        export type Ge = Stripe.Tax.Registration.CountryOptions.Ge;
+        export type Gn = Stripe.Tax.Registration.CountryOptions.Gn;
+        export type Gr = Stripe.Tax.Registration.CountryOptions.Gr;
+        export type Hr = Stripe.Tax.Registration.CountryOptions.Hr;
+        export type Hu = Stripe.Tax.Registration.CountryOptions.Hu;
+        export type Id = Stripe.Tax.Registration.CountryOptions.Id;
+        export type Ie = Stripe.Tax.Registration.CountryOptions.Ie;
+        export type In = Stripe.Tax.Registration.CountryOptions.In;
+        export type Is = Stripe.Tax.Registration.CountryOptions.Is;
+        export type It = Stripe.Tax.Registration.CountryOptions.It;
+        export type Jp = Stripe.Tax.Registration.CountryOptions.Jp;
+        export type Ke = Stripe.Tax.Registration.CountryOptions.Ke;
+        export type Kg = Stripe.Tax.Registration.CountryOptions.Kg;
+        export type Kh = Stripe.Tax.Registration.CountryOptions.Kh;
+        export type Kr = Stripe.Tax.Registration.CountryOptions.Kr;
+        export type Kz = Stripe.Tax.Registration.CountryOptions.Kz;
+        export type La = Stripe.Tax.Registration.CountryOptions.La;
+        export type Lk = Stripe.Tax.Registration.CountryOptions.Lk;
+        export type Lt = Stripe.Tax.Registration.CountryOptions.Lt;
+        export type Lu = Stripe.Tax.Registration.CountryOptions.Lu;
+        export type Lv = Stripe.Tax.Registration.CountryOptions.Lv;
+        export type Ma = Stripe.Tax.Registration.CountryOptions.Ma;
+        export type Md = Stripe.Tax.Registration.CountryOptions.Md;
+        export type Me = Stripe.Tax.Registration.CountryOptions.Me;
+        export type Mk = Stripe.Tax.Registration.CountryOptions.Mk;
+        export type Mr = Stripe.Tax.Registration.CountryOptions.Mr;
+        export type Mt = Stripe.Tax.Registration.CountryOptions.Mt;
+        export type Mx = Stripe.Tax.Registration.CountryOptions.Mx;
+        export type My = Stripe.Tax.Registration.CountryOptions.My;
+        export type Ng = Stripe.Tax.Registration.CountryOptions.Ng;
+        export type Nl = Stripe.Tax.Registration.CountryOptions.Nl;
+        export type No = Stripe.Tax.Registration.CountryOptions.No;
+        export type Np = Stripe.Tax.Registration.CountryOptions.Np;
+        export type Nz = Stripe.Tax.Registration.CountryOptions.Nz;
+        export type Om = Stripe.Tax.Registration.CountryOptions.Om;
+        export type Pe = Stripe.Tax.Registration.CountryOptions.Pe;
+        export type Ph = Stripe.Tax.Registration.CountryOptions.Ph;
+        export type Pl = Stripe.Tax.Registration.CountryOptions.Pl;
+        export type Pt = Stripe.Tax.Registration.CountryOptions.Pt;
+        export type Ro = Stripe.Tax.Registration.CountryOptions.Ro;
+        export type Rs = Stripe.Tax.Registration.CountryOptions.Rs;
+        export type Ru = Stripe.Tax.Registration.CountryOptions.Ru;
+        export type Sa = Stripe.Tax.Registration.CountryOptions.Sa;
+        export type Se = Stripe.Tax.Registration.CountryOptions.Se;
+        export type Sg = Stripe.Tax.Registration.CountryOptions.Sg;
+        export type Si = Stripe.Tax.Registration.CountryOptions.Si;
+        export type Sk = Stripe.Tax.Registration.CountryOptions.Sk;
+        export type Sn = Stripe.Tax.Registration.CountryOptions.Sn;
+        export type Sr = Stripe.Tax.Registration.CountryOptions.Sr;
+        export type Th = Stripe.Tax.Registration.CountryOptions.Th;
+        export type Tj = Stripe.Tax.Registration.CountryOptions.Tj;
+        export type Tr = Stripe.Tax.Registration.CountryOptions.Tr;
+        export type Tw = Stripe.Tax.Registration.CountryOptions.Tw;
+        export type Tz = Stripe.Tax.Registration.CountryOptions.Tz;
+        export type Ua = Stripe.Tax.Registration.CountryOptions.Ua;
+        export type Ug = Stripe.Tax.Registration.CountryOptions.Ug;
+        export type Us = Stripe.Tax.Registration.CountryOptions.Us;
+        export type Uy = Stripe.Tax.Registration.CountryOptions.Uy;
+        export type Uz = Stripe.Tax.Registration.CountryOptions.Uz;
+        export type Vn = Stripe.Tax.Registration.CountryOptions.Vn;
+        export type Za = Stripe.Tax.Registration.CountryOptions.Za;
+        export type Zm = Stripe.Tax.Registration.CountryOptions.Zm;
+        export type Zw = Stripe.Tax.Registration.CountryOptions.Zw;
+        export namespace Ae {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Ae.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Ae.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace At {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.At.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.At.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.At.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Au {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Au.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Au.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Be {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Be.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Be.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Be.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Bg {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Bg.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Bg.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Bg.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ca {
+          export type ProvinceStandard = Stripe.Tax.Registration.CountryOptions.Ca.ProvinceStandard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Ca.Type;
+        }
+        export namespace Ch {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Ch.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Ch.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Cy {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Cy.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Cy.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Cy.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Cz {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Cz.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Cz.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Cz.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace De {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.De.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.De.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.De.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Dk {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Dk.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Dk.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Dk.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ee {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Ee.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Ee.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Ee.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Es {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Es.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Es.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Es.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Fi {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Fi.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Fi.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Fi.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Fr {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Fr.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Fr.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Fr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Gb {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Gb.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Gb.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Gr {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Gr.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Gr.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Gr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Hr {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Hr.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Hr.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Hr.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Hu {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Hu.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Hu.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Hu.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ie {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Ie.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Ie.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Ie.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace It {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.It.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.It.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.It.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Jp {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Jp.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Jp.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Lt {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Lt.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Lt.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Lt.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Lu {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Lu.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Lu.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Lu.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Lv {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Lv.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Lv.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Lv.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Mt {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Mt.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Mt.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Mt.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Nl {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Nl.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Nl.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Nl.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace No {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.No.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.No.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Nz {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Nz.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Nz.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Pl {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Pl.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Pl.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Pl.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Pt {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Pt.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Pt.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Pt.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Ro {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Ro.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Ro.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Ro.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Se {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Se.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Se.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Se.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Sg {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Sg.Standard;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Sg.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Si {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Si.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Si.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Si.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Sk {
+          export type Standard = Stripe.Tax.Registration.CountryOptions.Sk.Standard;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Sk.Type;
+          export namespace Standard {
+            export type PlaceOfSupplyScheme = Stripe.Tax.Registration.CountryOptions.Sk.Standard.PlaceOfSupplyScheme;
+          }
+        }
+        export namespace Us {
+          export type LocalAmusementTax = Stripe.Tax.Registration.CountryOptions.Us.LocalAmusementTax;
+          export type LocalLeaseTax = Stripe.Tax.Registration.CountryOptions.Us.LocalLeaseTax;
+          export type StateSalesTax = Stripe.Tax.Registration.CountryOptions.Us.StateSalesTax;
+          export type Type = Stripe.Tax.Registration.CountryOptions.Us.Type;
+          export namespace StateSalesTax {
+            export type Election = Stripe.Tax.Registration.CountryOptions.Us.StateSalesTax.Election;
+            export namespace Election {
+              export type Type = Stripe.Tax.Registration.CountryOptions.Us.StateSalesTax.Election.Type;
+            }
+          }
+        }
+      }
     }
-    export namespace SettingsUpdateParams {
-      export type Defaults = Stripe.Tax.SettingsUpdateParams.Defaults;
-      export type HeadOffice = Stripe.Tax.SettingsUpdateParams.HeadOffice;
+    export namespace Settings {
+      export type Defaults = Stripe.Tax.Settings.Defaults;
+      export type HeadOffice = Stripe.Tax.Settings.HeadOffice;
+      export type Status = Stripe.Tax.Settings.Status;
+      export type StatusDetails = Stripe.Tax.Settings.StatusDetails;
+      export namespace Defaults {
+        export type Provider = Stripe.Tax.Settings.Defaults.Provider;
+        export type TaxBehavior = Stripe.Tax.Settings.Defaults.TaxBehavior;
+      }
+      export namespace StatusDetails {
+        export type Active = Stripe.Tax.Settings.StatusDetails.Active;
+        export type Pending = Stripe.Tax.Settings.StatusDetails.Pending;
+      }
     }
-    export namespace TransactionCreateReversalParams {
-      export type Mode = Stripe.Tax.TransactionCreateReversalParams.Mode;
-      export type LineItem = Stripe.Tax.TransactionCreateReversalParams.LineItem;
-      export type ShippingCost = Stripe.Tax.TransactionCreateReversalParams.ShippingCost;
+    export namespace Transaction {
+      export type CustomerDetails = Stripe.Tax.Transaction.CustomerDetails;
+      export type Reversal = Stripe.Tax.Transaction.Reversal;
+      export type ShipFromDetails = Stripe.Tax.Transaction.ShipFromDetails;
+      export type ShippingCost = Stripe.Tax.Transaction.ShippingCost;
+      export type Type = Stripe.Tax.Transaction.Type;
+      export namespace CustomerDetails {
+        export type AddressSource = Stripe.Tax.Transaction.CustomerDetails.AddressSource;
+        export type TaxId = Stripe.Tax.Transaction.CustomerDetails.TaxId;
+        export type TaxabilityOverride = Stripe.Tax.Transaction.CustomerDetails.TaxabilityOverride;
+        export namespace TaxId {
+          export type Type = Stripe.Tax.Transaction.CustomerDetails.TaxId.Type;
+        }
+      }
+      export namespace ShippingCost {
+        export type TaxBehavior = Stripe.Tax.Transaction.ShippingCost.TaxBehavior;
+        export type TaxBreakdown = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown;
+        export namespace TaxBreakdown {
+          export type Jurisdiction = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown.Jurisdiction;
+          export type Sourcing = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown.Sourcing;
+          export type TaxRateDetails = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown.TaxRateDetails;
+          export type TaxabilityReason = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown.TaxabilityReason;
+          export namespace Jurisdiction {
+            export type Level = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown.Jurisdiction.Level;
+          }
+          export namespace TaxRateDetails {
+            export type TaxType = Stripe.Tax.Transaction.ShippingCost.TaxBreakdown.TaxRateDetails.TaxType;
+          }
+        }
+      }
+    }
+    export namespace CalculationLineItem {
+      export type TaxBehavior = Stripe.Tax.CalculationLineItem.TaxBehavior;
+      export type TaxBreakdown = Stripe.Tax.CalculationLineItem.TaxBreakdown;
+      export namespace TaxBreakdown {
+        export type Jurisdiction = Stripe.Tax.CalculationLineItem.TaxBreakdown.Jurisdiction;
+        export type Sourcing = Stripe.Tax.CalculationLineItem.TaxBreakdown.Sourcing;
+        export type TaxRateDetails = Stripe.Tax.CalculationLineItem.TaxBreakdown.TaxRateDetails;
+        export type TaxabilityReason = Stripe.Tax.CalculationLineItem.TaxBreakdown.TaxabilityReason;
+        export namespace Jurisdiction {
+          export type Level = Stripe.Tax.CalculationLineItem.TaxBreakdown.Jurisdiction.Level;
+        }
+        export namespace TaxRateDetails {
+          export type TaxType = Stripe.Tax.CalculationLineItem.TaxBreakdown.TaxRateDetails.TaxType;
+        }
+      }
+    }
+    export namespace TransactionLineItem {
+      export type Reversal = Stripe.Tax.TransactionLineItem.Reversal;
+      export type TaxBehavior = Stripe.Tax.TransactionLineItem.TaxBehavior;
+      export type Type = Stripe.Tax.TransactionLineItem.Type;
     }
   }
   export namespace Terminal {
@@ -1895,54 +12139,179 @@ declare namespace StripeConstructor {
       export type VerifoneUx700 = Stripe.Terminal.ConfigurationCreateParams.VerifoneUx700;
       export type VerifoneV660p = Stripe.Terminal.ConfigurationCreateParams.VerifoneV660p;
       export type Wifi = Stripe.Terminal.ConfigurationCreateParams.Wifi;
+      export namespace Tipping {
+        export type Aed = Stripe.Terminal.ConfigurationCreateParams.Tipping.Aed;
+        export type Aud = Stripe.Terminal.ConfigurationCreateParams.Tipping.Aud;
+        export type Cad = Stripe.Terminal.ConfigurationCreateParams.Tipping.Cad;
+        export type Chf = Stripe.Terminal.ConfigurationCreateParams.Tipping.Chf;
+        export type Czk = Stripe.Terminal.ConfigurationCreateParams.Tipping.Czk;
+        export type Dkk = Stripe.Terminal.ConfigurationCreateParams.Tipping.Dkk;
+        export type Eur = Stripe.Terminal.ConfigurationCreateParams.Tipping.Eur;
+        export type Gbp = Stripe.Terminal.ConfigurationCreateParams.Tipping.Gbp;
+        export type Gip = Stripe.Terminal.ConfigurationCreateParams.Tipping.Gip;
+        export type Hkd = Stripe.Terminal.ConfigurationCreateParams.Tipping.Hkd;
+        export type Huf = Stripe.Terminal.ConfigurationCreateParams.Tipping.Huf;
+        export type Jpy = Stripe.Terminal.ConfigurationCreateParams.Tipping.Jpy;
+        export type Mxn = Stripe.Terminal.ConfigurationCreateParams.Tipping.Mxn;
+        export type Myr = Stripe.Terminal.ConfigurationCreateParams.Tipping.Myr;
+        export type Nok = Stripe.Terminal.ConfigurationCreateParams.Tipping.Nok;
+        export type Nzd = Stripe.Terminal.ConfigurationCreateParams.Tipping.Nzd;
+        export type Pln = Stripe.Terminal.ConfigurationCreateParams.Tipping.Pln;
+        export type Ron = Stripe.Terminal.ConfigurationCreateParams.Tipping.Ron;
+        export type Sek = Stripe.Terminal.ConfigurationCreateParams.Tipping.Sek;
+        export type Sgd = Stripe.Terminal.ConfigurationCreateParams.Tipping.Sgd;
+        export type Usd = Stripe.Terminal.ConfigurationCreateParams.Tipping.Usd;
+      }
+      export namespace Wifi {
+        export type EnterpriseEapPeap = Stripe.Terminal.ConfigurationCreateParams.Wifi.EnterpriseEapPeap;
+        export type EnterpriseEapTls = Stripe.Terminal.ConfigurationCreateParams.Wifi.EnterpriseEapTls;
+        export type PersonalPsk = Stripe.Terminal.ConfigurationCreateParams.Wifi.PersonalPsk;
+        export type Type = Stripe.Terminal.ConfigurationCreateParams.Wifi.Type;
+      }
     }
-    export namespace ConfigurationUpdateParams {
-      export type BbposWisepad3 = Stripe.Terminal.ConfigurationUpdateParams.BbposWisepad3;
-      export type BbposWiseposE = Stripe.Terminal.ConfigurationUpdateParams.BbposWiseposE;
-      export type Cellular = Stripe.Terminal.ConfigurationUpdateParams.Cellular;
-      export type Offline = Stripe.Terminal.ConfigurationUpdateParams.Offline;
-      export type RebootWindow = Stripe.Terminal.ConfigurationUpdateParams.RebootWindow;
-      export type StripeS700 = Stripe.Terminal.ConfigurationUpdateParams.StripeS700;
-      export type StripeS710 = Stripe.Terminal.ConfigurationUpdateParams.StripeS710;
-      export type Tipping = Stripe.Terminal.ConfigurationUpdateParams.Tipping;
-      export type VerifoneM425 = Stripe.Terminal.ConfigurationUpdateParams.VerifoneM425;
-      export type VerifoneP400 = Stripe.Terminal.ConfigurationUpdateParams.VerifoneP400;
-      export type VerifoneP630 = Stripe.Terminal.ConfigurationUpdateParams.VerifoneP630;
-      export type VerifoneUx700 = Stripe.Terminal.ConfigurationUpdateParams.VerifoneUx700;
-      export type VerifoneV660p = Stripe.Terminal.ConfigurationUpdateParams.VerifoneV660p;
-      export type Wifi = Stripe.Terminal.ConfigurationUpdateParams.Wifi;
+    export namespace Configuration {
+      export type BbposWisepad3 = Stripe.Terminal.Configuration.BbposWisepad3;
+      export type BbposWiseposE = Stripe.Terminal.Configuration.BbposWiseposE;
+      export type Cellular = Stripe.Terminal.Configuration.Cellular;
+      export type Offline = Stripe.Terminal.Configuration.Offline;
+      export type RebootWindow = Stripe.Terminal.Configuration.RebootWindow;
+      export type StripeS700 = Stripe.Terminal.Configuration.StripeS700;
+      export type StripeS710 = Stripe.Terminal.Configuration.StripeS710;
+      export type Tipping = Stripe.Terminal.Configuration.Tipping;
+      export type VerifoneM425 = Stripe.Terminal.Configuration.VerifoneM425;
+      export type VerifoneP400 = Stripe.Terminal.Configuration.VerifoneP400;
+      export type VerifoneP630 = Stripe.Terminal.Configuration.VerifoneP630;
+      export type VerifoneUx700 = Stripe.Terminal.Configuration.VerifoneUx700;
+      export type VerifoneV660p = Stripe.Terminal.Configuration.VerifoneV660p;
+      export type Wifi = Stripe.Terminal.Configuration.Wifi;
+      export namespace Tipping {
+        export type Aed = Stripe.Terminal.Configuration.Tipping.Aed;
+        export type Aud = Stripe.Terminal.Configuration.Tipping.Aud;
+        export type Cad = Stripe.Terminal.Configuration.Tipping.Cad;
+        export type Chf = Stripe.Terminal.Configuration.Tipping.Chf;
+        export type Czk = Stripe.Terminal.Configuration.Tipping.Czk;
+        export type Dkk = Stripe.Terminal.Configuration.Tipping.Dkk;
+        export type Eur = Stripe.Terminal.Configuration.Tipping.Eur;
+        export type Gbp = Stripe.Terminal.Configuration.Tipping.Gbp;
+        export type Gip = Stripe.Terminal.Configuration.Tipping.Gip;
+        export type Hkd = Stripe.Terminal.Configuration.Tipping.Hkd;
+        export type Huf = Stripe.Terminal.Configuration.Tipping.Huf;
+        export type Jpy = Stripe.Terminal.Configuration.Tipping.Jpy;
+        export type Mxn = Stripe.Terminal.Configuration.Tipping.Mxn;
+        export type Myr = Stripe.Terminal.Configuration.Tipping.Myr;
+        export type Nok = Stripe.Terminal.Configuration.Tipping.Nok;
+        export type Nzd = Stripe.Terminal.Configuration.Tipping.Nzd;
+        export type Pln = Stripe.Terminal.Configuration.Tipping.Pln;
+        export type Ron = Stripe.Terminal.Configuration.Tipping.Ron;
+        export type Sek = Stripe.Terminal.Configuration.Tipping.Sek;
+        export type Sgd = Stripe.Terminal.Configuration.Tipping.Sgd;
+        export type Usd = Stripe.Terminal.Configuration.Tipping.Usd;
+      }
+      export namespace Wifi {
+        export type EnterpriseEapPeap = Stripe.Terminal.Configuration.Wifi.EnterpriseEapPeap;
+        export type EnterpriseEapTls = Stripe.Terminal.Configuration.Wifi.EnterpriseEapTls;
+        export type PersonalPsk = Stripe.Terminal.Configuration.Wifi.PersonalPsk;
+        export type Type = Stripe.Terminal.Configuration.Wifi.Type;
+      }
     }
     export namespace LocationCreateParams {
       export type Address = Stripe.Terminal.LocationCreateParams.Address;
     }
+    export namespace Location {
+      export type AddressKana = Stripe.Terminal.Location.AddressKana;
+      export type AddressKanji = Stripe.Terminal.Location.AddressKanji;
+    }
     export namespace OnboardingLinkCreateParams {
       export type LinkOptions = Stripe.Terminal.OnboardingLinkCreateParams.LinkOptions;
+      export namespace LinkOptions {
+        export type AppleTermsAndConditions = Stripe.Terminal.OnboardingLinkCreateParams.LinkOptions.AppleTermsAndConditions;
+      }
     }
-    export namespace ReaderListParams {
-      export type DeviceType = Stripe.Terminal.ReaderListParams.DeviceType;
-      export type Status = Stripe.Terminal.ReaderListParams.Status;
+    export namespace OnboardingLink {
+      export type LinkOptions = Stripe.Terminal.OnboardingLink.LinkOptions;
+      export namespace LinkOptions {
+        export type AppleTermsAndConditions = Stripe.Terminal.OnboardingLink.LinkOptions.AppleTermsAndConditions;
+      }
     }
-    export namespace ReaderCollectInputsParams {
-      export type Input = Stripe.Terminal.ReaderCollectInputsParams.Input;
+    export namespace DeletedReader {
+      export type DeviceType = Stripe.Terminal.DeletedReader.DeviceType;
     }
-    export namespace ReaderCollectPaymentMethodParams {
-      export type CollectConfig = Stripe.Terminal.ReaderCollectPaymentMethodParams.CollectConfig;
-    }
-    export namespace ReaderConfirmPaymentIntentParams {
-      export type ConfirmConfig = Stripe.Terminal.ReaderConfirmPaymentIntentParams.ConfirmConfig;
-    }
-    export namespace ReaderProcessPaymentIntentParams {
-      export type ProcessConfig = Stripe.Terminal.ReaderProcessPaymentIntentParams.ProcessConfig;
-    }
-    export namespace ReaderProcessSetupIntentParams {
-      export type AllowRedisplay = Stripe.Terminal.ReaderProcessSetupIntentParams.AllowRedisplay;
-      export type ProcessConfig = Stripe.Terminal.ReaderProcessSetupIntentParams.ProcessConfig;
-    }
-    export namespace ReaderRefundPaymentParams {
-      export type RefundPaymentConfig = Stripe.Terminal.ReaderRefundPaymentParams.RefundPaymentConfig;
-    }
-    export namespace ReaderSetReaderDisplayParams {
-      export type Cart = Stripe.Terminal.ReaderSetReaderDisplayParams.Cart;
+    export namespace Reader {
+      export type Action = Stripe.Terminal.Reader.Action;
+      export type DeviceType = Stripe.Terminal.Reader.DeviceType;
+      export type Status = Stripe.Terminal.Reader.Status;
+      export namespace Action {
+        export type ApiError = Stripe.Terminal.Reader.Action.ApiError;
+        export type CollectInputs = Stripe.Terminal.Reader.Action.CollectInputs;
+        export type CollectPaymentMethod = Stripe.Terminal.Reader.Action.CollectPaymentMethod;
+        export type ConfirmPaymentIntent = Stripe.Terminal.Reader.Action.ConfirmPaymentIntent;
+        export type PrintContent = Stripe.Terminal.Reader.Action.PrintContent;
+        export type ProcessPaymentIntent = Stripe.Terminal.Reader.Action.ProcessPaymentIntent;
+        export type ProcessSetupIntent = Stripe.Terminal.Reader.Action.ProcessSetupIntent;
+        export type RefundPayment = Stripe.Terminal.Reader.Action.RefundPayment;
+        export type SetReaderDisplay = Stripe.Terminal.Reader.Action.SetReaderDisplay;
+        export type Status = Stripe.Terminal.Reader.Action.Status;
+        export type Type = Stripe.Terminal.Reader.Action.Type;
+        export namespace ApiError {
+          export type Code = Stripe.Terminal.Reader.Action.ApiError.Code;
+          export type Type = Stripe.Terminal.Reader.Action.ApiError.Type;
+        }
+        export namespace CollectInputs {
+          export type Input = Stripe.Terminal.Reader.Action.CollectInputs.Input;
+          export namespace Input {
+            export type CustomText = Stripe.Terminal.Reader.Action.CollectInputs.Input.CustomText;
+            export type Email = Stripe.Terminal.Reader.Action.CollectInputs.Input.Email;
+            export type Numeric = Stripe.Terminal.Reader.Action.CollectInputs.Input.Numeric;
+            export type Phone = Stripe.Terminal.Reader.Action.CollectInputs.Input.Phone;
+            export type Selection = Stripe.Terminal.Reader.Action.CollectInputs.Input.Selection;
+            export type Signature = Stripe.Terminal.Reader.Action.CollectInputs.Input.Signature;
+            export type Text = Stripe.Terminal.Reader.Action.CollectInputs.Input.Text;
+            export type Toggle = Stripe.Terminal.Reader.Action.CollectInputs.Input.Toggle;
+            export type Type = Stripe.Terminal.Reader.Action.CollectInputs.Input.Type;
+            export namespace Selection {
+              export type Choice = Stripe.Terminal.Reader.Action.CollectInputs.Input.Selection.Choice;
+              export namespace Choice {
+                export type Style = Stripe.Terminal.Reader.Action.CollectInputs.Input.Selection.Choice.Style;
+              }
+            }
+            export namespace Toggle {
+              export type DefaultValue = Stripe.Terminal.Reader.Action.CollectInputs.Input.Toggle.DefaultValue;
+              export type Value = Stripe.Terminal.Reader.Action.CollectInputs.Input.Toggle.Value;
+            }
+          }
+        }
+        export namespace CollectPaymentMethod {
+          export type CollectConfig = Stripe.Terminal.Reader.Action.CollectPaymentMethod.CollectConfig;
+          export namespace CollectConfig {
+            export type Tipping = Stripe.Terminal.Reader.Action.CollectPaymentMethod.CollectConfig.Tipping;
+          }
+        }
+        export namespace ConfirmPaymentIntent {
+          export type ConfirmConfig = Stripe.Terminal.Reader.Action.ConfirmPaymentIntent.ConfirmConfig;
+        }
+        export namespace PrintContent {
+          export type Image = Stripe.Terminal.Reader.Action.PrintContent.Image;
+        }
+        export namespace ProcessPaymentIntent {
+          export type ProcessConfig = Stripe.Terminal.Reader.Action.ProcessPaymentIntent.ProcessConfig;
+          export namespace ProcessConfig {
+            export type Tipping = Stripe.Terminal.Reader.Action.ProcessPaymentIntent.ProcessConfig.Tipping;
+          }
+        }
+        export namespace ProcessSetupIntent {
+          export type ProcessConfig = Stripe.Terminal.Reader.Action.ProcessSetupIntent.ProcessConfig;
+        }
+        export namespace RefundPayment {
+          export type Reason = Stripe.Terminal.Reader.Action.RefundPayment.Reason;
+          export type RefundPaymentConfig = Stripe.Terminal.Reader.Action.RefundPayment.RefundPaymentConfig;
+        }
+        export namespace SetReaderDisplay {
+          export type Cart = Stripe.Terminal.Reader.Action.SetReaderDisplay.Cart;
+          export namespace Cart {
+            export type LineItem = Stripe.Terminal.Reader.Action.SetReaderDisplay.Cart.LineItem;
+          }
+        }
+      }
     }
   }
   export namespace TestHelpers {
@@ -1954,6 +12323,13 @@ declare namespace StripeConstructor {
     export type TestClockDeleteParams = Stripe.TestHelpers.TestClockDeleteParams;
     export type TestClockAdvanceParams = Stripe.TestHelpers.TestClockAdvanceParams;
     export type TestClockResource = Stripe.TestHelpers.TestClockResource;
+    export namespace TestClock {
+      export type Status = Stripe.TestHelpers.TestClock.Status;
+      export type StatusDetails = Stripe.TestHelpers.TestClock.StatusDetails;
+      export namespace StatusDetails {
+        export type Advancing = Stripe.TestHelpers.TestClock.StatusDetails.Advancing;
+      }
+    }
   }
   export namespace Treasury {
     export type CreditReversal = Stripe.Treasury.CreditReversal;
@@ -2010,69 +12386,335 @@ declare namespace StripeConstructor {
     export type TransactionEntryListParams = Stripe.Treasury.TransactionEntryListParams;
     export type TransactionEntryResource = Stripe.Treasury.TransactionEntryResource;
     export type FinancialAccountFeatures = Stripe.Treasury.FinancialAccountFeatures;
-    export namespace CreditReversalListParams {
-      export type Status = Stripe.Treasury.CreditReversalListParams.Status;
+    export namespace CreditReversal {
+      export type Network = Stripe.Treasury.CreditReversal.Network;
+      export type Status = Stripe.Treasury.CreditReversal.Status;
+      export type StatusTransitions = Stripe.Treasury.CreditReversal.StatusTransitions;
     }
-    export namespace DebitReversalListParams {
-      export type Resolution = Stripe.Treasury.DebitReversalListParams.Resolution;
-      export type Status = Stripe.Treasury.DebitReversalListParams.Status;
+    export namespace DebitReversal {
+      export type LinkedFlows = Stripe.Treasury.DebitReversal.LinkedFlows;
+      export type Network = Stripe.Treasury.DebitReversal.Network;
+      export type Status = Stripe.Treasury.DebitReversal.Status;
+      export type StatusTransitions = Stripe.Treasury.DebitReversal.StatusTransitions;
     }
     export namespace FinancialAccountCreateParams {
       export type Features = Stripe.Treasury.FinancialAccountCreateParams.Features;
       export type PlatformRestrictions = Stripe.Treasury.FinancialAccountCreateParams.PlatformRestrictions;
+      export namespace Features {
+        export type CardIssuing = Stripe.Treasury.FinancialAccountCreateParams.Features.CardIssuing;
+        export type DepositInsurance = Stripe.Treasury.FinancialAccountCreateParams.Features.DepositInsurance;
+        export type FinancialAddresses = Stripe.Treasury.FinancialAccountCreateParams.Features.FinancialAddresses;
+        export type InboundTransfers = Stripe.Treasury.FinancialAccountCreateParams.Features.InboundTransfers;
+        export type IntraStripeFlows = Stripe.Treasury.FinancialAccountCreateParams.Features.IntraStripeFlows;
+        export type OutboundPayments = Stripe.Treasury.FinancialAccountCreateParams.Features.OutboundPayments;
+        export type OutboundTransfers = Stripe.Treasury.FinancialAccountCreateParams.Features.OutboundTransfers;
+        export namespace FinancialAddresses {
+          export type Aba = Stripe.Treasury.FinancialAccountCreateParams.Features.FinancialAddresses.Aba;
+        }
+        export namespace InboundTransfers {
+          export type Ach = Stripe.Treasury.FinancialAccountCreateParams.Features.InboundTransfers.Ach;
+        }
+        export namespace OutboundPayments {
+          export type Ach = Stripe.Treasury.FinancialAccountCreateParams.Features.OutboundPayments.Ach;
+          export type UsDomesticWire = Stripe.Treasury.FinancialAccountCreateParams.Features.OutboundPayments.UsDomesticWire;
+        }
+        export namespace OutboundTransfers {
+          export type Ach = Stripe.Treasury.FinancialAccountCreateParams.Features.OutboundTransfers.Ach;
+          export type UsDomesticWire = Stripe.Treasury.FinancialAccountCreateParams.Features.OutboundTransfers.UsDomesticWire;
+        }
+      }
+      export namespace PlatformRestrictions {
+        export type InboundFlows = Stripe.Treasury.FinancialAccountCreateParams.PlatformRestrictions.InboundFlows;
+        export type OutboundFlows = Stripe.Treasury.FinancialAccountCreateParams.PlatformRestrictions.OutboundFlows;
+      }
     }
-    export namespace FinancialAccountUpdateParams {
-      export type Features = Stripe.Treasury.FinancialAccountUpdateParams.Features;
-      export type ForwardingSettings = Stripe.Treasury.FinancialAccountUpdateParams.ForwardingSettings;
-      export type PlatformRestrictions = Stripe.Treasury.FinancialAccountUpdateParams.PlatformRestrictions;
+    export namespace FinancialAccount {
+      export type ActiveFeature = Stripe.Treasury.FinancialAccount.ActiveFeature;
+      export type Balance = Stripe.Treasury.FinancialAccount.Balance;
+      export type FinancialAddress = Stripe.Treasury.FinancialAccount.FinancialAddress;
+      export type PendingFeature = Stripe.Treasury.FinancialAccount.PendingFeature;
+      export type PlatformRestrictions = Stripe.Treasury.FinancialAccount.PlatformRestrictions;
+      export type RestrictedFeature = Stripe.Treasury.FinancialAccount.RestrictedFeature;
+      export type Status = Stripe.Treasury.FinancialAccount.Status;
+      export type StatusDetails = Stripe.Treasury.FinancialAccount.StatusDetails;
+      export namespace FinancialAddress {
+        export type Aba = Stripe.Treasury.FinancialAccount.FinancialAddress.Aba;
+        export type SupportedNetwork = Stripe.Treasury.FinancialAccount.FinancialAddress.SupportedNetwork;
+      }
+      export namespace PlatformRestrictions {
+        export type InboundFlows = Stripe.Treasury.FinancialAccount.PlatformRestrictions.InboundFlows;
+        export type OutboundFlows = Stripe.Treasury.FinancialAccount.PlatformRestrictions.OutboundFlows;
+      }
+      export namespace StatusDetails {
+        export type Closed = Stripe.Treasury.FinancialAccount.StatusDetails.Closed;
+        export namespace Closed {
+          export type Reason = Stripe.Treasury.FinancialAccount.StatusDetails.Closed.Reason;
+        }
+      }
     }
-    export namespace FinancialAccountListParams {
-      export type Status = Stripe.Treasury.FinancialAccountListParams.Status;
-    }
-    export namespace FinancialAccountCloseParams {
-      export type ForwardingSettings = Stripe.Treasury.FinancialAccountCloseParams.ForwardingSettings;
-    }
-    export namespace FinancialAccountUpdateFeaturesParams {
-      export type CardIssuing = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.CardIssuing;
-      export type DepositInsurance = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.DepositInsurance;
-      export type FinancialAddresses = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.FinancialAddresses;
-      export type InboundTransfers = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.InboundTransfers;
-      export type IntraStripeFlows = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.IntraStripeFlows;
-      export type OutboundPayments = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.OutboundPayments;
-      export type OutboundTransfers = Stripe.Treasury.FinancialAccountUpdateFeaturesParams.OutboundTransfers;
-    }
-    export namespace InboundTransferListParams {
-      export type Status = Stripe.Treasury.InboundTransferListParams.Status;
+    export namespace InboundTransfer {
+      export type FailureDetails = Stripe.Treasury.InboundTransfer.FailureDetails;
+      export type LinkedFlows = Stripe.Treasury.InboundTransfer.LinkedFlows;
+      export type OriginPaymentMethodDetails = Stripe.Treasury.InboundTransfer.OriginPaymentMethodDetails;
+      export type Status = Stripe.Treasury.InboundTransfer.Status;
+      export type StatusTransitions = Stripe.Treasury.InboundTransfer.StatusTransitions;
+      export namespace FailureDetails {
+        export type Code = Stripe.Treasury.InboundTransfer.FailureDetails.Code;
+      }
+      export namespace OriginPaymentMethodDetails {
+        export type BillingDetails = Stripe.Treasury.InboundTransfer.OriginPaymentMethodDetails.BillingDetails;
+        export type UsBankAccount = Stripe.Treasury.InboundTransfer.OriginPaymentMethodDetails.UsBankAccount;
+        export namespace UsBankAccount {
+          export type AccountHolderType = Stripe.Treasury.InboundTransfer.OriginPaymentMethodDetails.UsBankAccount.AccountHolderType;
+          export type AccountType = Stripe.Treasury.InboundTransfer.OriginPaymentMethodDetails.UsBankAccount.AccountType;
+        }
+      }
     }
     export namespace OutboundPaymentCreateParams {
       export type DestinationPaymentMethodData = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodData;
       export type DestinationPaymentMethodOptions = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodOptions;
       export type EndUserDetails = Stripe.Treasury.OutboundPaymentCreateParams.EndUserDetails;
+      export namespace DestinationPaymentMethodData {
+        export type BillingDetails = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodData.BillingDetails;
+        export type Type = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodData.Type;
+        export type UsBankAccount = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodData.UsBankAccount;
+        export namespace UsBankAccount {
+          export type AccountHolderType = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodData.UsBankAccount.AccountHolderType;
+          export type AccountType = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodData.UsBankAccount.AccountType;
+        }
+      }
+      export namespace DestinationPaymentMethodOptions {
+        export type UsBankAccount = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodOptions.UsBankAccount;
+        export namespace UsBankAccount {
+          export type Network = Stripe.Treasury.OutboundPaymentCreateParams.DestinationPaymentMethodOptions.UsBankAccount.Network;
+        }
+      }
     }
-    export namespace OutboundPaymentListParams {
-      export type Status = Stripe.Treasury.OutboundPaymentListParams.Status;
+    export namespace OutboundPayment {
+      export type DestinationPaymentMethodDetails = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails;
+      export type EndUserDetails = Stripe.Treasury.OutboundPayment.EndUserDetails;
+      export type ReturnedDetails = Stripe.Treasury.OutboundPayment.ReturnedDetails;
+      export type Status = Stripe.Treasury.OutboundPayment.Status;
+      export type StatusTransitions = Stripe.Treasury.OutboundPayment.StatusTransitions;
+      export type TrackingDetails = Stripe.Treasury.OutboundPayment.TrackingDetails;
+      export namespace DestinationPaymentMethodDetails {
+        export type BillingDetails = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.BillingDetails;
+        export type FinancialAccount = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.FinancialAccount;
+        export type Type = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.Type;
+        export type UsBankAccount = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.UsBankAccount;
+        export namespace UsBankAccount {
+          export type AccountHolderType = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.UsBankAccount.AccountHolderType;
+          export type AccountType = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.UsBankAccount.AccountType;
+          export type Network = Stripe.Treasury.OutboundPayment.DestinationPaymentMethodDetails.UsBankAccount.Network;
+        }
+      }
+      export namespace ReturnedDetails {
+        export type Code = Stripe.Treasury.OutboundPayment.ReturnedDetails.Code;
+      }
+      export namespace TrackingDetails {
+        export type Ach = Stripe.Treasury.OutboundPayment.TrackingDetails.Ach;
+        export type Type = Stripe.Treasury.OutboundPayment.TrackingDetails.Type;
+        export type UsDomesticWire = Stripe.Treasury.OutboundPayment.TrackingDetails.UsDomesticWire;
+      }
     }
     export namespace OutboundTransferCreateParams {
       export type DestinationPaymentMethodData = Stripe.Treasury.OutboundTransferCreateParams.DestinationPaymentMethodData;
       export type DestinationPaymentMethodOptions = Stripe.Treasury.OutboundTransferCreateParams.DestinationPaymentMethodOptions;
+      export namespace DestinationPaymentMethodOptions {
+        export type UsBankAccount = Stripe.Treasury.OutboundTransferCreateParams.DestinationPaymentMethodOptions.UsBankAccount;
+        export namespace UsBankAccount {
+          export type Network = Stripe.Treasury.OutboundTransferCreateParams.DestinationPaymentMethodOptions.UsBankAccount.Network;
+        }
+      }
     }
-    export namespace OutboundTransferListParams {
-      export type Status = Stripe.Treasury.OutboundTransferListParams.Status;
+    export namespace OutboundTransfer {
+      export type DestinationPaymentMethodDetails = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails;
+      export type ReturnedDetails = Stripe.Treasury.OutboundTransfer.ReturnedDetails;
+      export type Status = Stripe.Treasury.OutboundTransfer.Status;
+      export type StatusTransitions = Stripe.Treasury.OutboundTransfer.StatusTransitions;
+      export type TrackingDetails = Stripe.Treasury.OutboundTransfer.TrackingDetails;
+      export namespace DestinationPaymentMethodDetails {
+        export type BillingDetails = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.BillingDetails;
+        export type FinancialAccount = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.FinancialAccount;
+        export type Type = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.Type;
+        export type UsBankAccount = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.UsBankAccount;
+        export namespace UsBankAccount {
+          export type AccountHolderType = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.UsBankAccount.AccountHolderType;
+          export type AccountType = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.UsBankAccount.AccountType;
+          export type Network = Stripe.Treasury.OutboundTransfer.DestinationPaymentMethodDetails.UsBankAccount.Network;
+        }
+      }
+      export namespace ReturnedDetails {
+        export type Code = Stripe.Treasury.OutboundTransfer.ReturnedDetails.Code;
+      }
+      export namespace TrackingDetails {
+        export type Ach = Stripe.Treasury.OutboundTransfer.TrackingDetails.Ach;
+        export type Type = Stripe.Treasury.OutboundTransfer.TrackingDetails.Type;
+        export type UsDomesticWire = Stripe.Treasury.OutboundTransfer.TrackingDetails.UsDomesticWire;
+      }
     }
-    export namespace ReceivedCreditListParams {
-      export type LinkedFlows = Stripe.Treasury.ReceivedCreditListParams.LinkedFlows;
-      export type Status = Stripe.Treasury.ReceivedCreditListParams.Status;
+    export namespace ReceivedCredit {
+      export type FailureCode = Stripe.Treasury.ReceivedCredit.FailureCode;
+      export type InitiatingPaymentMethodDetails = Stripe.Treasury.ReceivedCredit.InitiatingPaymentMethodDetails;
+      export type LinkedFlows = Stripe.Treasury.ReceivedCredit.LinkedFlows;
+      export type Network = Stripe.Treasury.ReceivedCredit.Network;
+      export type ReversalDetails = Stripe.Treasury.ReceivedCredit.ReversalDetails;
+      export type Status = Stripe.Treasury.ReceivedCredit.Status;
+      export namespace InitiatingPaymentMethodDetails {
+        export type BillingDetails = Stripe.Treasury.ReceivedCredit.InitiatingPaymentMethodDetails.BillingDetails;
+        export type FinancialAccount = Stripe.Treasury.ReceivedCredit.InitiatingPaymentMethodDetails.FinancialAccount;
+        export type Type = Stripe.Treasury.ReceivedCredit.InitiatingPaymentMethodDetails.Type;
+        export type UsBankAccount = Stripe.Treasury.ReceivedCredit.InitiatingPaymentMethodDetails.UsBankAccount;
+      }
+      export namespace LinkedFlows {
+        export type SourceFlowDetails = Stripe.Treasury.ReceivedCredit.LinkedFlows.SourceFlowDetails;
+        export namespace SourceFlowDetails {
+          export type Type = Stripe.Treasury.ReceivedCredit.LinkedFlows.SourceFlowDetails.Type;
+        }
+      }
+      export namespace ReversalDetails {
+        export type RestrictedReason = Stripe.Treasury.ReceivedCredit.ReversalDetails.RestrictedReason;
+      }
     }
-    export namespace ReceivedDebitListParams {
-      export type Status = Stripe.Treasury.ReceivedDebitListParams.Status;
+    export namespace ReceivedDebit {
+      export type FailureCode = Stripe.Treasury.ReceivedDebit.FailureCode;
+      export type InitiatingPaymentMethodDetails = Stripe.Treasury.ReceivedDebit.InitiatingPaymentMethodDetails;
+      export type LinkedFlows = Stripe.Treasury.ReceivedDebit.LinkedFlows;
+      export type Network = Stripe.Treasury.ReceivedDebit.Network;
+      export type ReversalDetails = Stripe.Treasury.ReceivedDebit.ReversalDetails;
+      export type Status = Stripe.Treasury.ReceivedDebit.Status;
+      export namespace InitiatingPaymentMethodDetails {
+        export type BillingDetails = Stripe.Treasury.ReceivedDebit.InitiatingPaymentMethodDetails.BillingDetails;
+        export type FinancialAccount = Stripe.Treasury.ReceivedDebit.InitiatingPaymentMethodDetails.FinancialAccount;
+        export type Type = Stripe.Treasury.ReceivedDebit.InitiatingPaymentMethodDetails.Type;
+        export type UsBankAccount = Stripe.Treasury.ReceivedDebit.InitiatingPaymentMethodDetails.UsBankAccount;
+      }
+      export namespace ReversalDetails {
+        export type RestrictedReason = Stripe.Treasury.ReceivedDebit.ReversalDetails.RestrictedReason;
+      }
     }
-    export namespace TransactionListParams {
-      export type OrderBy = Stripe.Treasury.TransactionListParams.OrderBy;
-      export type Status = Stripe.Treasury.TransactionListParams.Status;
-      export type StatusTransitions = Stripe.Treasury.TransactionListParams.StatusTransitions;
+    export namespace Transaction {
+      export type BalanceImpact = Stripe.Treasury.Transaction.BalanceImpact;
+      export type FlowDetails = Stripe.Treasury.Transaction.FlowDetails;
+      export type FlowType = Stripe.Treasury.Transaction.FlowType;
+      export type Status = Stripe.Treasury.Transaction.Status;
+      export type StatusTransitions = Stripe.Treasury.Transaction.StatusTransitions;
+      export namespace FlowDetails {
+        export type Type = Stripe.Treasury.Transaction.FlowDetails.Type;
+      }
     }
-    export namespace TransactionEntryListParams {
-      export type OrderBy = Stripe.Treasury.TransactionEntryListParams.OrderBy;
+    export namespace TransactionEntry {
+      export type BalanceImpact = Stripe.Treasury.TransactionEntry.BalanceImpact;
+      export type FlowDetails = Stripe.Treasury.TransactionEntry.FlowDetails;
+      export type FlowType = Stripe.Treasury.TransactionEntry.FlowType;
+      export type Type = Stripe.Treasury.TransactionEntry.Type;
+      export namespace FlowDetails {
+        export type Type = Stripe.Treasury.TransactionEntry.FlowDetails.Type;
+      }
+    }
+    export namespace FinancialAccountFeatures {
+      export type CardIssuing = Stripe.Treasury.FinancialAccountFeatures.CardIssuing;
+      export type DepositInsurance = Stripe.Treasury.FinancialAccountFeatures.DepositInsurance;
+      export type FinancialAddresses = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses;
+      export type InboundTransfers = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers;
+      export type IntraStripeFlows = Stripe.Treasury.FinancialAccountFeatures.IntraStripeFlows;
+      export type OutboundPayments = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments;
+      export type OutboundTransfers = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers;
+      export namespace CardIssuing {
+        export type Status = Stripe.Treasury.FinancialAccountFeatures.CardIssuing.Status;
+        export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.CardIssuing.StatusDetail;
+        export namespace StatusDetail {
+          export type Code = Stripe.Treasury.FinancialAccountFeatures.CardIssuing.StatusDetail.Code;
+          export type Resolution = Stripe.Treasury.FinancialAccountFeatures.CardIssuing.StatusDetail.Resolution;
+          export type Restriction = Stripe.Treasury.FinancialAccountFeatures.CardIssuing.StatusDetail.Restriction;
+        }
+      }
+      export namespace DepositInsurance {
+        export type Status = Stripe.Treasury.FinancialAccountFeatures.DepositInsurance.Status;
+        export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.DepositInsurance.StatusDetail;
+        export namespace StatusDetail {
+          export type Code = Stripe.Treasury.FinancialAccountFeatures.DepositInsurance.StatusDetail.Code;
+          export type Resolution = Stripe.Treasury.FinancialAccountFeatures.DepositInsurance.StatusDetail.Resolution;
+          export type Restriction = Stripe.Treasury.FinancialAccountFeatures.DepositInsurance.StatusDetail.Restriction;
+        }
+      }
+      export namespace FinancialAddresses {
+        export type Aba = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses.Aba;
+        export namespace Aba {
+          export type Status = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses.Aba.Status;
+          export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses.Aba.StatusDetail;
+          export namespace StatusDetail {
+            export type Code = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses.Aba.StatusDetail.Code;
+            export type Resolution = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses.Aba.StatusDetail.Resolution;
+            export type Restriction = Stripe.Treasury.FinancialAccountFeatures.FinancialAddresses.Aba.StatusDetail.Restriction;
+          }
+        }
+      }
+      export namespace InboundTransfers {
+        export type Ach = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers.Ach;
+        export namespace Ach {
+          export type Status = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers.Ach.Status;
+          export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers.Ach.StatusDetail;
+          export namespace StatusDetail {
+            export type Code = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers.Ach.StatusDetail.Code;
+            export type Resolution = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers.Ach.StatusDetail.Resolution;
+            export type Restriction = Stripe.Treasury.FinancialAccountFeatures.InboundTransfers.Ach.StatusDetail.Restriction;
+          }
+        }
+      }
+      export namespace IntraStripeFlows {
+        export type Status = Stripe.Treasury.FinancialAccountFeatures.IntraStripeFlows.Status;
+        export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.IntraStripeFlows.StatusDetail;
+        export namespace StatusDetail {
+          export type Code = Stripe.Treasury.FinancialAccountFeatures.IntraStripeFlows.StatusDetail.Code;
+          export type Resolution = Stripe.Treasury.FinancialAccountFeatures.IntraStripeFlows.StatusDetail.Resolution;
+          export type Restriction = Stripe.Treasury.FinancialAccountFeatures.IntraStripeFlows.StatusDetail.Restriction;
+        }
+      }
+      export namespace OutboundPayments {
+        export type Ach = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.Ach;
+        export type UsDomesticWire = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.UsDomesticWire;
+        export namespace Ach {
+          export type Status = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.Ach.Status;
+          export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.Ach.StatusDetail;
+          export namespace StatusDetail {
+            export type Code = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.Ach.StatusDetail.Code;
+            export type Resolution = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.Ach.StatusDetail.Resolution;
+            export type Restriction = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.Ach.StatusDetail.Restriction;
+          }
+        }
+        export namespace UsDomesticWire {
+          export type Status = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.UsDomesticWire.Status;
+          export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.UsDomesticWire.StatusDetail;
+          export namespace StatusDetail {
+            export type Code = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.UsDomesticWire.StatusDetail.Code;
+            export type Resolution = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.UsDomesticWire.StatusDetail.Resolution;
+            export type Restriction = Stripe.Treasury.FinancialAccountFeatures.OutboundPayments.UsDomesticWire.StatusDetail.Restriction;
+          }
+        }
+      }
+      export namespace OutboundTransfers {
+        export type Ach = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.Ach;
+        export type UsDomesticWire = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.UsDomesticWire;
+        export namespace Ach {
+          export type Status = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.Ach.Status;
+          export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.Ach.StatusDetail;
+          export namespace StatusDetail {
+            export type Code = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.Ach.StatusDetail.Code;
+            export type Resolution = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.Ach.StatusDetail.Resolution;
+            export type Restriction = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.Ach.StatusDetail.Restriction;
+          }
+        }
+        export namespace UsDomesticWire {
+          export type Status = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.UsDomesticWire.Status;
+          export type StatusDetail = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.UsDomesticWire.StatusDetail;
+          export namespace StatusDetail {
+            export type Code = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.UsDomesticWire.StatusDetail.Code;
+            export type Resolution = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.UsDomesticWire.StatusDetail.Resolution;
+            export type Restriction = Stripe.Treasury.FinancialAccountFeatures.OutboundTransfers.UsDomesticWire.StatusDetail.Restriction;
+          }
+        }
+      }
     }
   }
   export namespace V2 {
@@ -2089,6 +12731,10 @@ declare namespace StripeConstructor {
       export type MeterEventSessionResource = Stripe.V2.Billing.MeterEventSessionResource;
       export namespace MeterEventAdjustmentCreateParams {
         export type Cancel = Stripe.V2.Billing.MeterEventAdjustmentCreateParams.Cancel;
+      }
+      export namespace MeterEventAdjustment {
+        export type Cancel = Stripe.V2.Billing.MeterEventAdjustment.Cancel;
+        export type Status = Stripe.V2.Billing.MeterEventAdjustment.Status;
       }
     }
     export namespace Core {
@@ -2130,28 +12776,1085 @@ declare namespace StripeConstructor {
         export type Defaults = Stripe.V2.Core.AccountCreateParams.Defaults;
         export type Identity = Stripe.V2.Core.AccountCreateParams.Identity;
         export type Include = Stripe.V2.Core.AccountCreateParams.Include;
+        export namespace Configuration {
+          export type Customer = Stripe.V2.Core.AccountCreateParams.Configuration.Customer;
+          export type Merchant = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant;
+          export type Recipient = Stripe.V2.Core.AccountCreateParams.Configuration.Recipient;
+          export namespace Customer {
+            export type AutomaticIndirectTax = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.AutomaticIndirectTax;
+            export type Billing = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Billing;
+            export type Capabilities = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Capabilities;
+            export type Shipping = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Shipping;
+            export namespace AutomaticIndirectTax {
+              export type Exempt = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.AutomaticIndirectTax.Exempt;
+            }
+            export namespace Billing {
+              export type Invoice = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Billing.Invoice;
+              export namespace Invoice {
+                export type CustomField = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Billing.Invoice.CustomField;
+                export type Rendering = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Billing.Invoice.Rendering;
+                export namespace Rendering {
+                  export type AmountTaxDisplay = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Billing.Invoice.Rendering.AmountTaxDisplay;
+                }
+              }
+            }
+            export namespace Capabilities {
+              export type AutomaticIndirectTax = Stripe.V2.Core.AccountCreateParams.Configuration.Customer.Capabilities.AutomaticIndirectTax;
+            }
+          }
+          export namespace Merchant {
+            export type BacsDebitPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.BacsDebitPayments;
+            export type Branding = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Branding;
+            export type Capabilities = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities;
+            export type CardPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.CardPayments;
+            export type KonbiniPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.KonbiniPayments;
+            export type ScriptStatementDescriptor = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.ScriptStatementDescriptor;
+            export type StatementDescriptor = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.StatementDescriptor;
+            export type Support = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Support;
+            export namespace Capabilities {
+              export type AchDebitPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AchDebitPayments;
+              export type AcssDebitPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AcssDebitPayments;
+              export type AffirmPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AffirmPayments;
+              export type AfterpayClearpayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AfterpayClearpayPayments;
+              export type AlmaPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AlmaPayments;
+              export type AmazonPayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AmazonPayPayments;
+              export type AuBecsDebitPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.AuBecsDebitPayments;
+              export type BacsDebitPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.BacsDebitPayments;
+              export type BancontactPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.BancontactPayments;
+              export type BlikPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.BlikPayments;
+              export type BoletoPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.BoletoPayments;
+              export type CardPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.CardPayments;
+              export type CartesBancairesPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.CartesBancairesPayments;
+              export type CashappPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.CashappPayments;
+              export type EpsPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.EpsPayments;
+              export type FpxPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.FpxPayments;
+              export type GbBankTransferPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.GbBankTransferPayments;
+              export type GrabpayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.GrabpayPayments;
+              export type IdealPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.IdealPayments;
+              export type JcbPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.JcbPayments;
+              export type JpBankTransferPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.JpBankTransferPayments;
+              export type KakaoPayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.KakaoPayPayments;
+              export type KlarnaPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.KlarnaPayments;
+              export type KonbiniPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.KonbiniPayments;
+              export type KrCardPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.KrCardPayments;
+              export type LinkPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.LinkPayments;
+              export type MobilepayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.MobilepayPayments;
+              export type MultibancoPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.MultibancoPayments;
+              export type MxBankTransferPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.MxBankTransferPayments;
+              export type NaverPayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.NaverPayPayments;
+              export type OxxoPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.OxxoPayments;
+              export type P24Payments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.P24Payments;
+              export type PayByBankPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.PayByBankPayments;
+              export type PaycoPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.PaycoPayments;
+              export type PaynowPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.PaynowPayments;
+              export type PromptpayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.PromptpayPayments;
+              export type RevolutPayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.RevolutPayPayments;
+              export type SamsungPayPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.SamsungPayPayments;
+              export type SepaBankTransferPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.SepaBankTransferPayments;
+              export type SepaDebitPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.SepaDebitPayments;
+              export type SwishPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.SwishPayments;
+              export type TwintPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.TwintPayments;
+              export type UsBankTransferPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.UsBankTransferPayments;
+              export type ZipPayments = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Capabilities.ZipPayments;
+            }
+            export namespace CardPayments {
+              export type DeclineOn = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.CardPayments.DeclineOn;
+            }
+            export namespace KonbiniPayments {
+              export type Support = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.KonbiniPayments.Support;
+              export namespace Support {
+                export type Hours = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.KonbiniPayments.Support.Hours;
+              }
+            }
+            export namespace ScriptStatementDescriptor {
+              export type Kana = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.ScriptStatementDescriptor.Kana;
+              export type Kanji = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.ScriptStatementDescriptor.Kanji;
+            }
+            export namespace Support {
+              export type Address = Stripe.V2.Core.AccountCreateParams.Configuration.Merchant.Support.Address;
+            }
+          }
+          export namespace Recipient {
+            export type Capabilities = Stripe.V2.Core.AccountCreateParams.Configuration.Recipient.Capabilities;
+            export namespace Capabilities {
+              export type StripeBalance = Stripe.V2.Core.AccountCreateParams.Configuration.Recipient.Capabilities.StripeBalance;
+              export namespace StripeBalance {
+                export type StripeTransfers = Stripe.V2.Core.AccountCreateParams.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers;
+              }
+            }
+          }
+        }
+        export namespace Defaults {
+          export type Locale = Stripe.V2.Core.AccountCreateParams.Defaults.Locale;
+          export type Profile = Stripe.V2.Core.AccountCreateParams.Defaults.Profile;
+          export type Responsibilities = Stripe.V2.Core.AccountCreateParams.Defaults.Responsibilities;
+          export namespace Responsibilities {
+            export type FeesCollector = Stripe.V2.Core.AccountCreateParams.Defaults.Responsibilities.FeesCollector;
+            export type LossesCollector = Stripe.V2.Core.AccountCreateParams.Defaults.Responsibilities.LossesCollector;
+          }
+        }
+        export namespace Identity {
+          export type Attestations = Stripe.V2.Core.AccountCreateParams.Identity.Attestations;
+          export type BusinessDetails = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails;
+          export type EntityType = Stripe.V2.Core.AccountCreateParams.Identity.EntityType;
+          export type Individual = Stripe.V2.Core.AccountCreateParams.Identity.Individual;
+          export namespace Attestations {
+            export type DirectorshipDeclaration = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.DirectorshipDeclaration;
+            export type OwnershipDeclaration = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.OwnershipDeclaration;
+            export type PersonsProvided = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.PersonsProvided;
+            export type RepresentativeDeclaration = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.RepresentativeDeclaration;
+            export type TermsOfService = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.TermsOfService;
+            export namespace PersonsProvided {
+              export type OwnershipExemptionReason = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.PersonsProvided.OwnershipExemptionReason;
+            }
+            export namespace TermsOfService {
+              export type Account = Stripe.V2.Core.AccountCreateParams.Identity.Attestations.TermsOfService.Account;
+            }
+          }
+          export namespace BusinessDetails {
+            export type Address = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Address;
+            export type AnnualRevenue = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.AnnualRevenue;
+            export type Documents = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents;
+            export type IdNumber = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.IdNumber;
+            export type MonthlyEstimatedRevenue = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.MonthlyEstimatedRevenue;
+            export type RegistrationDate = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.RegistrationDate;
+            export type ScriptAddresses = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.ScriptAddresses;
+            export type ScriptNames = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.ScriptNames;
+            export type Structure = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Structure;
+            export namespace Documents {
+              export type BankAccountOwnershipVerification = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.BankAccountOwnershipVerification;
+              export type CompanyLicense = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.CompanyLicense;
+              export type CompanyMemorandumOfAssociation = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.CompanyMemorandumOfAssociation;
+              export type CompanyMinisterialDecree = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.CompanyMinisterialDecree;
+              export type CompanyRegistrationVerification = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.CompanyRegistrationVerification;
+              export type CompanyTaxIdVerification = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.CompanyTaxIdVerification;
+              export type PrimaryVerification = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.PrimaryVerification;
+              export type ProofOfAddress = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.ProofOfAddress;
+              export type ProofOfRegistration = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.ProofOfRegistration;
+              export type ProofOfUltimateBeneficialOwnership = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.ProofOfUltimateBeneficialOwnership;
+              export namespace PrimaryVerification {
+                export type FrontBack = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.PrimaryVerification.FrontBack;
+              }
+              export namespace ProofOfRegistration {
+                export type Signer = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.ProofOfRegistration.Signer;
+              }
+              export namespace ProofOfUltimateBeneficialOwnership {
+                export type Signer = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.Documents.ProofOfUltimateBeneficialOwnership.Signer;
+              }
+            }
+            export namespace IdNumber {
+              export type Type = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.IdNumber.Type;
+            }
+            export namespace ScriptAddresses {
+              export type Kana = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.ScriptAddresses.Kana;
+              export type Kanji = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.ScriptAddresses.Kanji;
+            }
+            export namespace ScriptNames {
+              export type Kana = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.ScriptNames.Kana;
+              export type Kanji = Stripe.V2.Core.AccountCreateParams.Identity.BusinessDetails.ScriptNames.Kanji;
+            }
+          }
+          export namespace Individual {
+            export type AdditionalAddress = Stripe.V2.Core.AccountCreateParams.Identity.Individual.AdditionalAddress;
+            export type AdditionalName = Stripe.V2.Core.AccountCreateParams.Identity.Individual.AdditionalName;
+            export type Address = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Address;
+            export type DateOfBirth = Stripe.V2.Core.AccountCreateParams.Identity.Individual.DateOfBirth;
+            export type Documents = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents;
+            export type IdNumber = Stripe.V2.Core.AccountCreateParams.Identity.Individual.IdNumber;
+            export type LegalGender = Stripe.V2.Core.AccountCreateParams.Identity.Individual.LegalGender;
+            export type PoliticalExposure = Stripe.V2.Core.AccountCreateParams.Identity.Individual.PoliticalExposure;
+            export type Relationship = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Relationship;
+            export type ScriptAddresses = Stripe.V2.Core.AccountCreateParams.Identity.Individual.ScriptAddresses;
+            export type ScriptNames = Stripe.V2.Core.AccountCreateParams.Identity.Individual.ScriptNames;
+            export namespace AdditionalName {
+              export type Purpose = Stripe.V2.Core.AccountCreateParams.Identity.Individual.AdditionalName.Purpose;
+            }
+            export namespace Documents {
+              export type CompanyAuthorization = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.CompanyAuthorization;
+              export type Passport = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.Passport;
+              export type PrimaryVerification = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.PrimaryVerification;
+              export type SecondaryVerification = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.SecondaryVerification;
+              export type Visa = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.Visa;
+              export namespace PrimaryVerification {
+                export type FrontBack = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.PrimaryVerification.FrontBack;
+              }
+              export namespace SecondaryVerification {
+                export type FrontBack = Stripe.V2.Core.AccountCreateParams.Identity.Individual.Documents.SecondaryVerification.FrontBack;
+              }
+            }
+            export namespace IdNumber {
+              export type Type = Stripe.V2.Core.AccountCreateParams.Identity.Individual.IdNumber.Type;
+            }
+            export namespace ScriptAddresses {
+              export type Kana = Stripe.V2.Core.AccountCreateParams.Identity.Individual.ScriptAddresses.Kana;
+              export type Kanji = Stripe.V2.Core.AccountCreateParams.Identity.Individual.ScriptAddresses.Kanji;
+            }
+            export namespace ScriptNames {
+              export type Kana = Stripe.V2.Core.AccountCreateParams.Identity.Individual.ScriptNames.Kana;
+              export type Kanji = Stripe.V2.Core.AccountCreateParams.Identity.Individual.ScriptNames.Kanji;
+            }
+          }
+        }
       }
-      export namespace AccountRetrieveParams {
-        export type Include = Stripe.V2.Core.AccountRetrieveParams.Include;
-      }
-      export namespace AccountUpdateParams {
-        export type Configuration = Stripe.V2.Core.AccountUpdateParams.Configuration;
-        export type Dashboard = Stripe.V2.Core.AccountUpdateParams.Dashboard;
-        export type Defaults = Stripe.V2.Core.AccountUpdateParams.Defaults;
-        export type Identity = Stripe.V2.Core.AccountUpdateParams.Identity;
-        export type Include = Stripe.V2.Core.AccountUpdateParams.Include;
-      }
-      export namespace AccountListParams {
-        export type AppliedConfiguration = Stripe.V2.Core.AccountListParams.AppliedConfiguration;
-      }
-      export namespace AccountCloseParams {
-        export type AppliedConfiguration = Stripe.V2.Core.AccountCloseParams.AppliedConfiguration;
+      export namespace Account {
+        export type AppliedConfiguration = Stripe.V2.Core.Account.AppliedConfiguration;
+        export type Configuration = Stripe.V2.Core.Account.Configuration;
+        export type Dashboard = Stripe.V2.Core.Account.Dashboard;
+        export type Defaults = Stripe.V2.Core.Account.Defaults;
+        export type FutureRequirements = Stripe.V2.Core.Account.FutureRequirements;
+        export type Identity = Stripe.V2.Core.Account.Identity;
+        export type Requirements = Stripe.V2.Core.Account.Requirements;
+        export namespace Configuration {
+          export type Customer = Stripe.V2.Core.Account.Configuration.Customer;
+          export type Merchant = Stripe.V2.Core.Account.Configuration.Merchant;
+          export type Recipient = Stripe.V2.Core.Account.Configuration.Recipient;
+          export namespace Customer {
+            export type AutomaticIndirectTax = Stripe.V2.Core.Account.Configuration.Customer.AutomaticIndirectTax;
+            export type Billing = Stripe.V2.Core.Account.Configuration.Customer.Billing;
+            export type Capabilities = Stripe.V2.Core.Account.Configuration.Customer.Capabilities;
+            export type Shipping = Stripe.V2.Core.Account.Configuration.Customer.Shipping;
+            export namespace AutomaticIndirectTax {
+              export type Exempt = Stripe.V2.Core.Account.Configuration.Customer.AutomaticIndirectTax.Exempt;
+              export type Location = Stripe.V2.Core.Account.Configuration.Customer.AutomaticIndirectTax.Location;
+              export type LocationSource = Stripe.V2.Core.Account.Configuration.Customer.AutomaticIndirectTax.LocationSource;
+            }
+            export namespace Billing {
+              export type Invoice = Stripe.V2.Core.Account.Configuration.Customer.Billing.Invoice;
+              export namespace Invoice {
+                export type CustomField = Stripe.V2.Core.Account.Configuration.Customer.Billing.Invoice.CustomField;
+                export type Rendering = Stripe.V2.Core.Account.Configuration.Customer.Billing.Invoice.Rendering;
+                export namespace Rendering {
+                  export type AmountTaxDisplay = Stripe.V2.Core.Account.Configuration.Customer.Billing.Invoice.Rendering.AmountTaxDisplay;
+                }
+              }
+            }
+            export namespace Capabilities {
+              export type AutomaticIndirectTax = Stripe.V2.Core.Account.Configuration.Customer.Capabilities.AutomaticIndirectTax;
+              export namespace AutomaticIndirectTax {
+                export type Status = Stripe.V2.Core.Account.Configuration.Customer.Capabilities.AutomaticIndirectTax.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Customer.Capabilities.AutomaticIndirectTax.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Customer.Capabilities.AutomaticIndirectTax.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Customer.Capabilities.AutomaticIndirectTax.StatusDetail.Resolution;
+                }
+              }
+            }
+            export namespace Shipping {
+              export type Address = Stripe.V2.Core.Account.Configuration.Customer.Shipping.Address;
+            }
+          }
+          export namespace Merchant {
+            export type BacsDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.BacsDebitPayments;
+            export type Branding = Stripe.V2.Core.Account.Configuration.Merchant.Branding;
+            export type Capabilities = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities;
+            export type CardPayments = Stripe.V2.Core.Account.Configuration.Merchant.CardPayments;
+            export type KonbiniPayments = Stripe.V2.Core.Account.Configuration.Merchant.KonbiniPayments;
+            export type ScriptStatementDescriptor = Stripe.V2.Core.Account.Configuration.Merchant.ScriptStatementDescriptor;
+            export type SepaDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.SepaDebitPayments;
+            export type StatementDescriptor = Stripe.V2.Core.Account.Configuration.Merchant.StatementDescriptor;
+            export type Support = Stripe.V2.Core.Account.Configuration.Merchant.Support;
+            export namespace Capabilities {
+              export type AchDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AchDebitPayments;
+              export type AcssDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AcssDebitPayments;
+              export type AffirmPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AffirmPayments;
+              export type AfterpayClearpayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AfterpayClearpayPayments;
+              export type AlmaPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AlmaPayments;
+              export type AmazonPayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AmazonPayPayments;
+              export type AuBecsDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AuBecsDebitPayments;
+              export type BacsDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BacsDebitPayments;
+              export type BancontactPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BancontactPayments;
+              export type BlikPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BlikPayments;
+              export type BoletoPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BoletoPayments;
+              export type CardPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CardPayments;
+              export type CartesBancairesPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CartesBancairesPayments;
+              export type CashappPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CashappPayments;
+              export type EpsPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.EpsPayments;
+              export type FpxPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.FpxPayments;
+              export type GbBankTransferPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GbBankTransferPayments;
+              export type GrabpayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GrabpayPayments;
+              export type IdealPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.IdealPayments;
+              export type JcbPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JcbPayments;
+              export type JpBankTransferPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JpBankTransferPayments;
+              export type KakaoPayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KakaoPayPayments;
+              export type KlarnaPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KlarnaPayments;
+              export type KonbiniPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KonbiniPayments;
+              export type KrCardPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KrCardPayments;
+              export type LinkPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.LinkPayments;
+              export type MobilepayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MobilepayPayments;
+              export type MultibancoPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MultibancoPayments;
+              export type MxBankTransferPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MxBankTransferPayments;
+              export type NaverPayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.NaverPayPayments;
+              export type OxxoPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.OxxoPayments;
+              export type P24Payments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.P24Payments;
+              export type PayByBankPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PayByBankPayments;
+              export type PaycoPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaycoPayments;
+              export type PaynowPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaynowPayments;
+              export type PromptpayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PromptpayPayments;
+              export type RevolutPayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.RevolutPayPayments;
+              export type SamsungPayPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SamsungPayPayments;
+              export type SepaBankTransferPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaBankTransferPayments;
+              export type SepaDebitPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaDebitPayments;
+              export type StripeBalance = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.StripeBalance;
+              export type SwishPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SwishPayments;
+              export type TwintPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.TwintPayments;
+              export type UsBankTransferPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.UsBankTransferPayments;
+              export type ZipPayments = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.ZipPayments;
+              export namespace AchDebitPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AchDebitPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AchDebitPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AchDebitPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AchDebitPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace AcssDebitPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AcssDebitPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AcssDebitPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AcssDebitPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AcssDebitPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace AffirmPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AffirmPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AffirmPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AffirmPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AffirmPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace AfterpayClearpayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AfterpayClearpayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AfterpayClearpayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AfterpayClearpayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AfterpayClearpayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace AlmaPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AlmaPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AlmaPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AlmaPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AlmaPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace AmazonPayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AmazonPayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AmazonPayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AmazonPayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AmazonPayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace AuBecsDebitPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AuBecsDebitPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AuBecsDebitPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AuBecsDebitPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.AuBecsDebitPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace BacsDebitPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BacsDebitPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BacsDebitPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BacsDebitPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BacsDebitPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace BancontactPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BancontactPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BancontactPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BancontactPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BancontactPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace BlikPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BlikPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BlikPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BlikPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BlikPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace BoletoPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BoletoPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BoletoPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BoletoPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.BoletoPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace CardPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CardPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CardPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CardPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CardPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace CartesBancairesPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CartesBancairesPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CartesBancairesPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CartesBancairesPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CartesBancairesPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace CashappPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CashappPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CashappPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CashappPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.CashappPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace EpsPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.EpsPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.EpsPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.EpsPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.EpsPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace FpxPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.FpxPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.FpxPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.FpxPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.FpxPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace GbBankTransferPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GbBankTransferPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GbBankTransferPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GbBankTransferPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GbBankTransferPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace GrabpayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GrabpayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GrabpayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GrabpayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.GrabpayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace IdealPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.IdealPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.IdealPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.IdealPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.IdealPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace JcbPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JcbPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JcbPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JcbPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JcbPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace JpBankTransferPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JpBankTransferPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JpBankTransferPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JpBankTransferPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.JpBankTransferPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace KakaoPayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KakaoPayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KakaoPayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KakaoPayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KakaoPayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace KlarnaPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KlarnaPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KlarnaPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KlarnaPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KlarnaPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace KonbiniPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KonbiniPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KonbiniPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KonbiniPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KonbiniPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace KrCardPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KrCardPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KrCardPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KrCardPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.KrCardPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace LinkPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.LinkPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.LinkPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.LinkPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.LinkPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace MobilepayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MobilepayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MobilepayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MobilepayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MobilepayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace MultibancoPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MultibancoPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MultibancoPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MultibancoPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MultibancoPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace MxBankTransferPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MxBankTransferPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MxBankTransferPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MxBankTransferPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.MxBankTransferPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace NaverPayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.NaverPayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.NaverPayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.NaverPayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.NaverPayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace OxxoPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.OxxoPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.OxxoPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.OxxoPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.OxxoPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace P24Payments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.P24Payments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.P24Payments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.P24Payments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.P24Payments.StatusDetail.Resolution;
+                }
+              }
+              export namespace PayByBankPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PayByBankPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PayByBankPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PayByBankPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PayByBankPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace PaycoPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaycoPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaycoPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaycoPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaycoPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace PaynowPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaynowPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaynowPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaynowPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PaynowPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace PromptpayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PromptpayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PromptpayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PromptpayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.PromptpayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace RevolutPayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.RevolutPayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.RevolutPayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.RevolutPayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.RevolutPayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace SamsungPayPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SamsungPayPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SamsungPayPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SamsungPayPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SamsungPayPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace SepaBankTransferPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaBankTransferPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaBankTransferPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaBankTransferPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaBankTransferPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace SepaDebitPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaDebitPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaDebitPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaDebitPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SepaDebitPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace StripeBalance {
+                export type Payouts = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.StripeBalance.Payouts;
+                export namespace Payouts {
+                  export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.StripeBalance.Payouts.Status;
+                  export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.StripeBalance.Payouts.StatusDetail;
+                  export namespace StatusDetail {
+                    export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.StripeBalance.Payouts.StatusDetail.Code;
+                    export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.StripeBalance.Payouts.StatusDetail.Resolution;
+                  }
+                }
+              }
+              export namespace SwishPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SwishPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SwishPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SwishPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.SwishPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace TwintPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.TwintPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.TwintPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.TwintPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.TwintPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace UsBankTransferPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.UsBankTransferPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.UsBankTransferPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.UsBankTransferPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.UsBankTransferPayments.StatusDetail.Resolution;
+                }
+              }
+              export namespace ZipPayments {
+                export type Status = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.ZipPayments.Status;
+                export type StatusDetail = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.ZipPayments.StatusDetail;
+                export namespace StatusDetail {
+                  export type Code = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.ZipPayments.StatusDetail.Code;
+                  export type Resolution = Stripe.V2.Core.Account.Configuration.Merchant.Capabilities.ZipPayments.StatusDetail.Resolution;
+                }
+              }
+            }
+            export namespace CardPayments {
+              export type DeclineOn = Stripe.V2.Core.Account.Configuration.Merchant.CardPayments.DeclineOn;
+            }
+            export namespace KonbiniPayments {
+              export type Support = Stripe.V2.Core.Account.Configuration.Merchant.KonbiniPayments.Support;
+              export namespace Support {
+                export type Hours = Stripe.V2.Core.Account.Configuration.Merchant.KonbiniPayments.Support.Hours;
+              }
+            }
+            export namespace ScriptStatementDescriptor {
+              export type Kana = Stripe.V2.Core.Account.Configuration.Merchant.ScriptStatementDescriptor.Kana;
+              export type Kanji = Stripe.V2.Core.Account.Configuration.Merchant.ScriptStatementDescriptor.Kanji;
+            }
+            export namespace Support {
+              export type Address = Stripe.V2.Core.Account.Configuration.Merchant.Support.Address;
+            }
+          }
+          export namespace Recipient {
+            export type Capabilities = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities;
+            export namespace Capabilities {
+              export type StripeBalance = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance;
+              export namespace StripeBalance {
+                export type Payouts = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.Payouts;
+                export type StripeTransfers = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers;
+                export namespace Payouts {
+                  export type Status = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.Payouts.Status;
+                  export type StatusDetail = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.Payouts.StatusDetail;
+                  export namespace StatusDetail {
+                    export type Code = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.Payouts.StatusDetail.Code;
+                    export type Resolution = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.Payouts.StatusDetail.Resolution;
+                  }
+                }
+                export namespace StripeTransfers {
+                  export type Status = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers.Status;
+                  export type StatusDetail = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers.StatusDetail;
+                  export namespace StatusDetail {
+                    export type Code = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers.StatusDetail.Code;
+                    export type Resolution = Stripe.V2.Core.Account.Configuration.Recipient.Capabilities.StripeBalance.StripeTransfers.StatusDetail.Resolution;
+                  }
+                }
+              }
+            }
+          }
+        }
+        export namespace Defaults {
+          export type Locale = Stripe.V2.Core.Account.Defaults.Locale;
+          export type Profile = Stripe.V2.Core.Account.Defaults.Profile;
+          export type Responsibilities = Stripe.V2.Core.Account.Defaults.Responsibilities;
+          export namespace Responsibilities {
+            export type FeesCollector = Stripe.V2.Core.Account.Defaults.Responsibilities.FeesCollector;
+            export type LossesCollector = Stripe.V2.Core.Account.Defaults.Responsibilities.LossesCollector;
+            export type RequirementsCollector = Stripe.V2.Core.Account.Defaults.Responsibilities.RequirementsCollector;
+          }
+        }
+        export namespace FutureRequirements {
+          export type Entry = Stripe.V2.Core.Account.FutureRequirements.Entry;
+          export type Summary = Stripe.V2.Core.Account.FutureRequirements.Summary;
+          export namespace Entry {
+            export type AwaitingActionFrom = Stripe.V2.Core.Account.FutureRequirements.Entry.AwaitingActionFrom;
+            export type Error = Stripe.V2.Core.Account.FutureRequirements.Entry.Error;
+            export type Impact = Stripe.V2.Core.Account.FutureRequirements.Entry.Impact;
+            export type MinimumDeadline = Stripe.V2.Core.Account.FutureRequirements.Entry.MinimumDeadline;
+            export type Reference = Stripe.V2.Core.Account.FutureRequirements.Entry.Reference;
+            export type RequestedReason = Stripe.V2.Core.Account.FutureRequirements.Entry.RequestedReason;
+            export namespace Error {
+              export type Code = Stripe.V2.Core.Account.FutureRequirements.Entry.Error.Code;
+            }
+            export namespace Impact {
+              export type RestrictsCapability = Stripe.V2.Core.Account.FutureRequirements.Entry.Impact.RestrictsCapability;
+              export namespace RestrictsCapability {
+                export type Capability = Stripe.V2.Core.Account.FutureRequirements.Entry.Impact.RestrictsCapability.Capability;
+                export type Configuration = Stripe.V2.Core.Account.FutureRequirements.Entry.Impact.RestrictsCapability.Configuration;
+                export type Deadline = Stripe.V2.Core.Account.FutureRequirements.Entry.Impact.RestrictsCapability.Deadline;
+                export namespace Deadline {
+                  export type Status = Stripe.V2.Core.Account.FutureRequirements.Entry.Impact.RestrictsCapability.Deadline.Status;
+                }
+              }
+            }
+            export namespace MinimumDeadline {
+              export type Status = Stripe.V2.Core.Account.FutureRequirements.Entry.MinimumDeadline.Status;
+            }
+            export namespace Reference {
+              export type Type = Stripe.V2.Core.Account.FutureRequirements.Entry.Reference.Type;
+            }
+            export namespace RequestedReason {
+              export type Code = Stripe.V2.Core.Account.FutureRequirements.Entry.RequestedReason.Code;
+            }
+          }
+          export namespace Summary {
+            export type MinimumDeadline = Stripe.V2.Core.Account.FutureRequirements.Summary.MinimumDeadline;
+            export namespace MinimumDeadline {
+              export type Status = Stripe.V2.Core.Account.FutureRequirements.Summary.MinimumDeadline.Status;
+            }
+          }
+        }
+        export namespace Identity {
+          export type Attestations = Stripe.V2.Core.Account.Identity.Attestations;
+          export type BusinessDetails = Stripe.V2.Core.Account.Identity.BusinessDetails;
+          export type EntityType = Stripe.V2.Core.Account.Identity.EntityType;
+          export type Individual = Stripe.V2.Core.Account.Identity.Individual;
+          export namespace Attestations {
+            export type DirectorshipDeclaration = Stripe.V2.Core.Account.Identity.Attestations.DirectorshipDeclaration;
+            export type OwnershipDeclaration = Stripe.V2.Core.Account.Identity.Attestations.OwnershipDeclaration;
+            export type PersonsProvided = Stripe.V2.Core.Account.Identity.Attestations.PersonsProvided;
+            export type RepresentativeDeclaration = Stripe.V2.Core.Account.Identity.Attestations.RepresentativeDeclaration;
+            export type TermsOfService = Stripe.V2.Core.Account.Identity.Attestations.TermsOfService;
+            export namespace PersonsProvided {
+              export type OwnershipExemptionReason = Stripe.V2.Core.Account.Identity.Attestations.PersonsProvided.OwnershipExemptionReason;
+            }
+            export namespace TermsOfService {
+              export type Account = Stripe.V2.Core.Account.Identity.Attestations.TermsOfService.Account;
+            }
+          }
+          export namespace BusinessDetails {
+            export type Address = Stripe.V2.Core.Account.Identity.BusinessDetails.Address;
+            export type AnnualRevenue = Stripe.V2.Core.Account.Identity.BusinessDetails.AnnualRevenue;
+            export type Documents = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents;
+            export type IdNumber = Stripe.V2.Core.Account.Identity.BusinessDetails.IdNumber;
+            export type MonthlyEstimatedRevenue = Stripe.V2.Core.Account.Identity.BusinessDetails.MonthlyEstimatedRevenue;
+            export type RegistrationDate = Stripe.V2.Core.Account.Identity.BusinessDetails.RegistrationDate;
+            export type ScriptAddresses = Stripe.V2.Core.Account.Identity.BusinessDetails.ScriptAddresses;
+            export type ScriptNames = Stripe.V2.Core.Account.Identity.BusinessDetails.ScriptNames;
+            export type Structure = Stripe.V2.Core.Account.Identity.BusinessDetails.Structure;
+            export namespace Documents {
+              export type BankAccountOwnershipVerification = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.BankAccountOwnershipVerification;
+              export type CompanyLicense = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.CompanyLicense;
+              export type CompanyMemorandumOfAssociation = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.CompanyMemorandumOfAssociation;
+              export type CompanyMinisterialDecree = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.CompanyMinisterialDecree;
+              export type CompanyRegistrationVerification = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.CompanyRegistrationVerification;
+              export type CompanyTaxIdVerification = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.CompanyTaxIdVerification;
+              export type PrimaryVerification = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.PrimaryVerification;
+              export type ProofOfAddress = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.ProofOfAddress;
+              export type ProofOfRegistration = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.ProofOfRegistration;
+              export type ProofOfUltimateBeneficialOwnership = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.ProofOfUltimateBeneficialOwnership;
+              export namespace PrimaryVerification {
+                export type FrontBack = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.PrimaryVerification.FrontBack;
+              }
+              export namespace ProofOfRegistration {
+                export type Signer = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.ProofOfRegistration.Signer;
+              }
+              export namespace ProofOfUltimateBeneficialOwnership {
+                export type Signer = Stripe.V2.Core.Account.Identity.BusinessDetails.Documents.ProofOfUltimateBeneficialOwnership.Signer;
+              }
+            }
+            export namespace IdNumber {
+              export type Type = Stripe.V2.Core.Account.Identity.BusinessDetails.IdNumber.Type;
+            }
+            export namespace ScriptAddresses {
+              export type Kana = Stripe.V2.Core.Account.Identity.BusinessDetails.ScriptAddresses.Kana;
+              export type Kanji = Stripe.V2.Core.Account.Identity.BusinessDetails.ScriptAddresses.Kanji;
+            }
+            export namespace ScriptNames {
+              export type Kana = Stripe.V2.Core.Account.Identity.BusinessDetails.ScriptNames.Kana;
+              export type Kanji = Stripe.V2.Core.Account.Identity.BusinessDetails.ScriptNames.Kanji;
+            }
+          }
+          export namespace Individual {
+            export type AdditionalAddress = Stripe.V2.Core.Account.Identity.Individual.AdditionalAddress;
+            export type AdditionalName = Stripe.V2.Core.Account.Identity.Individual.AdditionalName;
+            export type AdditionalTermsOfService = Stripe.V2.Core.Account.Identity.Individual.AdditionalTermsOfService;
+            export type Address = Stripe.V2.Core.Account.Identity.Individual.Address;
+            export type DateOfBirth = Stripe.V2.Core.Account.Identity.Individual.DateOfBirth;
+            export type Documents = Stripe.V2.Core.Account.Identity.Individual.Documents;
+            export type IdNumber = Stripe.V2.Core.Account.Identity.Individual.IdNumber;
+            export type LegalGender = Stripe.V2.Core.Account.Identity.Individual.LegalGender;
+            export type PoliticalExposure = Stripe.V2.Core.Account.Identity.Individual.PoliticalExposure;
+            export type Relationship = Stripe.V2.Core.Account.Identity.Individual.Relationship;
+            export type ScriptAddresses = Stripe.V2.Core.Account.Identity.Individual.ScriptAddresses;
+            export type ScriptNames = Stripe.V2.Core.Account.Identity.Individual.ScriptNames;
+            export namespace AdditionalName {
+              export type Purpose = Stripe.V2.Core.Account.Identity.Individual.AdditionalName.Purpose;
+            }
+            export namespace AdditionalTermsOfService {
+              export type Account = Stripe.V2.Core.Account.Identity.Individual.AdditionalTermsOfService.Account;
+            }
+            export namespace Documents {
+              export type CompanyAuthorization = Stripe.V2.Core.Account.Identity.Individual.Documents.CompanyAuthorization;
+              export type Passport = Stripe.V2.Core.Account.Identity.Individual.Documents.Passport;
+              export type PrimaryVerification = Stripe.V2.Core.Account.Identity.Individual.Documents.PrimaryVerification;
+              export type SecondaryVerification = Stripe.V2.Core.Account.Identity.Individual.Documents.SecondaryVerification;
+              export type Visa = Stripe.V2.Core.Account.Identity.Individual.Documents.Visa;
+              export namespace PrimaryVerification {
+                export type FrontBack = Stripe.V2.Core.Account.Identity.Individual.Documents.PrimaryVerification.FrontBack;
+              }
+              export namespace SecondaryVerification {
+                export type FrontBack = Stripe.V2.Core.Account.Identity.Individual.Documents.SecondaryVerification.FrontBack;
+              }
+            }
+            export namespace IdNumber {
+              export type Type = Stripe.V2.Core.Account.Identity.Individual.IdNumber.Type;
+            }
+            export namespace ScriptAddresses {
+              export type Kana = Stripe.V2.Core.Account.Identity.Individual.ScriptAddresses.Kana;
+              export type Kanji = Stripe.V2.Core.Account.Identity.Individual.ScriptAddresses.Kanji;
+            }
+            export namespace ScriptNames {
+              export type Kana = Stripe.V2.Core.Account.Identity.Individual.ScriptNames.Kana;
+              export type Kanji = Stripe.V2.Core.Account.Identity.Individual.ScriptNames.Kanji;
+            }
+          }
+        }
+        export namespace Requirements {
+          export type Entry = Stripe.V2.Core.Account.Requirements.Entry;
+          export type Summary = Stripe.V2.Core.Account.Requirements.Summary;
+          export namespace Entry {
+            export type AwaitingActionFrom = Stripe.V2.Core.Account.Requirements.Entry.AwaitingActionFrom;
+            export type Error = Stripe.V2.Core.Account.Requirements.Entry.Error;
+            export type Impact = Stripe.V2.Core.Account.Requirements.Entry.Impact;
+            export type MinimumDeadline = Stripe.V2.Core.Account.Requirements.Entry.MinimumDeadline;
+            export type Reference = Stripe.V2.Core.Account.Requirements.Entry.Reference;
+            export type RequestedReason = Stripe.V2.Core.Account.Requirements.Entry.RequestedReason;
+            export namespace Error {
+              export type Code = Stripe.V2.Core.Account.Requirements.Entry.Error.Code;
+            }
+            export namespace Impact {
+              export type RestrictsCapability = Stripe.V2.Core.Account.Requirements.Entry.Impact.RestrictsCapability;
+              export namespace RestrictsCapability {
+                export type Capability = Stripe.V2.Core.Account.Requirements.Entry.Impact.RestrictsCapability.Capability;
+                export type Configuration = Stripe.V2.Core.Account.Requirements.Entry.Impact.RestrictsCapability.Configuration;
+                export type Deadline = Stripe.V2.Core.Account.Requirements.Entry.Impact.RestrictsCapability.Deadline;
+                export namespace Deadline {
+                  export type Status = Stripe.V2.Core.Account.Requirements.Entry.Impact.RestrictsCapability.Deadline.Status;
+                }
+              }
+            }
+            export namespace MinimumDeadline {
+              export type Status = Stripe.V2.Core.Account.Requirements.Entry.MinimumDeadline.Status;
+            }
+            export namespace Reference {
+              export type Type = Stripe.V2.Core.Account.Requirements.Entry.Reference.Type;
+            }
+            export namespace RequestedReason {
+              export type Code = Stripe.V2.Core.Account.Requirements.Entry.RequestedReason.Code;
+            }
+          }
+          export namespace Summary {
+            export type MinimumDeadline = Stripe.V2.Core.Account.Requirements.Summary.MinimumDeadline;
+            export namespace MinimumDeadline {
+              export type Status = Stripe.V2.Core.Account.Requirements.Summary.MinimumDeadline.Status;
+            }
+          }
+        }
       }
       export namespace AccountLinkCreateParams {
         export type UseCase = Stripe.V2.Core.AccountLinkCreateParams.UseCase;
+        export namespace UseCase {
+          export type AccountOnboarding = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountOnboarding;
+          export type AccountUpdate = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountUpdate;
+          export type Type = Stripe.V2.Core.AccountLinkCreateParams.UseCase.Type;
+          export namespace AccountOnboarding {
+            export type CollectionOptions = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountOnboarding.CollectionOptions;
+            export type Configuration = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountOnboarding.Configuration;
+            export namespace CollectionOptions {
+              export type Fields = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountOnboarding.CollectionOptions.Fields;
+              export type FutureRequirements = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountOnboarding.CollectionOptions.FutureRequirements;
+            }
+          }
+          export namespace AccountUpdate {
+            export type CollectionOptions = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountUpdate.CollectionOptions;
+            export type Configuration = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountUpdate.Configuration;
+            export namespace CollectionOptions {
+              export type Fields = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountUpdate.CollectionOptions.Fields;
+              export type FutureRequirements = Stripe.V2.Core.AccountLinkCreateParams.UseCase.AccountUpdate.CollectionOptions.FutureRequirements;
+            }
+          }
+        }
+      }
+      export namespace AccountLink {
+        export type UseCase = Stripe.V2.Core.AccountLink.UseCase;
+        export namespace UseCase {
+          export type AccountOnboarding = Stripe.V2.Core.AccountLink.UseCase.AccountOnboarding;
+          export type AccountUpdate = Stripe.V2.Core.AccountLink.UseCase.AccountUpdate;
+          export type Type = Stripe.V2.Core.AccountLink.UseCase.Type;
+          export namespace AccountOnboarding {
+            export type CollectionOptions = Stripe.V2.Core.AccountLink.UseCase.AccountOnboarding.CollectionOptions;
+            export type Configuration = Stripe.V2.Core.AccountLink.UseCase.AccountOnboarding.Configuration;
+            export namespace CollectionOptions {
+              export type Fields = Stripe.V2.Core.AccountLink.UseCase.AccountOnboarding.CollectionOptions.Fields;
+              export type FutureRequirements = Stripe.V2.Core.AccountLink.UseCase.AccountOnboarding.CollectionOptions.FutureRequirements;
+            }
+          }
+          export namespace AccountUpdate {
+            export type CollectionOptions = Stripe.V2.Core.AccountLink.UseCase.AccountUpdate.CollectionOptions;
+            export type Configuration = Stripe.V2.Core.AccountLink.UseCase.AccountUpdate.Configuration;
+            export namespace CollectionOptions {
+              export type Fields = Stripe.V2.Core.AccountLink.UseCase.AccountUpdate.CollectionOptions.Fields;
+              export type FutureRequirements = Stripe.V2.Core.AccountLink.UseCase.AccountUpdate.CollectionOptions.FutureRequirements;
+            }
+          }
+        }
       }
       export namespace AccountTokenCreateParams {
         export type Identity = Stripe.V2.Core.AccountTokenCreateParams.Identity;
+        export namespace Identity {
+          export type Attestations = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations;
+          export type BusinessDetails = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails;
+          export type EntityType = Stripe.V2.Core.AccountTokenCreateParams.Identity.EntityType;
+          export type Individual = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual;
+          export namespace Attestations {
+            export type DirectorshipDeclaration = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.DirectorshipDeclaration;
+            export type OwnershipDeclaration = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.OwnershipDeclaration;
+            export type PersonsProvided = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.PersonsProvided;
+            export type RepresentativeDeclaration = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.RepresentativeDeclaration;
+            export type TermsOfService = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.TermsOfService;
+            export namespace PersonsProvided {
+              export type OwnershipExemptionReason = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.PersonsProvided.OwnershipExemptionReason;
+            }
+            export namespace TermsOfService {
+              export type Account = Stripe.V2.Core.AccountTokenCreateParams.Identity.Attestations.TermsOfService.Account;
+            }
+          }
+          export namespace BusinessDetails {
+            export type AnnualRevenue = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.AnnualRevenue;
+            export type Documents = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents;
+            export type IdNumber = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.IdNumber;
+            export type MonthlyEstimatedRevenue = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.MonthlyEstimatedRevenue;
+            export type RegistrationDate = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.RegistrationDate;
+            export type ScriptAddresses = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.ScriptAddresses;
+            export type ScriptNames = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.ScriptNames;
+            export type Structure = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Structure;
+            export namespace Documents {
+              export type BankAccountOwnershipVerification = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.BankAccountOwnershipVerification;
+              export type CompanyLicense = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.CompanyLicense;
+              export type CompanyMemorandumOfAssociation = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.CompanyMemorandumOfAssociation;
+              export type CompanyMinisterialDecree = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.CompanyMinisterialDecree;
+              export type CompanyRegistrationVerification = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.CompanyRegistrationVerification;
+              export type CompanyTaxIdVerification = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.CompanyTaxIdVerification;
+              export type PrimaryVerification = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.PrimaryVerification;
+              export type ProofOfAddress = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.ProofOfAddress;
+              export type ProofOfRegistration = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.ProofOfRegistration;
+              export type ProofOfUltimateBeneficialOwnership = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.ProofOfUltimateBeneficialOwnership;
+              export namespace PrimaryVerification {
+                export type FrontBack = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.PrimaryVerification.FrontBack;
+              }
+              export namespace ProofOfRegistration {
+                export type Signer = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.ProofOfRegistration.Signer;
+              }
+              export namespace ProofOfUltimateBeneficialOwnership {
+                export type Signer = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.Documents.ProofOfUltimateBeneficialOwnership.Signer;
+              }
+            }
+            export namespace IdNumber {
+              export type Type = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.IdNumber.Type;
+            }
+            export namespace ScriptNames {
+              export type Kana = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.ScriptNames.Kana;
+              export type Kanji = Stripe.V2.Core.AccountTokenCreateParams.Identity.BusinessDetails.ScriptNames.Kanji;
+            }
+          }
+          export namespace Individual {
+            export type AdditionalAddress = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.AdditionalAddress;
+            export type AdditionalName = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.AdditionalName;
+            export type DateOfBirth = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.DateOfBirth;
+            export type Documents = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents;
+            export type IdNumber = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.IdNumber;
+            export type LegalGender = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.LegalGender;
+            export type PoliticalExposure = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.PoliticalExposure;
+            export type Relationship = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Relationship;
+            export type ScriptAddresses = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.ScriptAddresses;
+            export type ScriptNames = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.ScriptNames;
+            export namespace AdditionalName {
+              export type Purpose = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.AdditionalName.Purpose;
+            }
+            export namespace Documents {
+              export type CompanyAuthorization = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.CompanyAuthorization;
+              export type Passport = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.Passport;
+              export type PrimaryVerification = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.PrimaryVerification;
+              export type SecondaryVerification = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.SecondaryVerification;
+              export type Visa = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.Visa;
+              export namespace PrimaryVerification {
+                export type FrontBack = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.PrimaryVerification.FrontBack;
+              }
+              export namespace SecondaryVerification {
+                export type FrontBack = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.Documents.SecondaryVerification.FrontBack;
+              }
+            }
+            export namespace IdNumber {
+              export type Type = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.IdNumber.Type;
+            }
+            export namespace ScriptNames {
+              export type Kana = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.ScriptNames.Kana;
+              export type Kanji = Stripe.V2.Core.AccountTokenCreateParams.Identity.Individual.ScriptNames.Kanji;
+            }
+          }
+        }
+      }
+      export namespace Event {
+        export type Changes = Stripe.V2.Core.Event.Changes;
+        export type Reason = Stripe.V2.Core.Event.Reason;
+        export namespace Reason {
+          export type Request = Stripe.V2.Core.Event.Reason.Request;
+        }
       }
       export namespace EventDestinationCreateParams {
         export type EventPayload = Stripe.V2.Core.EventDestinationCreateParams.EventPayload;
@@ -2161,18 +13864,127 @@ declare namespace StripeConstructor {
         export type Include = Stripe.V2.Core.EventDestinationCreateParams.Include;
         export type WebhookEndpoint = Stripe.V2.Core.EventDestinationCreateParams.WebhookEndpoint;
       }
-      export namespace EventDestinationUpdateParams {
-        export type WebhookEndpoint = Stripe.V2.Core.EventDestinationUpdateParams.WebhookEndpoint;
+      export namespace EventDestination {
+        export type AmazonEventbridge = Stripe.V2.Core.EventDestination.AmazonEventbridge;
+        export type AzureEventGrid = Stripe.V2.Core.EventDestination.AzureEventGrid;
+        export type EventPayload = Stripe.V2.Core.EventDestination.EventPayload;
+        export type Status = Stripe.V2.Core.EventDestination.Status;
+        export type StatusDetails = Stripe.V2.Core.EventDestination.StatusDetails;
+        export type Type = Stripe.V2.Core.EventDestination.Type;
+        export type WebhookEndpoint = Stripe.V2.Core.EventDestination.WebhookEndpoint;
+        export namespace AmazonEventbridge {
+          export type AwsEventSourceStatus = Stripe.V2.Core.EventDestination.AmazonEventbridge.AwsEventSourceStatus;
+        }
+        export namespace AzureEventGrid {
+          export type AzurePartnerTopicStatus = Stripe.V2.Core.EventDestination.AzureEventGrid.AzurePartnerTopicStatus;
+        }
+        export namespace StatusDetails {
+          export type Disabled = Stripe.V2.Core.EventDestination.StatusDetails.Disabled;
+          export namespace Disabled {
+            export type Reason = Stripe.V2.Core.EventDestination.StatusDetails.Disabled.Reason;
+          }
+        }
+      }
+      export namespace AccountPerson {
+        export type AdditionalAddress = Stripe.V2.Core.AccountPerson.AdditionalAddress;
+        export type AdditionalName = Stripe.V2.Core.AccountPerson.AdditionalName;
+        export type AdditionalTermsOfService = Stripe.V2.Core.AccountPerson.AdditionalTermsOfService;
+        export type Address = Stripe.V2.Core.AccountPerson.Address;
+        export type DateOfBirth = Stripe.V2.Core.AccountPerson.DateOfBirth;
+        export type Documents = Stripe.V2.Core.AccountPerson.Documents;
+        export type IdNumber = Stripe.V2.Core.AccountPerson.IdNumber;
+        export type LegalGender = Stripe.V2.Core.AccountPerson.LegalGender;
+        export type PoliticalExposure = Stripe.V2.Core.AccountPerson.PoliticalExposure;
+        export type Relationship = Stripe.V2.Core.AccountPerson.Relationship;
+        export type ScriptAddresses = Stripe.V2.Core.AccountPerson.ScriptAddresses;
+        export type ScriptNames = Stripe.V2.Core.AccountPerson.ScriptNames;
+        export namespace AdditionalName {
+          export type Purpose = Stripe.V2.Core.AccountPerson.AdditionalName.Purpose;
+        }
+        export namespace AdditionalTermsOfService {
+          export type Account = Stripe.V2.Core.AccountPerson.AdditionalTermsOfService.Account;
+        }
+        export namespace Documents {
+          export type CompanyAuthorization = Stripe.V2.Core.AccountPerson.Documents.CompanyAuthorization;
+          export type Passport = Stripe.V2.Core.AccountPerson.Documents.Passport;
+          export type PrimaryVerification = Stripe.V2.Core.AccountPerson.Documents.PrimaryVerification;
+          export type SecondaryVerification = Stripe.V2.Core.AccountPerson.Documents.SecondaryVerification;
+          export type Visa = Stripe.V2.Core.AccountPerson.Documents.Visa;
+          export namespace PrimaryVerification {
+            export type FrontBack = Stripe.V2.Core.AccountPerson.Documents.PrimaryVerification.FrontBack;
+          }
+          export namespace SecondaryVerification {
+            export type FrontBack = Stripe.V2.Core.AccountPerson.Documents.SecondaryVerification.FrontBack;
+          }
+        }
+        export namespace IdNumber {
+          export type Type = Stripe.V2.Core.AccountPerson.IdNumber.Type;
+        }
+        export namespace ScriptAddresses {
+          export type Kana = Stripe.V2.Core.AccountPerson.ScriptAddresses.Kana;
+          export type Kanji = Stripe.V2.Core.AccountPerson.ScriptAddresses.Kanji;
+        }
+        export namespace ScriptNames {
+          export type Kana = Stripe.V2.Core.AccountPerson.ScriptNames.Kana;
+          export type Kanji = Stripe.V2.Core.AccountPerson.ScriptNames.Kanji;
+        }
       }
     }
     export namespace Commerce {
       export type ProductCatalogImport = Stripe.V2.Commerce.ProductCatalogImport;
+      export namespace ProductCatalogImport {
+        export type FeedType = Stripe.V2.Commerce.ProductCatalogImport.FeedType;
+        export type Status = Stripe.V2.Commerce.ProductCatalogImport.Status;
+        export type StatusDetails = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails;
+        export namespace StatusDetails {
+          export type AwaitingUpload = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.AwaitingUpload;
+          export type Failed = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.Failed;
+          export type Processing = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.Processing;
+          export type Succeeded = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.Succeeded;
+          export type SucceededWithErrors = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.SucceededWithErrors;
+          export namespace AwaitingUpload {
+            export type UploadUrl = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.AwaitingUpload.UploadUrl;
+          }
+          export namespace Failed {
+            export type Code = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.Failed.Code;
+            export type Type = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.Failed.Type;
+          }
+          export namespace SucceededWithErrors {
+            export type ErrorFile = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.SucceededWithErrors.ErrorFile;
+            export type Sample = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.SucceededWithErrors.Sample;
+            export namespace ErrorFile {
+              export type DownloadUrl = Stripe.V2.Commerce.ProductCatalogImport.StatusDetails.SucceededWithErrors.ErrorFile.DownloadUrl;
+            }
+          }
+        }
+      }
     }
   }
   export namespace Reserve {
     export type Hold = Stripe.Reserve.Hold;
     export type Plan = Stripe.Reserve.Plan;
     export type Release = Stripe.Reserve.Release;
+    export namespace Hold {
+      export type CreatedBy = Stripe.Reserve.Hold.CreatedBy;
+      export type Reason = Stripe.Reserve.Hold.Reason;
+      export type ReleaseSchedule = Stripe.Reserve.Hold.ReleaseSchedule;
+      export type SourceType = Stripe.Reserve.Hold.SourceType;
+    }
+    export namespace Plan {
+      export type CreatedBy = Stripe.Reserve.Plan.CreatedBy;
+      export type FixedRelease = Stripe.Reserve.Plan.FixedRelease;
+      export type RollingRelease = Stripe.Reserve.Plan.RollingRelease;
+      export type Status = Stripe.Reserve.Plan.Status;
+      export type Type = Stripe.Reserve.Plan.Type;
+    }
+    export namespace Release {
+      export type CreatedBy = Stripe.Reserve.Release.CreatedBy;
+      export type Reason = Stripe.Reserve.Release.Reason;
+      export type SourceTransaction = Stripe.Reserve.Release.SourceTransaction;
+      export namespace SourceTransaction {
+        export type Type = Stripe.Reserve.Release.SourceTransaction.Type;
+      }
+    }
   }
   export namespace Events {
     export type UnknownEventNotification = Stripe.V2.Core.Events.UnknownEventNotification;

--- a/testProjects/types-cjs-node16/typescriptTest.ts
+++ b/testProjects/types-cjs-node16/typescriptTest.ts
@@ -39,6 +39,23 @@ async (): Promise<void> => {
 let opts: Stripe.RequestOptions;
 let apiList: Stripe.ApiList<Stripe.Customer>;
 
+// Resource sub-types (companion namespace access)
+let priceRecurring: Stripe.Price.Recurring;
+let customerInvoiceSettings: Stripe.Customer.InvoiceSettings;
+let subscriptionBillingMode: Stripe.Subscription.BillingMode;
+
+// Deep resource sub-types (2+ levels)
+const billingModeType: Stripe.Subscription.BillingMode.Type = 'classic';
+
+// Nested resource sub-types (product namespace → resource → sub-type)
+let alertStatus: Stripe.Billing.Alert.Status;
+let terminalTipping: Stripe.Terminal.Configuration.Tipping;
+let appsSecretScope: Stripe.Apps.Secret.Scope;
+
+// Deep params sub-namespaces (2+ levels)
+let accountBizProfile: Stripe.AccountCreateParams.BusinessProfile;
+let accountBizRevenue: Stripe.AccountCreateParams.BusinessProfile.AnnualRevenue;
+
 // Config strictness
 // @ts-expect-error - unknown config properties should be rejected
 const bad = new Stripe('sk_test_123', {unknownProperty: true});

--- a/testProjects/types-cjs/typescriptTest.ts
+++ b/testProjects/types-cjs/typescriptTest.ts
@@ -443,6 +443,23 @@ const oAuthAuthorizeUrlParams: Stripe.OAuthAuthorizeUrlParams = {};
 const oAuthDeauthorization: Stripe.OAuthDeauthorization = {stripe_user_id: ''};
 const oAuthDeauthorizeParams: Stripe.OAuthDeauthorizeParams = {};
 
+// Resource sub-types (companion namespace access)
+let priceRecurring: Stripe.Price.Recurring;
+let customerInvoiceSettings: Stripe.Customer.InvoiceSettings;
+let subscriptionBillingMode: Stripe.Subscription.BillingMode;
+
+// Deep resource sub-types (2+ levels)
+const billingModeType: Stripe.Subscription.BillingMode.Type = 'classic';
+
+// Nested resource sub-types (product namespace → resource → sub-type)
+let alertStatus: Stripe.Billing.Alert.Status;
+let terminalTipping: Stripe.Terminal.Configuration.Tipping;
+let appsSecretScope: Stripe.Apps.Secret.Scope;
+
+// Deep params sub-namespaces (2+ levels)
+let accountBizProfile: Stripe.AccountCreateParams.BusinessProfile;
+let accountBizRevenue: Stripe.AccountCreateParams.BusinessProfile.AnnualRevenue;
+
 // Access and type top level resources and nested resources
 const customerResource: Stripe.CustomerResource = new Stripe.CustomerResource(
   stripe

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -449,6 +449,23 @@ const oAuthAuthorizeUrlParams: Stripe.OAuthAuthorizeUrlParams = {};
 const oAuthDeauthorization: Stripe.OAuthDeauthorization = {stripe_user_id: ''};
 const oAuthDeauthorizeParams: Stripe.OAuthDeauthorizeParams = {};
 
+// Resource sub-types (companion namespace access)
+let priceRecurring: Stripe.Price.Recurring;
+let customerInvoiceSettings: Stripe.Customer.InvoiceSettings;
+let subscriptionBillingMode: Stripe.Subscription.BillingMode;
+
+// Deep resource sub-types (2+ levels)
+const billingModeType: Stripe.Subscription.BillingMode.Type = 'classic';
+
+// Nested resource sub-types (product namespace → resource → sub-type)
+let alertStatus: Stripe.Billing.Alert.Status;
+let terminalTipping: Stripe.Terminal.Configuration.Tipping;
+let appsSecretScope: Stripe.Apps.Secret.Scope;
+
+// Deep params sub-namespaces (2+ levels)
+let accountBizProfile: Stripe.AccountCreateParams.BusinessProfile;
+let accountBizRevenue: Stripe.AccountCreateParams.BusinessProfile.AnnualRevenue;
+
 // Access and type top level resources and nested resources
 const customerResource: Stripe.CustomerResource = new Stripe.CustomerResource(
   stripe


### PR DESCRIPTION
### Why?

CJS consumers can't access nested type namespaces like `Stripe.Price.Recurring`, `Stripe.Billing.Alert.Status`, or `Stripe.Terminal.Configuration.Tipping`. The CJS declaration file uses flat type aliases inside `declare namespace StripeConstructor`, which drops companion namespaces that ESM carries automatically via `export { X }`.

Additionally, nested resource types (under product namespaces like Billing, Terminal, Apps, etc.) were broken in **both** ESM and CJS because companion namespace blocks were rendered nested under the product namespace instead of at module scope where they merge with the interface.

After this change, all type paths that work in ESM also work in CJS.



### What?

- Resource files: companion namespaces now render at module scope (`export namespace Alert { ... }`) instead of nested under the product namespace (`export namespace Billing { export namespace Alert { ... } }`)
- CJS declaration file: companion namespace blocks now emitted for resource sub-types (e.g. `Price.Recurring`, `Alert.Status`) at all depths
- CJS declaration file: params companion blocks now emitted at full depth (previously only 1 level)
- Internal references in resource files updated (e.g. `Billing.Alert.Status` → `Alert.Status`)

### See Also

- #2683
## Changelog

- Fixes TypeScript type access for nested namespaces in CJS mode (e.g. `Stripe.Price.Recurring`, `Stripe.Subscription.BillingMode`)
- Fixes TypeScript type access for nested resource types e.g. `Stripe.Billing.Alert.Status`, `Stripe.Terminal.Configuration.Tipping` in both ESM and CJS modes.