### PR TITLE
Fix request coercion for GET and DELETE parameters 🪿✨

### DIFF
--- a/src/StripeResource.ts
+++ b/src/StripeResource.ts
@@ -65,7 +65,7 @@ class StripeResource implements StripeResourceObject {
   ): Promise<any> {
     const requestMethod = method.toUpperCase();
     const encode = spec?.encode || ((data: RequestData): RequestData => data);
-    const data = encode(params ? {...params} : {});
+    let data = encode(params ? {...params} : {});
     const processed = processOptions(options);
     const apiBase = processed.apiBase || spec?.apiBase || null;
     const host = apiBase ? this._stripe.resolveBaseAddress(apiBase) : null;
@@ -73,25 +73,22 @@ class StripeResource implements StripeResourceObject {
     const headers = Object.assign(processed.headers, spec?.headers);
     const usage = spec?.usage || [];
 
-    const dataInQuery = requestMethod === 'GET' || requestMethod === 'DELETE';
-    let bodyData: RequestData | null = dataInQuery ? null : data;
-    const queryData: RequestData = dataInQuery ? data : {};
-
     try {
       if (spec?.validator) {
         spec.validator(data, {headers});
       }
 
-      // Coerce int64_string/decimal_string fields in request body
-      if (spec?.requestSchema && bodyData) {
-        bodyData = coerceV2RequestData(
-          bodyData,
-          spec.requestSchema
-        ) as RequestData;
+      // Coerce int64_string/decimal_string fields in request data
+      if (spec?.requestSchema) {
+        data = coerceV2RequestData(data, spec.requestSchema) as RequestData;
       }
     } catch (err) {
       return Promise.reject(err);
     }
+
+    const dataInQuery = requestMethod === 'GET' || requestMethod === 'DELETE';
+    const bodyData: RequestData | null = dataInQuery ? null : data;
+    const queryData: RequestData = dataInQuery ? data : {};
 
     // Capture the caller's stack trace before the async boundary so errors can
     // include the user's call site, not just SDK internals.

--- a/test/V2DecimalIntegration.spec.ts
+++ b/test/V2DecimalIntegration.spec.ts
@@ -1,0 +1,71 @@
+// @ts-nocheck
+import {expect} from 'chai';
+import {Decimal} from '../src/Decimal.js';
+import {StripeResource} from '../src/StripeResource.js';
+import {getSpyableStripe} from './testUtils.js';
+
+describe('V2 decimal_string integration', () => {
+  const requestSchema = {
+    kind: 'object',
+    fields: {
+      lines: {
+        kind: 'array',
+        element: {
+          kind: 'object',
+          fields: {
+            unit_amount_decimal: {kind: 'decimal_string'},
+          },
+        },
+      },
+    },
+  };
+
+  const makeRequest = (method: string) => {
+    const stripe = getSpyableStripe();
+    const resource = new StripeResource(stripe);
+
+    resource._makeRequest(
+      method,
+      '/v2/test/resources',
+      {
+        lines: [
+          {
+            unit_amount_decimal: Decimal.from('434'),
+            description: 'test',
+          },
+        ],
+      },
+      undefined,
+      {requestSchema}
+    );
+
+    return stripe.LAST_REQUEST;
+  };
+
+  it('coerces nested decimal_string fields in GET query parameters', () => {
+    const request = makeRequest('GET');
+
+    expect(request.data).to.equal(null);
+    expect(request.url).to.equal(
+      '/v2/test/resources?lines[0][unit_amount_decimal]=434&lines[0][description]=test'
+    );
+  });
+
+  it('coerces nested decimal_string fields in DELETE query parameters', () => {
+    const request = makeRequest('DELETE');
+
+    expect(request.data).to.equal(null);
+    expect(request.url).to.equal(
+      '/v2/test/resources?lines[0][unit_amount_decimal]=434&lines[0][description]=test'
+    );
+  });
+
+  it('continues to coerce nested decimal_string fields in POST bodies', () => {
+    const request = makeRequest('POST');
+
+    expect(request.data).to.deep.equal({
+      lines: [{unit_amount_decimal: '434', description: 'test'}],
+    });
+    expect(request.url).to.equal('/v2/test/resources');
+  });
+});

--- a/test/V2Int64Integration.spec.ts
+++ b/test/V2Int64Integration.spec.ts
@@ -74,25 +74,18 @@ describe('V2 int64_string integration', () => {
       expect(stripe.LAST_REQUEST.data).to.deep.equal({amount: 42});
     });
 
-    it('coerces int64_string fields in GET query parameters', () => {
+    it('keeps the GET request body null when a request schema is present', () => {
       const resource = new StripeResource(stripe);
 
-      resource._makeRequest(
-        'GET',
-        '/v2/test/resources',
-        {amount: 42},
-        undefined,
-        {
-          requestSchema: {
-            kind: 'object',
-            fields: {
-              amount: {kind: 'int64_string'},
-            },
+      resource._makeRequest('GET', '/v2/test/resources', undefined, undefined, {
+        requestSchema: {
+          kind: 'object',
+          fields: {
+            amount: {kind: 'int64_string'},
           },
-        }
-      );
+        },
+      });
       expect(stripe.LAST_REQUEST.data).to.equal(null);
-      expect(stripe.LAST_REQUEST.url).to.equal('/v2/test/resources?amount=42');
     });
   });
 

--- a/test/V2Int64Integration.spec.ts
+++ b/test/V2Int64Integration.spec.ts
@@ -74,19 +74,25 @@ describe('V2 int64_string integration', () => {
       expect(stripe.LAST_REQUEST.data).to.deep.equal({amount: 42});
     });
 
-    it('handles null body data gracefully', () => {
+    it('coerces int64_string fields in GET query parameters', () => {
       const resource = new StripeResource(stripe);
 
-      // GET requests have no body data, so coercion should be a no-op
-      resource._makeRequest('GET', '/v2/test/resources', undefined, undefined, {
-        requestSchema: {
-          kind: 'object',
-          fields: {
-            amount: {kind: 'int64_string'},
+      resource._makeRequest(
+        'GET',
+        '/v2/test/resources',
+        {amount: 42},
+        undefined,
+        {
+          requestSchema: {
+            kind: 'object',
+            fields: {
+              amount: {kind: 'int64_string'},
+            },
           },
-        },
-      });
+        }
+      );
       expect(stripe.LAST_REQUEST.data).to.equal(null);
+      expect(stripe.LAST_REQUEST.url).to.equal('/v2/test/resources?amount=42');
     });
   });
 


### PR DESCRIPTION
[Minion run](https://orbit.corp.stripe.com/sessions/74aba252-193b-41cd-8833-67fc198122cf)

### Why?
Reported in https://github.com/stripe/stripe-node/issues/2833.  `Decimal` and other schema-coerced values were only converted to their wire format in request bodies, so GET and DELETE parameters could be serialized incorrectly. Fixes https://github.com/stripe/stripe-node/issues/2833.

### What?
Coerce schema-backed request data before routing it to the body or query string. Add GET, DELETE, and POST regression coverage for nested `decimal_string` values and GET coverage for `int64_string` values.

### See Also
https://github.com/stripe/stripe-node/issues/2833

## Changelog
- Fixes serialization of schema-coerced values, including `Decimal`, in GET and DELETE query parameters.