### PR TITLE
Implement extensibility platform

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,6 +68,10 @@
     "prepack": "just install && just build"
   },
   "exports": {
+    "extensibility": {
+      "import": "./esm/stripe.esm.extensibility.js",
+      "require": "./cjs/stripe.cjs.extensibility.js"
+    },
     "browser": {
       "import": "./esm/stripe.esm.worker.js",
       "require": "./cjs/stripe.cjs.worker.js"

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -23,7 +23,11 @@ import {
   ApiMode,
 } from './Types.js';
 import {RawRequestOptions, RequestOptions} from './lib.js';
-import {HttpClient, HttpClientResponseInterface} from './net/HttpClient.js';
+import {
+  HttpClient,
+  HttpClientResponseInterface,
+  HttpClientRuntimeError,
+} from './net/HttpClient.js';
 import {Stripe} from './stripe.core.js';
 import {
   jsonStringifyRequestData,
@@ -679,37 +683,43 @@ export class RequestSender {
                 )(res);
               }
             })
-            .catch((error: HttpClientResponseError) => {
-              if (
-                RequestSender._shouldRetry(
-                  null,
-                  requestRetries,
-                  maxRetries,
-                  error
-                )
-              ) {
-                return retryRequest(
-                  makeRequest,
-                  apiVersion,
-                  headers,
-                  requestRetries
-                );
-              } else {
-                const isTimeoutError =
-                  error.code && error.code === HttpClient.TIMEOUT_ERROR_CODE;
+            .catch(
+              (error: HttpClientResponseError | HttpClientRuntimeError) => {
+                if (error instanceof HttpClientRuntimeError) {
+                  return callback(error);
+                }
 
-                return callback(
-                  new StripeConnectionError({
-                    message: isTimeoutError
-                      ? `Request aborted due to timeout being reached (${timeout}ms)`
-                      : RequestSender._generateConnectionErrorMessage(
-                          requestRetries
-                        ),
-                    detail: error,
-                  })
-                );
+                if (
+                  RequestSender._shouldRetry(
+                    null,
+                    requestRetries,
+                    maxRetries,
+                    error
+                  )
+                ) {
+                  return retryRequest(
+                    makeRequest,
+                    apiVersion,
+                    headers,
+                    requestRetries
+                  );
+                } else {
+                  const isTimeoutError =
+                    error.code && error.code === HttpClient.TIMEOUT_ERROR_CODE;
+
+                  return callback(
+                    new StripeConnectionError({
+                      message: isTimeoutError
+                        ? `Request aborted due to timeout being reached (${timeout}ms)`
+                        : RequestSender._generateConnectionErrorMessage(
+                            requestRetries
+                          ),
+                      detail: error,
+                    })
+                  );
+                }
               }
-            });
+            );
         })
         .catch((e: any) => {
           throw new StripeError({

--- a/src/StripeEventEmitter.ts
+++ b/src/StripeEventEmitter.ts
@@ -1,0 +1,78 @@
+import {RequestEvent, ResponseEvent} from './Types.js';
+
+type Listener = (...args: any[]) => any;
+type ListenerRegistration = {
+  listener: Listener;
+  once: boolean;
+};
+
+/**
+ * @private
+ * (For internal use in stripe-node.)
+ * Minimal EventEmitter for runtimes without Event or EventTarget.
+ */
+export class StripeEventEmitter {
+  private _listeners: Map<string, Array<ListenerRegistration>>;
+
+  constructor() {
+    this._listeners = new Map();
+  }
+
+  on(eventName: string, listener: Listener): void {
+    this._getListeners(eventName).push({listener, once: false});
+  }
+
+  once(eventName: string, listener: Listener): void {
+    this._getListeners(eventName).push({listener, once: true});
+  }
+
+  removeListener(eventName: string, listener: Listener): void {
+    const listeners = this._listeners.get(eventName);
+    if (!listeners) {
+      return;
+    }
+
+    const index = listeners.findIndex((entry) => entry.listener === listener);
+    if (index === -1) {
+      return;
+    }
+
+    this._removeAt(eventName, index);
+  }
+
+  emit(eventName: string, data?: RequestEvent | ResponseEvent): boolean {
+    const listeners = this._listeners.get(eventName);
+    if (!listeners || listeners.length === 0) {
+      return false;
+    }
+
+    for (const entry of [...listeners]) {
+      if (entry.once) {
+        this._removeAt(eventName, listeners.indexOf(entry));
+      }
+      entry.listener(data);
+    }
+    return true;
+  }
+
+  private _getListeners(eventName: string): Array<ListenerRegistration> {
+    let listeners = this._listeners.get(eventName);
+    if (!listeners) {
+      listeners = [];
+      this._listeners.set(eventName, listeners);
+    }
+    return listeners;
+  }
+
+  private _removeAt(eventName: string, index: number): void {
+    const listeners = this._listeners.get(eventName);
+    if (!listeners || index === -1) {
+      return;
+    }
+
+    listeners.splice(index, 1);
+    if (listeners.length === 0) {
+      this._listeners.delete(eventName);
+    }
+  }
+}

--- a/src/net/EndpointFetchHttpClient.ts
+++ b/src/net/EndpointFetchHttpClient.ts
@@ -1,0 +1,155 @@
+import {RequestHeaders} from '../Types.js';
+import {parseHttpHeaderAsString} from '../utils.js';
+import {
+  HttpClient,
+  HttpClientResponse,
+  HttpClientResponseInterface,
+  HttpClientRuntimeError,
+} from './HttpClient.js';
+
+type EndpointFetchRequest = {
+  endpoint: 'stripe_api';
+  path: string;
+  method: string;
+  body?: string;
+  headers?: Record<string, string>;
+};
+
+type EndpointFetchResponse = {
+  status: number;
+  body?: string | null;
+};
+
+type EndpointFetchSuccessResponse = EndpointFetchResponse & {
+  ok: true;
+};
+
+type EndpointFetchError = Error & {
+  status?: number;
+  body?: string | null;
+};
+
+type EndpointFetch = (
+  request: EndpointFetchRequest
+) => Promise<EndpointFetchSuccessResponse>;
+
+declare const endpointFetch: EndpointFetch | undefined;
+
+const STRIPE_API_HOST = 'api.stripe.com';
+
+export class EndpointFetchHttpClient extends HttpClient {
+  /** @override */
+  getClientName(): string {
+    return 'endpointFetch';
+  }
+
+  async makeRequest(
+    host: string,
+    port: string,
+    path: string,
+    method: string,
+    headers: RequestHeaders,
+    requestData: string,
+    protocol: string,
+    timeout: number
+  ): Promise<HttpClientResponseInterface> {
+    if (!path.startsWith('/')) {
+      throw new Error(`Only relative paths are supported, got: "${path}"`);
+    }
+
+    if (host !== STRIPE_API_HOST) {
+      throw new HttpClientRuntimeError(
+        `Stripe: This entrypoint only supports Stripe API requests to ${STRIPE_API_HOST}. Received request for ${host}.`
+      );
+    }
+
+    if (typeof endpointFetch !== 'function') {
+      throw new HttpClientRuntimeError(
+        'Stripe: `endpointFetch()` is not available.'
+      );
+    }
+
+    const methodHasPayload =
+      method == 'POST' || method == 'PUT' || method == 'PATCH';
+    const body = requestData || (methodHasPayload ? '' : undefined);
+
+    const endpointFetchRequest: EndpointFetchRequest = {
+      endpoint: 'stripe_api',
+      path,
+      method,
+      headers: this._getHeaders(headers),
+    };
+    if (body !== undefined) {
+      endpointFetchRequest.body = body;
+    }
+
+    try {
+      const response = await endpointFetch(endpointFetchRequest);
+      return new EndpointFetchHttpClientResponse(response);
+    } catch (e) {
+      const response = EndpointFetchHttpClient._responseFromError(e);
+      if (response) {
+        return new EndpointFetchHttpClientResponse(response);
+      }
+      throw e;
+    }
+  }
+
+  private _getHeaders(headers: RequestHeaders): Record<string, string> {
+    return Object.fromEntries(
+      Object.entries(headers).map(([key, value]) => [
+        key,
+        parseHttpHeaderAsString(value),
+      ])
+    );
+  }
+
+  private static _responseFromError(
+    error: unknown
+  ): EndpointFetchResponse | null {
+    if (!error || typeof error !== 'object') {
+      return null;
+    }
+
+    const endpointFetchError = error as EndpointFetchError;
+    if (typeof endpointFetchError.status !== 'number') {
+      return null;
+    }
+
+    return {
+      status: endpointFetchError.status,
+      body: endpointFetchError.body ?? '',
+    };
+  }
+}
+
+export class EndpointFetchHttpClientResponse extends HttpClientResponse {
+  private _res: EndpointFetchResponse;
+
+  constructor(res: EndpointFetchResponse) {
+    super(res.status, {});
+    this._res = res;
+  }
+
+  getRawResponse(): EndpointFetchResponse {
+    return this._res;
+  }
+
+  toStream(streamCompleteCallback: () => void): never {
+    throw new HttpClientRuntimeError(
+      'Stripe: Streaming responses are not supported in this runtime.'
+    );
+  }
+
+  toJSON(): Promise<any> {
+    const body = this._res.body || '';
+    try {
+      return Promise.resolve(JSON.parse(body));
+    } catch (e) {
+      if (e instanceof Error) {
+        (e as any).rawBody = body;
+      }
+      return Promise.reject(e);
+    }
+  }
+}

--- a/src/net/EndpointFetchHttpClient.ts
+++ b/src/net/EndpointFetchHttpClient.ts
@@ -143,13 +143,6 @@ export class EndpointFetchHttpClientResponse extends HttpClientResponse {
 
   toJSON(): Promise<any> {
     const body = this._res.body || '';
-    try {
-      return Promise.resolve(JSON.parse(body));
-    } catch (e) {
-      if (e instanceof Error) {
-        (e as any).rawBody = body;
-      }
-      return Promise.reject(e);
-    }
+    return Promise.resolve().then(() => this._parseResponseBody(body));
   }
 }

--- a/src/net/EndpointFetchHttpClient.ts
+++ b/src/net/EndpointFetchHttpClient.ts
@@ -65,7 +65,7 @@ export class EndpointFetchHttpClient extends HttpClient {
 
     if (typeof endpointFetch !== 'function') {
       throw new HttpClientRuntimeError(
-        'Stripe: `endpointFetch()` is not available.'
+        'Stripe: EndpointFetchHttpClient requires `endpointFetch()` from a Stripe Script runtime or a test mock.'
       );
     }
 
@@ -137,7 +137,7 @@ export class EndpointFetchHttpClientResponse extends HttpClientResponse {
 
   toStream(streamCompleteCallback: () => void): never {
     throw new HttpClientRuntimeError(
-      'Stripe: Streaming responses are not supported in this runtime.'
+      'Stripe: EndpointFetchHttpClient does not support streaming responses.'
     );
   }
 

--- a/src/net/FetchHttpClient.ts
+++ b/src/net/FetchHttpClient.ts
@@ -183,16 +183,7 @@ export class FetchHttpClientResponse extends HttpClientResponse
   }
 
   toJSON(): Promise<any> {
-    return this._res.text().then((text) => {
-      try {
-        return JSON.parse(text);
-      } catch (e) {
-        if (e instanceof Error) {
-          (e as any).rawBody = text;
-        }
-        throw e;
-      }
-    });
+    return this._res.text().then((text) => this._parseResponseBody(text));
   }
 
   static _transformHeadersToObject(headers: Headers): ResponseHeaders {

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -144,3 +144,5 @@ export class HttpClientResponse implements HttpClientResponseInterface {
     throw new Error('toJSON not implemented.');
   }
 }
+
+export class HttpClientRuntimeError extends Error {}

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -143,6 +143,17 @@ export class HttpClientResponse implements HttpClientResponseInterface {
   toJSON(): any {
     throw new Error('toJSON not implemented.');
   }
+
+  protected _parseResponseBody(body: string): any {
+    try {
+      return JSON.parse(body);
+    } catch (e) {
+      if (e instanceof Error) {
+        (e as any).rawBody = body;
+      }
+      throw e;
+    }
+  }
 }
 
 export class HttpClientRuntimeError extends Error {}

--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -135,11 +135,8 @@ export class NodeHttpClientResponse extends HttpClientResponse
       });
       this._res.once('end', () => {
         try {
-          resolve(JSON.parse(response));
+          resolve(this._parseResponseBody(response));
         } catch (e) {
-          if (e instanceof Error) {
-            (e as any).rawBody = response;
-          }
           reject(e);
         }
       });

--- a/src/platform/ExtensibilityPlatformFunctions.ts
+++ b/src/platform/ExtensibilityPlatformFunctions.ts
@@ -1,0 +1,98 @@
+import {CryptoProvider} from '../crypto/CryptoProvider.js';
+import {EndpointFetchHttpClient} from '../net/EndpointFetchHttpClient.js';
+import {
+  FetchHttpClientInterface,
+  HttpClient,
+  NodeHttpClientInterface,
+} from '../net/HttpClient.js';
+import {StripeEventEmitter} from '../StripeEventEmitter.js';
+import {
+  BufferedFile,
+  MultipartRequestData,
+  RequestAuthenticator,
+  RequestData,
+} from '../Types.js';
+import {PlatformFunctions} from './PlatformFunctions.js';
+
+const unsupportedRuntimeError = (method: string, alternative?: string): Error =>
+  new Error(
+    `Stripe: \`${method}()\` is not available in the extensibility runtime.` +
+      (alternative ? ` ${alternative}` : '')
+  );
+
+/**
+ * Platform functions for extensibility scripts.
+ */
+export class ExtensibilityPlatformFunctions extends PlatformFunctions {
+  /** @override */
+  emitWarning(_warning: string): void {
+    // Warnings have no host-visible sink in this runtime.
+  }
+
+  /** @override */
+  getEnv(): null {
+    return null;
+  }
+
+  /** @override */
+  getRuntimeVersion(): null {
+    return null;
+  }
+
+  /** @override */
+  getDefaultMaxNetworkRetries(): number {
+    return 0;
+  }
+
+  /** @override */
+  createDefaultAuthenticator(): RequestAuthenticator {
+    // Authentication is injected automatically.
+    return (): Promise<void> => Promise.resolve();
+  }
+
+  /** @override */
+  createEmitter(): StripeEventEmitter {
+    return new StripeEventEmitter();
+  }
+
+  /** @override */
+  tryBufferData(
+    data: MultipartRequestData
+  ): Promise<RequestData | BufferedFile> {
+    return Promise.resolve(data);
+  }
+
+  /** @override */
+  createDefaultHttpClient(): HttpClient {
+    return new EndpointFetchHttpClient();
+  }
+
+  /** @override */
+  createFetchHttpClient(): FetchHttpClientInterface {
+    throw unsupportedRuntimeError(
+      'createFetchHttpClient',
+      'Use the default `endpointFetch` HTTP client instead.'
+    );
+  }
+
+  /** @override */
+  createNodeHttpClient(): NodeHttpClientInterface {
+    throw unsupportedRuntimeError(
+      'createNodeHttpClient',
+      'Use the default `endpointFetch` HTTP client instead.'
+    );
+  }
+
+  /** @override */
+  createNodeCryptoProvider(): CryptoProvider {
+    throw unsupportedRuntimeError('createNodeCryptoProvider');
+  }
+
+  /** @override */
+  createDefaultCryptoProvider(): CryptoProvider {
+    throw unsupportedRuntimeError(
+      'createDefaultCryptoProvider',
+      'Pass an explicit `CryptoProvider` for crypto-dependent helpers.'
+    );
+  }
+}

--- a/src/platform/ExtensibilityPlatformFunctions.ts
+++ b/src/platform/ExtensibilityPlatformFunctions.ts
@@ -26,7 +26,7 @@ const unsupportedRuntimeError = (method: string, alternative?: string): Error =>
 export class ExtensibilityPlatformFunctions extends PlatformFunctions {
   /** @override */
   emitWarning(_warning: string): void {
-    // Warnings have no host-visible sink in this runtime.
+    // Extensibility runtime has no user-visible warning target.
   }
 
   /** @override */

--- a/src/platform/PlatformFunctions.ts
+++ b/src/platform/PlatformFunctions.ts
@@ -2,18 +2,28 @@
 // eslint-disable-next-line wintertc-compat
 import * as http from 'http';
 import {CryptoProvider} from '../crypto/CryptoProvider.js';
-// TODO(DEVSDK-3113): Remove EventEmitter from shared base class in next major version.
-// eslint-disable-next-line wintertc-compat
-import {EventEmitter} from 'events';
 import {FetchHttpClient} from '../net/FetchHttpClient.js';
 import {
   HttpClient,
   NodeHttpClientInterface,
   FetchHttpClientInterface,
 } from '../net/HttpClient.js';
-import {StripeEmitter} from '../StripeEmitter.js';
 import {SubtleCryptoProvider} from '../crypto/SubtleCryptoProvider.js';
-import {MultipartRequestData, RequestData, BufferedFile} from '../Types.js';
+import {
+  MultipartRequestData,
+  RequestData,
+  BufferedFile,
+  RequestEvent,
+  ResponseEvent,
+  RequestAuthenticator,
+} from '../Types.js';
+
+export interface StripeEmitterInterface {
+  on(eventName: string, listener: (...args: any[]) => any): void;
+  once(eventName: string, listener: (...args: any[]) => any): void;
+  removeListener(eventName: string, listener: (...args: any[]) => any): void;
+  emit(eventName: string, data?: RequestEvent | ResponseEvent): boolean;
+}
 
 /**
  * Interface encapsulating various utility functions whose
@@ -64,6 +74,20 @@ export class PlatformFunctions {
   }
 
   /**
+   * Returns the default number of network retries for this platform.
+   */
+  getDefaultMaxNetworkRetries(): number {
+    return 2;
+  }
+
+  /**
+   * Returns the default request authenticator for this platform.
+   */
+  createDefaultAuthenticator(): RequestAuthenticator | null {
+    return null;
+  }
+
+  /**
    * Generates a v4 UUID. See https://stackoverflow.com/a/2117523
    */
   uuid4(): string {
@@ -93,7 +117,7 @@ export class PlatformFunctions {
   /**
    * Creates an event emitter.
    */
-  createEmitter(): StripeEmitter | EventEmitter {
+  createEmitter(): StripeEmitterInterface {
     throw new Error('createEmitter not implemented.');
   }
 

--- a/src/stripe.cjs.extensibility.ts
+++ b/src/stripe.cjs.extensibility.ts
@@ -1,0 +1,44 @@
+import {ExtensibilityPlatformFunctions} from './platform/ExtensibilityPlatformFunctions.js';
+import {Stripe} from './stripe.core.js';
+import {StripeConfig} from './lib.js';
+
+// Initialize the Stripe class with Extensibility platform functions
+Stripe.initialize(new ExtensibilityPlatformFunctions());
+
+type StripeCallableConstructor = typeof Stripe & {
+  (key?: string, config?: StripeConfig): Stripe;
+  new (key?: string, config?: StripeConfig): Stripe;
+};
+
+// Callable constructor: supports both `new Stripe()` and `Stripe()` for CJS consumers.
+// typeof Stripe provides the construct signature and static members; the intersection
+// adds a call signature for backward compatibility.
+const StripeConstructor: StripeCallableConstructor = (function(
+  this: any,
+  key?: string,
+  config?: StripeConfig
+): Stripe {
+  // Support calling without `new`
+  if (!(this instanceof StripeConstructor)) {
+    return new Stripe(key || '', config);
+  }
+  return new Stripe(key || '', config);
+} as unknown) as StripeCallableConstructor;
+
+// Copy all static properties from Stripe to the wrapper
+Object.setPrototypeOf(StripeConstructor, Stripe);
+Object.setPrototypeOf(StripeConstructor.prototype, Stripe.prototype);
+
+// Copy static properties explicitly
+for (const key of Object.getOwnPropertyNames(Stripe)) {
+  if (key !== 'length' && key !== 'prototype' && key !== 'name') {
+    Object.defineProperty(StripeConstructor, key, {
+      value: (Stripe as any)[key],
+      writable: true,
+      enumerable: true,
+      configurable: true,
+    });
+  }
+}
+
+export = StripeConstructor;

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1139,7 +1139,7 @@ export class Stripe {
       maxNetworkRetries: validateInteger(
         'maxNetworkRetries',
         props.maxNetworkRetries,
-        2
+        this._platformFunctions.getDefaultMaxNetworkRetries()
       ),
       agent: agent,
       httpClient:
@@ -1290,6 +1290,10 @@ export class Stripe {
     key: string,
     authenticator: RequestAuthenticator | null
   ): void {
+    if (!key && !authenticator) {
+      authenticator = this._platformFunctions.createDefaultAuthenticator();
+    }
+
     if (key && authenticator) {
       throw new Error("Can't specify both apiKey and authenticator");
     }

--- a/src/stripe.esm.extensibility.ts
+++ b/src/stripe.esm.extensibility.ts
@@ -1,0 +1,15 @@
+import {ExtensibilityPlatformFunctions} from './platform/ExtensibilityPlatformFunctions.js';
+export {Decimal} from './Decimal.js';
+import {Stripe as StripeCore} from './stripe.core.js';
+import {StripeConfig} from './lib.js';
+
+// Initialize the Stripe class with Extensibility platform functions
+StripeCore.initialize(new ExtensibilityPlatformFunctions());
+
+type ExtensibilityStripeConstructor = typeof StripeCore & {
+  new (key?: string, config?: StripeConfig): StripeCore;
+};
+
+const Stripe = StripeCore as ExtensibilityStripeConstructor;
+export {Stripe};
+export default Stripe;

--- a/test/ExtensibilityPlatformFunctions.spec.ts
+++ b/test/ExtensibilityPlatformFunctions.spec.ts
@@ -1,0 +1,223 @@
+import {expect} from 'chai';
+import {RequestEvent, ResponseEvent} from '../src/lib.js';
+import {EndpointFetchHttpClient} from '../src/net/EndpointFetchHttpClient.js';
+import {ExtensibilityPlatformFunctions} from '../src/platform/ExtensibilityPlatformFunctions.js';
+import {NodePlatformFunctions} from '../src/platform/NodePlatformFunctions.js';
+import {StripeEventEmitter} from '../src/StripeEventEmitter.js';
+import {Stripe} from '../src/stripe.core.js';
+
+type TestGlobal = typeof globalThis & {
+  endpointFetch?: (request: {
+    endpoint: 'stripe_api';
+    path: string;
+    method: string;
+    body?: string;
+    headers?: Record<string, string>;
+  }) => Promise<{ok: true; status: number; body?: string}>;
+};
+type EndpointFetch = NonNullable<TestGlobal['endpointFetch']>;
+type EndpointFetchRequest = Parameters<EndpointFetch>[0];
+type EndpointFetchError = Error & {
+  status?: number;
+  body?: string | null;
+};
+type StripeError = Error & {
+  type?: string;
+  requestId?: string;
+};
+type HookEvent =
+  | ['request', RequestEvent['method'], RequestEvent['path']]
+  | ['response', ResponseEvent['status'], ResponseEvent['request_id']];
+
+describe('ExtensibilityPlatformFunctions', () => {
+  const testGlobal = globalThis as TestGlobal;
+  let platformFunctions: ExtensibilityPlatformFunctions;
+  let endpointFetch$: EndpointFetch | undefined;
+  let setTimeout$: typeof globalThis.setTimeout;
+
+  beforeEach(() => {
+    platformFunctions = new ExtensibilityPlatformFunctions();
+    endpointFetch$ = testGlobal.endpointFetch;
+    setTimeout$ = globalThis.setTimeout;
+  });
+
+  afterEach(() => {
+    Stripe.initialize(new NodePlatformFunctions());
+
+    if (endpointFetch$ === undefined) {
+      delete testGlobal.endpointFetch;
+    } else {
+      testGlobal.endpointFetch = endpointFetch$;
+    }
+
+    globalThis.setTimeout = setTimeout$;
+  });
+
+  it('uses extensibility runtime defaults', () => {
+    expect(platformFunctions.getEnv()).to.be.null;
+    expect(platformFunctions.getRuntimeVersion()).to.be.null;
+    expect(platformFunctions.getDefaultMaxNetworkRetries()).to.equal(0);
+    expect(platformFunctions.createDefaultAuthenticator()).to.be.a('function');
+    expect(() => platformFunctions.emitWarning('test')).to.not.throw();
+  });
+
+  it('creates a pure-JS emitter', () => {
+    expect(platformFunctions.createEmitter()).to.be.an.instanceOf(
+      StripeEventEmitter
+    );
+  });
+
+  it('creates an EndpointFetchHttpClient by default', () => {
+    expect(platformFunctions.createDefaultHttpClient()).to.be.an.instanceOf(
+      EndpointFetchHttpClient
+    );
+  });
+
+  it('throws clear unsupported-runtime errors for unavailable helpers', () => {
+    expect(() => platformFunctions.createFetchHttpClient()).to.throw(
+      /extensibility runtime/
+    );
+    expect(() => platformFunctions.createNodeHttpClient()).to.throw(
+      /extensibility runtime/
+    );
+    expect(() => platformFunctions.createNodeCryptoProvider()).to.throw(
+      /extensibility runtime/
+    );
+    expect(() => platformFunctions.createDefaultCryptoProvider()).to.throw(
+      /explicit `CryptoProvider`/
+    );
+  });
+
+  it('constructs, emits hooks, and sends requests with platform auth defaults', async () => {
+    Stripe.initialize(platformFunctions);
+    (globalThis as {setTimeout: unknown}).setTimeout = () => {
+      throw new Error('setTimeout should not be called');
+    };
+
+    const requests: EndpointFetchRequest[] = [];
+    testGlobal.endpointFetch = (request: EndpointFetchRequest) => {
+      requests.push(request);
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        body: JSON.stringify({id: 'cus_123', object: 'customer'}),
+      });
+    };
+
+    const stripe = new Stripe('');
+    expect(stripe.getMaxNetworkRetries()).to.equal(0);
+    expect(() =>
+      stripe.webhooks.generateTestHeaderString({
+        payload: '{}',
+        secret: 'whsec_test',
+      })
+    ).to.throw(/createDefaultCryptoProvider/);
+    expect(() =>
+      stripe.parseEventNotification('{}', 'bad_header', 'whsec_test')
+    ).to.throw(/createDefaultCryptoProvider/);
+
+    const events: HookEvent[] = [];
+    stripe.on('request', (event: RequestEvent) =>
+      events.push(['request', event.method, event.path])
+    );
+    stripe.once('response', (event: ResponseEvent) =>
+      events.push(['response', event.status, event.request_id])
+    );
+
+    const customer = await stripe.customers.retrieve('cus_123');
+    const request = requests[0];
+
+    expect(customer.id).to.equal('cus_123');
+    expect(requests).to.have.length(1);
+    expect(request.endpoint).to.equal('stripe_api');
+    expect(request.method).to.equal('GET');
+    expect(request.path).to.equal('/v1/customers/cus_123');
+    expect(request.headers?.Authorization).to.be.undefined;
+    expect(events).to.deep.equal([
+      ['request', 'GET', '/v1/customers/cus_123'],
+      ['response', 200, undefined],
+    ]);
+  });
+
+  it('preserves typed Stripe API errors from endpointFetch rejections', async () => {
+    Stripe.initialize(platformFunctions);
+    testGlobal.endpointFetch = () => {
+      const error: EndpointFetchError = new Error('Stripe API error');
+      error.status = 401;
+      error.body = JSON.stringify({
+        error: {
+          message: 'No API key provided',
+          type: 'authentication_error',
+        },
+      });
+      return Promise.reject(error);
+    };
+
+    try {
+      await new Stripe('').customers.retrieve('cus_123');
+      throw new Error('Expected request to fail');
+    } catch (err) {
+      const error = err as StripeError;
+      expect(error.type).to.equal('StripeAuthenticationError');
+      expect(error.message).to.equal('No API key provided');
+      expect(error.requestId).to.be.undefined;
+    }
+  });
+
+  it('rejects streaming requests clearly through public SDK requests', async () => {
+    Stripe.initialize(platformFunctions);
+    testGlobal.endpointFetch = () =>
+      Promise.resolve({
+        ok: true,
+        status: 200,
+        body: '{}',
+      });
+
+    try {
+      await new Stripe('').rawRequest('GET', '/v1/customers', undefined, {
+        streaming: true,
+      });
+      throw new Error('Expected streaming request to fail');
+    } catch (err) {
+      const error = err as StripeError;
+      expect(error.message).to.equal(
+        'Stripe: Streaming responses are not supported in this runtime.'
+      );
+      expect(error.type).to.be.undefined;
+    }
+  });
+
+  it('preserves clear runtime errors through public SDK requests', async () => {
+    Stripe.initialize(platformFunctions);
+    delete testGlobal.endpointFetch;
+
+    try {
+      await new Stripe('').customers.retrieve('cus_123');
+      throw new Error('Expected missing endpointFetch request to fail');
+    } catch (err) {
+      const error = err as StripeError;
+      expect(error.message).to.equal(
+        'Stripe: `endpointFetch()` is not available.'
+      );
+      expect(error.type).to.be.undefined;
+    }
+
+    testGlobal.endpointFetch = () =>
+      Promise.reject(
+        new Error('Should not call endpointFetch for unsupported host')
+      );
+
+    try {
+      await new Stripe('', {host: 'files.stripe.com'}).customers.retrieve(
+        'cus_123'
+      );
+      throw new Error('Expected unsupported host request to fail');
+    } catch (err) {
+      const error = err as StripeError;
+      expect(error.message).to.match(
+        /only supports Stripe API requests to api\.stripe\.com/
+      );
+      expect(error.type).to.be.undefined;
+    }
+  });
+});

--- a/test/ExtensibilityPlatformFunctions.spec.ts
+++ b/test/ExtensibilityPlatformFunctions.spec.ts
@@ -181,7 +181,7 @@ describe('ExtensibilityPlatformFunctions', () => {
     } catch (err) {
       const error = err as StripeError;
       expect(error.message).to.equal(
-        'Stripe: Streaming responses are not supported in this runtime.'
+        'Stripe: EndpointFetchHttpClient does not support streaming responses.'
       );
       expect(error.type).to.be.undefined;
     }
@@ -197,7 +197,7 @@ describe('ExtensibilityPlatformFunctions', () => {
     } catch (err) {
       const error = err as StripeError;
       expect(error.message).to.equal(
-        'Stripe: `endpointFetch()` is not available.'
+        'Stripe: EndpointFetchHttpClient requires `endpointFetch()` from a Stripe Script runtime or a test mock.'
       );
       expect(error.type).to.be.undefined;
     }

--- a/test/PackageExports.spec.ts
+++ b/test/PackageExports.spec.ts
@@ -1,0 +1,22 @@
+import * as childProcess from 'child_process';
+import {expect} from 'chai';
+
+describe('package exports', () => {
+  it('prefers extensibility over browser when both conditions are present', () => {
+    const resolved = childProcess
+      .execFileSync(
+        process.execPath,
+        [
+          '--conditions=browser',
+          '--conditions=extensibility',
+          '-p',
+          "require.resolve('stripe')",
+        ],
+        {cwd: process.cwd()}
+      )
+      .toString()
+      .trim();
+
+    expect(resolved).to.match(/cjs\/stripe\.cjs\.extensibility\.js$/);
+  });
+});

--- a/test/PackageExports.spec.ts
+++ b/test/PackageExports.spec.ts
@@ -1,4 +1,5 @@
 import * as childProcess from 'child_process';
+import * as path from 'path';
 import {expect} from 'chai';
 
 describe('package exports', () => {
@@ -17,6 +18,7 @@ describe('package exports', () => {
       .toString()
       .trim();
 
-    expect(resolved).to.match(/cjs\/stripe\.cjs\.extensibility\.js$/);
+    expect(path.basename(path.dirname(resolved))).to.equal('cjs');
+    expect(path.basename(resolved)).to.equal('stripe.cjs.extensibility.js');
   });
 });

--- a/test/StripeEventEmitter.spec.ts
+++ b/test/StripeEventEmitter.spec.ts
@@ -1,0 +1,109 @@
+import {expect} from 'chai';
+import {RequestEvent, ResponseEvent} from '../src/lib.js';
+import {StripeEventEmitter} from '../src/StripeEventEmitter.js';
+
+const requestEvent: RequestEvent = {
+  api_version: '2025-01-01',
+  method: 'GET',
+  path: '/v1/customers',
+  request_start_time: 123,
+};
+const responseEvent: ResponseEvent = {
+  ...requestEvent,
+  status: 200,
+  request_id: 'req_123',
+  elapsed: 10,
+  request_end_time: 133,
+};
+
+describe('StripeEventEmitter', () => {
+  it('emits data to listeners registered with on', () => {
+    const emitter = new StripeEventEmitter();
+    const calls: Array<RequestEvent | ResponseEvent | undefined> = [];
+
+    emitter.on('request', (data) => calls.push(data));
+
+    expect(emitter.emit('request', requestEvent)).to.equal(true);
+    expect(calls).to.deep.equal([requestEvent]);
+  });
+
+  it('listeners registered via once only fire once', () => {
+    const emitter = new StripeEventEmitter();
+    let calls = 0;
+
+    emitter.once('response', () => {
+      calls += 1;
+    });
+
+    expect(emitter.emit('response', responseEvent)).to.equal(true);
+    expect(emitter.emit('response', responseEvent)).to.equal(false);
+    expect(calls).to.equal(1);
+  });
+
+  it('removes a once listener before invoking it', () => {
+    const emitter = new StripeEventEmitter();
+    let calls = 0;
+
+    emitter.once('response', () => {
+      calls += 1;
+      throw new Error('listener failed');
+    });
+
+    expect(() => emitter.emit('response', responseEvent)).to.throw(
+      'listener failed'
+    );
+    expect(emitter.emit('response', responseEvent)).to.equal(false);
+    expect(calls).to.equal(1);
+  });
+
+  it('removes a listener from only the requested event name', () => {
+    const emitter = new StripeEventEmitter();
+    const calls: Array<RequestEvent | ResponseEvent | undefined> = [];
+    const listener = (data?: RequestEvent | ResponseEvent): void => {
+      calls.push(data);
+    };
+
+    emitter.on('request', listener);
+    emitter.on('response', listener);
+    emitter.removeListener('request', listener);
+
+    expect(emitter.emit('request', requestEvent)).to.equal(false);
+    expect(emitter.emit('response', responseEvent)).to.equal(true);
+    expect(calls).to.deep.equal([responseEvent]);
+  });
+
+  it('ignores removing listeners for never-registered event names', () => {
+    const emitter = new StripeEventEmitter();
+
+    expect(() => emitter.removeListener('request', () => {})).to.not.throw();
+  });
+
+  it('ignores removing listeners that were not registered', () => {
+    const emitter = new StripeEventEmitter();
+    let calls = 0;
+
+    emitter.on('request', () => {
+      calls += 1;
+    });
+    emitter.removeListener('request', () => {});
+
+    expect(emitter.emit('request', requestEvent)).to.equal(true);
+    expect(calls).to.equal(1);
+  });
+
+  it('supports the same listener registered more than once', () => {
+    const emitter = new StripeEventEmitter();
+    let calls = 0;
+    const listener = () => {
+      calls += 1;
+    };
+
+    emitter.on('request', listener);
+    emitter.once('request', listener);
+
+    expect(emitter.emit('request')).to.equal(true);
+    expect(calls).to.equal(2);
+    expect(emitter.emit('request')).to.equal(true);
+    expect(calls).to.equal(3);
+  });
+});

--- a/test/net/EndpointFetchHttpClient.spec.ts
+++ b/test/net/EndpointFetchHttpClient.spec.ts
@@ -1,0 +1,276 @@
+import {fail} from 'assert';
+import {expect} from 'chai';
+import {EndpointFetchHttpClient} from '../../src/net/EndpointFetchHttpClient.js';
+import {HttpClientRuntimeError} from '../../src/net/HttpClient.js';
+import {RequestHeaders} from '../../src/Types.js';
+
+type TestGlobal = typeof globalThis & {
+  endpointFetch?: (request: {
+    endpoint: 'stripe_api';
+    path: string;
+    method: string;
+    body?: string;
+    headers?: Record<string, string>;
+  }) => Promise<{
+    ok: true;
+    status: number;
+    body?: string;
+  }>;
+};
+type EndpointFetch = NonNullable<TestGlobal['endpointFetch']>;
+type EndpointFetchRequest = Parameters<EndpointFetch>[0];
+type EndpointFetchError = Error & {
+  status?: number;
+  body?: string | null;
+};
+type JsonParseError = Error & {
+  rawBody?: string;
+};
+type MakeRequestOptions = {
+  host?: string;
+  port?: string;
+  path?: string;
+  method?: string;
+  headers?: RequestHeaders;
+  requestData?: string;
+  protocol?: string;
+  timeout?: number;
+};
+
+describe('EndpointFetchHttpClient', () => {
+  const testGlobal = globalThis as TestGlobal;
+  let endpointFetch$: EndpointFetch | undefined;
+  let capturedRequest: EndpointFetchRequest | null;
+
+  const makeRequest = (options: MakeRequestOptions = {}) => {
+    const client = new EndpointFetchHttpClient();
+    return client.makeRequest(
+      options.host ?? 'api.stripe.com',
+      options.port ?? '443',
+      options.path ?? '/v1/customers',
+      options.method ?? 'GET',
+      options.headers ?? {},
+      options.requestData ?? '',
+      options.protocol ?? 'https',
+      options.timeout ?? 1000
+    );
+  };
+
+  beforeEach(() => {
+    endpointFetch$ = testGlobal.endpointFetch;
+    capturedRequest = null;
+    testGlobal.endpointFetch = (request: EndpointFetchRequest) => {
+      capturedRequest = request;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        body: '{"ok":true}',
+      });
+    };
+  });
+
+  afterEach(() => {
+    if (endpointFetch$ === undefined) {
+      delete testGlobal.endpointFetch;
+    } else {
+      testGlobal.endpointFetch = endpointFetch$;
+    }
+  });
+
+  it('sends method, path, headers, and body to endpointFetch', async () => {
+    const response = await makeRequest({
+      method: 'POST',
+      headers: {'Stripe-Version': '2025-01-01'},
+      requestData: 'description=test',
+    });
+
+    expect(capturedRequest).to.deep.equal({
+      endpoint: 'stripe_api',
+      path: '/v1/customers',
+      method: 'POST',
+      body: 'description=test',
+      headers: {'Stripe-Version': '2025-01-01'},
+    });
+    expect(response.getStatusCode()).to.equal(200);
+    expect(response.getHeaders()).to.deep.equal({});
+    expect(await response.toJSON()).to.deep.equal({ok: true});
+  });
+
+  it('uses an empty string body for payload methods without request data', async () => {
+    await makeRequest({method: 'POST'});
+
+    expect(capturedRequest?.body).to.equal('');
+  });
+
+  it('stringifies request header values for endpointFetch', async () => {
+    await makeRequest({
+      headers: {
+        'Content-Length': 12,
+        'X-Stripe-Client-User-Agent': ['a', 'b'],
+      },
+    });
+
+    expect(capturedRequest?.headers).to.deep.equal({
+      'Content-Length': '12',
+      'X-Stripe-Client-User-Agent': 'a, b',
+    });
+  });
+
+  it('does not send a body for GET requests without request data', async () => {
+    await makeRequest();
+
+    expect(capturedRequest).to.not.have.property('body');
+  });
+
+  it('throws clearly for streams', async () => {
+    const response = await makeRequest();
+
+    expect(() => response.toStream(() => {})).to.throw(
+      HttpClientRuntimeError,
+      /Streaming responses are not supported/
+    );
+  });
+
+  it('throws with rawBody when JSON parsing fails', async () => {
+    testGlobal.endpointFetch = () =>
+      Promise.resolve({
+        ok: true,
+        status: 500,
+        body: '{"a"',
+      });
+    const response = await makeRequest();
+
+    try {
+      await response.toJSON();
+      fail();
+    } catch (e) {
+      const error = e as JsonParseError;
+      expect(error.rawBody).to.equal('{"a"');
+    }
+  });
+
+  it('preserves response-shaped endpointFetch rejections', async () => {
+    testGlobal.endpointFetch = () => {
+      const error: EndpointFetchError = new Error('Stripe API error');
+      error.status = 401;
+      error.body =
+        '{"error":{"message":"No API key provided","type":"authentication_error"}}';
+      return Promise.reject(error);
+    };
+
+    const response = await makeRequest();
+
+    expect(response.getStatusCode()).to.equal(401);
+    expect(response.getHeaders()).to.deep.equal({});
+    expect(await response.toJSON()).to.deep.equal({
+      error: {
+        message: 'No API key provided',
+        type: 'authentication_error',
+      },
+    });
+  });
+
+  it('handles endpointFetch HTTP errors with empty response bodies', async () => {
+    testGlobal.endpointFetch = () => {
+      const error: EndpointFetchError = new Error('Stripe API error');
+      error.status = 400;
+      error.body = null;
+      return Promise.reject(error);
+    };
+
+    const response = await makeRequest();
+
+    expect(response.getStatusCode()).to.equal(400);
+    try {
+      await response.toJSON();
+      fail();
+    } catch (e) {
+      const error = e as JsonParseError;
+      expect(error.rawBody).to.equal('');
+    }
+  });
+
+  it('handles endpointFetch HTTP errors without response bodies', async () => {
+    testGlobal.endpointFetch = () => {
+      const error: EndpointFetchError = new Error('Stripe API error');
+      error.status = 400;
+      return Promise.reject(error);
+    };
+
+    const response = await makeRequest();
+
+    expect(response.getStatusCode()).to.equal(400);
+    try {
+      await response.toJSON();
+      fail();
+    } catch (e) {
+      const error = e as JsonParseError;
+      expect(error.rawBody).to.equal('');
+    }
+  });
+
+  it('rethrows endpointFetch transport failures', async () => {
+    testGlobal.endpointFetch = () =>
+      Promise.reject(new Error('egress unavailable'));
+
+    try {
+      await makeRequest();
+      fail();
+    } catch (e) {
+      const error = e as Error;
+      expect(error.message).to.equal('egress unavailable');
+    }
+  });
+
+  it('rethrows non-object endpointFetch failures', async () => {
+    testGlobal.endpointFetch = () =>
+      new Promise((resolve, reject) => {
+        // eslint-disable-next-line prefer-promise-reject-errors -- endpointFetch is external, so defensive pass-through covers non-Error rejections.
+        reject(null);
+      });
+
+    try {
+      await makeRequest();
+      fail();
+    } catch (e) {
+      expect(e).to.be.null;
+    }
+  });
+
+  it('throws clearly when endpointFetch is unavailable', async () => {
+    delete testGlobal.endpointFetch;
+
+    try {
+      await makeRequest();
+      fail();
+    } catch (e) {
+      const error = e as Error;
+      expect(error.message).to.contain('`endpointFetch()` is not available');
+      expect(error).to.be.an.instanceOf(HttpClientRuntimeError);
+    }
+  });
+
+  it('throws clearly for unsupported Stripe API hosts', async () => {
+    try {
+      await makeRequest({host: 'files.stripe.com', path: '/v1/files'});
+      fail();
+    } catch (e) {
+      const error = e as Error;
+      expect(error.message).to.contain(
+        'only supports Stripe API requests to api.stripe.com'
+      );
+      expect(error).to.be.an.instanceOf(HttpClientRuntimeError);
+    }
+    expect(capturedRequest).to.be.null;
+  });
+
+  it('throws when path is an absolute URL', async () => {
+    try {
+      await makeRequest({path: 'https://example.com/steal'});
+      fail();
+    } catch (e) {
+      const error = e as Error;
+      expect(error.message).to.match(/Only relative paths are supported/);
+    }
+  });
+});

--- a/test/net/EndpointFetchHttpClient.spec.ts
+++ b/test/net/EndpointFetchHttpClient.spec.ts
@@ -127,7 +127,7 @@ describe('EndpointFetchHttpClient', () => {
 
     expect(() => response.toStream(() => {})).to.throw(
       HttpClientRuntimeError,
-      /Streaming responses are not supported/
+      'Stripe: EndpointFetchHttpClient does not support streaming responses.'
     );
   });
 
@@ -245,7 +245,9 @@ describe('EndpointFetchHttpClient', () => {
       fail();
     } catch (e) {
       const error = e as Error;
-      expect(error.message).to.contain('`endpointFetch()` is not available');
+      expect(error.message).to.equal(
+        'Stripe: EndpointFetchHttpClient requires `endpointFetch()` from a Stripe Script runtime or a test mock.'
+      );
       expect(error).to.be.an.instanceOf(HttpClientRuntimeError);
     }
   });

--- a/test/net/HttpClient.spec.ts
+++ b/test/net/HttpClient.spec.ts
@@ -1,0 +1,33 @@
+import {expect} from 'chai';
+import {HttpClientResponse} from '../../src/net/HttpClient.js';
+
+type JsonParseError = SyntaxError & {
+  rawBody?: string;
+};
+
+class TestHttpClientResponse extends HttpClientResponse {
+  parseResponseBody(body: string): any {
+    return this._parseResponseBody(body);
+  }
+}
+
+describe('HttpClientResponse', () => {
+  const response = new TestHttpClientResponse(200, {});
+
+  it('parses JSON response bodies', () => {
+    expect(response.parseResponseBody('{"ok":true}')).to.deep.equal({ok: true});
+  });
+
+  it('attaches the raw body to JSON parsing errors', () => {
+    let error: JsonParseError | undefined;
+
+    try {
+      response.parseResponseBody('{"ok"');
+    } catch (e) {
+      error = e as JsonParseError;
+    }
+
+    expect(error).to.be.an.instanceOf(SyntaxError);
+    expect(error?.rawBody).to.equal('{"ok"');
+  });
+});

--- a/tsconfig.cjs.json
+++ b/tsconfig.cjs.json
@@ -17,5 +17,5 @@
     "esModuleInterop": false // This is a viral option, do not enable https://www.semver-ts.org/#module-interop
   },
   "include": ["./src/**/*"],
-  "exclude": ["./src/stripe.esm.node.ts", "./src/stripe.esm.worker.ts"],
+  "exclude": ["./src/stripe.esm.extensibility.ts", "./src/stripe.esm.node.ts", "./src/stripe.esm.worker.ts"],
 }

--- a/tsconfig.esm.json
+++ b/tsconfig.esm.json
@@ -4,5 +4,5 @@
     "outDir": "./esm",
     "module": "es2022",
   },
-  "exclude": ["./src/stripe.cjs.node.ts", "./src/stripe.cjs.worker.ts"],
+  "exclude": ["./src/stripe.cjs.extensibility.ts", "./src/stripe.cjs.node.ts", "./src/stripe.cjs.worker.ts"],
 }


### PR DESCRIPTION
### Why?
* Support using Stripe SDK as part of the [Scripts](https://docs.stripe.com/extensions/how-extensions-work#scripts)
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
* Create a new platform, extensibility, to support this SDK when running scripts in Stripe environment.
* Minimal necessary plumbing to support using `extensibility` as a platform target
* Also implement a bare `StripeEventEmitter`, as it's not part of the runtime.

### See Also
<!-- Include any links or additional information that help explain this change. -->

## Changelog
<!-- Heads up! This section should include entries for any user-facing changes.

List breaking changes first with a ⚠️ prefix, e.g.
- ⚠️ Removes deprecated `legacy_method` function
-->
