### PR TITLE
Add `.preHandle` method to `EventNotificationHandler`

### DIFF
--- a/examples/snippets/event_notification_handler_endpoint.ts
+++ b/examples/snippets/event_notification_handler_endpoint.ts
@@ -5,6 +5,8 @@
  *   - write a fallback callback to handle unrecognized event notifications
  *   - create a StripeClient called client
  *   - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
+ *   - register a preHandle hook that deduplicates events we've already processed, stopping
+ *     handling entirely (no registered handler, no fallback) for events we've seen before
  *   - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
  *   - use handler.handle() to process the received notification webhook body
  */
@@ -23,6 +25,19 @@ const handler = client.notificationHandler(
     console.log(`Received unhandled event type: ${unhandledEvent.type}`);
   }
 );
+
+// Track ids we've already processed so retried deliveries are skipped entirely.
+// preHandle runs before any callback: resolving false here means neither the
+// registered handler below nor the fallback above will run for this event.
+const processedEventIds = new Set<string>();
+handler.preHandle(async (event) => {
+  if (processedEventIds.has(event.id)) {
+    console.log(`Skipping already-processed event: ${event.id}`);
+    return false;
+  }
+  processedEventIds.add(event.id);
+  return true;
+});
 
 handler.on('v1.billing.meter.error_report_triggered', async (event) => {
   const meter = await event.fetchRelatedObject();
@@ -50,7 +65,7 @@ app.post(
   '/webhook',
   express.raw({type: 'application/json'}),
   async (req, res) => {
-    handler.handle(req.body, req.headers['stripe-signature']!);
+    await handler.handle(req.body, req.headers['stripe-signature']!);
   }
 );
 

--- a/examples/snippets/event_notification_handler_endpoint.ts
+++ b/examples/snippets/event_notification_handler_endpoint.ts
@@ -5,8 +5,7 @@
  *   - write a fallback callback to handle unrecognized event notifications
  *   - create a StripeClient called client
  *   - Initialize an EventNotificationHandler with the client, webhook secret, and fallback callback
- *   - register a preHandle hook that deduplicates events we've already processed, stopping
- *     handling entirely (no registered handler, no fallback) for events we've seen before
+ *   - register a preHandle hook that deduplicates events by id before any callback runs
  *   - register a specific handler for the "v1.billing.meter.no_meter_found" event notification type
  *   - use handler.handle() to process the received notification webhook body
  */
@@ -26,24 +25,6 @@ const handler = client.notificationHandler(
   }
 );
 
-// Track ids we've already processed so retried deliveries are skipped entirely.
-// preHandle runs before any callback: resolving false here means neither the
-// registered handler below nor the fallback above will run for this event.
-const processedEventIds = new Set<string>();
-handler.preHandle(async (event) => {
-  if (processedEventIds.has(event.id)) {
-    console.log(`Skipping already-processed event: ${event.id}`);
-    return false;
-  }
-  processedEventIds.add(event.id);
-  return true;
-});
-
-handler.on('v1.billing.meter.error_report_triggered', async (event) => {
-  const meter = await event.fetchRelatedObject();
-  console.log(`Billing Meter ${meter.display_name} had a problem`);
-});
-
 // Handles events delivered through a channel that has already authenticated them, such as
 // AWS EventBridge or Azure Event Grid. Those payloads carry no Stripe-Signature header, so
 // this handler skips verification. Callbacks are registered separately from the one above.
@@ -52,6 +33,37 @@ const unverifiedHandler = client.notificationHandlerWithoutVerification(
     console.log(`Received unhandled event type: ${unhandledEvent.type}`);
   }
 );
