### PR TITLE
Add typescript dependency to mjs-ts

### DIFF
--- a/testProjects/mjs-ts/package.json
+++ b/testProjects/mjs-ts/package.json
@@ -16,6 +16,7 @@
     "@typescript-eslint/eslint-plugin": "^5.50.0",
     "@typescript-eslint/parser": "^5.50.0",
     "eslint": "^8.33.0",
-    "eslint-plugin-import": "^2.27.5"
+    "eslint-plugin-import": "^2.27.5",
+    "typescript": "^5.9.3"
   }
 }


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Our Node tests [started failing](https://github.com/stripe/stripe-node/actions/runs/28959494625/job/85927475016?pr=2777) this morning because of issues inside the `mjs-ts` test project:

```
TypeError: Failed to load plugin '@typescript-eslint' declared in '.eslintrc.cjs': Cannot read properties of undefined (reading 'Any')
  Referenced from: /home/runner/work/stripe-node/stripe-node/testProjects/mjs-ts/.eslintrc.cjs
```

We hadn't touched this, so it was weird that it just fell over. I had an inkling it had to do with today's [Typescript 7 release](https://devblogs.microsoft.com/typescript/announcing-typescript-7-0/), which doesn't include the code-level API that eslint expects. Some local finagling confirmed it!

So for now, we'll pin our TS dependency (like the other projects do) and we can update everything once the JS api is ready in TS 7.1.

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- added explicit typescript dependency to test project

### See Also
<!-- Include any links or additional information that help explain this change. -->
