### PR TITLE
correctly throw connection errors if the server drops while sending the HTTP response body

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -25,6 +25,7 @@ import {
 import {RawRequestOptions, RequestOptions} from './lib.js';
 import {
   HttpClient,
+  HttpClientResponseBodyError,
   HttpClientResponseInterface,
   HttpClientRuntimeError,
 } from './net/HttpClient.js';
@@ -160,6 +161,8 @@ export class RequestSender {
     requestEvent: RequestEvent,
     apiMode: 'v1' | 'v2',
     usage: Array<string>,
+    timeout: number,
+    requestRetries: number,
     callback: RequestCallback
   ) {
     return (res: HttpClientResponseInterface): void => {
@@ -218,6 +221,18 @@ export class RequestSender {
             ) {
               responseEvent.body = (e as any).rawBody;
             }
+
+            // A body we could not read to completion is a transport failure,
+            // not a malformed payload, so report it as such.
+            if (e instanceof HttpClientResponseBodyError) {
+              throw RequestSender._generateConnectionError(
+                e,
+                timeout,
+                requestRetries,
+                requestId
+              );
+            }
+
             throw new StripeAPIError({
               message: 'Invalid JSON received from the Stripe API',
               exception: e,
@@ -254,6 +269,25 @@ export class RequestSender {
     return `An error occurred with our connection to Stripe.${
       requestRetries > 0 ? ` Request was retried ${requestRetries} times.` : ''
     }`;
+  }
+
+  static _generateConnectionError(
+    error: HttpClientResponseError | HttpClientResponseBodyError,
+    timeout: number,
+    requestRetries: number,
+    // Only available when the failure happened after the headers arrived.
+    requestId?: string
+  ): StripeConnectionError {
+    const isTimeoutError =
+      !!error.code && error.code === HttpClient.TIMEOUT_ERROR_CODE;
+
+    return new StripeConnectionError({
+      message: isTimeoutError
+        ? `Request aborted due to timeout being reached (${timeout}ms)`
+        : RequestSender._generateConnectionErrorMessage(requestRetries),
+      detail: error,
+      requestId,
+    });
   }
 
   // For more on when and how to retry API requests, see https://stripe.com/docs/error-handling#safely-retrying-requests-with-idempotency
@@ -679,6 +713,8 @@ export class RequestSender {
                   requestEvent,
                   apiMode,
                   usage,
+                  timeout,
+                  requestRetries,
                   callback
                 )(res);
               }
@@ -704,18 +740,12 @@ export class RequestSender {
                     requestRetries
                   );
                 } else {
-                  const isTimeoutError =
-                    error.code && error.code === HttpClient.TIMEOUT_ERROR_CODE;
-
                   return callback(
-                    new StripeConnectionError({
-                      message: isTimeoutError
-                        ? `Request aborted due to timeout being reached (${timeout}ms)`
-                        : RequestSender._generateConnectionErrorMessage(
-                            requestRetries
-                          ),
-                      detail: error,
-                    })
+                    RequestSender._generateConnectionError(
+                      error,
+                      timeout,
+                      requestRetries
+                    )
                   );
                 }
               }

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -223,8 +223,17 @@ export class RequestSender {
             }
 
             // A body we could not read to completion is a transport failure,
-            // not a malformed payload, so report it as such.
-            if (e instanceof HttpClientResponseBodyError) {
+            // not a malformed payload. Only a timeout is reported as such for
+            // now: a connection severed mid-body already surfaced here as a
+            // StripeAPIError on the fetch client, so reclassifying it would
+            // break anyone catching it. A timeout, by contrast, never got this
+            // far -- it hung -- so there is no behavior to preserve.
+            // TODO(DEVSDK-3247): report every HttpClientResponseBodyError as a
+            // StripeConnectionError, since none of them are parse failures.
+            if (
+              e instanceof HttpClientResponseBodyError &&
+              e.code === HttpClient.TIMEOUT_ERROR_CODE
+            ) {
               throw RequestSender._generateConnectionError(
                 e,
                 timeout,

--- a/src/net/FetchHttpClient.ts
+++ b/src/net/FetchHttpClient.ts
@@ -7,11 +7,33 @@ import {
   FetchHttpClientResponseInterface,
 } from './HttpClient.js';
 
+/**
+ * Keeps the request timeout applicable to work that happens after the response
+ * headers arrive, so that `timeout` bounds the whole request rather than just
+ * the time to headers.
+ */
+type RequestTimeout = {
+  /** Applies the remaining timeout to reading the response body. */
+  guard: <T>(promise: Promise<T>) => Promise<T>;
+  /** Disarms the timeout; call once the body is read or handed off. */
+  release: () => void;
+};
+
+const NOOP_REQUEST_TIMEOUT: RequestTimeout = {
+  guard: (promise) => promise,
+  release: (): void => {},
+};
+
+type TimedFetchResponse = {
+  res: Response;
+  requestTimeout: RequestTimeout;
+};
+
 type FetchWithTimeout = (
   url: string,
   init: RequestInit,
   timeout: number
-) => Promise<Response>;
+) => Promise<TimedFetchResponse>;
 
 /**
  * HTTP client which uses a `fetch` function to issue requests.
@@ -56,7 +78,7 @@ export class FetchHttpClient extends HttpClient
   private static makeFetchWithRaceTimeout(
     fetchFn: typeof fetch
   ): FetchWithTimeout {
-    return (url, init, timeout): Promise<Response> => {
+    return async (url, init, timeout): Promise<TimedFetchResponse> => {
       let pendingTimeoutId: ReturnType<typeof setTimeout> | null;
       const timeoutPromise = new Promise<never>((_, reject) => {
         pendingTimeoutId = setTimeout(() => {
@@ -64,44 +86,80 @@ export class FetchHttpClient extends HttpClient
           reject(HttpClient.makeTimeoutError());
         }, timeout);
       });
+      // The timeout keeps racing against the body read below, so make sure its
+      // rejection is always observed even if nothing is racing it any more.
+      timeoutPromise.catch(() => {});
 
-      const fetchPromise = fetchFn(url, init);
-      return Promise.race([fetchPromise, timeoutPromise]).finally(() => {
+      const release = (): void => {
         if (pendingTimeoutId) {
           clearTimeout(pendingTimeoutId);
+          pendingTimeoutId = null;
         }
-      });
+      };
+
+      const requestTimeout: RequestTimeout = {
+        // Racing cannot cancel the underlying read, but it does stop the
+        // request from hanging past the timeout.
+        guard: (promise) => Promise.race([promise, timeoutPromise]),
+        release,
+      };
+
+      try {
+        const res = await Promise.race([fetchFn(url, init), timeoutPromise]);
+        return {res, requestTimeout};
+      } catch (err) {
+        release();
+        throw err;
+      }
     };
   }
 
   private static makeFetchWithAbortTimeout(
     fetchFn: typeof fetch
   ): FetchWithTimeout {
-    return async (url, init, timeout): Promise<Response> => {
+    return async (url, init, timeout): Promise<TimedFetchResponse> => {
       // Use AbortController because AbortSignal.timeout() was added later in Node v17.3.0, v16.14.0
       const abort = new AbortController();
       let timeoutId: ReturnType<typeof setTimeout> | null = setTimeout(() => {
         timeoutId = null;
         abort.abort(HttpClient.makeTimeoutError());
       }, timeout);
+
+      const release = (): void => {
+        if (timeoutId) {
+          clearTimeout(timeoutId);
+          timeoutId = null;
+        }
+      };
+
+      // Some implementations, like node-fetch, do not respect the reason passed to AbortController.abort()
+      // and instead it always throws an AbortError
+      // We catch this case to normalise all timeout errors
+      const normalizeAbortError = (err: unknown): never => {
+        if ((err as any)?.name === 'AbortError') {
+          throw HttpClient.makeTimeoutError();
+        }
+        throw err;
+      };
+
+      const requestTimeout: RequestTimeout = {
+        // The signal stays armed after the headers arrive, so aborting it also
+        // interrupts the body read.
+        guard: (promise) => promise.catch(normalizeAbortError),
+        release,
+      };
+
       try {
-        return await fetchFn(url, {
+        const res = await fetchFn(url, {
           ...init,
           signal: abort.signal,
         });
+        return {res, requestTimeout};
       } catch (err) {
-        // Some implementations, like node-fetch, do not respect the reason passed to AbortController.abort()
-        // and instead it always throws an AbortError
-        // We catch this case to normalise all timeout errors
-        if ((err as any).name === 'AbortError') {
-          throw HttpClient.makeTimeoutError();
-        } else {
-          throw err;
-        }
-      } finally {
-        if (timeoutId) {
-          clearTimeout(timeoutId);
-        }
+        // Only release on failure; a successful response still needs the
+        // timeout armed while its body is read.
+        release();
+        return normalizeAbortError(err);
       }
     };
   }
@@ -139,7 +197,7 @@ export class FetchHttpClient extends HttpClient
       method == 'POST' || method == 'PUT' || method == 'PATCH';
     const body = requestData || (methodHasPayload ? '' : undefined);
 
-    const res = await this._fetchFn(
+    const {res, requestTimeout} = await this._fetchFn(
       url.toString(),
       {
         method,
@@ -148,20 +206,22 @@ export class FetchHttpClient extends HttpClient
       },
       timeout
     );
-    return new FetchHttpClientResponse(res);
+    return new FetchHttpClientResponse(res, requestTimeout);
   }
 }
 
 export class FetchHttpClientResponse extends HttpClientResponse
   implements FetchHttpClientResponseInterface {
   _res: Response;
+  _requestTimeout: RequestTimeout;
 
-  constructor(res: Response) {
+  constructor(res: Response, requestTimeout?: RequestTimeout) {
     super(
       res.status,
       FetchHttpClientResponse._transformHeadersToObject(res.headers)
     );
     this._res = res;
+    this._requestTimeout = requestTimeout ?? NOOP_REQUEST_TIMEOUT;
   }
 
   getRawResponse(): Response {
@@ -171,6 +231,11 @@ export class FetchHttpClientResponse extends HttpClientResponse
   toStream(
     streamCompleteCallback: () => void
   ): ReadableStream<Uint8Array> | null {
+    // The caller consumes this stream on its own schedule, and a legitimate
+    // download may well outlast `timeout`, so hand ownership of the body over
+    // rather than aborting it.
+    this._requestTimeout.release();
+
     // Unfortunately `fetch` does not have event handlers for when the stream is
     // completely read. We therefore invoke the streamCompleteCallback right
     // away. This callback emits a response event with metadata and completes
@@ -182,8 +247,21 @@ export class FetchHttpClientResponse extends HttpClientResponse
     return this._res.body;
   }
 
-  toJSON(): Promise<any> {
-    return this._res.text().then((text) => this._parseResponseBody(text));
+  async toJSON(): Promise<any> {
+    let text: string;
+    try {
+      // `timeout` is meant to cover the entire request, so it has to stay armed
+      // while the body is read. Otherwise a connection that stalls or drops
+      // after the headers arrive hangs forever.
+      // See https://github.com/stripe/stripe-node/issues/2814.
+      text = await this._requestTimeout.guard(this._res.text());
+    } catch (e) {
+      throw HttpClient.makeResponseBodyError(e);
+    } finally {
+      this._requestTimeout.release();
+    }
+
+    return this._parseResponseBody(text);
   }
 
   static _transformHeadersToObject(headers: Headers): ResponseHeaders {

--- a/src/net/HttpClient.ts
+++ b/src/net/HttpClient.ts
@@ -109,6 +109,23 @@ export class HttpClient implements HttpClientInterface {
     timeoutErr.code = HttpClient.TIMEOUT_ERROR_CODE;
     return timeoutErr;
   }
+
+  /**
+   * Helper to wrap a failure that occurred while reading a response body, so
+   * that implementations can report one consistently.
+   */
+  static makeResponseBodyError(
+    exception: unknown
+  ): HttpClientResponseBodyError {
+    const error = new HttpClientResponseBodyError(
+      'Failed to read the response body'
+    );
+    error.exception = exception;
+    if (exception && typeof (exception as {code?: unknown}).code === 'string') {
+      error.code = (exception as {code: string}).code;
+    }
+    return error;
+  }
 }
 
 // Public API accessible via Stripe.HttpClient
@@ -157,3 +174,17 @@ export class HttpClientResponse implements HttpClientResponseInterface {
 }
 
 export class HttpClientRuntimeError extends Error {}
+
+/**
+ * Raised when the response body could not be read to completion, e.g. because
+ * the connection stalled or was severed after the headers arrived. This is
+ * distinct from a body that was received in full but is not valid JSON, so that
+ * a transport failure can be surfaced as a connection error rather than as a
+ * parsing error.
+ */
+export class HttpClientResponseBodyError extends Error {
+  /** The error code of the underlying failure, when the runtime supplies one. */
+  code?: string;
+  /** The underlying failure, when the runtime supplies one. */
+  exception?: unknown;
+}

--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -68,12 +68,23 @@ export class NodeHttpClient extends HttpClient
           ciphers: 'DEFAULT:!aNULL:!eNULL:!LOW:!EXPORT:!SSLv2:!MD5',
         });
 
+        let res: http_.IncomingMessage | null = null;
+
         req.setTimeout(timeout, () => {
-          req.destroy(HttpClient.makeTimeoutError());
+          const timeoutError = HttpClient.makeTimeoutError();
+          // The socket timeout stays armed while the body is being read, but
+          // tearing down the request alone surfaces on the response as a
+          // generic ECONNRESET. Destroying the response with the timeout error
+          // first lets a stalled body be reported as the timeout it is.
+          if (res && !res.complete) {
+            res.destroy(timeoutError);
+          }
+          req.destroy(timeoutError);
         });
 
-        req.on('response', (res) => {
-          resolve(new NodeHttpClientResponse(res));
+        req.on('response', (response) => {
+          res = response;
+          resolve(new NodeHttpClientResponse(response));
         });
 
         req.on('error', (error) => {
@@ -132,6 +143,20 @@ export class NodeHttpClientResponse extends HttpClientResponse
       this._res.setEncoding('utf8');
       this._res.on('data', (chunk) => {
         response += chunk;
+      });
+      // Node only emits 'error' on an IncomingMessage when a listener is
+      // attached; without one, a connection that stalls or drops after the
+      // headers arrive never emits 'end' either, and this promise would hang
+      // forever. See https://github.com/stripe/stripe-node/issues/2814.
+      this._res.once('error', (error) => {
+        reject(HttpClient.makeResponseBodyError(error));
+      });
+      // Not every truncated response emits an 'error', so treat closing before
+      // the body is complete as a failure too.
+      this._res.once('close', () => {
+        if (!this._res.complete) {
+          reject(HttpClient.makeResponseBodyError(null));
+        }
       });
       this._res.once('end', () => {
         try {

--- a/src/net/NodeHttpClient.ts
+++ b/src/net/NodeHttpClient.ts
@@ -76,6 +76,19 @@ export class NodeHttpClient extends HttpClient
           // tearing down the request alone surfaces on the response as a
           // generic ECONNRESET. Destroying the response with the timeout error
           // first lets a stalled body be reported as the timeout it is.
+          //
+          // The cost is that this is the same error a toStream() caller sees, so
+          // a stalled download now emits an ETIMEDOUT TypeError where it used to
+          // emit an ECONNRESET Error with the message "aborted". The timing is
+          // unchanged and 'aborted' still fires either way.
+          // TODO(DEVSDK-3247): decouple the two by dropping this destroy() and
+          // instead recording that the timeout fired (e.g. a getter handed to
+          // NodeHttpClientResponse), so only toJSON() translates the teardown
+          // into a timeout and the stream keeps its original error. Dropping
+          // this destroy() on its own is not enough: the request teardown does
+          // still reach toJSON's listeners at the same time, but as a generic
+          // failure, which the response body error then reports as a
+          // StripeAPIError instead of a timeout.
           if (res && !res.complete) {
             res.destroy(timeoutError);
           }

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -957,6 +957,82 @@ describe('RequestSender', () => {
         );
       });
 
+      // The `timeout` option has to cover reading the response body, not just
+      // the time to headers. See https://github.com/stripe/stripe-node/issues/2814
+      [
+        {name: 'the Node client', httpClient: undefined},
+        {
+          name: 'the fetch client',
+          httpClient: require('../src/stripe.cjs.node.js').createFetchHttpClient(),
+        },
+      ].forEach(({name, httpClient}) => {
+        describe(`response body failures with ${name}`, () => {
+          it('throws a timeout error when the body stalls after the headers arrive', (done) => {
+            return getTestServerStripe(
+              {timeout: 50, maxNetworkRetries: 0, httpClient},
+              (req, res) => {
+                // Promise more body than we send, then never finish it.
+                res.writeHead(200, {'Content-Length': '100'});
+                res.write('{"ab');
+                return {shouldStayOpen: true};
+              },
+              (err, stripe, closeServer) => {
+                if (err) {
+                  return done(err);
+                }
+                stripe.charges
+                  .create(options.data)
+                  .then(() => {
+                    closeServer();
+                    done(new Error('Expected an error'));
+                  })
+                  .catch((err) => {
+                    expect(err).to.be.an.instanceOf(StripeConnectionError);
+                    expect(err.message).to.deep.equal(
+                      'Request aborted due to timeout being reached (50ms)'
+                    );
+                    closeServer();
+                    done();
+                  });
+              }
+            );
+          });
+
+          it('throws a connection error when the connection drops after the headers arrive', (done) => {
+            return getTestServerStripe(
+              {timeout: 5000, maxNetworkRetries: 0, httpClient},
+              (req, res) => {
+                res.writeHead(200, {'Content-Length': '100'});
+                res.write('{"ab');
+                // Flush the headers and partial body before severing, so this
+                // fails while reading the body rather than before it.
+                setTimeout(() => res.socket.destroy(), 20);
+                return {shouldStayOpen: true};
+              },
+              (err, stripe, closeServer) => {
+                if (err) {
+                  return done(err);
+                }
+                stripe.charges
+                  .create(options.data)
+                  .then(() => {
+                    closeServer();
+                    done(new Error('Expected an error'));
+                  })
+                  .catch((err) => {
+                    expect(err).to.be.an.instanceOf(StripeConnectionError);
+                    expect(err.message).to.deep.equal(
+                      'An error occurred with our connection to Stripe.'
+                    );
+                    closeServer();
+                    done();
+                  });
+              }
+            );
+          });
+        });
+      });
+
       it('throws a StripeAuthenticationError on 401', (done) => {
         nock(`https://${options.host}`)
           .post(options.path, options.params)

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -3,6 +3,7 @@ import {expect} from 'chai';
 import nock = require('nock');
 
 import {
+  StripeAPIError,
   StripeAuthenticationError,
   StripeConnectionError,
   StripeError,
@@ -967,6 +968,29 @@ describe('RequestSender', () => {
         },
       ].forEach(({name, httpClient}) => {
         describe(`response body failures with ${name}`, () => {
+          // Routes a failed assertion to `done` rather than letting it reject an
+          // orphaned promise, where it would surface as a mocha timeout and be
+          // indistinguishable from the hang these tests guard against.
+          const expectRejection = (promise, closeServer, done, assertions) => {
+            promise
+              .then(
+                () => {
+                  throw new Error('Expected an error');
+                },
+                (err) => assertions(err)
+              )
+              .then(
+                () => {
+                  closeServer();
+                  done();
+                },
+                (err) => {
+                  closeServer();
+                  done(err);
+                }
+              );
+          };
+
           it('throws a timeout error when the body stalls after the headers arrive', (done) => {
             return getTestServerStripe(
               {timeout: 50, maxNetworkRetries: 0, httpClient},
@@ -980,25 +1004,57 @@ describe('RequestSender', () => {
                 if (err) {
                   return done(err);
                 }
-                stripe.charges
-                  .create(options.data)
-                  .then(() => {
-                    closeServer();
-                    done(new Error('Expected an error'));
-                  })
-                  .catch((err) => {
+                expectRejection(
+                  stripe.charges.create(options.data),
+                  closeServer,
+                  done,
+                  (err) => {
                     expect(err).to.be.an.instanceOf(StripeConnectionError);
                     expect(err.message).to.deep.equal(
                       'Request aborted due to timeout being reached (50ms)'
                     );
-                    closeServer();
-                    done();
-                  });
+                  }
+                );
               }
             );
           });
 
-          it('throws a connection error when the connection drops after the headers arrive', (done) => {
+          // The reported reproduction, which stalls a GET rather than a POST.
+          it('throws a timeout error on a GET whose body stalls', (done) => {
+            return getTestServerStripe(
+              {timeout: 50, maxNetworkRetries: 0, httpClient},
+              (req, res) => {
+                res.writeHead(200, {
+                  'Content-Type': 'application/json',
+                  'Content-Length': '100',
+                });
+                res.write('{"id": "cus_123", "objec');
+                return {shouldStayOpen: true};
+              },
+              (err, stripe, closeServer) => {
+                if (err) {
+                  return done(err);
+                }
+                expectRejection(
+                  stripe.customers.retrieve('cus_123'),
+                  closeServer,
+                  done,
+                  (err) => {
+                    expect(err).to.be.an.instanceOf(StripeConnectionError);
+                    expect(err.message).to.deep.equal(
+                      'Request aborted due to timeout being reached (50ms)'
+                    );
+                  }
+                );
+              }
+            );
+          });
+
+          // A StripeAPIError is not really the right shape for a severed
+          // connection, but it is what the fetch client already threw here, so
+          // it is preserved until the next major.
+          // TODO(DEVSDK-3247): report every HttpClientResponseBodyError as a
+          it('throws an API error when the connection drops after the headers arrive', (done) => {
             return getTestServerStripe(
               {timeout: 5000, maxNetworkRetries: 0, httpClient},
               (req, res) => {
@@ -1013,24 +1069,65 @@ describe('RequestSender', () => {
                 if (err) {
                   return done(err);
                 }
-                stripe.charges
-                  .create(options.data)
-                  .then(() => {
-                    closeServer();
-                    done(new Error('Expected an error'));
-                  })
-                  .catch((err) => {
-                    expect(err).to.be.an.instanceOf(StripeConnectionError);
+                expectRejection(
+                  stripe.charges.create(options.data),
+                  closeServer,
+                  done,
+                  (err) => {
+                    expect(err).to.be.an.instanceOf(StripeAPIError);
                     expect(err.message).to.deep.equal(
-                      'An error occurred with our connection to Stripe.'
+                      'Invalid JSON received from the Stripe API'
                     );
-                    closeServer();
-                    done();
-                  });
+                  }
+                );
               }
             );
           });
         });
+      });
+
+      // Pins the error identity a stalled download surfaces, which is the
+      // coupled cost of reporting a stalled toJSON() body as a timeout. The
+      // TODO(DEVSDK-3247) in NodeHttpClient will deliberately change this back
+      // to an ECONNRESET Error with the message 'aborted'.
+      it('surfaces a stalled streaming response as an ETIMEDOUT error', (done) => {
+        return getTestServerStripe(
+          {timeout: 50, maxNetworkRetries: 0},
+          (req, res) => {
+            res.writeHead(200, {'Content-Type': 'application/pdf'});
+            res.write('%PDF-1.4 partial');
+            return {shouldStayOpen: true};
+          },
+          (err, stripe, closeServer) => {
+            if (err) {
+              return done(err);
+            }
+            stripe
+              .rawRequest('GET', '/v1/quotes/qt_123/pdf', {}, {streaming: true})
+              .then((stream) => {
+                // Flowing mode, so the stall is in the body rather than in our
+                // own backpressure.
+                stream.on('data', () => {});
+                stream.on('error', (streamErr) => {
+                  closeServer();
+                  try {
+                    expect(streamErr.code).to.equal('ETIMEDOUT');
+                    done();
+                  } catch (e) {
+                    done(e);
+                  }
+                });
+                stream.on('end', () => {
+                  closeServer();
+                  done(new Error('Expected the stream to error'));
+                });
+              })
+              .catch((e) => {
+                closeServer();
+                done(e);
+              });
+          }
+        );
       });
 
       it('throws a StripeAuthenticationError on 401', (done) => {

--- a/test/net/FetchHttpClient.spec.ts
+++ b/test/net/FetchHttpClient.spec.ts
@@ -151,6 +151,81 @@ describe('FetchHttpClient', () => {
 
     expect(capturedBody).to.be.undefined;
   });
+
+  // The timeout has to cover reading the body, not just the time to headers.
+  // See https://github.com/stripe/stripe-node/issues/2814
+  describe('response body timeout', () => {
+    /** A body which sends a partial payload and then stalls forever. */
+    const stalledBody = (): Readable => {
+      let sentPartialBody = false;
+      return new Readable({
+        read() {
+          if (!sentPartialBody) {
+            sentPartialBody = true;
+            this.push('{"ab');
+          }
+          // Never push again and never end, so the read stalls.
+        },
+      });
+    };
+
+    const sendRequest = (client) =>
+      client.makeRequest(
+        'stripe.com',
+        80,
+        '/test',
+        'GET',
+        {},
+        undefined,
+        'http',
+        50
+      );
+
+    afterEach(() => {
+      nock.cleanAll();
+    });
+
+    it('times out reading the body when aborting', async () => {
+      nock('http://stripe.com')
+        .get('/test')
+        .reply(200, stalledBody);
+
+      const response = await sendRequest(createFetchHttpClient());
+
+      try {
+        await response.toJSON();
+        throw new Error('Expected an error to be thrown');
+      } catch (e) {
+        expect(e.code).to.equal('ETIMEDOUT');
+      }
+    });
+
+    it('times out reading the body when racing', async () => {
+      nock('http://stripe.com')
+        .get('/test')
+        .reply(200, stalledBody);
+
+      // Runtimes without AbortController fall back to racing a timer, which
+      // cannot cancel the read but still has to stop the request from hanging.
+      const {AbortController} = globalThis;
+      delete globalThis.AbortController;
+      let client;
+      try {
+        client = new FetchHttpClient(fetch);
+      } finally {
+        globalThis.AbortController = AbortController;
+      }
+
+      const response = await sendRequest(client);
+
+      try {
+        await response.toJSON();
+        throw new Error('Expected an error to be thrown');
+      } catch (e) {
+        expect(e.code).to.equal('ETIMEDOUT');
+      }
+    });
+  });
 });
 
 export {};


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixed a bug where, if the server hangs while still serving the body, the SDK would hang indefinitely instead of respecting the configured timeout. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- add new connection error helper method
- throw that new error after a timeout happens
- add `RequestTimeout` interface to track cleanup steps if/when a request fails
- weave that stuff through the other HTTP hardware
- add tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

- https://github.com/stripe/stripe-node/issues/2814

### Changelog

- This change results in new exceptions being thrown instead of hanging indefinitely
- in an effort to make this change backwards compatible, it doesn't affect a case that was already throwing an error: if the stripe API sends invalid JSON, we were treating it as an API error instead of a connection error.
    - In the next major version, we'll change the exception thrown from `StripeAPIError` to `StripeConnectionError` and document it accordingly.