### PR TITLE
Validate that webhook secrets are non-empty

### DIFF
--- a/examples/snippets/event_notification_handler_endpoint.ts
+++ b/examples/snippets/event_notification_handler_endpoint.ts
@@ -14,7 +14,12 @@ import {Stripe} from 'stripe';
 import express from 'express';
 
 const apiKey = process.env.STRIPE_API_KEY ?? '';
-const webhookSecret = process.env.WEBHOOK_SECRET ?? '';
+const webhookSecret = process.env.WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+  console.error('Please set the WEBHOOK_SECRET environment variable');
+  process.exit(1);
+}
 
 const app = express();
 const client = new Stripe(apiKey);

--- a/examples/snippets/event_notification_webhook_handler.ts
+++ b/examples/snippets/event_notification_webhook_handler.ts
@@ -19,7 +19,12 @@ import express from 'express';
 const app = express();
 
 const apiKey = process.env.STRIPE_API_KEY ?? '';
-const webhookSecret = process.env.WEBHOOK_SECRET ?? '';
+const webhookSecret = process.env.WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+  console.error('Please set the WEBHOOK_SECRET environment variable');
+  process.exit(1);
+}
 
 const client = new Stripe(apiKey);
 

--- a/examples/webhook-signing/deno/main.ts
+++ b/examples/webhook-signing/deno/main.ts
@@ -7,6 +7,13 @@ import Stripe from 'npm:stripe@^11.16';
 
 const stripe = Stripe(Deno.env.get('STRIPE_API_KEY'));
 
+const webhookSecret = Deno.env.get('STRIPE_WEBHOOK_SECRET');
+
+if (!webhookSecret) {
+  console.error('Please set the STRIPE_WEBHOOK_SECRET environment variable');
+  Deno.exit(1);
+}
+
 // Must specify hostname explicitly, see https://github.com/denoland/deno/issues/5144
 const server = Deno.listen({hostname: '127.0.0.1', port: 0});
 const {port} = server.addr;
