### PR TITLE
Remove unused Retry-After header support

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -32,13 +32,10 @@ import {
   removeNullish,
   getAPIMode,
   parseHttpHeaderAsString,
-  parseHttpHeaderAsNumber,
   processOptions,
 } from './utils.js';
 
 export type HttpClientResponseError = {code: string};
-
-const MAX_RETRY_AFTER_WAIT = 60;
 
 export class RequestSender {
   protected _stripe: Stripe;
@@ -306,7 +303,7 @@ export class RequestSender {
     return false;
   }
 
-  _getSleepTimeInMS(numRetries: number, retryAfter?: number): number {
+  _getSleepTimeInMS(numRetries: number): number {
     const initialNetworkRetryDelay = this._stripe.getInitialNetworkRetryDelay();
     const maxNetworkRetryDelay = this._stripe.getMaxNetworkRetryDelay();
 
@@ -324,11 +321,6 @@ export class RequestSender {
 
     // But never sleep less than the base sleep seconds.
     sleepSeconds = Math.max(initialNetworkRetryDelay, sleepSeconds);
-
-    // And never sleep less than the time the API asks us to wait, assuming it's a reasonable ask.
-    if (Number.isInteger(retryAfter) && retryAfter! <= MAX_RETRY_AFTER_WAIT) {
-      sleepSeconds = Math.max(sleepSeconds, retryAfter!);
-    }
 
     return sleepSeconds * 1000;
   }
@@ -586,12 +578,11 @@ export class RequestSender {
       requestFn: typeof makeRequest,
       apiVersion: string,
       headers: RequestHeaders,
-      requestRetries: number,
-      retryAfter?: number
+      requestRetries: number
     ): ReturnType<typeof setTimeout> => {
       return setTimeout(
         requestFn,
-        this._getSleepTimeInMS(requestRetries, retryAfter),
+        this._getSleepTimeInMS(requestRetries),
         apiVersion,
         headers,
         requestRetries + 1
@@ -671,8 +662,7 @@ export class RequestSender {
                   makeRequest,
                   apiVersion,
                   headers,
-                  requestRetries,
-                  parseHttpHeaderAsNumber(res.getHeaders()['retry-after'])
+                  requestRetries
                 );
               } else if (options.streaming && res.getStatusCode() < 400) {
                 return this._streamingResponseHandler(

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -457,24 +457,6 @@ export function parseHttpHeaderAsString<K extends keyof RequestHeaders>(
   return String(header);
 }
 
-export function parseHttpHeaderAsNumber<K extends keyof RequestHeaders>(
-  header: RequestHeaders[K] | null | undefined
-): number | undefined {
-  const value = Array.isArray(header) ? header[0] : header;
-  if (value == null) {
-    return undefined;
-  }
-  const trimmed = String(value).trim();
-  if (trimmed === '') {
-    return undefined;
-  }
-  const parsed = Number(trimmed);
-  if (!Number.isFinite(parsed)) {
-    return undefined;
-  }
-  return parsed;
-}
-
 export function parseHeadersForFetch(
   headers: RequestHeaders
 ): [string, string][] {

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -1834,19 +1834,6 @@ describe('RequestSender', () => {
           expect(sleepSeconds).to.be.at.least(min);
         }
       });
-
-      it('should allow a maximum override', () => {
-        const maxSec = stripe.getMaxNetworkRetryDelay();
-        const minMS = stripe.getInitialNetworkRetryDelay() * 1000;
-
-        expect(sender._getSleepTimeInMS(3, 0)).to.be.gt(minMS);
-        expect(sender._getSleepTimeInMS(2, 3)).to.equal(3000);
-        expect(sender._getSleepTimeInMS(0, 3)).to.equal(3000);
-        expect(sender._getSleepTimeInMS(0, 0)).to.equal(minMS);
-        expect(sender._getSleepTimeInMS(0, maxSec * 2)).to.equal(
-          maxSec * 2 * 1000
-        );
-      });
     });
   });
 

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -816,65 +816,6 @@ describe('utils', () => {
     });
   });
 
-  describe('parseHttpHeaderAsNumber', () => {
-    it('returns the number for valid integer strings', () => {
-      expect(utils.parseHttpHeaderAsNumber('30')).to.equal(30);
-      expect(utils.parseHttpHeaderAsNumber('0')).to.equal(0);
-    });
-
-    it('returns the number for valid decimal strings', () => {
-      expect(utils.parseHttpHeaderAsNumber('1.5')).to.equal(1.5);
-    });
-
-    it('returns the number for strings with surrounding whitespace', () => {
-      expect(utils.parseHttpHeaderAsNumber('  42  ')).to.equal(42);
-    });
-
-    it('returns undefined for undefined', () => {
-      expect(utils.parseHttpHeaderAsNumber(undefined)).to.be.undefined;
-    });
-
-    it('returns undefined for null', () => {
-      expect(utils.parseHttpHeaderAsNumber(null)).to.be.undefined;
-    });
-
-    it('returns undefined for empty string', () => {
-      expect(utils.parseHttpHeaderAsNumber('')).to.be.undefined;
-    });
-
-    it('returns undefined for whitespace-only strings', () => {
-      expect(utils.parseHttpHeaderAsNumber('   ')).to.be.undefined;
-    });
-
-    it('returns undefined for non-numeric strings', () => {
-      expect(utils.parseHttpHeaderAsNumber('bad')).to.be.undefined;
-    });
-
-    it('returns undefined for "NaN"', () => {
-      expect(utils.parseHttpHeaderAsNumber('NaN')).to.be.undefined;
-    });
-
-    it('returns undefined for "Infinity"', () => {
-      expect(utils.parseHttpHeaderAsNumber('Infinity')).to.be.undefined;
-    });
-
-    it('returns undefined for "-Infinity"', () => {
-      expect(utils.parseHttpHeaderAsNumber('-Infinity')).to.be.undefined;
-    });
-
-    it('takes the first element for array input', () => {
-      expect(utils.parseHttpHeaderAsNumber(['30', '60'])).to.equal(30);
-    });
-
-    it('returns undefined for array with non-numeric first element', () => {
-      expect(utils.parseHttpHeaderAsNumber(['bad', '30'])).to.be.undefined;
-    });
-
-    it('returns undefined for array with empty string first element', () => {
-      expect(utils.parseHttpHeaderAsNumber(['', '30'])).to.be.undefined;
-    });
-  });
-
   describe('concat', () => {
     it('should return a joined Uint8Array', () => {
       const arr1 = new Uint8Array([1, 2, 3]);


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We confirmed in [RUN_API-26216](https://go/j/RUN_API-26216) that the Stripe API doesn't (and has not ever, as far as we can tell) sent `Retry-After` to external consumers.

This was one of the SDKs that included support for reading that header. Given that it's always a no-op, we can remove the dead code.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove the code that reads the `Retry-After` header and associated calculations
- remove related tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

[RUN_DEVSDK-2569](https://go/j/RUN_DEVSDK-2569)
