### PR TITLE
Preserve endpointFetch response headers

### DIFF
--- a/src/net/EndpointFetchHttpClient.ts
+++ b/src/net/EndpointFetchHttpClient.ts
@@ -18,6 +18,7 @@ type EndpointFetchRequest = {
 type EndpointFetchResponse = {
   status: number;
   body?: string | null;
+  headers?: Record<string, string>;
 };
 
 type EndpointFetchSuccessResponse = EndpointFetchResponse & {
@@ -27,6 +28,7 @@ type EndpointFetchSuccessResponse = EndpointFetchResponse & {
 type EndpointFetchError = Error & {
   status?: number;
   body?: string | null;
+  headers?: Record<string, string>;
 };
 
 type EndpointFetch = (
@@ -119,6 +121,7 @@ export class EndpointFetchHttpClient extends HttpClient {
     return {
       status: endpointFetchError.status,
       body: endpointFetchError.body ?? '',
+      headers: endpointFetchError.headers,
     };
   }
 }
@@ -127,7 +130,7 @@ export class EndpointFetchHttpClientResponse extends HttpClientResponse {
   private _res: EndpointFetchResponse;
 
   constructor(res: EndpointFetchResponse) {
-    super(res.status, {});
+    super(res.status, res.headers ?? {});
     this._res = res;
   }
 

--- a/test/ExtensibilityPlatformFunctions.spec.ts
+++ b/test/ExtensibilityPlatformFunctions.spec.ts
@@ -13,17 +13,24 @@ type TestGlobal = typeof globalThis & {
     method: string;
     body?: string;
     headers?: Record<string, string>;
-  }) => Promise<{ok: true; status: number; body?: string}>;
+  }) => Promise<{
+    ok: true;
+    status: number;
+    body?: string;
+    headers?: Record<string, string>;
+  }>;
 };
 type EndpointFetch = NonNullable<TestGlobal['endpointFetch']>;
 type EndpointFetchRequest = Parameters<EndpointFetch>[0];
 type EndpointFetchError = Error & {
   status?: number;
   body?: string | null;
+  headers?: Record<string, string>;
 };
 type StripeError = Error & {
   type?: string;
   requestId?: string;
+  headers?: Record<string, string>;
 };
 type HookEvent =
   | ['request', RequestEvent['method'], RequestEvent['path']]
@@ -150,6 +157,7 @@ describe('ExtensibilityPlatformFunctions', () => {
           type: 'authentication_error',
         },
       });
+      error.headers = {'retry-after': '5'};
       return Promise.reject(error);
     };
 
@@ -161,6 +169,7 @@ describe('ExtensibilityPlatformFunctions', () => {
       expect(error.type).to.equal('StripeAuthenticationError');
       expect(error.message).to.equal('No API key provided');
       expect(error.requestId).to.be.undefined;
+      expect(error.headers?.['retry-after']).to.equal('5');
     }
   });
 

--- a/test/net/EndpointFetchHttpClient.spec.ts
+++ b/test/net/EndpointFetchHttpClient.spec.ts
@@ -15,6 +15,7 @@ type TestGlobal = typeof globalThis & {
     ok: true;
     status: number;
     body?: string;
+    headers?: Record<string, string>;
   }>;
 };
 type EndpointFetch = NonNullable<TestGlobal['endpointFetch']>;
@@ -22,6 +23,7 @@ type EndpointFetchRequest = Parameters<EndpointFetch>[0];
 type EndpointFetchError = Error & {
   status?: number;
   body?: string | null;
+  headers?: Record<string, string>;
 };
 type JsonParseError = Error & {
   rawBody?: string;
@@ -38,6 +40,15 @@ type MakeRequestOptions = {
 };
 
 describe('EndpointFetchHttpClient', () => {
+  const responseHeaders = {
+    'retry-after': '5',
+    'request-id': 'req_123',
+    'stripe-account': 'acct_123',
+    'stripe-version': '2025-01-01',
+    'idempotency-key': 'idempotency-key',
+    'stripe-notice': 'notice',
+    'stripe-should-retry': 'true',
+  };
   const testGlobal = globalThis as TestGlobal;
   let endpointFetch$: EndpointFetch | undefined;
   let capturedRequest: EndpointFetchRequest | null;
@@ -94,6 +105,22 @@ describe('EndpointFetchHttpClient', () => {
     expect(response.getStatusCode()).to.equal(200);
     expect(response.getHeaders()).to.deep.equal({});
     expect(await response.toJSON()).to.deep.equal({ok: true});
+  });
+
+  it('preserves response headers from endpointFetch', async () => {
+    testGlobal.endpointFetch = (request: EndpointFetchRequest) => {
+      capturedRequest = request;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        body: '{"ok":true}',
+        headers: responseHeaders,
+      });
+    };
+
+    const response = await makeRequest();
+
+    expect(response.getHeaders()).to.deep.equal(responseHeaders);
   });
 
   it('uses an empty string body for payload methods without request data', async () => {
@@ -155,13 +182,14 @@ describe('EndpointFetchHttpClient', () => {
       error.status = 401;
       error.body =
         '{"error":{"message":"No API key provided","type":"authentication_error"}}';
+      error.headers = responseHeaders;
       return Promise.reject(error);
     };
 
     const response = await makeRequest();
 
     expect(response.getStatusCode()).to.equal(401);
-    expect(response.getHeaders()).to.deep.equal({});
+    expect(response.getHeaders()).to.deep.equal(responseHeaders);
     expect(await response.toJSON()).to.deep.equal({
       error: {
         message: 'No API key provided',


### PR DESCRIPTION
### Why?

`EndpointFetchHttpClient` currently replaces response headers with an empty object. This prevents response metadata and retry signals returned by `endpointFetch` from reaching stripe-node responses and errors.

### What?

- Preserve optional response headers from successful `endpointFetch` calls.
- Preserve optional response headers from response-shaped rejections.
- Keep the existing empty-header behavior when the runtime omits headers.
- Add coverage for SDK response headers and `retry-after` on Stripe API errors.

### Test Plan

- `tsc -p tsconfig.cjs.json --pretty false`
- `mocha test/net/EndpointFetchHttpClient.spec.ts test/ExtensibilityPlatformFunctions.spec.ts`
- Targeted ESLint and Prettier checks for changed files

## Changelog

- Preserves response headers returned by `endpointFetch` in extensibility runtimes.