@@ -24,7 +31,7 @@ async function handler(request) {
     event = await stripe.webhooks.constructEventAsync(
       body,
       signature,
-      Deno.env.get('STRIPE_WEBHOOK_SECRET'),
+      webhookSecret,
       undefined
     );
   } catch (err) {

--- a/examples/webhook-signing/express/main.ts
+++ b/examples/webhook-signing/express/main.ts
@@ -9,7 +9,12 @@ env.config();
 
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
-const webhookSecret: string = process.env.STRIPE_WEBHOOK_SECRET;
+const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+if (!webhookSecret) {
+  console.error('Please set the STRIPE_WEBHOOK_SECRET environment variable');
+  process.exit(1);
+}
 
 const app = express();
 

--- a/examples/webhook-signing/koa/main.ts
+++ b/examples/webhook-signing/koa/main.ts
@@ -11,6 +11,11 @@ const app = new Koa();
 env.config();
 const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
 
+if (!webhookSecret) {
+  console.error('Please set the STRIPE_WEBHOOK_SECRET environment variable');
+  process.exit(1);
+}
+
 const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
 const handleWebhook = async (ctx: Koa.ParameterizedContext, next: Koa.Next) => {

--- a/examples/webhook-signing/nestjs/config.ts
+++ b/examples/webhook-signing/nestjs/config.ts
@@ -5,9 +5,18 @@ type Config = {
   };
 };
 
-export const config = (): Config => ({
-  Stripe: {
-    secret_key: process.env.STRIPE_SECRET_KEY || '',
-    webhook_secret: process.env.STRIPE_WEBHOOK_SECRET || '',
-  },
-});
+export const config = (): Config => {
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+  if (!webhookSecret) {
+    throw new Error(
+      'Please set the STRIPE_WEBHOOK_SECRET environment variable'
+    );
+  }
+
+  return {
+    Stripe: {
+      secret_key: process.env.STRIPE_SECRET_KEY || '',
+      webhook_secret: webhookSecret,
+    },
+  };
+};

--- a/examples/webhook-signing/nextjs/app/api/webhooks/route.ts
+++ b/examples/webhook-signing/nextjs/app/api/webhooks/route.ts
@@ -10,10 +10,17 @@ export async function POST(req: Request) {
   try {
     const stripeSignature = (await headers()).get('stripe-signature');
 
+    const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+    if (!webhookSecret) {
+      throw new Error(
+        'Please set the STRIPE_WEBHOOK_SECRET environment variable'
+      );
+    }
+
     event = stripe.webhooks.constructEvent(
       await req.text(),
       stripeSignature as string,
-      process.env.STRIPE_WEBHOOK_SECRET as string
+      webhookSecret
     );
   } catch (err) {
     const errorMessage = err instanceof Error ? err.message : 'Unknown error';

--- a/examples/webhook-signing/nextjs/pages/api/webhooks.ts
+++ b/examples/webhook-signing/nextjs/pages/api/webhooks.ts
@@ -7,7 +7,13 @@ const handler = async (
 ): Promise<void> => {
   const stripe = new Stripe(process.env.STRIPE_SECRET_KEY);
 
-  const webhookSecret: string = process.env.STRIPE_WEBHOOK_SECRET;
+  const webhookSecret = process.env.STRIPE_WEBHOOK_SECRET;
+
+  if (!webhookSecret) {
+    console.error('Please set the STRIPE_WEBHOOK_SECRET environment variable');
+    res.status(500).send('Webhook secret is not configured');
+    return;
+  }
 
   if (req.method === 'POST') {
     const sig = req.headers['stripe-signature'];

--- a/src/Webhooks.ts
+++ b/src/Webhooks.ts
@@ -258,6 +258,12 @@ export function createWebhooks(
         encodedHeader,
         this.EXPECTED_SCHEME
       );
+      if (!secret) {
+        throw new StripeSignatureVerificationError(header, payload, {
+          message:
+            'No webhook secret value was provided. It should start with `whsec_`',
+        });
+      }
       const secretContainsWhitespace = /\s/.test(secret);
 
       cryptoProvider = cryptoProvider || getCryptoProvider();
@@ -303,6 +309,12 @@ export function createWebhooks(
         encodedHeader,
         this.EXPECTED_SCHEME
       );
+      if (!secret) {
+        throw new StripeSignatureVerificationError(header, payload, {
+          message:
+            'No webhook secret value was provided. It should start with `whsec_`',
+        });
+      }
       const secretContainsWhitespace = /\s/.test(secret);
 
       cryptoProvider = cryptoProvider || getCryptoProvider();

--- a/test/Webhook.spec.ts
+++ b/test/Webhook.spec.ts
@@ -466,6 +466,27 @@ function createWebhooksTestSuite(stripe) {
         );
       });
 
+      it('should raise a SignatureVerificationError when the signing secret is empty or nullish', async () => {
+        const header = stripe.webhooks.generateTestHeaderString({
+          payload: EVENT_PAYLOAD_STRING,
+          secret: SECRET,
+        });
+
+        const expectedMessage = /No webhook secret value was provided\. It should start with `whsec_`/;
+
+        await expect(
+          verifyHeaderFn(EVENT_PAYLOAD_STRING, header, '')
+        ).to.be.rejectedWith(StripeSignatureVerificationError, expectedMessage);
+
+        await expect(
+          verifyHeaderFn(EVENT_PAYLOAD_STRING, header, null)
+        ).to.be.rejectedWith(StripeSignatureVerificationError, expectedMessage);
+
+        await expect(
+          verifyHeaderFn(EVENT_PAYLOAD_STRING, header, undefined)
+        ).to.be.rejectedWith(StripeSignatureVerificationError, expectedMessage);
+      });
+
       describe('custom CryptoProvider', () => {
         const cryptoProvider = new FakeCryptoProvider();
 


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

Fixes a potential security issue where, if the user passes an empty string into the event validation functions, the SDK would still generate a signature. If an attacker knew that a victim was inadvertently using an empty webhook secret, the attacker could send signed webhooks (using the empty secret) that a victim's integration would treat as valid.

The solution is to throw an error if the webhook secret is empty. This ensures all payloads are validated against an actual secret.

We also updated our examples to have better defaults, helping users to avoid this issue.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- verify that a webhook secret is non-empty & non-null when verifying a webhook
- update examples
- add tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2953](https://go/j/RUN_DEVSDK-2953)
