### PR TITLE
Harden API requestor code against malicious URLs

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -31,6 +31,7 @@ import {
 } from './net/HttpClient.js';
 import {Stripe} from './stripe.core.js';
 import {
+  validatePath,
   jsonStringifyRequestData,
   normalizeHeaders,
   queryStringifyRequestData,
@@ -620,6 +621,9 @@ export class RequestSender {
   ): void {
     let requestData: string | Uint8Array;
     authenticator = authenticator ?? this._stripe._authenticator;
+    // Validate before anything derives meaning from the path -- apiMode is
+    // sniffed from its prefix, and the path may have come from remote data.
+    validatePath(path);
     const apiMode: ApiMode = getAPIMode(path);
     const retryRequest = (
       requestFn: typeof makeRequest,

--- a/src/stripe.core.ts
+++ b/src/stripe.core.ts
@@ -1626,7 +1626,9 @@ export class Stripe {
     parsed.fetchEvent = (): Promise<unknown> => {
       return this._requestSender._rawRequest(
         'GET',
-        `/v2/core/events/${parsed.id}`,
+        // `id` comes from the notification body, so encode it the way the
+        // generated resources do -- otherwise it can inject path or query segments.
+        `/v2/core/events/${encodeURIComponent(parsed.id as string)}`,
         undefined,
         {
           stripeContext: parsed.context as any,

--- a/src/stripe.esm.node.ts
+++ b/src/stripe.esm.node.ts
@@ -1604,7 +1604,9 @@ export class Stripe {
     parsed.fetchEvent = (): Promise<unknown> => {
       return this._requestSender._rawRequest(
         'GET',
-        `/v2/core/events/${parsed.id}`,
+        // `id` comes from the notification body, so encode it the way the
+        // generated resources do -- otherwise it can inject path or query segments.
+        `/v2/core/events/${encodeURIComponent(parsed.id as string)}`,
         undefined,
         {
           stripeContext: parsed.context as any,

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -444,19 +444,16 @@ export function jsonStringifyRequestData(data: RequestData | string): string {
  *
  * Some HTTP clients build the absolute URL by concatenating a host onto this
  * path, and the configured hosts carry no trailing slash. A path like
- * '@evil.example/v1/x' or '.evil.example/v1/x' would then land inside the
- * authority component and send the request -- Authorization header included --
- * to a host of the path's choosing. Some request paths originate in remote data
- * (a webhook body's related_object.url, a response's next_page_url), so the path
- * cannot be assumed to be well-formed.
+ * '@evil.example/v1/x' or '.evil.example/v1/x' would modify the resulting host
+ * and direct the request (including the API key) to a non-Stripe host.
  *
- * NodeHttpClient passes {host, path} to http.request separately and so is not
- * itself vulnerable, but `httpClient` is a public option: a caller-supplied
- * client that concatenates would be. Asserting centrally makes the guarantee
- * hold for every client rather than only the ones that happen to check.
+ * Because some relative urls arrive from potentially untrusted sources (like
+ * webhook bodies), we have to be a little defensive.
  *
- * A single leading slash is sufficient: it terminates the authority component,
- * after which nothing in the path can extend it.
+ * So, we require that a path starts with a leading slash.
+ *
+ * NodeHttpClient passes {host, path} to `http.request` individually, so it doesn't need the same checks
+ * but the public `httpClient` needs the same security guarantees.
  */
 export function validatePath(path: string): void {
   if (

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -439,6 +439,40 @@ export function jsonStringifyRequestData(data: RequestData | string): string {
 }
 
 /**
+ * Asserts that a request path is origin-relative: that it begins with a single
+ * '/'.
+ *
+ * Some HTTP clients build the absolute URL by concatenating a host onto this
+ * path, and the configured hosts carry no trailing slash. A path like
+ * '@evil.example/v1/x' or '.evil.example/v1/x' would then land inside the
+ * authority component and send the request -- Authorization header included --
+ * to a host of the path's choosing. Some request paths originate in remote data
+ * (a webhook body's related_object.url, a response's next_page_url), so the path
+ * cannot be assumed to be well-formed.
+ *
+ * NodeHttpClient passes {host, path} to http.request separately and so is not
+ * itself vulnerable, but `httpClient` is a public option: a caller-supplied
+ * client that concatenates would be. Asserting centrally makes the guarantee
+ * hold for every client rather than only the ones that happen to check.
+ *
+ * A single leading slash is sufficient: it terminates the authority component,
+ * after which nothing in the path can extend it.
+ */
+export function validatePath(path: string): void {
+  if (
+    typeof path !== 'string' ||
+    !path.startsWith('/') ||
+    path.startsWith('//')
+  ) {
+    throw new Error(
+      `Request path must be a string beginning with a single "/", got: ${JSON.stringify(
+        path
+      )}`
+    );
+  }
+}
+
+/**
  * Inspects the given path to determine if the endpoint is for v1 or v2 API
  */
 export function getAPIMode(path?: string): ApiMode {

--- a/test/stripe.spec.ts
+++ b/test/stripe.spec.ts
@@ -1669,7 +1669,7 @@ describe('Stripe Module', function() {
       );
     });
 
-    it('should throw a descriptive error when an absolute URL is passed as path with FetchHttpClient', async () => {
+    it('should throw a descriptive error when an absolute URL is passed as path', async () => {
       const fetchStripe = Stripe(FAKE_API_KEY, {
         httpClient: new FetchHttpClient(require('node-fetch')),
       });
@@ -1680,8 +1680,24 @@ describe('Stripe Module', function() {
         caughtError = e;
       }
       expect(caughtError).to.exist;
-      expect(caughtError.detail?.message).to.match(
-        /Only relative paths are supported/
+      expect(caughtError.message).to.match(
+        /must be a string beginning with a single/
+      );
+    });
+
+    it('should reject a path that would move the request authority', async () => {
+      // A webhook body's related_object.url or a response's next_page_url
+      // reaches this sink, so a path like this must never be sent.
+      const stripe = Stripe(FAKE_API_KEY);
+      let caughtError: any;
+      try {
+        await stripe.rawRequest('GET', '@evil.example/v1/leak');
+      } catch (e) {
+        caughtError = e;
+      }
+      expect(caughtError).to.exist;
+      expect(caughtError.message).to.match(
+        /must be a string beginning with a single/
       );
     });
   });

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -839,11 +839,6 @@ describe('utils', () => {
   });
 
   describe('assertOriginRelativePath', () => {
-    // A path that does not begin with a single '/' can land inside the URL's
-    // authority component when a client concatenates host + path, redirecting
-    // the request -- Authorization header included -- to a host of the path's
-    // choosing. Some request paths come from remote data: a webhook body's
-    // related_object.url, a response's next_page_url.
     it('accepts origin-relative paths', () => {
       const valid = [
         '/v1/customers/cus_123',

--- a/test/utils.spec.ts
+++ b/test/utils.spec.ts
@@ -837,6 +837,55 @@ describe('utils', () => {
       expect(mergedBufToString).to.equal('foobar');
     });
   });
+
+  describe('assertOriginRelativePath', () => {
+    // A path that does not begin with a single '/' can land inside the URL's
+    // authority component when a client concatenates host + path, redirecting
+    // the request -- Authorization header included -- to a host of the path's
+    // choosing. Some request paths come from remote data: a webhook body's
+    // related_object.url, a response's next_page_url.
+    it('accepts origin-relative paths', () => {
+      const valid = [
+        '/v1/customers/cus_123',
+        '/v1/customers',
+        '/v2/core/accounts?page=page_123&limit=2',
+        // '@' is legal inside a path or query string -- it only opens an
+        // authority when it precedes the first '/'.
+        '/v1/customers?email=user%40example.com',
+        '/v1/invoices/in_123@456',
+        // A backslash does not open an authority: the '/' already closed it.
+        '/v1/\\evil.example',
+      ];
+      valid.forEach((path) => {
+        expect(() => utils.validatePath(path)).to.not.throw();
+      });
+    });
+
+    it('rejects paths that could move the request authority', () => {
+      const hostile = [
+        '@evil.example/v1/leak',
+        ':pw@evil.example/v1/leak',
+        ':80@evil.example/v1/leak',
+        // Extends the host into an attacker-owned subdomain
+        // (api.stripe.com.evil.example), which has a valid certificate.
+        '.evil.example/v1/leak',
+        '-evil.example/v1/leak',
+        'https://evil.example/v1/leak',
+        '//evil.example/v1/leak',
+        '',
+        'v1/customers',
+        null,
+        undefined,
+        42,
+      ];
+      hostile.forEach((path) => {
+        expect(
+          () => utils.validatePath(path),
+          `expected to reject ${JSON.stringify(path)}`
+        ).to.throw(/must be a string beginning with a single/);
+      });
+    });
+  });
 });
 
 function handleWarnings(doWithShimmedConsoleWarn, onWarn): void {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

If an attacker got access to a user's webhook secret (or the user wasn't validating incoming webhook signatures) _and_ a user was calling the built-in `event_notification.fetch_related_object()` method, a malicious webhook payload could cause a user integration to make an authenticated request to an attacker-controlled domain (leaking the secret key)

To solve, we're being more careful during url construction to ensure user input can't be used to send requests to non-`stripe.com` domains (on a per-request basis).

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add path validation method and call it before the final URL is built
- Encode the `event.id` path param in `fetch_event()` to match the sanitation in the rest of the generated endpoints
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2808](https://go/j/RUN_DEVSDK-2808)
