### PR TITLE
Print npm HTTP logs in the publish job when debug logging is on

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -137,7 +137,7 @@ jobs:
           # `verbose`. `notice` is npm's own default, so an ordinary release logs exactly
           # what it does today, and re-running this job with debug logging enabled shows
           # where a failed publish gave up.
-          NPM_CONFIG_LOGLEVEL: ${{ runner.debug == '1' && 'verbose' || 'notice' }}
+          NPM_CONFIG_LOGLEVEL: ${{ runner.debug && 'verbose' || 'notice' }}
         run: |
           set -euxo pipefail
           VERSION=$(cat package.json | jq -r '.version')

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,6 +133,11 @@ jobs:
           # before anything is uploaded, but we need to have a value for yarn install
           # to work.
           NODE_AUTH_TOKEN: XXXXX-XXXXX-XXXXX-XXXXX
+          # npm hides its HTTP exchange, and the OIDC token exchange with it, below
+          # `verbose`. `notice` is npm's own default, so an ordinary release logs exactly
+          # what it does today, and re-running this job with debug logging enabled shows
+          # where a failed publish gave up.
+          NPM_CONFIG_LOGLEVEL: ${{ runner.debug == '1' && 'verbose' || 'notice' }}
         run: |
           set -euxo pipefail
           VERSION=$(cat package.json | jq -r '.version')


### PR DESCRIPTION
### Why?

npm does not print its `http` log lines at the default `notice` loglevel. When a
release fails, the log shows only the final error.

### What?

- sets `NPM_CONFIG_LOGLEVEL` on the publish step to `verbose` when the run has
  debug logging enabled, and to npm's default `notice` when it does not

`verbose` does not print secrets. npm shows `_authToken` as `(protected)`, and it
does not log request headers at any loglevel.

### See Also

- #2837 — the release failure that motivated this
- [`runner` context reference](https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#runner-context)
