### PR TITLE
Replace source hash with Telemetry UUID

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+# Prevent CRLF conversion for binary test fixtures
+*.pdf binary

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -105,10 +105,14 @@ jobs:
         run: deno -V
 
       - name: Get yarn cache directory path
+        # caches are platform-specific and there's only one windows job, so don't bother caching
+        if: runner.os != 'Windows'
         id: yarn-cache-dir-path
         run: echo "dir=$(yarn cache dir)" >> "$GITHUB_OUTPUT"
 
       - uses: actions/cache@v4
+        # caches are platform-specific and there's only one windows job, so don't bother caching
+        if: runner.os != 'Windows'
         id: yarn-cache
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -69,7 +69,7 @@ jobs:
 
           # note that starting in Oct 2026, every version will be LTS, so it's not just even numbers anymore
           # see: https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule
-          - '26'
+          # - '26' # not yet compatible with mocha's yargs dependency
           - '24'
           - '22'
           - '20'
@@ -77,7 +77,7 @@ jobs:
         include:
           - os: windows-latest
             # use any modern-ish version
-            node: '26'
+            node: '24'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -95,13 +95,11 @@ jobs:
 
       # used for one of the integration tests
       - name: Setup Deno
-        if: runner.os != 'Windows'
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 
       - name: Print Deno version
-        if: runner.os != 'Windows'
         run: deno -V
 
       - name: Get yarn cache directory path

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -55,7 +55,7 @@ jobs:
         run: just format-check
 
   test:
-    name: Test (${{ matrix.node }})
+    name: Test (${{ matrix.node }}, ${{ matrix.os }})
     needs: [build]
     strategy:
       fail-fast: false
@@ -65,12 +65,19 @@ jobs:
         node:
           # should include even numbers >= 18
           # see: https://docs.stripe.com/sdks/versioning?lang=node#stripe-sdk-language-version-support-policy
-          # note that in Oct 2026, every version will be LTS, so it's not just even numbers anymore
+          # https://endoflife.date/nodejs
+
+          # note that starting in Oct 2026, every version will be LTS, so it's not just even numbers anymore
           # see: https://nodejs.org/en/blog/announcements/evolving-the-nodejs-release-schedule
+          - '26'
           - '24'
           - '22'
           - '20'
           - '18'
+        include:
+          - os: windows-latest
+            # use any modern-ish version
+            node: '26'
     runs-on: ${{ matrix.os }}
     permissions:
       contents: read
@@ -88,11 +95,13 @@ jobs:
 
       # used for one of the integration tests
       - name: Setup Deno
+        if: runner.os != 'Windows'
         uses: denoland/setup-deno@v1
         with:
           deno-version: v1.x
 
       - name: Print Deno version
+        if: runner.os != 'Windows'
         run: deno -V
 
       - name: Get yarn cache directory path

--- a/src/platform/NodePlatformFunctions.ts
+++ b/src/platform/NodePlatformFunctions.ts
@@ -1,6 +1,8 @@
 import * as crypto from 'crypto';
+import * as fs from 'fs';
 import * as http from 'http';
 import * as os from 'os';
+import * as path from 'path';
 import {CryptoProvider} from '../crypto/CryptoProvider.js';
 import {EventEmitter} from 'events';
 import {HttpClient, NodeHttpClientInterface} from '../net/HttpClient.js';
@@ -50,36 +52,59 @@ export class NodePlatformFunctions extends PlatformFunctions {
     return process.version;
   }
 
-  private getUname(): string | null {
-    try {
-      const parts = [os.type(), os.release(), os.arch()];
-      // os.version() returns detailed kernel version, available since Node 10.7.0
-      // It may not exist in older typings, so access carefully
-      const version = (os as any).version?.();
-      if (version) parts.push(version);
-      try {
-        parts.push(os.hostname());
-        // eslint-disable-next-line no-empty
-      } catch (_e) {}
-      return parts.join(' ');
-    } catch {
-      return null;
-    }
-  }
+  private _telemetryId: string | null | undefined = undefined;
 
   /** @override */
