### PR TITLE
add event notif object tests

### DIFF
--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -835,6 +835,7 @@ describe('Stripe Module', function() {
 
     it('can parse event from JSON payload', () => {
       const jsonPayload = {
+        object: 'v2.core.event',
         type: 'account.created',
         data: 'hello',
         related_object: {id: '123', url: 'hello_again'},
@@ -846,6 +847,7 @@ describe('Stripe Module', function() {
       });
       const event = stripe.parseEventNotification(payload, header, secret);
 
+      expect(event.object).to.equal('v2.core.event');
       expect(event.type).to.equal(jsonPayload.type);
       expect(event.data).to.equal(jsonPayload.data);
       expect(event.related_object.id).to.equal(jsonPayload.related_object.id);

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -359,6 +359,8 @@ const v2ContextObj: Stripe.StripeContextType | undefined = v2EventNotif.context;
 async (): Promise<void> => {
   // parsing event notifications
   const eventNotification = stripe.parseEventNotification('', '', '');
+  // literal type, so this is really checking the (purported) value
+  eventNotification.object === 'v2.core.event';
 
   if (eventNotification.type === 'v1.billing.meter.error_report_triggered') {
     eventNotification.related_object;
@@ -426,8 +428,9 @@ event = stripe.webhooks.constructEventWithoutVerification('payload');
 event = stripe.constructEventWithoutVerification('payload');
 
 // parseEventNotificationWithoutVerification on client
-const _notificationWV: Stripe.V2.Core.EventNotification =
-  stripe.parseEventNotificationWithoutVerification('payload');
+const _notificationWV: Stripe.V2.Core.EventNotification = stripe.parseEventNotificationWithoutVerification(
+  'payload'
+);
 
 // Verify that nested types with names matching imported types resolve correctly.
 // e.g. Checkout.Session.TotalDetails.Breakdown.Discount.discount should be


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

While I was adding the `object` property to `EventNotification` in other SDKs (e.g. https://github.com/stripe/stripe-python/pull/1869), I noticed that while Node had the property public already, it didn't have any tests around it. So here are some tests!

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->
- [DEVSDK-3101](https://go/j/DEVSDK-3101)