### PR TITLE
Add new `EventNotificationHandler` class for better thin event management

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -136,7 +136,6 @@ module.exports = {
     'no-restricted-properties': 'error',
     'no-restricted-syntax': 'error',
     'no-return-assign': 'error',
-    'no-return-await': 'error',
     'no-script-url': 'error',
     'no-self-compare': 'error',
     'no-sequences': 'error',

--- a/examples/snippets/event_notification_handler_endpoint.ts
+++ b/examples/snippets/event_notification_handler_endpoint.ts
@@ -1,0 +1,66 @@
+/**
+ * event_notification_handler_endpoint.ts - receive and process event notifications like the
+ * v1.billing.meter.error_report_triggered event.
+ * In this example, we:
+ *   - write a fallback callback to handle unrecognized event notifications
+ *   - create a StripeClient called client
+ *   - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+ *   - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
+ *   - use handler.handle() to process the received notification webhook body
+ */
+
+import {Stripe} from 'stripe';
+import express from 'express';
+
+const apiKey = process.env.STRIPE_API_KEY ?? '';
+const webhookSecret = process.env.WEBHOOK_SECRET ?? '';
+
+const app = express();
+const client = new Stripe(apiKey);
+const handler = client.notificationHandler(
+  webhookSecret,
+  async (unhandledEvent, client, details) => {
+    console.log(`Received unhandled event type: ${unhandledEvent.type}`);
+  }
+);
+
+handler.on('v1.billing.meter.error_report_triggered', async (event) => {
+  const meter = await event.fetchRelatedObject();
+  console.log(`Billing Meter ${meter.display_name} had a problem`);
+});
+
+// Handles events delivered through a channel that has already authenticated them, such as
+// AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
+// this handler skips verification. Callbacks are registered separately from the one above.
+const unverifiedHandler = client.notificationHandlerWithoutVerification(
+  async (unhandledEvent, client, details) => {
+    console.log(`Received unhandled event type: ${unhandledEvent.type}`);
+  }
+);
+
+unverifiedHandler.on(
+  'v1.billing.meter.error_report_triggered',
+  async (event) => {
+    const meter = await event.fetchRelatedObject();
+    console.log(`Billing Meter ${meter.display_name} had a problem`);
+  }
+);
+
+app.post(
+  '/webhook',
+  express.raw({type: 'application/json'}),
+  async (req, res) => {
+    handler.handle(req.body, req.headers['stripe-signature']!);
+  }
+);
+
+app.post(
+  '/webhook-from-cloud-provider',
+  express.raw({type: 'application/json'}),
+  async (req, res) => {
+    // handle() takes only the body here; there's no signature to check
+    await unverifiedHandler.handle(req.body);
+  }
+);
+
+app.listen(4242, () => console.log('Running on port 4242'));

--- a/src/StripeEventNotificationHandler.ts
+++ b/src/StripeEventNotificationHandler.ts
@@ -1,0 +1,179 @@
+import {Stripe} from './stripe.core.js';
+import * as Events from './resources/V2/Core/Events.js';
+import {WebhookHeader, WebhookPayload} from './Webhooks.js';
+
+export interface UnhandledNotificationDetails {
+  isKnownEventType: boolean;
+}
+
+export type FallbackCallback = (
+  event: Events.UnknownEventNotification,
+  client: Stripe,
+  details: UnhandledNotificationDetails
+) => Promise<void>;
+
+// this is an internal-only type; we write a user-facing one separately
+type HandlerCallback = (event: any, client: any) => Promise<void>;
+
+// most languages can check if we have an UnknownEventNotification at runtime
+// but JS only has interfaces so we fall back to a string match to determine known events
+const KNOWN_EVENT_TYPES = new Set([
+  // event-types: The beginning of the section generated from our OpenAPI spec
+  'v1.billing.meter.error_report_triggered',
+  'v1.billing.meter.no_meter_found',
+  'v2.commerce.product_catalog.imports.failed',
+  'v2.commerce.product_catalog.imports.processing',
+  'v2.commerce.product_catalog.imports.succeeded',
+  'v2.commerce.product_catalog.imports.succeeded_with_errors',
+  'v2.core.account.closed',
+  'v2.core.account.created',
+  'v2.core.account.updated',
+  'v2.core.account[configuration.customer].capability_status_updated',
+  'v2.core.account[configuration.customer].updated',
+  'v2.core.account[configuration.merchant].capability_status_updated',
+  'v2.core.account[configuration.merchant].updated',
+  'v2.core.account[configuration.recipient].capability_status_updated',
+  'v2.core.account[configuration.recipient].updated',
+  'v2.core.account[defaults].updated',
+  'v2.core.account[future_requirements].updated',
+  'v2.core.account[identity].updated',
+  'v2.core.account[requirements].updated',
+  'v2.core.account_link.returned',
+  'v2.core.account_person.created',
+  'v2.core.account_person.deleted',
+  'v2.core.account_person.updated',
+  'v2.core.event_destination.ping',
+  // event-types: The end of the section generated from our OpenAPI spec
+]);
+
+/**
+ * Shared registration and dispatch machinery for the two handlers below.
+ *
+ * Deliberately does not declare `handle`, and is not exported. TypeScript won't
+ * let a subclass add a required parameter to an inherited method, so a verifying
+ * handler cannot extend a non-verifying one (or vice versa) without either
+ * loosening a signature or suppressing the error. Making them siblings lets each
+ * declare its own exact `handle` while sharing everything else.
+ */
+class BaseEventNotificationHandler {
+  private registeredHandlers: Record<string, HandlerCallback> = {};
+  protected hasHandledEvent = false;
+
+  // the body is empty but the parameter properties are not, so the lint is ignorable
+  // eslint-disable-next-line no-useless-constructor
+  constructor(
+    protected client: Stripe,
+    private fallbackCallback: FallbackCallback
+  ) {}
+
+  // these types are duplicated in the manual types
+  public on<T extends Stripe.V2.Core.EventNotification['type']>(
+    type: T,
+    callback: (
+      event: Extract<Stripe.V2.Core.EventNotification, {type: T}>,
+      client: Stripe
+    ) => Promise<void>
+  ): this;
+  public on(type: string, callback: HandlerCallback): this {
+    if (this.hasHandledEvent) {
+      throw new Error(
+        'Cannot register new handlers after an event has been handled. This is indicative of a bug.'
+      );
+    }
+    // the matched types are validated by the type system
+    if (this.registeredHandlers[type]) {
+      throw new Error(`Handler already registered for event type: ${type}`);
+    }
+
+    this.registeredHandlers[type] = callback;
+    return this;
+  }
+
+  public registeredEventTypes(): string[] {
+    const keys = Object.keys(this.registeredHandlers);
+    keys.sort();
+    return keys;
+  }
+
+  protected async dispatchEvent(
+    event: Stripe.V2.Core.EventNotification
+  ): Promise<void> {
+    // Create a new client with the event's context instead of modifying the shared client
+    // This ensures thread-safety when processing webhooks in parallel
+    // We create a shallow copy and override _api with a new object containing the event context
+    // This reuses expensive resources like httpClient (Flyweight pattern)
+    const eventClient = Object.create(Object.getPrototypeOf(this.client));
+    Object.assign(eventClient, this.client);
+    eventClient._api = {
+      ...this.client._api,
+      stripeContext: event.context,
+    };
+
+    const handler = this.registeredHandlers[event.type];
+    if (handler) {
+      return await handler(event, eventClient);
+    } else {
+      return await this.fallbackCallback(
+        event as Events.UnknownEventNotification,
+        eventClient,
+        {
+          isKnownEventType: KNOWN_EVENT_TYPES.has(event.type),
+        }
+      );
+    }
+  }
+}
+
+export class StripeEventNotificationHandler extends BaseEventNotificationHandler {
+  constructor(
+    client: Stripe,
+    private webhookSecret: string,
+    fallbackCallback: FallbackCallback
+  ) {
+    super(client, fallbackCallback);
+    if (!webhookSecret) {
+      throw new Error('webhookSecret must be a non-empty string');
+    }
+  }
+
+  static withoutVerification(
+    client: Stripe,
+    fallbackCallback: FallbackCallback
+  ): StripeEventNotificationHandlerWithoutVerification {
+    return new StripeEventNotificationHandlerWithoutVerification(
+      client,
+      fallbackCallback
+    );
+  }
+
+  public async handle(
+    rawBody: WebhookPayload,
+    signature: WebhookHeader
+  ): Promise<void> {
+    // set before parsing, so that even a failed parse locks out registration.
+    // we're not worried about thread safety here because we expect callbacks will be registered synchronously on app startup
+    this.hasHandledEvent = true;
+
+    return await this.dispatchEvent(
+      this.client.parseEventNotification(rawBody, signature, this.webhookSecret)
+    );
+  }
+}
+
+/**
+ * A variant of StripeEventNotificationHandler that parses events without
+ * verifying webhook signatures. Intended for pre-authenticated channels
+ * like AWS EventBridge or Azure Event Grid.
+ *
+ * Prefer StripeEventNotificationHandler.withoutVerification() or
+ * client.notificationHandlerWithoutVerification() to construct one.
+ */
+export class StripeEventNotificationHandlerWithoutVerification extends BaseEventNotificationHandler {
+  public async handle(rawBody: WebhookPayload): Promise<void> {
+    this.hasHandledEvent = true;
+
+    return await this.dispatchEvent(
+      this.client.parseEventNotificationWithoutVerification(rawBody)
+    );
+  }
+}

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -17,7 +17,7 @@ import {maybeExtractFromCloudProviderEnvelope, parsePayload} from './utils.js';
  * since express should never return this header as an array,
  * only a string.
  */
-type WebhookHeader = string | string[] | Uint8Array;
+export type WebhookHeader = string | string[] | Uint8Array;
 type WebhookParsedHeader = {
   signatures: Array<string>;
   timestamp: number;
@@ -37,7 +37,7 @@ export type WebhookTestHeaderOptions = {
   cryptoProvider?: CryptoProvider;
 };
 
-type WebhookPayload = string | Uint8Array;
+export type WebhookPayload = string | Uint8Array;
 export type WebhookSignatureObject = {
   /**
    * Verifies the authenticity (and recency) of a webhook, throwing a `SignatureVerificationError`

--- a/src/stripe.cjs.node.ts
+++ b/src/stripe.cjs.node.ts
@@ -14513,6 +14513,9 @@ declare namespace StripeConstructor {
   export type Signature = Stripe_.Signature;
   export type StripeContextType = Stripe_.StripeContextType;
   export type StripeRawError = Stripe_.StripeRawError;
+  export type UnhandledNotificationDetails = Stripe_.UnhandledNotificationDetails;
+  export type StripeEventNotificationHandler = Stripe_.StripeEventNotificationHandler;
+  export type StripeEventNotificationHandlerWithoutVerification = Stripe_.StripeEventNotificationHandlerWithoutVerification;
   export type Decimal = Stripe_.Decimal;
   export namespace errors {
     export type StripeError = InstanceType<typeof Stripe_.errors.StripeError>;

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -10,7 +10,7 @@ import {
   StripeRawError,
   DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
-import {createWebhooks} from './Webhooks.js';
+import {createWebhooks, WebhookHeader, WebhookPayload} from './Webhooks.js';
 import {ApiVersion, ApiMajorVersion} from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
@@ -24,6 +24,11 @@ import {
   pascalToCamelCase,
   validateInteger,
 } from './utils.js';
+import {
+  StripeEventNotificationHandler,
+  StripeEventNotificationHandlerWithoutVerification,
+  UnhandledNotificationDetails,
+} from './StripeEventNotificationHandler.js';
 import {
   Response,
   RequestOptions,
@@ -54,7 +59,7 @@ import {
   Emptyable,
   Decimal,
 } from './shared.js';
-import {EventNotification as V2EventNotification} from './resources/V2/Core/Events.js';
+import {UnknownEventNotification} from './resources/V2/Core/Events.js';
 
 // StripeInstanceImports: The beginning of the section generated from our OpenAPI spec
 import {
@@ -1661,8 +1666,8 @@ export class Stripe {
    * `parseEventNotificationWithoutVerification`.
    */
   parseEventNotification(
-    payload: string | Uint8Array,
-    header: string | Uint8Array,
+    payload: WebhookPayload,
+    header: WebhookHeader,
     secret: string,
     tolerance?: number,
     cryptoProvider?: CryptoProvider,
@@ -1688,8 +1693,8 @@ export class Stripe {
   }
 
   async parseEventNotificationAsync(
-    payload: string | Uint8Array,
-    header: string | Uint8Array,
+    payload: WebhookPayload,
+    header: WebhookHeader,
     secret: string,
     tolerance?: number,
     cryptoProvider?: CryptoProvider,
@@ -1721,8 +1726,12 @@ export class Stripe {
    * [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge), or
    * [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) payload). Or, to verify &
    * construct in a single call, use `webhooks.constructEvent(...)` instead.
+   *
+   * @deprecated Use `stripe.webhooks.constructEventWithoutVerification(...)` instead.
+   * This will be removed in the next major version.
    */
   constructEventWithoutVerification(payload: string): Event {
+    // TODO(DEVSDK-3248) remove this
     return this.webhooks.constructEventWithoutVerification(payload);
   }
 
@@ -1735,10 +1744,38 @@ export class Stripe {
    * parse in a single call, use `parseEventNotification(...)` instead.
    */
   parseEventNotificationWithoutVerification(
-    payload: string
+    payload: WebhookPayload
   ): V2.Core.EventNotification {
     return this._buildEventNotification(
       maybeExtractFromCloudProviderEnvelope(payload)
+    );
+  }
+
+  notificationHandler(
+    webhookSecret: string,
+    fallbackCallback: (
+      event: UnknownEventNotification,
+      client: Stripe,
+      details: UnhandledNotificationDetails
+    ) => Promise<void>
+  ): StripeEventNotificationHandler {
+    return new StripeEventNotificationHandler(
+      this,
+      webhookSecret,
+      fallbackCallback
+    );
+  }
+
+  notificationHandlerWithoutVerification(
+    fallbackCallback: (
+      event: UnknownEventNotification,
+      client: Stripe,
+      details: UnhandledNotificationDetails
+    ) => Promise<void>
+  ): StripeEventNotificationHandlerWithoutVerification {
+    return StripeEventNotificationHandler.withoutVerification(
+      this,
+      fallbackCallback
     );
   }
 }
@@ -2628,6 +2665,12 @@ export declare namespace Stripe {
 
   export {StripeContext as StripeContextType};
   export {StripeRawError};
+  // Type-only: these classes are not attached as statics on the Stripe constructor,
+  // so they can be named in annotations but not used as values. Construct handlers
+  // through stripe.notificationHandler() / stripe.notificationHandlerWithoutVerification().
+  export type UnhandledNotificationDetails = import('./StripeEventNotificationHandler.js').UnhandledNotificationDetails;
+  export type StripeEventNotificationHandler = import('./StripeEventNotificationHandler.js').StripeEventNotificationHandler;
+  export type StripeEventNotificationHandlerWithoutVerification = import('./StripeEventNotificationHandler.js').StripeEventNotificationHandlerWithoutVerification;
   // ErrorTypeNamespaces: The beginning of the section generated from our OpenAPI spec
   export namespace ErrorType {
     export type StripeError = InstanceType<typeof _Error.StripeError>;

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -11,7 +11,7 @@ import {
   StripeRawError,
   DEFAULT_BASE_ADDRESSES,
 } from './Types.js';
-import {createWebhooks} from './Webhooks.js';
+import {createWebhooks, WebhookHeader, WebhookPayload} from './Webhooks.js';
 import {ApiVersion, ApiMajorVersion} from './apiVersion.js';
 import {CryptoProvider} from './crypto/CryptoProvider.js';
 import {HttpClient, HttpClientResponse} from './net/HttpClient.js';
@@ -24,6 +24,11 @@ import {
   pascalToCamelCase,
   validateInteger,
 } from './utils.js';
+import {
+  StripeEventNotificationHandler,
+  StripeEventNotificationHandlerWithoutVerification,
+  UnhandledNotificationDetails,
+} from './StripeEventNotificationHandler.js';
 import {
   Response,
   RequestOptions,
@@ -54,7 +59,7 @@ import {
   Emptyable,
   Decimal,
 } from './shared.js';
-import {EventNotification as V2EventNotification} from './resources/V2/Core/Events.js';
+import {UnknownEventNotification} from './resources/V2/Core/Events.js';
 
 // StripeInstanceImports: The beginning of the section generated from our OpenAPI spec
 import {
@@ -1633,8 +1638,8 @@ export class Stripe {
   }
 
   parseEventNotification(
-    payload: string | Uint8Array,
-    header: string | Uint8Array,
+    payload: WebhookPayload,
+    header: WebhookHeader,
     secret: string,
     tolerance?: number,
     cryptoProvider?: CryptoProvider,
@@ -1676,8 +1681,8 @@ export class Stripe {
   }
 
   async parseEventNotificationAsync(
-    payload: string | Uint8Array,
-    header: string | Uint8Array,
+    payload: WebhookPayload,
+    header: WebhookHeader,
     secret: string,
     tolerance?: number,
     cryptoProvider?: CryptoProvider,
@@ -1723,8 +1728,12 @@ export class Stripe {
    * Accepts raw Stripe Event JSON as well as payloads wrapped in an
    * [AWS EventBridge](https://docs.stripe.com/event-destinations/eventbridge)
    * or [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) envelope.
+   *
+   * @deprecated Use `stripe.webhooks.constructEventWithoutVerification(...)` instead.
+   * This will be removed in the next major version.
    */
   constructEventWithoutVerification(payload: string): Event {
+    // TODO(DEVSDK-3248) remove this
     return this.webhooks.constructEventWithoutVerification(payload);
   }
 
@@ -1735,7 +1744,7 @@ export class Stripe {
    * or [Azure Event Grid](https://docs.stripe.com/event-destinations/eventgrid) envelope.
    */
   parseEventNotificationWithoutVerification(
-    payload: string
+    payload: WebhookPayload
   ): V2.Core.EventNotification {
     const inner = maybeExtractFromCloudProviderEnvelope(payload);
     if (inner.object === 'event') {
@@ -1749,6 +1758,34 @@ export class Stripe {
       );
     }
     return this._buildEventNotification(inner);
+  }
+
+  notificationHandler(
+    webhookSecret: string,
+    fallbackCallback: (
+      event: UnknownEventNotification,
+      client: Stripe,
+      details: UnhandledNotificationDetails
+    ) => Promise<void>
+  ): StripeEventNotificationHandler {
+    return new StripeEventNotificationHandler(
+      this,
+      webhookSecret,
+      fallbackCallback
+    );
+  }
+
+  notificationHandlerWithoutVerification(
+    fallbackCallback: (
+      event: UnknownEventNotification,
+      client: Stripe,
+      details: UnhandledNotificationDetails
+    ) => Promise<void>
+  ): StripeEventNotificationHandlerWithoutVerification {
+    return StripeEventNotificationHandler.withoutVerification(
+      this,
+      fallbackCallback
+    );
   }
 }
 
@@ -2637,6 +2674,12 @@ export declare namespace Stripe {
 
   export {StripeContext as StripeContextType};
   export {StripeRawError};
+  export {UnhandledNotificationDetails};
+  // Type-only: these classes are not attached as statics on the Stripe constructor,
+  // so they can be named in annotations but not used as values. Construct handlers
+  // through stripe.notificationHandler() / stripe.notificationHandlerWithoutVerification().
+  export type StripeEventNotificationHandler = import('./StripeEventNotificationHandler.js').StripeEventNotificationHandler;
+  export type StripeEventNotificationHandlerWithoutVerification = import('./StripeEventNotificationHandler.js').StripeEventNotificationHandlerWithoutVerification;
   // ErrorTypeNamespaces: The beginning of the section generated from our OpenAPI spec
   export namespace ErrorType {
     export type StripeError = InstanceType<typeof _Error.StripeError>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -479,7 +479,7 @@ export function parsePayload(
 }
 
 export function maybeExtractFromCloudProviderEnvelope(
-  payload: string
+  payload: string | Uint8Array
 ): Record<string, unknown> {
   const parsed = parsePayload(payload);
 

--- a/test/StripeEventNotificationHandler.spec.ts
+++ b/test/StripeEventNotificationHandler.spec.ts
@@ -1,0 +1,703 @@
+/* eslint-disable require-await */
+
+import {expect} from 'chai';
+import {getSpyableStripe, FAKE_API_KEY} from './testUtils.js';
+
+const DUMMY_WEBHOOK_SECRET = 'whsec_test_secret';
+
+// Helper to generate webhook signature
+function generateHeader(payload: string): string {
+  const stripe = getSpyableStripe({});
+  return stripe.webhooks.generateTestHeaderString({
+    payload,
+    secret: DUMMY_WEBHOOK_SECRET,
+  });
+}
+
+describe('StripeEventNotificationHandler', () => {
+  let stripe: any;
+  let eventHandler: any;
+  let fallbackCallback: any;
+
+  // Event payloads
+  const v1BillingMeterPayload = JSON.stringify({
+    id: 'evt_123',
+    object: 'v2.core.event',
+    type: 'v1.billing.meter.error_report_triggered',
+    livemode: false,
+    created: '2022-02-15T00:27:45.330Z',
+    context: 'event_context_456',
+    related_object: {
+      id: 'mtr_123',
+      type: 'billing.meter',
+      url: '/v1/billing/meters/mtr_123',
+    },
+  });
+
+  const v1BillingMeterNoMeterFoundPayload = JSON.stringify({
+    id: 'evt_456',
+    object: 'v2.core.event',
+    type: 'v1.billing.meter.no_meter_found',
+    livemode: false,
+    created: '2022-02-15T00:27:45.330Z',
+    context: 'event_context_789',
+  });
+
+  const unknownEventPayload = JSON.stringify({
+    id: 'evt_unknown',
+    object: 'v2.core.event',
+    type: 'llama.created',
+    livemode: false,
+    created: '2022-02-15T00:27:45.330Z',
+    context: 'event_context_unknown',
+    related_object: {
+      id: 'llama_123',
+      type: 'llama',
+      url: '/v1/llamas/llama_123',
+    },
+  });
+
+  beforeEach(() => {
+    stripe = getSpyableStripe({});
+    fallbackCallback = async () => {};
+    eventHandler = stripe.notificationHandler(
+      DUMMY_WEBHOOK_SECRET,
+      fallbackCallback
+    );
+  });
+
+  describe('handler registration and routing', () => {
+    it('should route event to registered handler', async () => {
+      let callbackCalled = false;
+      let receivedEvent: any = null;
+      let receivedClient: any = null;
+
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async (event: any, client: any) => {
+          callbackCalled = true;
+          receivedEvent = event;
+          receivedClient = client;
+        }
+      );
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(callbackCalled).to.be.true;
+      expect(receivedEvent.type).to.equal(
+        'v1.billing.meter.error_report_triggered'
+      );
+      expect(receivedEvent.id).to.equal('evt_123');
+      expect(receivedEvent.related_object.id).to.equal('mtr_123');
+      expect(receivedClient).to.exist;
+    });
+
+    it('should route different events to their respective handlers', async () => {
+      let billingCallbackCalled = false;
+      let noMeterCallbackCalled = false;
+
+      eventHandler.on('v1.billing.meter.error_report_triggered', async () => {
+        billingCallbackCalled = true;
+      });
+
+      eventHandler.on('v1.billing.meter.no_meter_found', async () => {
+        noMeterCallbackCalled = true;
+      });
+
+      const sigHeader1 = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader1);
+      expect(billingCallbackCalled).to.be.true;
+
+      const sigHeader2 = generateHeader(v1BillingMeterNoMeterFoundPayload);
+      await eventHandler.handle(v1BillingMeterNoMeterFoundPayload, sigHeader2);
+      expect(noMeterCallbackCalled).to.be.true;
+    });
+
+    it('should throw error when registering handler after handling', async () => {
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(() => {
+        eventHandler.on('v1.billing.meter.no_meter_found', async () => {});
+      }).to.throw(
+        /Cannot register new handlers after an event has been handled/
+      );
+    });
+
+    it('should throw error when registering handler after a failed parse', async () => {
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      // attempting to handle locks registration even though verification fails
+      let parseFailed = false;
+      try {
+        await eventHandler.handle(v1BillingMeterPayload, 't=1,v1=not-a-sig');
+      } catch (e) {
+        parseFailed = true;
+      }
+      expect(parseFailed).to.be.true;
+
+      expect(() => {
+        eventHandler.on('v1.billing.meter.no_meter_found', async () => {});
+      }).to.throw(
+        /Cannot register new handlers after an event has been handled/
+      );
+    });
+
+    it('should throw error when registering duplicate handler', () => {
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      expect(() => {
+        eventHandler.on(
+          'v1.billing.meter.error_report_triggered',
+          async () => {}
+        );
+      }).to.throw(/Handler already registered for event type/);
+    });
+  });
+
+  describe('stripe context management', () => {
+    it('should use event stripe context in handler', async () => {
+      let receivedContext: any = null;
+      let normalizedContext: any = null;
+
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async (event: any, client: any) => {
+          receivedContext = client._api.stripeContext;
+          // Verify that _normalizeStripeContext uses the mutated context as default
+          normalizedContext = client._requestSender._normalizeStripeContext(
+            undefined,
+            client.getApiField('stripeContext')
+          );
+        }
+      );
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      // The event has context 'event_context_456'
+      expect(receivedContext?.toString()).to.equal('event_context_456');
+      // Verify normalized context (what would be used in headers) matches
+      expect(normalizedContext).to.equal('event_context_456');
+    });
+
+    it('should not modify original client context after handler success', async () => {
+      const stripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
+        stripeContext: 'original_context_123',
+      });
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {}
+      );
+
+      let contextInHandler: any = null;
+      let normalizedInHandler: any = null;
+
+      handler.on(
+        'v1.billing.meter.error_report_triggered',
+        async (event: any, client: any) => {
+          contextInHandler = client._api.stripeContext;
+          normalizedInHandler = client._requestSender._normalizeStripeContext(
+            undefined,
+            client.getApiField('stripeContext')
+          );
+        }
+      );
+
+      const originalContext = stripe._api.stripeContext;
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await handler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(contextInHandler?.toString()).to.equal('event_context_456');
+      expect(normalizedInHandler).to.equal('event_context_456');
+      expect(stripe._api.stripeContext).to.equal(originalContext);
+      // Verify original client context is unchanged
+      const normalizedAfter = stripe._requestSender._normalizeStripeContext(
+        undefined,
+        stripe.getApiField('stripeContext')
+      );
+      expect(normalizedAfter).to.equal('original_context_123');
+    });
+
+    it('should not modify original client context after handler error', async () => {
+      const stripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
+        stripeContext: 'original_context_123',
+      });
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {}
+      );
+
+      handler.on(
+        'v1.billing.meter.error_report_triggered',
+        async (event: any, client: any) => {
+          const context = client._api.stripeContext;
+          const normalized = client._requestSender._normalizeStripeContext(
+            undefined,
+            client.getApiField('stripeContext')
+          );
+          expect(context?.toString()).to.equal('event_context_456');
+          expect(normalized).to.equal('event_context_456');
+          throw new Error('Handler error!');
+        }
+      );
+
+      const originalContext = stripe._api.stripeContext;
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+
+      try {
+        await handler.handle(v1BillingMeterPayload, sigHeader);
+        expect.fail('Should have thrown error');
+      } catch (err) {
+        // @ts-expect-error
+        expect(err.message).to.equal('Handler error!');
+      }
+
+      expect(stripe._api.stripeContext).to.equal(originalContext);
+      // Verify original client context is unchanged even after error
+      const normalizedAfter = stripe._requestSender._normalizeStripeContext(
+        undefined,
+        stripe.getApiField('stripeContext')
+      );
+      expect(normalizedAfter).to.equal('original_context_123');
+    });
+
+    it('should create client with null context when event has no context', async () => {
+      const stripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
+        stripeContext: 'original_context_123',
+      });
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {}
+      );
+
+      let receivedContext: any = null;
+      let normalizedInHandler: any = null;
+
+      // Create payload with null context
+      const noContextPayload = JSON.stringify({
+        id: 'evt_789',
+        object: 'v2.core.event',
+        type: 'v1.billing.meter.no_meter_found',
+        livemode: false,
+        created: '2022-02-15T00:27:45.330Z',
+        context: null,
+      });
+
+      handler.on(
+        'v1.billing.meter.no_meter_found',
+        async (event: any, client: any) => {
+          receivedContext = client._api.stripeContext;
+          normalizedInHandler = client._requestSender._normalizeStripeContext(
+            undefined,
+            client.getApiField('stripeContext')
+          );
+        }
+      );
+
+      const originalContext = stripe._api.stripeContext;
+      expect(originalContext?.toString()).to.equal('original_context_123');
+
+      const sigHeader = generateHeader(noContextPayload);
+      await handler.handle(noContextPayload, sigHeader);
+
+      expect(receivedContext).to.be.null;
+      expect(normalizedInHandler).to.be.null;
+      expect(stripe._api.stripeContext?.toString()).to.equal(
+        'original_context_123'
+      );
+      // Verify original client context is unchanged
+      const normalizedAfter = stripe._requestSender._normalizeStripeContext(
+        undefined,
+        stripe.getApiField('stripeContext')
+      );
+      expect(normalizedAfter).to.equal('original_context_123');
+    });
+  });
+
+  describe('unhandled events', () => {
+    it('should route unknown event to on_unhandled handler', async () => {
+      let unhandledCalled = false;
+      let unhandledEvent: any = null;
+      let unhandledClient: any = null;
+      let unhandledInfo: any = null;
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async (event: any, client: any, info: any) => {
+          unhandledCalled = true;
+          unhandledEvent = event;
+          unhandledClient = client;
+          unhandledInfo = info;
+        }
+      );
+
+      const sigHeader = generateHeader(unknownEventPayload);
+      await handler.handle(unknownEventPayload, sigHeader);
+
+      expect(unhandledCalled).to.be.true;
+      expect(unhandledEvent.type).to.equal('llama.created');
+      expect(unhandledClient).to.exist;
+      expect(unhandledInfo.isKnownEventType).to.be.false;
+    });
+
+    it('should route known unregistered event to on_unhandled handler', async () => {
+      let unhandledCalled = false;
+      let unhandledEvent: any = null;
+      let unhandledInfo: any = null;
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async (event: any, client: any, info: any) => {
+          unhandledCalled = true;
+          unhandledEvent = event;
+          unhandledInfo = info;
+        }
+      );
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await handler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(unhandledCalled).to.be.true;
+      expect(unhandledEvent.type).to.equal(
+        'v1.billing.meter.error_report_triggered'
+      );
+      expect(unhandledInfo.isKnownEventType).to.be.true;
+    });
+
+    it('should not call on_unhandled for registered events', async () => {
+      let handlerCalled = false;
+      let unhandledCalled = false;
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {
+          unhandledCalled = true;
+        }
+      );
+
+      handler.on('v1.billing.meter.error_report_triggered', async () => {
+        handlerCalled = true;
+      });
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await handler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(handlerCalled).to.be.true;
+      expect(unhandledCalled).to.be.false;
+    });
+  });
+
+  describe('client configuration', () => {
+    it('should pass new client instance with event stripe context', async () => {
+      const stripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
+        stripeContext: 'original_context_xyz',
+      });
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {}
+      );
+
+      let receivedClient: any = null;
+      let receivedContext: any = null;
+
+      handler.on(
+        'v1.billing.meter.error_report_triggered',
+        async (event: any, client: any) => {
+          receivedClient = client;
+          receivedContext = client._api.stripeContext;
+        }
+      );
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await handler.handle(v1BillingMeterPayload, sigHeader);
+
+      // The handler should receive a new client instance (not the same reference)
+      expect(receivedClient).to.not.equal(stripe);
+      // With the event's context
+      expect(receivedContext?.toString()).to.equal('event_context_456');
+      // And the original client's context should remain unchanged
+      expect(stripe._api.stripeContext?.toString()).to.equal(
+        'original_context_xyz'
+      );
+    });
+  });
+
+  describe('webhook signature validation', () => {
+    it('should reject invalid webhook signatures', async () => {
+      let errorThrown = false;
+
+      try {
+        await eventHandler.handle(v1BillingMeterPayload, 'invalid_signature');
+      } catch (err) {
+        errorThrown = true;
+        // @ts-expect-error
+        expect(err.type).to.include('StripeSignatureVerification');
+      }
+
+      expect(errorThrown).to.be.true;
+    });
+  });
+
+  describe('registeredEventTypes', () => {
+    it('should return empty list when no handlers are registered', () => {
+      const types = eventHandler.registeredEventTypes();
+      expect(types).to.deep.equal([]);
+    });
+
+    it('should return single event type when one handler is registered', () => {
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      const types = eventHandler.registeredEventTypes();
+      expect(types).to.deep.equal(['v1.billing.meter.error_report_triggered']);
+    });
+
+    it('should return multiple event types in alphabetical order', () => {
+      // Register in non-alphabetical order
+      eventHandler.on('v1.billing.meter.no_meter_found', async () => {});
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      const types = eventHandler.registeredEventTypes();
+      expect(types).to.deep.equal([
+        'v1.billing.meter.error_report_triggered',
+        'v1.billing.meter.no_meter_found',
+      ]);
+    });
+  });
+});
+
+describe('StripeEventNotificationHandlerWithoutVerification', () => {
+  let stripe: any;
+  let withoutVerifHandler: any;
+
+  // Event payloads (duplicated here since they are scoped to the sibling describe block)
+  const v1BillingMeterPayload = JSON.stringify({
+    id: 'evt_123',
+    object: 'v2.core.event',
+    type: 'v1.billing.meter.error_report_triggered',
+    livemode: false,
+    created: '2022-02-15T00:27:45.330Z',
+    context: 'event_context_456',
+    related_object: {
+      id: 'mtr_123',
+      type: 'billing.meter',
+      url: '/v1/billing/meters/mtr_123',
+    },
+  });
+
+  const unknownEventPayload = JSON.stringify({
+    id: 'evt_unknown',
+    object: 'v2.core.event',
+    type: 'llama.created',
+    livemode: false,
+    created: '2022-02-15T00:27:45.330Z',
+    context: 'event_context_unknown',
+  });
+
+  beforeEach(() => {
+    stripe = getSpyableStripe({});
+    withoutVerifHandler = stripe.notificationHandlerWithoutVerification(
+      async () => {}
+    );
+  });
+
+  it('should route event to registered handler without a signature', async () => {
+    let callbackCalled = false;
+    let receivedEvent: any = null;
+    let receivedClient: any = null;
+
+    withoutVerifHandler.on(
+      'v1.billing.meter.error_report_triggered',
+      async (event: any, client: any) => {
+        callbackCalled = true;
+        receivedEvent = event;
+        receivedClient = client;
+      }
+    );
+
+    // No signature argument — just the raw body
+    await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+    expect(callbackCalled).to.be.true;
+    expect(receivedEvent.type).to.equal(
+      'v1.billing.meter.error_report_triggered'
+    );
+    expect(receivedEvent.id).to.equal('evt_123');
+    expect(receivedClient).to.exist;
+  });
+
+  it('should throw error when registering handler after a failed parse', async () => {
+    withoutVerifHandler.on(
+      'v1.billing.meter.error_report_triggered',
+      async () => {}
+    );
+
+    // attempting to handle locks registration even though the parse fails
+    let parseFailed = false;
+    try {
+      await withoutVerifHandler.handle('not json');
+    } catch (e) {
+      parseFailed = true;
+    }
+    expect(parseFailed).to.be.true;
+
+    expect(() => {
+      withoutVerifHandler.on('v1.billing.meter.no_meter_found', async () => {});
+    }).to.throw(/Cannot register new handlers after an event has been handled/);
+  });
+
+  it('should accept a Uint8Array body without a signature', async () => {
+    let callbackCalled = false;
+
+    withoutVerifHandler.on(
+      'v1.billing.meter.error_report_triggered',
+      async () => {
+        callbackCalled = true;
+      }
+    );
+
+    const bodyAsBytes = new TextEncoder().encode(v1BillingMeterPayload);
+    await withoutVerifHandler.handle(bodyAsBytes);
+
+    expect(callbackCalled).to.be.true;
+  });
+
+  it('should route known unregistered event to fallback with isKnownEventType: true', async () => {
+    let unhandledCalled = false;
+    let unhandledEvent: any = null;
+    let unhandledInfo: any = null;
+
+    const handler = stripe.notificationHandlerWithoutVerification(
+      async (event: any, _client: any, info: any) => {
+        unhandledCalled = true;
+        unhandledEvent = event;
+        unhandledInfo = info;
+      }
+    );
+
+    await handler.handle(v1BillingMeterPayload);
+
+    expect(unhandledCalled).to.be.true;
+    expect(unhandledEvent.type).to.equal(
+      'v1.billing.meter.error_report_triggered'
+    );
+    expect(unhandledInfo.isKnownEventType).to.be.true;
+  });
+
+  it('should route unknown event type to fallback with isKnownEventType: false', async () => {
+    let unhandledCalled = false;
+    let unhandledEvent: any = null;
+    let unhandledInfo: any = null;
+
+    const handler = stripe.notificationHandlerWithoutVerification(
+      async (event: any, _client: any, info: any) => {
+        unhandledCalled = true;
+        unhandledEvent = event;
+        unhandledInfo = info;
+      }
+    );
+
+    await handler.handle(unknownEventPayload);
+
+    expect(unhandledCalled).to.be.true;
+    expect(unhandledEvent.type).to.equal('llama.created');
+    expect(unhandledInfo.isKnownEventType).to.be.false;
+  });
+
+  it('should propagate event stripe context to the callback client', async () => {
+    let receivedContext: any = null;
+    let normalizedContext: any = null;
+
+    withoutVerifHandler.on(
+      'v1.billing.meter.error_report_triggered',
+      async (event: any, client: any) => {
+        receivedContext = client._api.stripeContext;
+        normalizedContext = client._requestSender._normalizeStripeContext(
+          undefined,
+          client.getApiField('stripeContext')
+        );
+      }
+    );
+
+    await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+    // The event has context 'event_context_456'
+    expect(receivedContext?.toString()).to.equal('event_context_456');
+    expect(normalizedContext).to.equal('event_context_456');
+  });
+
+  it('should return StripeEventNotificationHandlerWithoutVerification from static factory', () => {
+    // Access the parent class via an existing handler instance to avoid a
+    // separate import that would break when this file is copied to stripe-node.
+    const tempHandler = stripe.notificationHandler(
+      'whsec_test_secret',
+      async () => {}
+    );
+    const StripeEventNotificationHandlerClass = tempHandler.constructor;
+
+    const handler = StripeEventNotificationHandlerClass.withoutVerification(
+      stripe,
+      async () => {}
+    );
+
+    expect(handler.constructor.name).to.equal(
+      'StripeEventNotificationHandlerWithoutVerification'
+    );
+    expect(typeof handler.on).to.equal('function');
+    expect(typeof handler.handle).to.equal('function');
+  });
+
+  it('should throw when constructing the original handler with an empty webhookSecret', () => {
+    expect(() => {
+      stripe.notificationHandler('', async () => {});
+    }).to.throw(/webhookSecret must be a non-empty string/);
+  });
+
+  it('should treat every webhookSecret as a real secret, with no magic bypass value', async () => {
+    // there is no sentinel to forge: the verifying and non-verifying handlers are
+    // separate classes, so any string passed here is just an ordinary (wrong) secret
+    const handler = stripe.notificationHandler(
+      '__without_verification__',
+      async () => {}
+    );
+
+    let errorThrown = false;
+
+    try {
+      await handler.handle(
+        v1BillingMeterPayload,
+        generateHeader(v1BillingMeterPayload)
+      );
+    } catch (err) {
+      errorThrown = true;
+      // @ts-expect-error
+      expect(err.type).to.include('StripeSignatureVerification');
+    }
+
+    expect(errorThrown).to.be.true;
+  });
+});