-  getSourceHash(): string | null {
-    try {
-      const uname = this.getUname();
-      return uname
-        ? crypto
-            .createHash('md5')
-            .update(uname)
-            .digest('hex')
-        : null;
-    } catch {
+  getTelemetryId(): string | null {
+    if (this._telemetryId !== undefined) {
+      return this._telemetryId;
+    }
+
+    const filePath = this._getTelemetryIdPath();
+    if (!filePath) {
+      this._telemetryId = null;
       return null;
     }
+
+    try {
+      // eslint-disable-next-line no-sync
+      const content = fs.readFileSync(filePath, 'utf8').trim();
+      if (content) {
+        this._telemetryId = content;
+        return content;
+      }
+      // eslint-disable-next-line no-empty
+    } catch {}
+
+    const newId = crypto.randomBytes(16).toString('hex');
+
+    try {
+      // eslint-disable-next-line no-sync
+      fs.mkdirSync(path.dirname(filePath), {recursive: true});
+      // eslint-disable-next-line no-sync
+      fs.writeFileSync(filePath, newId, 'utf8');
+    } catch {
+      this._telemetryId = null;
+      return null;
+    }
+
+    this._telemetryId = newId;
+    return newId;
+  }
+
+  private _getTelemetryIdPath(): string | null {
+    if (process.platform === 'win32') {
+      const appData = process.env.APPDATA;
+      if (!appData) return null;
+      return path.join(appData, 'Stripe', 'telemetry_id');
+    }
+    const xdg = process.env.XDG_CONFIG_HOME;
+    if (xdg) {
+      return path.join(xdg, 'stripe', 'telemetry_id');
+    }
+    const home = os.homedir();
+    if (!home) return null;
+    return path.join(home, '.config', 'stripe', 'telemetry_id');
   }
 
   /**

--- a/src/platform/PlatformFunctions.ts
+++ b/src/platform/PlatformFunctions.ts
@@ -35,7 +35,7 @@ export class PlatformFunctions {
     return null;
   }
 
-  getSourceHash(): string | null {
+  getTelemetryId(): string | null {
     return null;
   }
 

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -957,7 +957,6 @@ export class Stripe {
     lang: 'node',
     typescript: false,
   };
-  static SOURCE_HASH: string | null = null;
   static StripeResource = StripeResource;
   static resources = resources;
   static HttpClient = HttpClient;
@@ -1101,8 +1100,6 @@ export class Stripe {
       ...(runtimeVersion ? {lang_version: runtimeVersion} : {}),
       ...(Stripe.aiAgent ? {ai_agent: Stripe.aiAgent} : {}),
     };
-
-    Stripe.SOURCE_HASH = platformFunctions.getSourceHash();
   }
 
   constructor(key: string, config: StripeConfig = {}) {
@@ -1449,8 +1446,11 @@ export class Stripe {
       userAgent.application = this._appInfo;
     }
 
-    if (Stripe.SOURCE_HASH) {
-      userAgent.source = Stripe.SOURCE_HASH;
+    if (this.getTelemetryEnabled()) {
+      const telemetryId = this._platformFunctions.getTelemetryId();
+      if (telemetryId) {
+        userAgent.telemetry_id = telemetryId;
+      }
     }
 
     cb(JSON.stringify(userAgent));

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -163,69 +163,49 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
 
     describe('getTelemetryId', () => {
       if (isNodeEnvironment) {
+        const isWindows = process.platform === 'win32';
+        const envKey = isWindows ? 'APPDATA' : 'XDG_CONFIG_HOME';
+        const stripeDir = isWindows ? 'Stripe' : 'stripe';
         let tmpDir: string;
+        let origEnv: string | undefined;
+
         beforeEach(() => {
-          // Reset the cached telemetry ID between tests
           (platformFunctions as any)._telemetryId = undefined;
           tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stripe-telemetry-'));
+          origEnv = process.env[envKey];
+          process.env[envKey] = tmpDir;
         });
         afterEach(() => {
           (platformFunctions as any)._telemetryId = undefined;
+          if (origEnv !== undefined) {
+            process.env[envKey] = origEnv;
+          } else {
+            delete process.env[envKey];
+          }
           fs.rmSync(tmpDir, {recursive: true, force: true});
         });
 
         it('returns a 32-character hex string', () => {
-          const origXdg = process.env.XDG_CONFIG_HOME;
-          process.env.XDG_CONFIG_HOME = tmpDir;
-          try {
-            const id = platformFunctions.getTelemetryId();
-            expect(id).to.be.a('string');
-            expect(id).to.match(/^[0-9a-f]{32}$/);
-          } finally {
-            if (origXdg !== undefined) {
-              process.env.XDG_CONFIG_HOME = origXdg;
-            } else {
-              delete process.env.XDG_CONFIG_HOME;
-            }
-          }
+          const id = platformFunctions.getTelemetryId();
+          expect(id).to.be.a('string');
+          expect(id).to.match(/^[0-9a-f]{32}$/);
         });
 
         it('returns the same id on subsequent calls (caches in memory)', () => {
-          const origXdg = process.env.XDG_CONFIG_HOME;
-          process.env.XDG_CONFIG_HOME = tmpDir;
-          try {
-            const id1 = platformFunctions.getTelemetryId();
-            const id2 = platformFunctions.getTelemetryId();
-            expect(id1).to.equal(id2);
-          } finally {
-            if (origXdg !== undefined) {
-              process.env.XDG_CONFIG_HOME = origXdg;
-            } else {
-              delete process.env.XDG_CONFIG_HOME;
-            }
-          }
+          const id1 = platformFunctions.getTelemetryId();
+          const id2 = platformFunctions.getTelemetryId();
+          expect(id1).to.equal(id2);
         });
 
         it('reads an existing telemetry_id file', () => {
-          const origXdg = process.env.XDG_CONFIG_HOME;
-          process.env.XDG_CONFIG_HOME = tmpDir;
-          const idFile = path.join(tmpDir, 'stripe', 'telemetry_id');
+          const idFile = path.join(tmpDir, stripeDir, 'telemetry_id');
           fs.mkdirSync(path.dirname(idFile), {recursive: true});
           fs.writeFileSync(idFile, 'deadbeef1234567890abcdef12345678', 'utf8');
-          try {
-            const id = platformFunctions.getTelemetryId();
-            expect(id).to.equal('deadbeef1234567890abcdef12345678');
-          } finally {
-            if (origXdg !== undefined) {
-              process.env.XDG_CONFIG_HOME = origXdg;
-            } else {
-              delete process.env.XDG_CONFIG_HOME;
-            }
-          }
+          const id = platformFunctions.getTelemetryId();
+          expect(id).to.equal('deadbeef1234567890abcdef12345678');
         });
 
         it('returns null when the path cannot be determined (no home dir on non-win32)', () => {
-          // Simulate unavailable path by pointing _getTelemetryIdPath to return null
           const orig = (platformFunctions as any)._getTelemetryIdPath.bind(
             platformFunctions
           );

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -1,6 +1,7 @@
 // @ts-nocheck
 
 import * as fs from 'fs';
+import * as os from 'os';
 import * as path from 'path';
 
 import {FetchHttpClient} from '../src/net/FetchHttpClient.js';
@@ -160,23 +161,81 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
       }
     });
 
-    describe('getSourceHash', () => {
+    describe('getTelemetryId', () => {
       if (isNodeEnvironment) {
-        it('returns a 32-character hex MD5 string', () => {
-          const hash = platformFunctions.getSourceHash();
-          expect(hash).to.be.a('string');
-          expect(hash).to.match(/^[0-9a-f]{32}$/);
+        let tmpDir: string;
+        beforeEach(() => {
+          // Reset the cached telemetry ID between tests
+          (platformFunctions as any)._telemetryId = undefined;
+          tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stripe-telemetry-'));
+        });
+        afterEach(() => {
+          (platformFunctions as any)._telemetryId = undefined;
+          fs.rmSync(tmpDir, {recursive: true, force: true});
         });
 
-        it('returns null when getUname returns null', () => {
-          const orig = platformFunctions.getUname.bind(platformFunctions);
-          (platformFunctions as any).getUname = () => null;
-          expect(platformFunctions.getSourceHash()).to.be.null;
-          (platformFunctions as any).getUname = orig;
+        it('returns a 32-character hex string', () => {
+          const origXdg = process.env.XDG_CONFIG_HOME;
+          process.env.XDG_CONFIG_HOME = tmpDir;
+          try {
+            const id = platformFunctions.getTelemetryId();
+            expect(id).to.be.a('string');
+            expect(id).to.match(/^[0-9a-f]{32}$/);
+          } finally {
+            if (origXdg !== undefined) {
+              process.env.XDG_CONFIG_HOME = origXdg;
+            } else {
+              delete process.env.XDG_CONFIG_HOME;
+            }
+          }
+        });
+
+        it('returns the same id on subsequent calls (caches in memory)', () => {
+          const origXdg = process.env.XDG_CONFIG_HOME;
+          process.env.XDG_CONFIG_HOME = tmpDir;
+          try {
+            const id1 = platformFunctions.getTelemetryId();
+            const id2 = platformFunctions.getTelemetryId();
+            expect(id1).to.equal(id2);
+          } finally {
+            if (origXdg !== undefined) {
+              process.env.XDG_CONFIG_HOME = origXdg;
+            } else {
+              delete process.env.XDG_CONFIG_HOME;
+            }
+          }
+        });
+
+        it('reads an existing telemetry_id file', () => {
+          const origXdg = process.env.XDG_CONFIG_HOME;
+          process.env.XDG_CONFIG_HOME = tmpDir;
+          const idFile = path.join(tmpDir, 'stripe', 'telemetry_id');
+          fs.mkdirSync(path.dirname(idFile), {recursive: true});
+          fs.writeFileSync(idFile, 'deadbeef1234567890abcdef12345678', 'utf8');
+          try {
+            const id = platformFunctions.getTelemetryId();
+            expect(id).to.equal('deadbeef1234567890abcdef12345678');
+          } finally {
+            if (origXdg !== undefined) {
+              process.env.XDG_CONFIG_HOME = origXdg;
+            } else {
+              delete process.env.XDG_CONFIG_HOME;
+            }
+          }
+        });
+
+        it('returns null when the path cannot be determined (no home dir on non-win32)', () => {
+          // Simulate unavailable path by pointing _getTelemetryIdPath to return null
+          const orig = (platformFunctions as any)._getTelemetryIdPath.bind(
+            platformFunctions
+          );
+          (platformFunctions as any)._getTelemetryIdPath = () => null;
+          expect(platformFunctions.getTelemetryId()).to.be.null;
+          (platformFunctions as any)._getTelemetryIdPath = orig;
         });
       } else {
         it('returns null on non-Node environments', () => {
-          expect(platformFunctions.getSourceHash()).to.be.null;
+          expect(platformFunctions.getTelemetryId()).to.be.null;
         });
       }
     });

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -254,9 +254,12 @@ describe('Stripe Module', function() {
       ).to.eventually.have.property('httplib', 'node');
     });
 
-    it('Should include source field when SOURCE_HASH is set', async () => {
-      const origSourceHash = StripeCore.SOURCE_HASH;
-      StripeCore.SOURCE_HASH = 'abc123def456abc123def456abc123de';
+    it('Should include telemetry_id field when telemetry is enabled and getTelemetryId returns a value', async () => {
+      const orig = (stripe as any)._platformFunctions.getTelemetryId.bind(
+        (stripe as any)._platformFunctions
+      );
+      (stripe as any)._platformFunctions.getTelemetryId = () =>
+        'abc123def456abc123def456abc123de';
 
       const userAgent: Record<string, string> = await new Promise((resolve) => {
         stripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
@@ -264,16 +267,18 @@ describe('Stripe Module', function() {
         });
       });
 
-      StripeCore.SOURCE_HASH = origSourceHash;
+      (stripe as any)._platformFunctions.getTelemetryId = orig;
       expect(userAgent).to.have.property(
-        'source',
+        'telemetry_id',
         'abc123def456abc123def456abc123de'
       );
     });
 
-    it('Should omit source field when SOURCE_HASH is null', async () => {
-      const origSourceHash = StripeCore.SOURCE_HASH;
-      StripeCore.SOURCE_HASH = null;
+    it('Should omit telemetry_id field when getTelemetryId returns null', async () => {
+      const orig = (stripe as any)._platformFunctions.getTelemetryId.bind(
+        (stripe as any)._platformFunctions
+      );
+      (stripe as any)._platformFunctions.getTelemetryId = () => null;
 
       const userAgent: Record<string, string> = await new Promise((resolve) => {
         stripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
@@ -281,8 +286,26 @@ describe('Stripe Module', function() {
         });
       });
 
-      StripeCore.SOURCE_HASH = origSourceHash;
-      expect(userAgent).to.not.have.property('source');
+      (stripe as any)._platformFunctions.getTelemetryId = orig;
+      expect(userAgent).to.not.have.property('telemetry_id');
+    });
+
+    it('Should omit telemetry_id field when telemetry is disabled', async () => {
+      const noTelemetryStripe = Stripe(FAKE_API_KEY, {telemetry: false});
+      const orig = (noTelemetryStripe as any)._platformFunctions.getTelemetryId.bind(
+        (noTelemetryStripe as any)._platformFunctions
+      );
+      (noTelemetryStripe as any)._platformFunctions.getTelemetryId = () =>
+        'abc123def456abc123def456abc123de';
+
+      const userAgent: Record<string, string> = await new Promise((resolve) => {
+        noTelemetryStripe.getClientUserAgentSeeded({lang: 'node'}, (c) => {
+          resolve(JSON.parse(c));
+        });
+      });
+
+      (noTelemetryStripe as any)._platformFunctions.getTelemetryId = orig;
+      expect(userAgent).to.not.have.property('telemetry_id');
     });
   });
 
@@ -355,13 +378,11 @@ describe('Stripe Module', function() {
     const origAIAgent = StripeCore.aiAgent;
     const origAiAgentStatic = StripeCore.AI_AGENT;
     const origUserAgent = StripeCore.USER_AGENT;
-    const origSourceHash = StripeCore.SOURCE_HASH;
 
     afterEach(() => {
       StripeCore.aiAgent = origAIAgent;
       StripeCore.AI_AGENT = origAiAgentStatic;
       StripeCore.USER_AGENT = origUserAgent;
-      StripeCore.SOURCE_HASH = origSourceHash;
       StripeCore.initialize(new NodePlatformFunctions());
     });
 
@@ -390,32 +411,6 @@ describe('Stripe Module', function() {
       expect(StripeCore.AI_AGENT).to.equal('');
       expect(StripeCore.USER_AGENT).to.not.have.property('ai_agent');
       expect(StripeCore.USER_AGENT).to.not.have.property('lang_version');
-    });
-
-    it('sets SOURCE_HASH to an MD5 hex string when getSourceHash is available', () => {
-      const mockPlatform = new NodePlatformFunctions();
-      const expectedHash = crypto
-        .createHash('md5')
-        .update('Linux hostname 5.4.0 #1 SMP x86_64 GNU/Linux')
-        .digest('hex');
-      mockPlatform.getSourceHash = () => expectedHash;
-
-      StripeCore.initialize(mockPlatform);
-
-      expect(StripeCore.SOURCE_HASH).to.be.a('string');
-      expect(StripeCore.SOURCE_HASH).to.match(/^[0-9a-f]{32}$/);
-      expect(StripeCore.SOURCE_HASH).to.equal(expectedHash);
-    });
-
-    it('sets SOURCE_HASH to null when getSourceHash returns null', () => {
-      const {
-        PlatformFunctions,
-      } = require('../src/platform/PlatformFunctions.js');
-      const basePlatform = new PlatformFunctions();
-
-      StripeCore.initialize(basePlatform);
-
-      expect(StripeCore.SOURCE_HASH).to.be.null;
     });
   });
 

--- a/test/telemetryId.spec.ts
+++ b/test/telemetryId.spec.ts
@@ -35,13 +35,11 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
       } else {
         delete process.env.APPDATA;
       }
-    } else {
-      if (origXdg !== undefined) {
+    } else if (origXdg !== undefined) {
         process.env.XDG_CONFIG_HOME = origXdg;
       } else {
         delete process.env.XDG_CONFIG_HOME;
       }
-    }
     fs.rmSync(tmpDir, {recursive: true, force: true});
   });
 

--- a/test/telemetryId.spec.ts
+++ b/test/telemetryId.spec.ts
@@ -1,0 +1,127 @@
+// @ts-nocheck
+
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+
+import {expect} from 'chai';
+import {NodePlatformFunctions} from '../src/platform/NodePlatformFunctions.js';
+
+describe('NodePlatformFunctions#getTelemetryId', () => {
+  let platform: NodePlatformFunctions;
+  let tmpDir: string;
+  let origXdg: string | undefined;
+
+  beforeEach(() => {
+    platform = new NodePlatformFunctions();
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stripe-telemetry-test-'));
+    origXdg = process.env.XDG_CONFIG_HOME;
+    process.env.XDG_CONFIG_HOME = tmpDir;
+  });
+
+  afterEach(() => {
+    if (origXdg !== undefined) {
+      process.env.XDG_CONFIG_HOME = origXdg;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
+    fs.rmSync(tmpDir, {recursive: true, force: true});
+  });
+
+  it('returns a 32-character hex string', () => {
+    const id = platform.getTelemetryId();
+    expect(id).to.be.a('string');
+    expect(id).to.match(/^[0-9a-f]{32}$/);
+  });
+
+  it('is deterministic — returns the same value on repeated calls', () => {
+    const id1 = platform.getTelemetryId();
+    const id2 = platform.getTelemetryId();
+    expect(id1).to.equal(id2);
+  });
+
+  it('is cached in memory — second call does not re-read the file', () => {
+    const id1 = platform.getTelemetryId();
+
+    // Overwrite the file with a different value after the first call
+    const filePath = path.join(tmpDir, 'stripe', 'telemetry_id');
+    fs.writeFileSync(filePath, 'ffffffffffffffffffffffffffffffff', 'utf8');
+
+    // Second call should return the cached value, not the new file content
+    const id2 = platform.getTelemetryId();
+    expect(id2).to.equal(id1);
+    expect(id2).to.not.equal('ffffffffffffffffffffffffffffffff');
+  });
+
+  it('reads an existing telemetry_id from the file', () => {
+    const existingId = 'deadbeef1234567890abcdef12345678';
+    const filePath = path.join(tmpDir, 'stripe', 'telemetry_id');
+    fs.mkdirSync(path.dirname(filePath), {recursive: true});
+    fs.writeFileSync(filePath, existingId, 'utf8');
+
+    const id = platform.getTelemetryId();
+    expect(id).to.equal(existingId);
+  });
+
+  it('generates and persists a new ID when the file is absent', () => {
+    // No pre-existing file; the directory exists but the file does not
+    const filePath = path.join(tmpDir, 'stripe', 'telemetry_id');
+    expect(fs.existsSync(filePath)).to.be.false;
+
+    const id = platform.getTelemetryId();
+    expect(id).to.be.a('string');
+    expect(id).to.match(/^[0-9a-f]{32}$/);
+
+    // Verify the ID was written to disk
+    expect(fs.existsSync(filePath)).to.be.true;
+    const persisted = fs.readFileSync(filePath, 'utf8');
+    expect(persisted).to.equal(id);
+  });
+
+  it('returns null when the file cannot be written', () => {
+    // Point to a path whose parent cannot be created: use a file as a directory
+    const blockingFile = path.join(tmpDir, 'not-a-dir');
+    fs.writeFileSync(blockingFile, 'collision', 'utf8');
+    // Redirect XDG_CONFIG_HOME to a subpath that passes through the blocking file
+    process.env.XDG_CONFIG_HOME = path.join(blockingFile, 'stripe-nested');
+
+    const id = platform.getTelemetryId();
+    expect(id).to.be.null;
+  });
+
+  it('creates parent directories automatically when they are missing', () => {
+    // XDG_CONFIG_HOME is set to a path that does not yet exist
+    const deepDir = path.join(tmpDir, 'a', 'b', 'c');
+    process.env.XDG_CONFIG_HOME = deepDir;
+
+    const id = platform.getTelemetryId();
+    expect(id).to.be.a('string');
+    expect(id).to.match(/^[0-9a-f]{32}$/);
+
+    const filePath = path.join(deepDir, 'stripe', 'telemetry_id');
+    expect(fs.existsSync(filePath)).to.be.true;
+  });
+
+  describe('_getTelemetryIdPath', () => {
+    it('uses XDG_CONFIG_HOME when set', () => {
+      const xdgBase = path.join(tmpDir, 'custom-xdg');
+      process.env.XDG_CONFIG_HOME = xdgBase;
+
+      const result = (platform as any)._getTelemetryIdPath();
+      expect(result).to.equal(path.join(xdgBase, 'stripe', 'telemetry_id'));
+    });
+
+    it('falls back to ~/.config/stripe/telemetry_id when XDG_CONFIG_HOME is unset', () => {
+      delete process.env.XDG_CONFIG_HOME;
+
+      const result = (platform as any)._getTelemetryIdPath();
+      const expected = path.join(
+        os.homedir(),
+        '.config',
+        'stripe',
+        'telemetry_id'
+      );
+      expect(result).to.equal(expected);
+    });
+  });
+});

--- a/test/telemetryId.spec.ts
+++ b/test/telemetryId.spec.ts
@@ -36,10 +36,10 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
         delete process.env.APPDATA;
       }
     } else if (origXdg !== undefined) {
-        process.env.XDG_CONFIG_HOME = origXdg;
-      } else {
-        delete process.env.XDG_CONFIG_HOME;
-      }
+      process.env.XDG_CONFIG_HOME = origXdg;
+    } else {
+      delete process.env.XDG_CONFIG_HOME;
+    }
     fs.rmSync(tmpDir, {recursive: true, force: true});
   });
 
@@ -93,7 +93,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
     expect(persisted).to.equal(id);
   });
 
-  it('returns null when the file cannot be written', function () {
+  it('returns null when the file cannot be written', function() {
     if (isWindows) return this.skip();
     // Point to a path whose parent cannot be created: use a file as a directory
     const blockingFile = path.join(tmpDir, 'not-a-dir');
@@ -105,7 +105,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
     expect(id).to.be.null;
   });
 
-  it('creates parent directories automatically when they are missing', function () {
+  it('creates parent directories automatically when they are missing', function() {
     if (isWindows) return this.skip();
     // XDG_CONFIG_HOME is set to a path that does not yet exist
     const deepDir = path.join(tmpDir, 'a', 'b', 'c');
@@ -120,7 +120,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
   });
 
   describe('_getTelemetryIdPath', () => {
-    it('uses XDG_CONFIG_HOME when set', function () {
+    it('uses XDG_CONFIG_HOME when set', function() {
       if (isWindows) return this.skip();
       const xdgBase = path.join(tmpDir, 'custom-xdg');
       process.env.XDG_CONFIG_HOME = xdgBase;
@@ -129,7 +129,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
       expect(result).to.equal(path.join(xdgBase, 'stripe', 'telemetry_id'));
     });
 
-    it('falls back to ~/.config/stripe/telemetry_id when XDG_CONFIG_HOME is unset', function () {
+    it('falls back to ~/.config/stripe/telemetry_id when XDG_CONFIG_HOME is unset', function() {
       if (isWindows) return this.skip();
       delete process.env.XDG_CONFIG_HOME;
 

--- a/test/telemetryId.spec.ts
+++ b/test/telemetryId.spec.ts
@@ -7,23 +7,40 @@ import * as path from 'path';
 import {expect} from 'chai';
 import {NodePlatformFunctions} from '../src/platform/NodePlatformFunctions.js';
 
+const isWindows = process.platform === 'win32';
+const stripeDir = isWindows ? 'Stripe' : 'stripe';
+
 describe('NodePlatformFunctions#getTelemetryId', () => {
   let platform: NodePlatformFunctions;
   let tmpDir: string;
   let origXdg: string | undefined;
+  let origAppData: string | undefined;
 
   beforeEach(() => {
     platform = new NodePlatformFunctions();
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'stripe-telemetry-test-'));
-    origXdg = process.env.XDG_CONFIG_HOME;
-    process.env.XDG_CONFIG_HOME = tmpDir;
+    if (isWindows) {
+      origAppData = process.env.APPDATA;
+      process.env.APPDATA = tmpDir;
+    } else {
+      origXdg = process.env.XDG_CONFIG_HOME;
+      process.env.XDG_CONFIG_HOME = tmpDir;
+    }
   });
 
   afterEach(() => {
-    if (origXdg !== undefined) {
-      process.env.XDG_CONFIG_HOME = origXdg;
+    if (isWindows) {
+      if (origAppData !== undefined) {
+        process.env.APPDATA = origAppData;
+      } else {
+        delete process.env.APPDATA;
+      }
     } else {
-      delete process.env.XDG_CONFIG_HOME;
+      if (origXdg !== undefined) {
+        process.env.XDG_CONFIG_HOME = origXdg;
+      } else {
+        delete process.env.XDG_CONFIG_HOME;
+      }
     }
     fs.rmSync(tmpDir, {recursive: true, force: true});
   });
@@ -44,7 +61,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
     const id1 = platform.getTelemetryId();
 
     // Overwrite the file with a different value after the first call
-    const filePath = path.join(tmpDir, 'stripe', 'telemetry_id');
+    const filePath = path.join(tmpDir, stripeDir, 'telemetry_id');
     fs.writeFileSync(filePath, 'ffffffffffffffffffffffffffffffff', 'utf8');
 
     // Second call should return the cached value, not the new file content
@@ -55,7 +72,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
 
   it('reads an existing telemetry_id from the file', () => {
     const existingId = 'deadbeef1234567890abcdef12345678';
-    const filePath = path.join(tmpDir, 'stripe', 'telemetry_id');
+    const filePath = path.join(tmpDir, stripeDir, 'telemetry_id');
     fs.mkdirSync(path.dirname(filePath), {recursive: true});
     fs.writeFileSync(filePath, existingId, 'utf8');
 
@@ -65,7 +82,7 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
 
   it('generates and persists a new ID when the file is absent', () => {
     // No pre-existing file; the directory exists but the file does not
-    const filePath = path.join(tmpDir, 'stripe', 'telemetry_id');
+    const filePath = path.join(tmpDir, stripeDir, 'telemetry_id');
     expect(fs.existsSync(filePath)).to.be.false;
 
     const id = platform.getTelemetryId();
@@ -78,7 +95,8 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
     expect(persisted).to.equal(id);
   });
 
-  it('returns null when the file cannot be written', () => {
+  it('returns null when the file cannot be written', function () {
+    if (isWindows) return this.skip();
     // Point to a path whose parent cannot be created: use a file as a directory
     const blockingFile = path.join(tmpDir, 'not-a-dir');
     fs.writeFileSync(blockingFile, 'collision', 'utf8');
@@ -89,7 +107,8 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
     expect(id).to.be.null;
   });
 
-  it('creates parent directories automatically when they are missing', () => {
+  it('creates parent directories automatically when they are missing', function () {
+    if (isWindows) return this.skip();
     // XDG_CONFIG_HOME is set to a path that does not yet exist
     const deepDir = path.join(tmpDir, 'a', 'b', 'c');
     process.env.XDG_CONFIG_HOME = deepDir;
@@ -103,7 +122,8 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
   });
 
   describe('_getTelemetryIdPath', () => {
-    it('uses XDG_CONFIG_HOME when set', () => {
+    it('uses XDG_CONFIG_HOME when set', function () {
+      if (isWindows) return this.skip();
       const xdgBase = path.join(tmpDir, 'custom-xdg');
       process.env.XDG_CONFIG_HOME = xdgBase;
 
@@ -111,7 +131,8 @@ describe('NodePlatformFunctions#getTelemetryId', () => {
       expect(result).to.equal(path.join(xdgBase, 'stripe', 'telemetry_id'));
     });
 
-    it('falls back to ~/.config/stripe/telemetry_id when XDG_CONFIG_HOME is unset', () => {
+    it('falls back to ~/.config/stripe/telemetry_id when XDG_CONFIG_HOME is unset', function () {
+      if (isWindows) return this.skip();
       delete process.env.XDG_CONFIG_HOME;
 
       const result = (platform as any)._getTelemetryIdPath();


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Recently, we introduced the `source` hash in the user-agent header to help our support team track down exactly where incoming requests originated from.

They've reported back to us that this hasn't been as useful as we wanted, so we're going a different direction.

Instead, we're adopting an industry-standard method of persisting a small UUID on disk that we include with subsequent requests. It's easy for users to read this file and it contains no PII. It also honors our existing telemetry opt outs.

It's meant to be lightweight and failure tolerant.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- remove `source` key from user-agent header
- add `telemetry_id` to the user-agent header
- adjust tests accordingly

### See Also

<!-- Include any links or additional information that help explain this change. -->

- original request: [DEVSDK-3131](https://go/j/DEVSDK-3131)
- update request: [RUN_DEVSDK-2563](https://go/j/RUN_DEVSDK-2563)
