### PR TITLE
Add `stripe.major_api_version` constant

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,8 +4,10 @@
 
 - Run all tests: `just test` (builds first)
 - Run a specific test: `just test --grep "test name pattern"`
+- Run type tests: `just types-test` (builds first, then type-checks `testProjects/types/typescriptTest.ts`)
 - Tests use mocha
 - Must build TypeScript before testing (handled automatically by `just` commands)
+- Most changes that add or modify public API surface should include a corresponding type test in `testProjects/types/typescriptTest.ts`
 
 ## Formatting & Linting
 
@@ -19,7 +21,7 @@
 - Node.js HTTP implementation: `src/net/NodeHttpClient.ts`
 - Fetch-based HTTP implementation: `src/net/FetchHttpClient.ts`
 - Request orchestration (headers, auth, retries): `src/RequestSender.ts`
-- Core client setup: `src/stripe.core.ts`
+- Core client setup: `src/stripe.core.ts` (CJS) and `src/stripe.esm.node.ts` (ESM) — changes to one usually need mirroring in the other
 - API version: `src/apiVersion.ts`
 
 ## Generated Code

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -957,6 +957,10 @@ const defaultRequestSenderFactory: RequestSenderFactory = (stripe) =>
 export class Stripe {
   static PACKAGE_VERSION = '22.4.0';
   static API_VERSION: typeof ApiVersion = ApiVersion;
+  /**
+   * The major API version that this SDK uses. Objects retrieved using the same
+   * major version are compatible. Is an empty string in preview versions of the SDK.
+   */
   static MAJOR_API_VERSION = ApiMajorVersion;
   static aiAgent = '';
   static AI_AGENT = '';

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -11,7 +11,7 @@ import {
   DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
 import {createWebhooks} from './Webhooks.js';
-import {ApiVersion} from './apiVersion.js';
+import {ApiVersion, ApiMajorVersion} from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
 import {PlatformFunctions} from './platform/PlatformFunctions.js';
@@ -957,6 +957,7 @@ const defaultRequestSenderFactory: RequestSenderFactory = (stripe) =>
 export class Stripe {
   static PACKAGE_VERSION = '22.4.0';
   static API_VERSION: typeof ApiVersion = ApiVersion;
+  static MAJOR_API_VERSION = ApiMajorVersion;
   static aiAgent = '';
   static AI_AGENT = '';
   static USER_AGENT: Record<string, string | boolean | null> = {

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -12,7 +12,7 @@ import {
   DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
 import {createWebhooks} from './Webhooks.js';
-import {ApiVersion} from './apiVersion.js';
+import {ApiVersion, ApiMajorVersion} from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
 import {PlatformFunctions} from './platform/PlatformFunctions.js';
@@ -959,6 +959,7 @@ const defaultRequestSenderFactory: RequestSenderFactory = (stripe) =>
 export class Stripe {
   static PACKAGE_VERSION = '22.4.0';
   static API_VERSION: typeof ApiVersion = ApiVersion;
+  static MAJOR_API_VERSION = ApiMajorVersion;
   static aiAgent = '';
   static AI_AGENT = '';
   static USER_AGENT: Record<string, string | boolean | null> = {

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -959,6 +959,10 @@ const defaultRequestSenderFactory: RequestSenderFactory = (stripe) =>
 export class Stripe {
   static PACKAGE_VERSION = '22.4.0';
   static API_VERSION: typeof ApiVersion = ApiVersion;
+  /**
+   * The major API version that this SDK uses. Objects retrieved using the same
+   * major version are compatible. Is an empty string in preview versions of the SDK.
+   */
   static MAJOR_API_VERSION = ApiMajorVersion;
   static aiAgent = '';
   static AI_AGENT = '';

--- a/testProjects/types-cjs-node16/typescriptTest.ts
+++ b/testProjects/types-cjs-node16/typescriptTest.ts
@@ -10,6 +10,9 @@ import Stripe from 'stripe';
 // Construction
 const stripe = new Stripe('sk_test_123');
 
+// Static members
+const majorApiVersion: string = Stripe.MAJOR_API_VERSION;
+
 // Top-level resource types
 let customer: Stripe.Customer;
 let charge: Stripe.Charge;

--- a/testProjects/types-cjs/typescriptTest.ts
+++ b/testProjects/types-cjs/typescriptTest.ts
@@ -33,6 +33,7 @@ let opts: Stripe.RequestOptions;
 
 // Static members
 const version: typeof Stripe.API_VERSION = Stripe.API_VERSION;
+const majorApiVersion: string = Stripe.MAJOR_API_VERSION;
 Stripe.errors;
 Stripe.errors.StripeError;
 

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -7,6 +7,8 @@
 
 import Stripe from 'stripe';
 
+const majorApiVersion: string = Stripe.MAJOR_API_VERSION;
+
 let stripe = new Stripe('sk_test_123', {
   apiVersion: Stripe.API_VERSION,
 });
@@ -282,7 +284,9 @@ const errorTypeInterchangeable = (
 ): Stripe.ErrorType.StripeError => e;
 
 // instanceof narrows to the correct type
-const instanceofNarrowing = (e: unknown): Stripe.ErrorType.StripeError | null => {
+const instanceofNarrowing = (
+  e: unknown
+): Stripe.ErrorType.StripeError | null => {
   if (e instanceof Stripe.errors.StripeError) {
     return e;
   }
@@ -505,5 +509,4 @@ const _signatureType: Stripe.Signature = null as any;
 
 // Factory function return types must be assignable to their interface types.
 const _nodeHttpClient: Stripe.HttpClient = Stripe.createNodeHttpClient();
-const _nodeCryptoProvider: Stripe.CryptoProvider =
-  Stripe.createNodeCryptoProvider();
+const _nodeCryptoProvider: Stripe.CryptoProvider = Stripe.createNodeCryptoProvider();


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

We've been generating information about the current API version into the SDKs for a while (codegen PR `2555`), but accidentally didn't make those constants user-facing.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- adds a user-facing `major_api_version` constant set to the generated value (currently `"dahlia"`)

### See Also

<!-- Include any links or additional information that help explain this change. -->

- (originally from https://github.com/stripe/stripe-java/issues/2001)