--- a/testProjects/types-cjs-node16/typescriptTest.ts
+++ b/testProjects/types-cjs-node16/typescriptTest.ts
@@ -20,7 +20,10 @@ let subscription: Stripe.Subscription;
 let invoice: Stripe.Invoice;
 let refund: Stripe.Refund;
 let paymentIntent: Stripe.PaymentIntent;
-let event: Stripe.Event;
+let event: Stripe.Event; // union of types
+let et: Stripe.EventBase; // actual base interface
+let et2: Stripe.V2.Core.EventBase; // actual v2 base interface
+let notif: Stripe.V2.Core.EventNotification; // union of thin event types
 
 // Param types
 let params: Stripe.CustomerCreateParams;
@@ -66,8 +69,9 @@ const bad = new Stripe('sk_test_123', {unknownProperty: true});
 // Webhook methods: constructEventWithoutVerification and parseEventNotificationWithoutVerification
 event = stripe.webhooks.constructEventWithoutVerification('payload');
 event = stripe.constructEventWithoutVerification('payload');
-const _notificationWV: Stripe.V2.Core.EventNotification =
-  stripe.parseEventNotificationWithoutVerification('payload');
+const _notificationWV: Stripe.V2.Core.EventNotification = stripe.parseEventNotificationWithoutVerification(
+  'payload'
+);
 
 // Namespace type exports that must remain accessible (v21 parity).
 const _stripeConfig: Stripe.StripeConfig = {maxNetworkRetries: 3};
