### PR TITLE
Support `EventNotification`s with singleton related objects

### DIFF
--- a/src/resources/V2/Core/Events.ts
+++ b/src/resources/V2/Core/Events.ts
@@ -1174,6 +1174,6 @@ export declare namespace Events {
     V2CoreAccountPersonUpdatedEventNotification,
     V2CoreEventDestinationPingEventNotification,
   };
-  export import RelatedObject = V2.Core.Events.RelatedObject;
-  export import RelatedSingletonObject = V2.Core.Events.RelatedSingletonObject;
+  export type RelatedObject = V2.Core.Events.RelatedObject;
+  export type RelatedSingletonObject = V2.Core.Events.RelatedSingletonObject;
 }

--- a/src/resources/V2/Core/Events.ts
+++ b/src/resources/V2/Core/Events.ts
@@ -249,6 +249,23 @@ export namespace V2 {
   }
 }
 
+export namespace V2 {
+  export namespace Core {
+    export namespace Events {
+      /**
+       * A reference to an API resource that has no standalone identifier, so there is no `id` to retrieve it by.
+       */ export interface RelatedSingletonObject {
+        /**
+         * Type of the object relevant to the event.
+         */ type: string;
+        /**
+         * URL to retrieve the resource.
+         */ url: string;
+      }
+    }
+  }
+}
+
 /**
  * Represents the shape of an EventNotification that the SDK didn't know about when it was generated.
  */ export interface UnknownEventNotification extends EventNotificationBase {
@@ -1157,4 +1174,6 @@ export declare namespace Events {
     V2CoreAccountPersonUpdatedEventNotification,
     V2CoreEventDestinationPingEventNotification,
   };
+  export import RelatedObject = V2.Core.Events.RelatedObject;
+  export import RelatedSingletonObject = V2.Core.Events.RelatedSingletonObject;
 }

--- a/src/stripe.cjs.node.ts
+++ b/src/stripe.cjs.node.ts
@@ -14375,6 +14375,8 @@ declare namespace StripeConstructor {
   }
   export namespace Events {
     export type UnknownEventNotification = Stripe_.V2.Core.Events.UnknownEventNotification;
+    export type RelatedObject = Stripe_.V2.Core.Events.RelatedObject;
+    export type RelatedSingletonObject = Stripe_.V2.Core.Events.RelatedSingletonObject;
     export type V1BillingMeterErrorReportTriggeredEvent = Stripe_.V2.Core.Events.V1BillingMeterErrorReportTriggeredEvent;
     export type V1BillingMeterErrorReportTriggeredEventNotification = Stripe_.V2.Core.Events.V1BillingMeterErrorReportTriggeredEventNotification;
     export type V1BillingMeterNoMeterFoundEvent = Stripe_.V2.Core.Events.V1BillingMeterNoMeterFoundEvent;

--- a/testProjects/types-cjs-node16/typescriptTest.ts
+++ b/testProjects/types-cjs-node16/typescriptTest.ts
@@ -128,3 +128,11 @@ async (): Promise<void> => {
 // both handler types must be nameable off the namespace
 let _verifyingHandler: Stripe.StripeEventNotificationHandler;
 let _unverifiedHandler: Stripe.StripeEventNotificationHandlerWithoutVerification;
+
+// both related-object shapes must be nameable off the namespace. "Singleton"
+// events use the second one, whose related object has no standalone id.
+let _relatedObject: Stripe.Events.RelatedObject;
+let _relatedSingletonObject: Stripe.Events.RelatedSingletonObject;
+
+// @ts-expect-error - a singleton related object has no id
+({} as Stripe.Events.RelatedSingletonObject).id;

--- a/testProjects/types-cjs/typescriptTest.ts
+++ b/testProjects/types-cjs/typescriptTest.ts
@@ -393,6 +393,24 @@ async (): Promise<void> => {
   // let h: Stripe.V2.Core.EventNotificationBase; // doesn't work, can export later
   // union of all v1 events
   let i: Stripe.Event;
+  // the shape of an event's `related_object`
+  let j: Stripe.Events.RelatedObject;
+  // ...and the variant that "singleton" events use, whose related object has no
+  // standalone id
+  let k: Stripe.Events.RelatedSingletonObject;
+}
+
+{
+  // a singleton related object is reachable only by url
+  const singleton = {} as Stripe.Events.RelatedSingletonObject;
+  const singletonType: string = singleton.type;
+  const singletonUrl: string = singleton.url;
+  // @ts-expect-error - a singleton related object has no id
+  singleton.id;
+
+  // whereas the usual related object does have one
+  const related = {} as Stripe.Events.RelatedObject;
+  const relatedId: string = related.id;
 }
 
 // Test that the Decimal type is exported

--- a/testProjects/types/typescriptTest.ts
+++ b/testProjects/types/typescriptTest.ts
@@ -395,6 +395,24 @@ async (): Promise<void> => {
   let g: Stripe.V2.Core.Event;
   // union of all v1 events
   let h: Stripe.Event;
+  // the shape of an event's `related_object`
+  let i: Stripe.Events.RelatedObject;
+  // ...and the variant that "singleton" events use, whose related object has no
+  // standalone id
+  let j: Stripe.Events.RelatedSingletonObject;
+}
+
+{
+  // a singleton related object is reachable only by url
+  const singleton = {} as Stripe.Events.RelatedSingletonObject;
+  const singletonType: string = singleton.type;
+  const singletonUrl: string = singleton.url;
+  // @ts-expect-error - a singleton related object has no id
+  singleton.id;
+
+  // whereas the usual related object does have one
+  const related = {} as Stripe.Events.RelatedObject;
+  const relatedId: string = related.id;
 }
 
 async (): Promise<void> => {


### PR DESCRIPTION
### Why?

<!-- Describe why this change is being made.  Briefly include history and context, high-level what this PR does, and what the world looks like afterward. -->

There are a few event notification types whose related object is a singleton. As a result, its `id` field will always be `null`. Rather than mark the root `RelatedObject` class as having a nullable string for its id (causing every user to have to do null checks even when we _know_ it'll be there), we're adding a second class and generating accordingly. There'll never be any ambiguity as ot whether a id field will be present in the response.

### What?

<!--
List out the key changes made in this PR, e.g.
- implements the antimatter particle trace in the nitronium microfilament drive
- updated tests -->

- add `RelatedSingletonObject` class, which is a copy of `RelatedObject`, but without an `id`. I didn't do inheritance (when relevant) because it's such a tiny, colocated class. If the repetition bothers us, we can reassess.
- add related methods, as needed
- tests

### See Also

<!-- Include any links or additional information that help explain this change. -->

- [RUN_DEVSDK-2825](https://go/j/RUN_DEVSDK-2825)
