### PR TITLE
Use cryptographically secure boundaries for multipart file uploads

### DIFF
--- a/src/RequestSender.ts
+++ b/src/RequestSender.ts
@@ -388,8 +388,22 @@ export class RequestSender {
   }
 
   _defaultIdempotencyKey(method: string, apiMode: ApiMode): string | null {
-    const genKey = (): string =>
-      `stripe-node-retry-${this._stripe._platformFunctions.uuid4()}`;
+    const genKey = (): string => {
+      let uuid: string;
+      try {
+        uuid = this._stripe._platformFunctions.uuid4();
+      } catch {
+        // our uuid4 function needs to be cryptographically secure, but idempotency key just needs to be unique
+        // so we can safely fall back to a basic approach
+        uuid = 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
+          const r = (Math.random() * 16) | 0;
+          const v = c === 'x' ? r : (r & 0x3) | 0x8;
+          return v.toString(16);
+        });
+      }
+
+      return `stripe-node-retry-${uuid}`;
+    };
 
     // more verbose than it needs to be, but gives clear separation between V1 and V2 behavior
     if (apiMode === 'v2') {

--- a/src/multipart.ts
+++ b/src/multipart.ts
@@ -15,14 +15,11 @@ type MultipartCallback = (
 // Mostly taken from Fermata.js
 // https://github.com/natevw/fermata/blob/5d9732a33d776ce925013a265935facd1626cc88/fermata.js#L315-L343
 const multipartDataGenerator = (
-  method: string,
   data: MultipartRequestData,
-  headers: RequestHeaders
+  headers: RequestHeaders,
+  segmentBoundary: string
 ): Uint8Array => {
-  const segno = (
-    Math.round(Math.random() * 1e16) + Math.round(Math.random() * 1e16)
-  ).toString();
-  headers['Content-Type'] = `multipart/form-data; boundary=${segno}`;
+  headers['Content-Type'] = `multipart/form-data; boundary=${segmentBoundary}`;
   const textEncoder = new TextEncoder();
 
   let buffer = new Uint8Array(0);
@@ -39,8 +36,14 @@ const multipartDataGenerator = (
     buffer.set(endBuffer, buffer.length - 2);
   }
 
-  function q(s: string): string {
-    return `"${s.replace(/"|"/g, '%22').replace(/\r\n|\r|\n/g, ' ')}"`;
+  // CR/LF would end the header line, letting a caller-supplied value introduce
+  // additional part headers.
+  function stripCrLf(s: string): string {
+    return s.replace(/\r\n|\r|\n/g, ' ');
+  }
+
+  function quote(s: string): string {
+    return `"${stripCrLf(s.replace(/"/g, '%22'))}"`;
   }
 
   const flattenedData = flattenAndStringify(data);
@@ -51,7 +54,7 @@ const multipartDataGenerator = (
     }
 
     const v = flattenedData[k];
-    push(`--${segno}`);
+    push(`--${segmentBoundary}`);
     if (Object.prototype.hasOwnProperty.call(v, 'data')) {
       const typedEntry: {
         name: string;
@@ -59,20 +62,24 @@ const multipartDataGenerator = (
         type: string;
       } = v as any;
       push(
-        `Content-Disposition: form-data; name=${q(k)}; filename=${q(
+        `Content-Disposition: form-data; name=${quote(k)}; filename=${quote(
           typedEntry.name || 'blob'
         )}`
       );
-      push(`Content-Type: ${typedEntry.type || 'application/octet-stream'}`);
+      push(
+        `Content-Type: ${stripCrLf(
+          typedEntry.type || 'application/octet-stream'
+        )}`
+      );
       push('');
       push(typedEntry.data);
     } else {
-      push(`Content-Disposition: form-data; name=${q(k)}`);
+      push(`Content-Disposition: form-data; name=${quote(k)}`);
       push('');
       push(v);
     }
   }
-  push(`--${segno}--`);
+  push(`--${segmentBoundary}--`);
 
   return buffer;
 };
@@ -93,7 +100,13 @@ export function multipartRequestDataProcessor(
   this._stripe._platformFunctions
     .tryBufferData(data)
     .then((bufferedData: MultipartRequestData) => {
-      const buffer = multipartDataGenerator(method, bufferedData, headers);
+      const buffer = multipartDataGenerator(
+        bufferedData,
+        headers,
+        // segment boundaries must be generated from a cryptographically secure method
+        // see: https://go/j/RUN_DEVSDK-2807
+        this._stripe._platformFunctions.uuid4()
+      );
       return callback(null, buffer);
     })
     .catch((err: Error) => callback(err, null));

--- a/src/platform/ExtensibilityPlatformFunctions.ts
+++ b/src/platform/ExtensibilityPlatformFunctions.ts
@@ -21,7 +21,7 @@ const unsupportedRuntimeError = (method: string, alternative?: string): Error =>
   );
 
 /**
- * Platform functions for extensibility scripts.
+ * Platform functions for extensibility scripts. It uses a pretty plain Deno ECMAScript implementation without many imports.
  */
 export class ExtensibilityPlatformFunctions extends PlatformFunctions {
   /** @override */

--- a/src/platform/NodePlatformFunctions.ts
+++ b/src/platform/NodePlatformFunctions.ts
@@ -21,11 +21,10 @@ class StreamProcessingError extends StripeError {}
 export class NodePlatformFunctions extends PlatformFunctions {
   /** @override */
   uuid4(): string {
-    // available in: v14.17.x+
-    if (crypto.randomUUID) {
-      return crypto.randomUUID();
-    }
-    return super.uuid4();
+    // Available since v14.17, so available on every Node versions we support
+    // The base PlatformFunctions implementation reads `globalThis.crypto`, which is only unflagged as of Node 19 (and we support down to Node 18 until Sept 2026)
+    // TODO(https://go/j/DEVSDK-3253)
+    return crypto.randomUUID();
   }
 
   /** @override */

--- a/src/platform/NodePlatformFunctions.ts
+++ b/src/platform/NodePlatformFunctions.ts
@@ -21,8 +21,7 @@ class StreamProcessingError extends StripeError {}
 export class NodePlatformFunctions extends PlatformFunctions {
   /** @override */
   uuid4(): string {
-    // Available since v14.17, so available on every Node versions we support
-    // The base PlatformFunctions implementation reads `globalThis.crypto`, which is only unflagged as of Node 19 (and we support down to Node 18 until Sept 2026)
+    // we need to override the base `uuid4` implementation because it uses `globalThis.crypto`, which isn't available in unflagged in node until Node 19
     // TODO(https://go/j/DEVSDK-3253)
     return crypto.randomUUID();
   }

--- a/src/platform/PlatformFunctions.ts
+++ b/src/platform/PlatformFunctions.ts
@@ -93,14 +93,21 @@ export class PlatformFunctions {
   }
 
   /**
-   * Generates a v4 UUID. See https://stackoverflow.com/a/2117523
+   * Generates a v4 UUID. Must be cryptographically secure: this seeds both
+   * `Idempotency-Key` values and the multipart/form-data boundary.
+   *
+   * `crypto.randomUUID` is part of the WinterTC Minimum Common API, so it is
+   * available in browsers, Deno, Bun and Cloudflare Workers.
+   *
+   * Deliberately throws rather than degrading to `Math.random()`.
    */
   uuid4(): string {
-    return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, (c) => {
-      const r = (Math.random() * 16) | 0;
-      const v = c === 'x' ? r : (r & 0x3) | 0x8;
-      return v.toString(16);
-    });
+    if (typeof crypto === 'undefined' || !crypto.randomUUID) {
+      throw new Error(
+        'Stripe: no cryptographically secure random number generator is available in this runtime; `crypto.randomUUID` is required.'
+      );
+    }
+    return crypto.randomUUID();
   }
 
   /**

--- a/src/platform/PlatformFunctions.ts
+++ b/src/platform/PlatformFunctions.ts
@@ -93,11 +93,7 @@ export class PlatformFunctions {
   }
 
   /**
-   * Generates a v4 UUID. Must be cryptographically secure: this seeds both
-   * `Idempotency-Key` values and the multipart/form-data boundary.
-   *
-   * `crypto.randomUUID` is part of the WinterTC Minimum Common API, so it is
-   * available in browsers, Deno, Bun and Cloudflare Workers.
+   * Generates a v4 UUID. Must be cryptographically secure: this seeds both `Idempotency-Key` values and the multipart/form-data boundary.
    *
    * Deliberately throws rather than degrading to `Math.random()`.
    */

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -14,9 +14,10 @@ import {SubtleCryptoProvider} from '../src/crypto/SubtleCryptoProvider.js';
 import {expect} from 'chai';
 import {webcrypto} from 'crypto';
 
-if (process.versions.node < '15') {
+if (process.versions.node < '19') {
+  // Node 18 has no `globalThis.crypto` in CommonJS module scope, so WebPlatformFunctions has no CSPRNG to derive a boundary from.
   console.log(
-    `Skipping WebPlatformFunctions tests. Cannot load WebPlatformFunctions because 'Event' is not available in the global scope for ${process.version}.`
+    `Skipping WebPlatformFunctions tests. No 'globalThis.crypto' in module scope for ${process.version}.`
   );
 } else {
   import(
@@ -451,7 +452,14 @@ describe('PlatformFunctions.uuid4 without crypto.randomUUID', () => {
   // `crypto.getRandomValues` would still work. Every v1 POST calls uuid4 for
   // its Idempotency-Key, so this is the error those runtimes surface.
   // Tracked by https://go/j/DEVSDK-3253.
+  //
+  // On Node 18 there is no `globalThis.crypto` in CommonJS module scope at all
+  // (it landed unflagged in Node 19), so the condition under test is already
+  // ambient and there is nothing to stub.
+  const hasCryptoGlobal = typeof globalThis.crypto !== 'undefined';
+
   beforeEach(() => {
+    if (!hasCryptoGlobal) return;
     Object.defineProperty(globalThis.crypto, 'randomUUID', {
       value: undefined,
       configurable: true,
@@ -460,6 +468,7 @@ describe('PlatformFunctions.uuid4 without crypto.randomUUID', () => {
   });
 
   afterEach(() => {
+    if (!hasCryptoGlobal) return;
     delete (globalThis.crypto as any).randomUUID;
   });
 

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -14,8 +14,9 @@ import {SubtleCryptoProvider} from '../src/crypto/SubtleCryptoProvider.js';
 import {expect} from 'chai';
 import {webcrypto} from 'crypto';
 
+// TODO(https://go/j/DEVSDK-3253)
 if (process.versions.node < '19') {
-  // Node 18 has no `globalThis.crypto` in CommonJS module scope, so WebPlatformFunctions has no CSPRNG to derive a boundary from.
+  // Node 18 has no `globalThis.crypto`, so we can only run our WebPlatformFunctions tests on more modern node versions
   console.log(
     `Skipping WebPlatformFunctions tests. No 'globalThis.crypto' in module scope for ${process.version}.`
   );
@@ -446,16 +447,12 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
   });
 }
 
-describe('PlatformFunctions.uuid4 without crypto.randomUUID', () => {
-  // `crypto.randomUUID` is secure-context-only, so it is absent on plain
-  // `http://` origins and on browsers predating ~2022, where
-  // `crypto.getRandomValues` would still work. Every v1 POST calls uuid4 for
-  // its Idempotency-Key, so this is the error those runtimes surface.
-  // Tracked by https://go/j/DEVSDK-3253.
-  //
-  // On Node 18 there is no `globalThis.crypto` in CommonJS module scope at all
-  // (it landed unflagged in Node 19), so the condition under test is already
-  // ambient and there is nothing to stub.
+describe('PlatformFunctions.uuid4 without globalThis.crypto', () => {
+  // because uuid4 is used in a cryptographic context, PlatformFunctions.uuid4 should throw if it can't access a CSPRNG
+
+  // some extra housekeeping for node 18, which truly _doesn't_ have the global crypto
+  // no need to remove what isn't there
+  // TODO(https://go/j/DEVSDK-3253) - can remove when we drop node 18
   const hasCryptoGlobal = typeof globalThis.crypto !== 'undefined';
 
   beforeEach(() => {
@@ -495,43 +492,24 @@ describe('PlatformFunctions.uuid4 without crypto.randomUUID', () => {
 });
 
 // TODO(https://go/j/DEVSDK-3253) - can remove when we drop node 18
-describe('NodePlatformFunctions.uuid4 without globalThis.crypto', () => {
-  // This is the property that keeps Node 18 working: Node 18 exposes no
-  // `globalThis.crypto` in CommonJS module scope (it landed unflagged in Node
-  // 19), so NodePlatformFunctions must depend on the `crypto` *module* alone.
-  // Simulating the absence means the guarantee is checked on every Node
-  // version rather than only when CI happens to run 18. Every v1 POST needs a
-  // uuid4 for its Idempotency-Key, so a regression here breaks all writes.
-  let descriptor: PropertyDescriptor | undefined;
+if (process.versions.node < '19') {
+  describe('NodePlatformFunctions.uuid4 without globalThis.crypto', () => {
+    it('still generates a valid v4 UUID', () => {
+      expect(typeof globalThis.crypto).to.equal('undefined');
+      expect(new NodePlatformFunctions().uuid4()).to.match(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+      );
+    });
 
-  beforeEach(() => {
-    descriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
-    if (descriptor) {
-      delete (globalThis as any).crypto;
-    }
-  });
+    it('generates a distinct key each call', () => {
+      const fns = new NodePlatformFunctions();
+      expect(fns.uuid4()).to.not.equal(fns.uuid4());
+    });
 
-  afterEach(() => {
-    if (descriptor) {
-      Object.defineProperty(globalThis, 'crypto', descriptor);
-    }
+    it('is why the override exists: the base implementation cannot', () => {
+      expect(() => new PlatformFunctions().uuid4()).to.throw(
+        /no cryptographically secure random number generator is available/
+      );
+    });
   });
-
-  it('still generates a valid v4 UUID', () => {
-    expect(typeof globalThis.crypto).to.equal('undefined');
-    expect(new NodePlatformFunctions().uuid4()).to.match(
-      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-    );
-  });
-
-  it('generates a distinct key each call', () => {
-    const fns = new NodePlatformFunctions();
-    expect(fns.uuid4()).to.not.equal(fns.uuid4());
-  });
-
-  it('is why the override exists: the base implementation cannot', () => {
-    expect(() => new PlatformFunctions().uuid4()).to.throw(
-      /no cryptographically secure random number generator is available/
-    );
-  });
-});
+}

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -58,14 +58,6 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
             expect(called).to.equal(isNodeEnvironment);
           }
         });
-
-        it('returns a valid v4 UUID without it', () => {
-          crypto.randomUUID = null;
-          expect(platformFunctions.uuid4()).to.match(
-            // regex from https://createuuid.com/validator/, specifically for v4
-            /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
-          );
-        });
       });
 
       it('should return a well-formatted v4 UUID', () => {
@@ -75,6 +67,20 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
         );
         // further test: could spy on crypto.randomUUID to ensure it's being used, if available
         // whether that's useful is a race between using jest/sinon for these tests and dropping support for node < 14
+      });
+
+      it('is not derived from Math.random', () => {
+        // Idempotency-Key values come from uuid4, so pinning Math.random must
+        // not pin them.
+        const random$ = Math.random;
+        Math.random = (): number => 0.5;
+        try {
+          expect(platformFunctions.uuid4()).to.not.equal(
+            platformFunctions.uuid4()
+          );
+        } finally {
+          Math.random = random$;
+        }
       });
     });
 
@@ -438,3 +444,43 @@ function testPlatform(platformFunctions: PlatformFunctions): void {
     });
   });
 }
+
+describe('PlatformFunctions.uuid4 without crypto.randomUUID', () => {
+  // `crypto.randomUUID` is secure-context-only, so it is absent on plain
+  // `http://` origins and on browsers predating ~2022, where
+  // `crypto.getRandomValues` would still work. Every v1 POST calls uuid4 for
+  // its Idempotency-Key, so this is the error those runtimes surface.
+  // Tracked by https://go/j/DEVSDK-3253.
+  beforeEach(() => {
+    Object.defineProperty(globalThis.crypto, 'randomUUID', {
+      value: undefined,
+      configurable: true,
+      writable: true,
+    });
+  });
+
+  afterEach(() => {
+    delete (globalThis.crypto as any).randomUUID;
+  });
+
+  it('throws instead of degrading to a weak RNG', () => {
+    expect(() => new PlatformFunctions().uuid4()).to.throw(
+      /no cryptographically secure random number generator is available/
+    );
+  });
+
+  it('does not fall back to Math.random', () => {
+    const random$ = Math.random;
+    let called = false;
+    Math.random = (): number => {
+      called = true;
+      return 0.5;
+    };
+    try {
+      expect(() => new PlatformFunctions().uuid4()).to.throw();
+      expect(called).to.equal(false);
+    } finally {
+      Math.random = random$;
+    }
+  });
+});

--- a/test/PlatformFunctions.spec.ts
+++ b/test/PlatformFunctions.spec.ts
@@ -493,3 +493,45 @@ describe('PlatformFunctions.uuid4 without crypto.randomUUID', () => {
     }
   });
 });
