### PR TITLE
Add better documentation for setting `maxNetworkRetires` to `0`

### DIFF
--- a/README.md
+++ b/README.md
@@ -309,6 +309,13 @@ const stripeClient = Stripe('sk_test_...', {
 });
 ```
 
+> [!NOTE]
+> Even with `maxNetworkRetries: 0`, a request whose connection is closed before a
+> response arrives (`ECONNRESET` or `EPIPE`) is still reattempted once. Such a
+> request almost certainly never reached the API — commonly a stale keep-alive
+> socket — so re-sending it is safe. Subsequent connection-closed errors are not
+> retried.
+
 ```js
 const stripeClient = Stripe('sk_test_...', {
   maxNetworkRetries: 2, // Retry a request twice before giving up

--- a/README.md
+++ b/README.md
@@ -310,11 +310,11 @@ const stripeClient = Stripe('sk_test_...', {
 ```
 
 > [!NOTE]
-> Even with `maxNetworkRetries: 0`, a request whose connection is closed before a
-> response arrives (`ECONNRESET` or `EPIPE`) is still reattempted once. Such a
-> request almost certainly never reached the API — commonly a stale keep-alive
-> socket — so re-sending it is safe. Subsequent connection-closed errors are not
-> retried.
+> Even with `maxNetworkRetries: 0`, a request that fails with a closed connection
+> (`ECONNRESET` or `EPIPE`) is still reattempted once. These usually mean the
+> request never reached the API — most often a stale keep-alive socket, such as
+> one held across a frozen AWS Lambda execution context. Subsequent
+> connection-closed errors are not retried.
 
 ```js
 const stripeClient = Stripe('sk_test_...', {

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -263,9 +263,13 @@ export class RequestSender {
     maxRetries: number,
     error?: HttpClientResponseError
   ): boolean {
-    // A connection closed before we got a response is always retried once,
-    // even when retries are disabled: the request was very likely never
-    // processed (e.g. a stale keep-alive socket), so re-sending it is safe.
+    // A closed connection is retried once even when retries are disabled,
+    // since it usually means the request never reached the API (e.g. a stale
+    // keep-alive socket held across a frozen Lambda context). See https://github.com/stripe/stripe-node/issues/1040.
+    //
+    // This intentionally precedes the maxRetries check. Note that these codes
+    // can also surface after the API processed the request, so this retry is
+    // not guaranteed to be a no-op.
     if (
       error &&
       numRetries === 0 &&
@@ -340,14 +344,7 @@ export class RequestSender {
       : this._stripe.getMaxNetworkRetries();
   }
 
-  _defaultIdempotencyKey(
-    method: string,
-    settings: RequestSettings,
-    apiMode: ApiMode
-  ): string | null {
-    // If this is a POST and we allow multiple retries, ensure an idempotency key.
-    const maxRetries = this._getMaxNetworkRetries(settings);
-
+  _defaultIdempotencyKey(method: string, apiMode: ApiMode): string | null {
     const genKey = (): string =>
       `stripe-node-retry-${this._stripe._platformFunctions.uuid4()}`;
 
@@ -357,7 +354,11 @@ export class RequestSender {
         return genKey();
       }
     } else if (apiMode === 'v1') {
-      if (method === 'POST' && maxRetries > 0) {
+      // Key every POST, including when maxNetworkRetries is 0. Closed-connection
+      // errors are retried regardless of that setting (see _shouldRetry), and
+      // those codes can surface after the API processed the request, so the
+      // retry needs a key to dedupe against.
+      if (method === 'POST') {
         return genKey();
       }
     }
@@ -397,11 +398,7 @@ export class RequestSender {
       'Stripe-Version': apiVersion,
       'Stripe-Account': stripeAccount,
       'Stripe-Context': stripeContext,
-      'Idempotency-Key': this._defaultIdempotencyKey(
-        method,
-        userSuppliedSettings,
-        apiMode
-      ),
+      'Idempotency-Key': this._defaultIdempotencyKey(method, apiMode),
     } as RequestHeaders;
 
     // As per https://datatracker.ietf.org/doc/html/rfc7230#section-3.3.2:

--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -263,6 +263,9 @@ export class RequestSender {
     maxRetries: number,
     error?: HttpClientResponseError
   ): boolean {
+    // A connection closed before we got a response is always retried once,
+    // even when retries are disabled: the request was very likely never
+    // processed (e.g. a stale keep-alive socket), so re-sending it is safe.
     if (
       error &&
       numRetries === 0 &&

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -89,7 +89,7 @@ describe('RequestSender', () => {
       expect(headers).to.not.include.keys('Stripe-Context');
     });
     describe('idempotency keys', () => {
-      it('only creates creates an idempotency key if a v1 request will retry', () => {
+      it('creates an idempotency key for v1 POST requests', () => {
         const headers = sender._makeHeaders({
           method: 'POST',
           userSuppliedSettings: {maxNetworkRetries: 3},
@@ -97,10 +97,19 @@ describe('RequestSender', () => {
         });
         expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
       });
-      // should probably always create an IK; until then, codify the behavior
-      it("skips idempotency generation for v1 request if we're not retrying the request", () => {
+      // closed-connection errors are retried even with retries disabled, so
+      // these requests still need a key to dedupe against
+      it('creates an idempotency key for v1 POST requests when retries are disabled', () => {
         const headers = sender._makeHeaders({
           method: 'POST',
+          userSuppliedSettings: {maxNetworkRetries: 0},
+          apiMode: 'v1',
+        });
+        expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
+      });
+      it('does not create an idempotency key for v1 GET requests', () => {
+        const headers = sender._makeHeaders({
+          method: 'GET',
           userSuppliedSettings: {maxNetworkRetries: 0},
           apiMode: 'v1',
         });
@@ -115,8 +124,8 @@ describe('RequestSender', () => {
         expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
       });
       it('generates a new key every time', () => {
-        expect(sender._defaultIdempotencyKey('POST', {}, 'v2')).not.to.equal(
-          sender._defaultIdempotencyKey('POST', {}, 'v2')
+        expect(sender._defaultIdempotencyKey('POST', 'v2')).not.to.equal(
+          sender._defaultIdempotencyKey('POST', 'v2')
         );
       });
     });
@@ -1188,6 +1197,32 @@ describe('RequestSender', () => {
             expect(err.detail.code).to.deep.equal('ECONNRESET');
             done();
           });
+      });
+
+      // this retry bypasses maxNetworkRetries, so it must still carry a key to
+      // dedupe against the original in case the API did process it
+      it('reuses an idempotency key on the closed-connection retry', (done) => {
+        const keys = [];
+
+        const scope = nock(`https://${options.host}`)
+          .post(options.path, options.params)
+          .replyWithError({code: 'ECONNRESET', errno: 'ECONNRESET'})
+          .post(options.path, options.params)
+          .reply(200, {id: 'ch_123', object: 'charge', amount: 1000});
+
+        scope.on('request', (req) => {
+          keys.push(req.headers['idempotency-key']);
+        });
+
+        realStripe.charges
+          .create(options.data)
+          .then(() => {
+            expect(keys).to.have.lengthOf(2);
+            expect(keys[0]).to.match(/^stripe-node-retry/);
+            expect(keys[1]).to.equal(keys[0]);
+            done();
+          })
+          .catch(done);
       });
 
       it('should retry the request if max retries are set', (done) => {

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -167,6 +167,30 @@ describe('RequestSender', () => {
 
       expect(res).to.equal(false);
     });
+
+    // a closed connection is retried once regardless of maxNetworkRetries,
+    // since the request almost certainly never reached the API
+    it('should return true on a connection-closed error even if retries are disabled', () => {
+      const econnreset = RequestSender._shouldRetry(null, 0, 0, {
+        code: 'ECONNRESET',
+      });
+      const epipe = RequestSender._shouldRetry(null, 0, 0, {code: 'EPIPE'});
+
+      expect(econnreset).to.equal(true);
+      expect(epipe).to.equal(true);
+    });
+
+    it('should only bypass maxNetworkRetries for the first connection-closed error', () => {
+      const res = RequestSender._shouldRetry(null, 1, 0, {code: 'ECONNRESET'});
+
+      expect(res).to.equal(false);
+    });
+
+    it('should not bypass maxNetworkRetries for other error codes', () => {
+      const res = RequestSender._shouldRetry(null, 0, 0, {code: 'ETIMEDOUT'});
+
+      expect(res).to.equal(false);
+    });
   });
 
   describe('_getContentLength', () => {


### PR DESCRIPTION
### Why?
<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

As flagged in https://github.com/stripe/stripe-node/issues/2808, `maxNetworkRetires` (confusingly) doesn't _always_ mean a request isn't retried. There are specific cases in Lambda where we want to retry once anyway.

To better codify this behavior, I made some docs changes and ensured we _always_ generate an idempotency key, just in case. 

### What?
<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->
- always generate an idempotency key
- update readme
- update tests

### See Also
<!-- Include any links or additional information that help explain this change. -->

- fixes https://github.com/stripe/stripe-node/issues/2808