+
+// Webhooks can be delivered more than once, so we track ids we've already
+// processed. In production, back this with something durable and shared
+// across processes (e.g. Redis or a database table) instead of an in-memory Set.
+const processedEventIds = new Set<string>();
+
+/**
+ * Runs before any registered callback. Returning false
+ * here skips handling entirely for this delivery, which is useful for
+ * deduplicating webhooks.
+ */
+async function deduplicateEvents(
+  event: Stripe.V2.Core.EventNotification
+): Promise<boolean> {
+  if (processedEventIds.has(event.id)) {
+    console.log(`Skipping already-processed event: ${event.id}`);
+    return false;
+  }
+  processedEventIds.add(event.id);
+  return true;
+}
+
+handler.preHandle(deduplicateEvents);
+unverifiedHandler.preHandle(deduplicateEvents);
+
+// can be anywhere in your codebase; registering on both handlers means either
+// endpoint below will route this event type
+handler.on('v1.billing.meter.error_report_triggered', async (event) => {
+  const meter = await event.fetchRelatedObject();
+  console.log(`Billing Meter ${meter.display_name} had a problem`);
+});
 
 unverifiedHandler.on(
   'v1.billing.meter.error_report_triggered',

--- a/src/StripeEventNotificationHandler.ts
+++ b/src/StripeEventNotificationHandler.ts
@@ -89,7 +89,9 @@ class BaseEventNotificationHandler {
     this.assertCanRegister();
     // the matched types are validated by the type system
     if (this.registeredHandlers[type]) {
-      throw new Error(`Handler already registered for event type: ${type}`);
+      throw new Error(
+        `Callback for event type "${type}" is already registered.`
+      );
     }
 
     this.registeredHandlers[type] = callback;
@@ -103,7 +105,7 @@ class BaseEventNotificationHandler {
   private assertCanRegister(): void {
     if (this.hasHandledEvent) {
       throw new Error(
-        'Cannot register new handlers after an event has been handled. This is indicative of a bug.'
+        'Cannot register new callbacks after an event has been handled. This is indicative of a bug.'
       );
     }
   }

--- a/src/StripeEventNotificationHandler.ts
+++ b/src/StripeEventNotificationHandler.ts
@@ -12,11 +12,6 @@ export type FallbackCallback = (
   details: UnhandledNotificationDetails
 ) => Promise<void>;
 
-/**
- * Runs after `handle()` parses the payload but before any registered
- * handler or fallback callback fires. Resolving `false` stops handling
- * entirely: neither the registered handler nor the fallback will run.
- */
 export type PreHandleCallback = (
   event: Stripe.V2.Core.EventNotification,
   client: Stripe
@@ -110,6 +105,11 @@ class BaseEventNotificationHandler {
     }
   }
 
+  /**
+   * Registers a function that will be run before any event-specific callbacks. A useful place to store event-agnostic logic, such as logging or checking for [duplicate event deliveries](https://docs.stripe.com/webhooks#handle-duplicate-events).
+   *
+   * Returning `true` causes handling to continue as normal; returning `false` returns from `.handle()` immediately, so neither the registered callback nor the fallback callback are called.
+   */
   public preHandle(callback: PreHandleCallback): this {
     this.assertCanRegister();
     if (this.preHandleCallback) {

--- a/src/StripeEventNotificationHandler.ts
+++ b/src/StripeEventNotificationHandler.ts
@@ -12,6 +12,16 @@ export type FallbackCallback = (
   details: UnhandledNotificationDetails
 ) => Promise<void>;
 
+/**
+ * Runs after `handle()` parses the payload but before any registered
+ * handler or fallback callback fires. Resolving `false` stops handling
+ * entirely: neither the registered handler nor the fallback will run.
+ */
+export type PreHandleCallback = (
+  event: Stripe.V2.Core.EventNotification,
+  client: Stripe
+) => Promise<boolean>;
+
 // this is an internal-only type; we write a user-facing one separately
 type HandlerCallback = (event: any, client: any) => Promise<void>;
 
@@ -57,6 +67,7 @@ const KNOWN_EVENT_TYPES = new Set([
  */
 class BaseEventNotificationHandler {
   private registeredHandlers: Record<string, HandlerCallback> = {};
+  private preHandleCallback: PreHandleCallback | null = null;
   protected hasHandledEvent = false;
 
   // the body is empty but the parameter properties are not, so the lint is ignorable
@@ -75,17 +86,35 @@ class BaseEventNotificationHandler {
     ) => Promise<void>
   ): this;
   public on(type: string, callback: HandlerCallback): this {
-    if (this.hasHandledEvent) {
-      throw new Error(
-        'Cannot register new handlers after an event has been handled. This is indicative of a bug.'
-      );
-    }
+    this.assertCanRegister();
     // the matched types are validated by the type system
     if (this.registeredHandlers[type]) {
       throw new Error(`Handler already registered for event type: ${type}`);
     }
 
     this.registeredHandlers[type] = callback;
+    return this;
+  }
+
+  /**
+   * Callbacks are expected to be registered once on startup, so registering
+   * anything after handling has begun indicates a bug.
+   */
+  private assertCanRegister(): void {
+    if (this.hasHandledEvent) {
+      throw new Error(
+        'Cannot register new handlers after an event has been handled. This is indicative of a bug.'
+      );
+    }
+  }
+
+  public preHandle(callback: PreHandleCallback): this {
+    this.assertCanRegister();
+    if (this.preHandleCallback) {
+      throw new Error('A preHandle callback is already registered');
+    }
+
+    this.preHandleCallback = callback;
     return this;
   }
 
@@ -108,6 +137,13 @@ class BaseEventNotificationHandler {
       ...this.client._api,
       stripeContext: event.context,
     };
+
+    if (
+      this.preHandleCallback &&
+      !(await this.preHandleCallback(event, eventClient))
+    ) {
+      return;
+    }
 
     const handler = this.registeredHandlers[event.type];
     if (handler) {

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -25,6 +25,7 @@ import {
   validateInteger,
 } from './utils.js';
 import {
+  FallbackCallback,
   StripeEventNotificationHandler,
   StripeEventNotificationHandlerWithoutVerification,
   UnhandledNotificationDetails,
@@ -1753,11 +1754,7 @@ export class Stripe {
 
   notificationHandler(
     webhookSecret: string,
-    fallbackCallback: (
-      event: UnknownEventNotification,
-      client: Stripe,
-      details: UnhandledNotificationDetails
-    ) => Promise<void>
+    fallbackCallback: FallbackCallback
   ): StripeEventNotificationHandler {
     return new StripeEventNotificationHandler(
       this,
@@ -1767,11 +1764,7 @@ export class Stripe {
   }
 
   notificationHandlerWithoutVerification(
-    fallbackCallback: (
-      event: UnknownEventNotification,
-      client: Stripe,
-      details: UnhandledNotificationDetails
-    ) => Promise<void>
+    fallbackCallback: FallbackCallback
   ): StripeEventNotificationHandlerWithoutVerification {
     return StripeEventNotificationHandler.withoutVerification(
       this,

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -25,6 +25,7 @@ import {
   validateInteger,
 } from './utils.js';
 import {
+  FallbackCallback,
   StripeEventNotificationHandler,
   StripeEventNotificationHandlerWithoutVerification,
   UnhandledNotificationDetails,
@@ -1762,11 +1763,7 @@ export class Stripe {
 
   notificationHandler(
     webhookSecret: string,
-    fallbackCallback: (
-      event: UnknownEventNotification,
-      client: Stripe,
-      details: UnhandledNotificationDetails
-    ) => Promise<void>
+    fallbackCallback: FallbackCallback
   ): StripeEventNotificationHandler {
     return new StripeEventNotificationHandler(
       this,
@@ -1776,11 +1773,7 @@ export class Stripe {
   }
 
   notificationHandlerWithoutVerification(
-    fallbackCallback: (
-      event: UnknownEventNotification,
-      client: Stripe,
-      details: UnhandledNotificationDetails
-    ) => Promise<void>
+    fallbackCallback: FallbackCallback
   ): StripeEventNotificationHandlerWithoutVerification {
     return StripeEventNotificationHandler.withoutVerification(
       this,

--- a/test/StripeEventNotificationHandler.spec.ts
+++ b/test/StripeEventNotificationHandler.spec.ts
@@ -126,7 +126,7 @@ describe('StripeEventNotificationHandler', () => {
       expect(() => {
         eventHandler.on('v1.billing.meter.no_meter_found', async () => {});
       }).to.throw(
-        /Cannot register new handlers after an event has been handled/
+        /Cannot register new callbacks after an event has been handled/
       );
     });
 
@@ -148,7 +148,7 @@ describe('StripeEventNotificationHandler', () => {
       expect(() => {
         eventHandler.on('v1.billing.meter.no_meter_found', async () => {});
       }).to.throw(
-        /Cannot register new handlers after an event has been handled/
+        /Cannot register new callbacks after an event has been handled/
       );
     });
 
@@ -163,7 +163,7 @@ describe('StripeEventNotificationHandler', () => {
           'v1.billing.meter.error_report_triggered',
           async () => {}
         );
-      }).to.throw(/Handler already registered for event type/);
+      }).to.throw(/Callback for event type ".*" is already registered/);
     });
   });
 
@@ -310,7 +310,7 @@ describe('StripeEventNotificationHandler', () => {
       expect(() => {
         eventHandler.preHandle(async () => true);
       }).to.throw(
-        /Cannot register new handlers after an event has been handled/
+        /Cannot register new callbacks after an event has been handled/
       );
     });
 
@@ -746,7 +746,9 @@ describe('StripeEventNotificationHandlerWithoutVerification', () => {
 
     expect(() => {
       withoutVerifHandler.on('v1.billing.meter.no_meter_found', async () => {});
-    }).to.throw(/Cannot register new handlers after an event has been handled/);
+    }).to.throw(
+      /Cannot register new callbacks after an event has been handled/
+    );
   });
 
   it('should accept a Uint8Array body without a signature', async () => {
@@ -984,7 +986,7 @@ describe('StripeEventNotificationHandlerWithoutVerification', () => {
       expect(() => {
         withoutVerifHandler.preHandle(async () => true);
       }).to.throw(
-        /Cannot register new handlers after an event has been handled/
+        /Cannot register new callbacks after an event has been handled/
       );
     });
 

--- a/test/StripeEventNotificationHandler.spec.ts
+++ b/test/StripeEventNotificationHandler.spec.ts
@@ -167,6 +167,185 @@ describe('StripeEventNotificationHandler', () => {
     });
   });
 
+  describe('preHandle', () => {
+    it('should run the registered handler when no preHandle hook is registered', async () => {
+      let callbackCalled = false;
+
+      eventHandler.on('v1.billing.meter.error_report_triggered', async () => {
+        callbackCalled = true;
+      });
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(callbackCalled).to.be.true;
+    });
+
+    it('should run the handler after the hook when the hook resolves true', async () => {
+      const order: string[] = [];
+
+      eventHandler.preHandle(async () => {
+        order.push('preHandle');
+        return true;
+      });
+
+      eventHandler.on('v1.billing.meter.error_report_triggered', async () => {
+        order.push('handler');
+      });
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(order).to.deep.equal(['preHandle', 'handler']);
+    });
+
+    it('should not run the registered handler when the hook resolves false', async () => {
+      let callbackCalled = false;
+
+      eventHandler.preHandle(async () => false);
+
+      eventHandler.on('v1.billing.meter.error_report_triggered', async () => {
+        callbackCalled = true;
+      });
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(callbackCalled).to.be.false;
+    });
+
+    it('should not run the fallback callback for an unknown event type when the hook resolves false', async () => {
+      let fallbackCalled = false;
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {
+          fallbackCalled = true;
+        }
+      );
+
+      handler.preHandle(async () => false);
+
+      const sigHeader = generateHeader(unknownEventPayload);
+      await handler.handle(unknownEventPayload, sigHeader);
+
+      expect(fallbackCalled).to.be.false;
+    });
+
+    it('should receive the context-scoped client, leaving the shared client unmutated', async () => {
+      const stripe = require('../src/stripe.cjs.node.js')(FAKE_API_KEY, {
+        stripeContext: 'original_context_123',
+      });
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {}
+      );
+
+      let receivedContext: any = null;
+      let receivedClient: any = null;
+
+      handler.preHandle(async (_event: any, client: any) => {
+        receivedClient = client;
+        receivedContext = client._api.stripeContext;
+        return true;
+      });
+
+      handler.on('v1.billing.meter.error_report_triggered', async () => {});
+
+      const originalContext = stripe._api.stripeContext;
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await handler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(receivedClient).to.not.equal(stripe);
+      expect(receivedContext?.toString()).to.equal('event_context_456');
+      expect(stripe._api.stripeContext).to.equal(originalContext);
+    });
+
+    it('should propagate a rejection from the hook and not run any callback', async () => {
+      let handlerCalled = false;
+      let fallbackCalled = false;
+
+      const handler = stripe.notificationHandler(
+        DUMMY_WEBHOOK_SECRET,
+        async () => {
+          fallbackCalled = true;
+        }
+      );
+
+      handler.preHandle(async () => {
+        throw new Error('preHandle blew up!');
+      });
+
+      handler.on('v1.billing.meter.error_report_triggered', async () => {
+        handlerCalled = true;
+      });
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+
+      let errorThrown = false;
+      try {
+        await handler.handle(v1BillingMeterPayload, sigHeader);
+      } catch (err) {
+        errorThrown = true;
+        // @ts-expect-error
+        expect(err.message).to.equal('preHandle blew up!');
+      }
+
+      expect(errorThrown).to.be.true;
+      expect(handlerCalled).to.be.false;
+      expect(fallbackCalled).to.be.false;
+    });
+
+    it('should throw when registering a hook after an event has been handled', async () => {
+      eventHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(() => {
+        eventHandler.preHandle(async () => true);
+      }).to.throw(
+        /Cannot register new handlers after an event has been handled/
+      );
+    });
+
+    it('should throw when registering a preHandle hook twice', () => {
+      eventHandler.preHandle(async () => true);
+
+      expect(() => {
+        eventHandler.preHandle(async () => true);
+      }).to.throw(/A preHandle callback is already registered/);
+    });
+
+    it('should genuinely await the hook before dispatching', async () => {
+      let handlerCalled = false;
+
+      eventHandler.preHandle(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return false;
+      });
+
+      eventHandler.on('v1.billing.meter.error_report_triggered', async () => {
+        handlerCalled = true;
+      });
+
+      const sigHeader = generateHeader(v1BillingMeterPayload);
+      await eventHandler.handle(v1BillingMeterPayload, sigHeader);
+
+      expect(handlerCalled).to.be.false;
+    });
+
+    it('should return the handler instance for chaining', () => {
+      const result = eventHandler.preHandle(async () => true);
+      expect(result).to.equal(eventHandler);
+    });
+  });
+
   describe('stripe context management', () => {
     it('should use event stripe context in handler', async () => {
       let receivedContext: any = null;
@@ -675,6 +854,172 @@ describe('StripeEventNotificationHandlerWithoutVerification', () => {
     expect(() => {
       stripe.notificationHandler('', async () => {});
     }).to.throw(/webhookSecret must be a non-empty string/);
+  });
+
+  describe('preHandle', () => {
+    it('should run the registered handler when no preHandle hook is registered', async () => {
+      let callbackCalled = false;
+
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {
+          callbackCalled = true;
+        }
+      );
+
+      await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+      expect(callbackCalled).to.be.true;
+    });
+
+    it('should run the handler after the hook when the hook resolves true', async () => {
+      const order: string[] = [];
+
+      withoutVerifHandler.preHandle(async () => {
+        order.push('preHandle');
+        return true;
+      });
+
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {
+          order.push('handler');
+        }
+      );
+
+      await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+      expect(order).to.deep.equal(['preHandle', 'handler']);
+    });
+
+    it('should not run the registered handler when the hook resolves false', async () => {
+      let callbackCalled = false;
+
+      withoutVerifHandler.preHandle(async () => false);
+
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {
+          callbackCalled = true;
+        }
+      );
+
+      await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+      expect(callbackCalled).to.be.false;
+    });
+
+    it('should not run the fallback callback for an unknown event type when the hook resolves false', async () => {
+      let fallbackCalled = false;
+
+      const handler = stripe.notificationHandlerWithoutVerification(
+        async () => {
+          fallbackCalled = true;
+        }
+      );
+
+      handler.preHandle(async () => false);
+
+      await handler.handle(unknownEventPayload);
+
+      expect(fallbackCalled).to.be.false;
+    });
+
+    it('should receive the context-scoped client', async () => {
+      let receivedContext: any = null;
+      let receivedClient: any = null;
+
+      withoutVerifHandler.preHandle(async (_event: any, client: any) => {
+        receivedClient = client;
+        receivedContext = client._api.stripeContext;
+        return true;
+      });
+
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+      expect(receivedClient).to.not.equal(stripe);
+      expect(receivedContext?.toString()).to.equal('event_context_456');
+    });
+
+    it('should propagate a rejection from the hook and not run any callback', async () => {
+      let handlerCalled = false;
+
+      withoutVerifHandler.preHandle(async () => {
+        throw new Error('preHandle blew up!');
+      });
+
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {
+          handlerCalled = true;
+        }
+      );
+
+      let errorThrown = false;
+      try {
+        await withoutVerifHandler.handle(v1BillingMeterPayload);
+      } catch (err) {
+        errorThrown = true;
+        // @ts-expect-error
+        expect(err.message).to.equal('preHandle blew up!');
+      }
+
+      expect(errorThrown).to.be.true;
+      expect(handlerCalled).to.be.false;
+    });
+
+    it('should throw when registering a hook after an event has been handled', async () => {
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {}
+      );
+
+      await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+      expect(() => {
+        withoutVerifHandler.preHandle(async () => true);
+      }).to.throw(
+        /Cannot register new handlers after an event has been handled/
+      );
+    });
+
+    it('should throw when registering a preHandle hook twice', () => {
+      withoutVerifHandler.preHandle(async () => true);
+
+      expect(() => {
+        withoutVerifHandler.preHandle(async () => true);
+      }).to.throw(/A preHandle callback is already registered/);
+    });
+
+    it('should genuinely await the hook before dispatching', async () => {
+      let handlerCalled = false;
+
+      withoutVerifHandler.preHandle(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+        return false;
+      });
+
+      withoutVerifHandler.on(
+        'v1.billing.meter.error_report_triggered',
+        async () => {
+          handlerCalled = true;
+        }
+      );
+
+      await withoutVerifHandler.handle(v1BillingMeterPayload);
+
+      expect(handlerCalled).to.be.false;
+    });
+
+    it('should return the handler instance for chaining', () => {
+      const result = withoutVerifHandler.preHandle(async () => true);
+      expect(result).to.equal(withoutVerifHandler);
+    });
   });
 
   it('should treat every webhookSecret as a real secret, with no magic bypass value', async () => {

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -409,6 +409,11 @@ async (): Promise<void> => {
   );
 
   handler
+    .preHandle(async (event, client) => {
+      const e: Stripe.V2.Core.EventNotification = event;
+      const s: Stripe = client;
+      return true;
+    })
     .on('v1.billing.meter.error_report_triggered', async (event) => {
       const meter: Stripe.Billing.Meter = await event.fetchRelatedObject();
       const e: Stripe.Events.V1BillingMeterErrorReportTriggeredEventNotification = event;
@@ -422,6 +427,12 @@ async (): Promise<void> => {
     });
 
   const res: void = await handler.handle('', '');
+
+  // @ts-expect-error - preHandle callback must resolve boolean, not void
+  handler.preHandle(async () => {});
+  // @ts-expect-error - preHandle callback must resolve boolean, not int
+  handler.preHandle(async () => 3);
+  handler.preHandle(async () => false);
 };
 
 // event handler that skips signature verification


### PR DESCRIPTION
### Why?

In final testing, users have expressed interest in being able to centrally run code before any other handler executes. It can be used for centralized logging, event deduplication, and more. I don't want to go full middleware, but this felt like a reasonable way to dip our toe into the waters.

Because users are responsible for [deduplicating events](https://docs.stripe.com/webhooks#handle-duplicate-events), this pre-handle hook (if present) should return a `bool`, signifying whether handling should continue.

If the function returns `true` (or is missing entirely), the handler proceeds like normal (running at-most-one other callback). If it returns `false`, no further callback is run and the original `.handle()` call finishes cleanly.

### What?

- add the `.pre_handle` method
- & associated tests
- update some error messages with correct verbs & consistency
- refactored some internal error handling
- updated example
- node: use `FallbackCallback` type instead of inlining it

### See Also

- http://go/j/DEVSDK-3249