+
+// TODO(https://go/j/DEVSDK-3253) - can remove when we drop node 18
+describe('NodePlatformFunctions.uuid4 without globalThis.crypto', () => {
+  // This is the property that keeps Node 18 working: Node 18 exposes no
+  // `globalThis.crypto` in CommonJS module scope (it landed unflagged in Node
+  // 19), so NodePlatformFunctions must depend on the `crypto` *module* alone.
+  // Simulating the absence means the guarantee is checked on every Node
+  // version rather than only when CI happens to run 18. Every v1 POST needs a
+  // uuid4 for its Idempotency-Key, so a regression here breaks all writes.
+  let descriptor: PropertyDescriptor | undefined;
+
+  beforeEach(() => {
+    descriptor = Object.getOwnPropertyDescriptor(globalThis, 'crypto');
+    if (descriptor) {
+      delete (globalThis as any).crypto;
+    }
+  });
+
+  afterEach(() => {
+    if (descriptor) {
+      Object.defineProperty(globalThis, 'crypto', descriptor);
+    }
+  });
+
+  it('still generates a valid v4 UUID', () => {
+    expect(typeof globalThis.crypto).to.equal('undefined');
+    expect(new NodePlatformFunctions().uuid4()).to.match(
+      /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i
+    );
+  });
+
+  it('generates a distinct key each call', () => {
+    const fns = new NodePlatformFunctions();
+    expect(fns.uuid4()).to.not.equal(fns.uuid4());
+  });
+
+  it('is why the override exists: the base implementation cannot', () => {
+    expect(() => new PlatformFunctions().uuid4()).to.throw(
+      /no cryptographically secure random number generator is available/
+    );
+  });
+});