@@ -88,5 +92,39 @@ const _signatureType: Stripe.Signature = null as any;
 
 // Factory function return types must be assignable to their interface types.
 const _nodeHttpClient: Stripe.HttpClient = Stripe.createNodeHttpClient();
-const _nodeCryptoProvider: Stripe.CryptoProvider =
-  Stripe.createNodeCryptoProvider();
+const _nodeCryptoProvider: Stripe.CryptoProvider = Stripe.createNodeCryptoProvider();
+
+// notificationHandlerWithoutVerification must be reachable under moduleResolution node16
+async (): Promise<void> => {
+  const unverifiedHandler = stripe.notificationHandlerWithoutVerification(
+    async (unhandledEvent, client, details) => {
+      const e: Stripe.Events.UnknownEventNotification = unhandledEvent;
+      const s: Stripe = client;
+      const d: Stripe.UnhandledNotificationDetails = details;
+    }
+  );
+
+  unverifiedHandler.on(
+    'v1.billing.meter.error_report_triggered',
+    async (event) => {
+      const meter: Stripe.Billing.Meter = await event.fetchRelatedObject();
+    }
+  );
+
+  // handle() takes only the body; there is no signature to pass
+  const res: void = await unverifiedHandler.handle('');
+
+  // @ts-expect-error - the verifying two-argument handle is not available here
+  await unverifiedHandler.handle('', 'sig_header');
+
+  // Node exposes only the client factory; the handler classes are type-only.
+  // @ts-expect-error - StripeEventNotificationHandler is not a runtime value
+  Stripe.StripeEventNotificationHandler.withoutVerification(
+    stripe,
+    async () => {}
+  );
+};
+
+// both handler types must be nameable off the namespace
+let _verifyingHandler: Stripe.StripeEventNotificationHandler;
+let _unverifiedHandler: Stripe.StripeEventNotificationHandlerWithoutVerification;

