### PR TITLE
Restore the NODE_AUTH_TOKEN placeholder in the publish job

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,23 +123,26 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
+          registry-url: 'https://registry.npmjs.org'
           # Disable automatic dependency caching to reduce cache poisoning risk
           package-manager-cache: false
-          # Deliberately no `registry-url`. It makes setup-node write an .npmrc holding
-          # `_authToken=${NODE_AUTH_TOKEN}` and point NPM_CONFIG_USERCONFIG at it, but as
-          # of v7 setup-node only exports NODE_AUTH_TOKEN when the caller supplied one.
-          # `npm publish` runs `prepack`, which runs yarn, and yarn aborts rather than
-          # leave an unresolvable `${...}` in a config it reads. OIDC supplies the
-          # credential and the registry is passed to `npm publish` below, so that file
-          # has nothing left to contribute.
       - name: Publish to NPM
+        env:
+          # `registry-url` above makes setup-node write an .npmrc holding
+          # `_authToken=${NODE_AUTH_TOKEN}` and point NPM_CONFIG_USERCONFIG at it. Through
+          # v4 the action supplied this placeholder itself; v7 only exports the variable
+          # when the caller already set one (actions/setup-node#1558). Publishing here goes
+          # through OIDC, so nothing sets it, and yarn -- which `npm publish` runs via
+          # `prepack` -- aborts rather than leave an unresolvable `${...}` in a config it
+          # reads. OIDC overwrites this with a real token before anything is uploaded.
+          NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
         run: |
           set -euxo pipefail
           VERSION=$(cat package.json | jq -r '.version')
           # use the tag correlating to this release channel
           NPM_TAG=$(cat package.json | jq -r '.version | if contains("beta") then "public-preview" else if contains("alpha") then "private-preview" else "latest" end end')
           echo "Publishing $VERSION with $NPM_TAG tag."
-          npm publish --registry https://registry.npmjs.org --tag $NPM_TAG
+          npm publish --tag $NPM_TAG
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -128,13 +128,10 @@ jobs:
           package-manager-cache: false
       - name: Publish to NPM
         env:
-          # `registry-url` above makes setup-node write an .npmrc holding
-          # `_authToken=${NODE_AUTH_TOKEN}` and point NPM_CONFIG_USERCONFIG at it. Through
-          # v4 the action supplied this placeholder itself; v7 only exports the variable
-          # when the caller already set one (actions/setup-node#1558). Publishing here goes
-          # through OIDC, so nothing sets it, and yarn -- which `npm publish` runs via
-          # `prepack` -- aborts rather than leave an unresolvable `${...}` in a config it
-          # reads. OIDC overwrites this with a real token before anything is uploaded.
+          # needed because setup-node writes a .npmrc file with `registry-url` and
+          # `_authToken=${NODE_AUTH_TOKEN}`. OIDC overwrites this with a real token
+          # before anything is uploaded, but we need to have a value for yarn install
+          # to work.
           NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
         run: |
           set -euxo pipefail

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -123,9 +123,15 @@ jobs:
       - uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
           node-version: '24'
-          registry-url: 'https://registry.npmjs.org'
           # Disable automatic dependency caching to reduce cache poisoning risk
           package-manager-cache: false
+          # Deliberately no `registry-url`. It makes setup-node write an .npmrc holding
+          # `_authToken=${NODE_AUTH_TOKEN}` and point NPM_CONFIG_USERCONFIG at it, but as
+          # of v7 setup-node only exports NODE_AUTH_TOKEN when the caller supplied one.
+          # `npm publish` runs `prepack`, which runs yarn, and yarn aborts rather than
+          # leave an unresolvable `${...}` in a config it reads. OIDC supplies the
+          # credential and the registry is passed to `npm publish` below, so that file
+          # has nothing left to contribute.
       - name: Publish to NPM
         run: |
           set -euxo pipefail
@@ -133,7 +139,7 @@ jobs:
           # use the tag correlating to this release channel
           NPM_TAG=$(cat package.json | jq -r '.version | if contains("beta") then "public-preview" else if contains("alpha") then "private-preview" else "latest" end end')
           echo "Publishing $VERSION with $NPM_TAG tag."
-          npm publish --tag $NPM_TAG
+          npm publish --registry https://registry.npmjs.org --tag $NPM_TAG
       - uses: stripe/openapi/actions/notify-release@master
         if: always()
         with:


### PR DESCRIPTION
### Why?

The publish job currently fails in inside `prepack` with `Failed to replace env in config: ${NODE_AUTH_TOKEN}`.  #2824 moved this job's `setup-node` from v4 to v7; both versions write an `.npmrc` holding `_authToken=${NODE_AUTH_TOKEN}` when given `registry-url` but only v4 also supplied a placeholder value for that variable which allows yarn to work.

### What?

- sets `NODE_AUTH_TOKEN` to setup-node's former placeholder on the publish step

### See Also

- [Failing v22.6.1 publish run](https://github.com/stripe/stripe-node/actions/runs/33545405357/job/99982735401)
- #2824 — the action version bump this follows from
- [actions/setup-node#1558](https://github.com/actions/setup-node/pull/1558) — removed the placeholder this restores