--- a/test/RequestSender.spec.ts
+++ b/test/RequestSender.spec.ts
@@ -32,6 +32,8 @@ import {StripeContext} from '../src/StripeContext.js';
 
 const stripe = getSpyableStripe();
 
+const IDEMPOTENCY_KEY = /^stripe-node-retry-[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
 describe('RequestSender', () => {
   const sender = new RequestSender(stripe, 0);
 
@@ -96,7 +98,7 @@ describe('RequestSender', () => {
           userSuppliedSettings: {maxNetworkRetries: 3},
           apiMode: 'v1',
         });
-        expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
+        expect(headers['Idempotency-Key']).matches(IDEMPOTENCY_KEY);
       });
       // closed-connection errors are retried even with retries disabled, so
       // these requests still need a key to dedupe against
@@ -106,7 +108,7 @@ describe('RequestSender', () => {
           userSuppliedSettings: {maxNetworkRetries: 0},
           apiMode: 'v1',
         });
-        expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
+        expect(headers['Idempotency-Key']).matches(IDEMPOTENCY_KEY);
       });
       it('does not create an idempotency key for v1 GET requests', () => {
         const headers = sender._makeHeaders({
@@ -118,11 +120,11 @@ describe('RequestSender', () => {
       });
       it('always creates an idempotency key for v2 POST requests', () => {
         const headers = sender._makeHeaders({method: 'POST', apiMode: 'v2'});
-        expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
+        expect(headers['Idempotency-Key']).matches(IDEMPOTENCY_KEY);
       });
       it('always creates an idempotency key for v2 DELETE requests', () => {
         const headers = sender._makeHeaders({method: 'DELETE', apiMode: 'v2'});
-        expect(headers['Idempotency-Key']).matches(/^stripe-node-retry/);
+        expect(headers['Idempotency-Key']).matches(IDEMPOTENCY_KEY);
       });
       it('generates a new key every time', () => {
         expect(sender._defaultIdempotencyKey('POST', 'v2')).not.to.equal(

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -18,13 +18,10 @@ const file = {
   type: 'application/pdf',
 };
 
-// The `worker`/`workerd`/`browser`/`bun`/`deno` exports all resolve to
-// WebPlatformFunctions, which has no `uuid4` override — it uses the base
-// implementation. Run the whole suite against both so the boundary is covered
-// on the web path too, not just the Node one the bug was reported against.
-if (process.versions.node < '15') {
+if (process.versions.node < '19') {
+  // Node 18 has no `globalThis.crypto` in CommonJS module scope, so WebPlatformFunctions has no CSPRNG to derive a boundary from.
   console.log(
-    `Skipping WebPlatformFunctions multipart tests. Cannot load WebPlatformFunctions because 'Event' is not available in the global scope for ${process.version}.`
+    `Skipping WebPlatformFunctions multipart tests. No 'globalThis.crypto' in module scope for ${process.version}.`
   );
 } else {
   import(

--- a/test/multipart.spec.ts
+++ b/test/multipart.spec.ts
@@ -1,0 +1,163 @@
+// @ts-nocheck
+
+import {NodePlatformFunctions} from '../src/platform/NodePlatformFunctions.js';
+import {PlatformFunctions} from '../src/platform/PlatformFunctions.js';
+import {multipartRequestDataProcessor} from '../src/multipart.js';
+
+import {expect} from 'chai';
+
+// Lines of the body that begin a header, so an injected CRLF that opens a new
+// header line is visible even though the escaped text still contains the name.
+function headerLines(body: string, prefix: string): Array<string> {
+  return body.split('\r\n').filter((line) => line.startsWith(prefix));
+}
+
+const file = {
+  data: 'file contents',
+  name: 'minimal.pdf',
+  type: 'application/pdf',
+};
+
+// The `worker`/`workerd`/`browser`/`bun`/`deno` exports all resolve to
+// WebPlatformFunctions, which has no `uuid4` override — it uses the base
+// implementation. Run the whole suite against both so the boundary is covered
+// on the web path too, not just the Node one the bug was reported against.
+if (process.versions.node < '15') {
+  console.log(
+    `Skipping WebPlatformFunctions multipart tests. Cannot load WebPlatformFunctions because 'Event' is not available in the global scope for ${process.version}.`
+  );
+} else {
+  import(
+    '../src/platform/WebPlatformFunctions.js'
+  ).then(({WebPlatformFunctions}) => testMultipart(new WebPlatformFunctions()));
+}
+
+testMultipart(new NodePlatformFunctions());
+
+function testMultipart(platformFunctions: PlatformFunctions): void {
+  // Drives `multipartRequestDataProcessor` through a minimal stand-in for a
+  // StripeResourceObject so the `headers` object it mutates is observable.
+  function generate(data: any): Promise<{body: string; boundary: string}> {
+    const headers: Record<string, string> = {};
+    const resource = {_stripe: {_platformFunctions: platformFunctions}};
+
+    return new Promise((resolve, reject) => {
+      multipartRequestDataProcessor.call(
+        resource,
+        'POST',
+        data,
+        headers,
+        (error: Error | null, buffer: Uint8Array | string | null) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          const match = /boundary=(.+)$/.exec(headers['Content-Type']);
+          resolve({
+            body: new TextDecoder('utf8').decode(buffer as Uint8Array),
+            boundary: match ? match[1] : '',
+          });
+        }
+      );
+    });
+  }
+
+  describe(`multipart (${platformFunctions.constructor.name})`, () => {
+    describe('boundary', () => {
+      it('is not derived from Math.random', async () => {
+        // Pinning Math.random must not pin the boundary. A boundary an attacker
+        // can predict lets a caller-influenced value (including the file bytes)
+        // inject additional parts.
+        const random$ = Math.random;
+        Math.random = (): number => 0.5;
+        try {
+          const first = await generate({purpose: 'dispute_evidence', file});
+          const second = await generate({purpose: 'dispute_evidence', file});
+
+          // A v4 UUID. Hyphens are legal boundary characters (RFC 2046 §5.1.1).
+          const v4 = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+          expect(first.boundary).to.match(v4);
+          expect(second.boundary).to.match(v4);
+          expect(first.boundary).to.not.equal(second.boundary);
+        } finally {
+          Math.random = random$;
+        }
+      });
+
+      it('matches the delimiter used in the body', async () => {
+        const {body, boundary} = await generate({
+          purpose: 'dispute_evidence',
+          file,
+        });
+
+        expect(body.startsWith(`--${boundary}\r\n`)).to.equal(true);
+        expect(body.endsWith(`--${boundary}--\r\n`)).to.equal(true);
+        // Two parts: two opening delimiters plus the closing one.
+        expect(body.split(`--${boundary}`).length - 1).to.equal(3);
+      });
+    });
+
+    describe('part header escaping', () => {
+      it('strips CR/LF from a param name', async () => {
+        const {body, boundary} = await generate({
+          'a\r\nContent-Disposition: form-data; name="purpose': 'value',
+          file,
+        });
+
+        expect(headerLines(body, 'Content-Disposition:')).to.have.lengthOf(2);
+        expect(body.split(`--${boundary}`).length - 1).to.equal(3);
+      });
+
+      it('escapes quotes in a param name', async () => {
+        const {body} = await generate({'a"b': 'value', file});
+
+        expect(headerLines(body, 'Content-Disposition:')).to.deep.equal([
+          'Content-Disposition: form-data; name="a%22b"',
+          'Content-Disposition: form-data; name="file"; filename="minimal.pdf"',
+        ]);
+      });
+
+      it('strips CR/LF from a filename', async () => {
+        const {body} = await generate({
+          file: {...file, name: 'a\r\nX-Injected: yes"b.pdf'},
+        });
+
+        expect(headerLines(body, 'X-Injected:')).to.deep.equal([]);
+        expect(headerLines(body, 'Content-Disposition:')).to.deep.equal([
+          'Content-Disposition: form-data; name="file"; ' +
+            'filename="a X-Injected: yes%22b.pdf"',
+        ]);
+      });
+
+      it('strips CR/LF from a file content type', async () => {
+        const {body} = await generate({
+          file: {...file, type: 'text/plain\r\nX-Injected: yes'},
+        });
+
+        expect(headerLines(body, 'X-Injected:')).to.deep.equal([]);
+        expect(headerLines(body, 'Content-Type:')).to.deep.equal([
+          'Content-Type: text/plain X-Injected: yes',
+        ]);
+      });
+    });
+
+    it('leaves a value carrying a guessed delimiter inert', async () => {
+      // The value below is a complete forged part terminated by an epilogue
+      // marker. Values cannot be sanitized — the file bytes *are* the document —
+      // so the defense is that the real boundary is unguessable: the forgery
+      // stays literal text inside a part body rather than reframing the request.
+      const guessed = '00000000-0000-4000-8000-000000000000';
+      const {body, boundary} = await generate({
+        purpose: `--${guessed}\r\nContent-Disposition: form-data; name="file"; filename="evil.pdf"\r\n\r\nevil\r\n--${guessed}--`,
+        file,
+      });
+
+      expect(boundary).to.not.equal(guessed);
+      // Still two parts, and the real closing delimiter is still last: the
+      // forged epilogue marker discarded nothing.
+      expect(body.split(`--${boundary}`).length - 1).to.equal(3);
+      expect(body.endsWith(`--${boundary}--\r\n`)).to.equal(true);
+      expect(body).to.contain('file contents');
+    });
+  });
+}


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a bug where the boundary markers in multi-part file uploads weren't cryptographically secure. As a result, it could be possible for an attacker-controlled file to specify additional properties in the upload request.

Similarly, a maliciously crafted filename could be used to add additional properties to the request.

This only affects the `files.create` method.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- use a cryptographically secure method of generating multipart file boundaries
- sanitize filename input before adding to requests
- make UUID cryptographically secure and use it for both idempotency key generation and multipart boundaries
- add fallback for idempotency key generation for environments without the global `crypto` module (which i'm not sure we need to worry about? it's maybe just pre-2022 browsers)
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2807](https://go/j/RUN_DEVSDK-2807)