--- a/testProjects/types-cjs/typescriptTest.ts
+++ b/testProjects/types-cjs/typescriptTest.ts
@@ -390,6 +390,9 @@ async (): Promise<void> => {
   let f: Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification;
   // union of all V2 Events
   let g: Stripe.V2.Core.Event;
+  // let h: Stripe.V2.Core.EventNotificationBase; // doesn't work, can export later
+  // union of all v1 events
+  let i: Stripe.Event;
 }
 
 // Test that the Decimal type is exported
@@ -427,6 +430,38 @@ event = stripe.constructEventWithoutVerification('payload');
 // parseEventNotificationWithoutVerification on client
 const _notificationWV: Stripe.V2.Core.EventNotification =
   stripe.parseEventNotificationWithoutVerification('payload');
+
+// notificationHandlerWithoutVerification must be reachable through the CJS entry
+async (): Promise<void> => {
+  const unverifiedHandler = stripe.notificationHandlerWithoutVerification(
+    async (unhandledEvent, client, details) => {
+      const e: Stripe.Events.UnknownEventNotification = unhandledEvent;
+      const s: Stripe = client;
+      const d: Stripe.UnhandledNotificationDetails = details;
+    }
+  );
+
+  unverifiedHandler.on(
+    'v1.billing.meter.error_report_triggered',
+    async (event) => {
+      const meter: Stripe.Billing.Meter = await event.fetchRelatedObject();
+    }
+  );
+
+  // handle() takes only the body; there is no signature to pass
+  const res: void = await unverifiedHandler.handle('');
+
+  // @ts-expect-error - the verifying two-argument handle is not available here
+  await unverifiedHandler.handle('', 'sig_header');
+
+  // Node exposes only the client factory; the handler classes are type-only.
+  // @ts-expect-error - StripeEventNotificationHandler is not a runtime value
+  Stripe.StripeEventNotificationHandler.withoutVerification(stripe, async () => {});
+};
+
+// both handler types must be nameable off the namespace
+let _verifyingHandler: Stripe.StripeEventNotificationHandler;
+let _unverifiedHandler: Stripe.StripeEventNotificationHandlerWithoutVerification;
 
 const taxExempt: Stripe.CustomerUpdateParams.TaxExempt = 'exempt';
 let subscription: Stripe.Subscription;

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -393,7 +393,93 @@ async (): Promise<void> => {
   let f: Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification;
   // union of all V2 Events
   let g: Stripe.V2.Core.Event;
+  // union of all v1 events
+  let h: Stripe.Event;
 }
+
+async (): Promise<void> => {
+  // event handler
+  const handler = stripe.notificationHandler(
+    'whsec_123',
+    async (unhandledEvent, client, details) => {
+      const e: Stripe.Events.UnknownEventNotification = unhandledEvent;
+      const s: Stripe = client;
+      const d: Stripe.UnhandledNotificationDetails = details;
+    }
+  );
+
+  handler
+    .on('v1.billing.meter.error_report_triggered', async (event) => {
+      const meter: Stripe.Billing.Meter = await event.fetchRelatedObject();
+      const e: Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification = event;
+      const evt: Stripe.Events.V1BillingMeterErrorReportTriggeredEvent = await event.fetchEvent();
+    })
+    .on('v1.billing.meter.no_meter_found', async (event) => {
+      const e: Stripe.Events.V1BillingMeterNoMeterFoundEventNotification = event;
+      // @ts-expect-error - shouldn't be available
+      const meter: Stripe.Billing.Meter = await event.fetchRelatedObject();
+      const evt: Stripe.Events.V1BillingMeterNoMeterFoundEvent = await event.fetchEvent();
+    });
+
+  const res: void = await handler.handle('', '');
+};
+
+// event handler that skips signature verification
+async (): Promise<void> => {
+  const unverifiedHandler = stripe.notificationHandlerWithoutVerification(
+    async (unhandledEvent, client, details) => {
+      const e: Stripe.Events.UnknownEventNotification = unhandledEvent;
+      const s: Stripe = client;
+      const d: Stripe.UnhandledNotificationDetails = details;
+    }
+  );
+
+  unverifiedHandler.on(
+    'v1.billing.meter.error_report_triggered',
+    async (event) => {
+      const meter: Stripe.Billing.Meter = await event.fetchRelatedObject();
+      const e: Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification = event;
+    }
+  );
+
+  // handle() takes only the body; there is no signature to pass
+  const res: void = await unverifiedHandler.handle('');
+
+  // @ts-expect-error - the verifying two-argument handle is not available here
+  await unverifiedHandler.handle('', 'sig_header');
+
+  // Node exposes only the client factory. The handler classes are type-only (they are
+  // not attached as statics on the constructor), so the static factory that the other
+  // SDKs offer is intentionally unreachable here.
+  // @ts-expect-error - StripeEventNotificationHandler is not a runtime value
+  Stripe.StripeEventNotificationHandler.withoutVerification(
+    stripe,
+    async () => {}
+  );
+};
+
+// both handler types must be nameable off the namespace
+let _verifyingHandler: Stripe.StripeEventNotificationHandler;
+let _unverifiedHandler: Stripe.StripeEventNotificationHandlerWithoutVerification;
+
+// event-notification methods take the same payload/header types as the v1 webhook
+// methods: WebhookPayload (string | Uint8Array) and WebhookHeader, which includes
+// string[] so it composes with express's `Request#headers` type.
+async (): Promise<void> => {
+  const arrayHeader: string[] = ['sig'];
+  const bytesBody: Uint8Array = new TextEncoder().encode('{}');
+
+  stripe.parseEventNotification(bytesBody, arrayHeader, 'whsec_123');
+  await stripe.parseEventNotificationAsync(bytesBody, arrayHeader, 'whsec_123');
+  stripe.parseEventNotificationWithoutVerification(bytesBody);
+
+  await stripe
+    .notificationHandler('whsec_123', async () => {})
+    .handle(bytesBody, arrayHeader);
+  await stripe
+    .notificationHandlerWithoutVerification(async () => {})
+    .handle(bytesBody);
+};
 
 // Test that the Decimal type is exported
 {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

The event notification handler code has been in the `beta` and `private-preview` branches since last year, but it's time to take it to GA!

This PR is entirely pre-approved code from previous PRs. It takes the static files from codegen, plus all the manual changes I made directly in `beta` to get everything working. It's stacked on top of the non-verified work from this week, too. Once this lands, the managed handler code should be in sync across all channels.

Notably, the static files that we used to share functionality are no longer sourced from codegen. Instead, they're now true manual files in `master` whose changes will flow into preview branches like normal.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `EventNotificationHandler` class & supporting infrastructure (ability to copy a `StripeClient`, etc)
- add `stripeClient` methods for creating a handler bound to that client
- add example
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- https://stripe.dev/blog/event-notification-handlers-thin-events
- [internal doc](https://docs.google.com/document/d/1hRpQLMLGfOHhZwXrYt5tvsKT-oIya11M4atunvTOih0/edit?tab=t.w21fiib3jsl3#heading=h.p5iqpr8dzdsz)
- Initial PR: https://github.com/stripe/stripe-node/pull/2498
- Update PR (adds non-verified handlers): https://github.com/stripe/stripe-node/pull/2813

## Changelog

- We've been putting a lot of time into rethinking the event handling experience in the SDKs. This new class is the culmination [of that effort](https://stripe.dev/blog/event-notification-handlers-thin-events).
- They're designed for a tight coupling with both `StripeClient` and the fully-typed nature of [thin events](https://docs.stripe.com/event-destinations#thin-events). This delivers painless event destination upgrades, in-editor checks for common mistakes, and better code modularity.
- Now that we've released [thin event notifications for v1 objects](https://docs.stripe.com/changelog#2026-08-26.dahlia), these new handlers are our recommended path for all integrations using thin event notifications.
- See more detailed docs here: https://docs.stripe.com/webhooks/event-notification-handlers
